### PR TITLE
Promote Marketing V2 runtime helper permissions

### DIFF
--- a/supabase/migrations/20260812145500_grant_marketing_v2_timestamp_helpers.sql
+++ b/supabase/migrations/20260812145500_grant_marketing_v2_timestamp_helpers.sql
@@ -1,0 +1,9 @@
+-- ASCENDA OS — Marketing V2 runtime permissions
+-- These helpers only normalize event timestamps from arguments.
+-- They are SECURITY INVOKER, STABLE and do not read/write tables.
+
+grant execute on function public.aos_lead_event_ts(date, timestamptz, timestamptz)
+  to anon, authenticated;
+
+grant execute on function public.aos_llamada_event_ts(date, text, timestamptz, timestamptz, timestamptz)
+  to anon, authenticated;


### PR DESCRIPTION
Promoción de la migración ya aplicada y validada en Supabase. No cambia lógica de UI ni datos; versiona el permiso mínimo EXECUTE de los helpers temporales usados por las RPC V2 de Marketing.