### PR TITLE
Fix Marketing V2 runtime helper permissions

### DIFF
--- a/supabase/migrations/20260812145500_grant_marketing_v2_timestamp_helpers.sql
+++ b/supabase/migrations/20260812145500_grant_marketing_v2_timestamp_helpers.sql
@@ -1,0 +1,9 @@
+-- ASCENDA OS — Marketing V2 runtime permissions
+-- These helpers only normalize event timestamps from arguments.
+-- They are SECURITY INVOKER, STABLE and do not read/write tables.
+
+grant execute on function public.aos_lead_event_ts(date, timestamptz, timestamptz)
+  to anon, authenticated;
+
+grant execute on function public.aos_llamada_event_ts(date, text, timestamptz, timestamptz, timestamptz)
+  to anon, authenticated;


### PR DESCRIPTION
Documenta el permiso mínimo requerido por las RPC V2 de Marketing para ejecutar los helpers de normalización temporal bajo los roles usados por el frontend.

No modifica datos, tablas, RLS ni lógica de negocio. Solo concede EXECUTE sobre dos funciones STABLE/SECURITY INVOKER que transforman argumentos de fecha/hora a timestamp.

QA producción ya validado bajo rol anon: aos_marketing_leads_detalle_v2 + aos_marketing_period_summary_v2 devuelven agosto con 358 ingresos, 350 personas, 2 vendidos y S/1,045.