### PR TITLE
Promote Marketing historical public gateway

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -113,7 +113,7 @@
   function loadBlocks(){
     var req=++S.blockReq;
     var anio=Number(el('mk-anio').value);
-    vrpc('aos_marketing_historico_aligned_v2',{p_anio:anio}).then(function(rows){if(req!==S.blockReq)return;applyHistory(rows);}).catch(function(e){console.warn('[MKT progressive] histórico mantiene legacy:',e.message);});
+    vrpc('aos_marketing_historico_public_v2',{p_anio:anio}).then(function(rows){if(req!==S.blockReq)return;applyHistory(rows);}).catch(function(e){console.warn('[MKT progressive] histórico mantiene legacy:',e.message);});
     if(MK.modo==='mes'){
       var r=currentMonthRange();
       vrpc('aos_marketing_period_summary_v2',{p_fecha_desde:r.desde,p_fecha_hasta:r.hasta}).then(function(s){if(req!==S.blockReq)return;renderTopFromSummary(s||{});}).catch(function(e){console.warn('[MKT progressive] KPIs mantienen legacy:',e.message);});
@@ -141,7 +141,7 @@
     var filtro=(typeof _ldFiltroEstado!=='undefined'?_ldFiltroEstado:'todos');
     var q=(el('ld-buscar').value||'').trim();
     var note=ensureLeadNote();
-    if(note)note.innerHTML='<b>'+n(s.ingresos)+' ingresos</b> corresponden a <b>'+n(s.personasUnicas)+' personas únicas</b> ('+n(s.reingresos)+' reingresos). Personas: '+n(s.personasGestionadas)+' gestionadas después del ingreso · '+n(s.personasCitaTel)+' Citas Tel. · '+n(s.personasConCita)+' citas en Agenda · '+n(s.clientesM0)+' clientes M0. La tabla y sus filtros representan <b>touchpoints/ingresos</b>; “VENDIDO” solo aparece cuando la venta fue atribuida a ese ingreso.';
+    if(note)note.innerHTML='<b>'+n(s.ingresos)+' ingresos</b> corresponden a <b>'+n(s.personasUnicas)+' personas únicas</b> ('+n(s.reingresos)+' reingresos). Personas: '+n(s.personasGestionadas)+' gestionadas después del ingreso · '+n(s.personasCitaTel)+' Citas Tel. · '+n(s.personasConCita)+' citas en Agenda · '+n(s.clientesM0)+' clientes M0 · '+n(s.ventasM0)+' operaciones M0 · '+money(s.factM0)+' M0. La tabla y sus filtros representan <b>touchpoints/ingresos</b>; “VENDIDO” solo aparece cuando la venta fue atribuida a ese ingreso.';
     var count=document.getElementById('ld-count');
     if(filtro==='todos'&&!q){
       if(count)count.textContent=n(s.ingresos)+' ingresos · '+n(s.personasUnicas)+' personas';

--- a/docs/control/MARKETING_SAFE_RELEASE_LOOP.md
+++ b/docs/control/MARKETING_SAFE_RELEASE_LOOP.md
@@ -1,0 +1,61 @@
+# ASCENDA OS — Marketing Safe Release Loop
+
+## Objetivo
+
+Aplicar mejoras de Marketing sin volver a introducir regresiones visibles, inconsistencias de atribución ni pérdida de trazabilidad.
+
+## Principio operativo
+
+El panel legacy se mantiene visible como fallback. Una mejora V2 solo reemplaza un bloque después de que su RPC responda correctamente con el mismo rol usado por el navegador y sus resultados pasen reconciliación de datos.
+
+## Loop obligatorio por bloque
+
+1. **Baseline** — congelar cifras actuales y casos patrón del bloque.
+2. **Fuente de verdad** — identificar tablas/RPC/eventos exactos que alimentan la métrica.
+3. **Causalidad** — impedir que llamadas, citas o ventas anteriores al touchpoint se atribuyan al lead nuevo.
+4. **Unidad de medida** — declarar si la cifra representa ingresos/touchpoints, personas únicas, clientes o operaciones.
+5. **Preview paralelo** — construir cálculo V2 sin retirar el renderer legacy.
+6. **QA SQL propietario** — validar resultados y anomalías contra casos conocidos.
+7. **QA runtime real** — ejecutar la RPC con `SET ROLE anon`/rol usado por frontend y confirmar permisos de toda la cadena.
+8. **Gateway mínimo** — exponer solo la RPC agregada necesaria; no abrir funciones internas ni PII innecesariamente.
+9. **Frontend progressive enhancement** — legacy renderiza primero; V2 sustituye únicamente el bloque validado; cualquier error conserva legacy.
+10. **Feature/fix branch** — nunca editar `main` para desarrollo normal.
+11. **Syntax/CI** — `node --check`, `git diff --check`, Ascenda CI y checks existentes.
+12. **PR → staging** — revisar diff exacto y confirmar ausencia de cambios ajenos.
+13. **Staging CI** — no promover si el head de staging no está verde.
+14. **PR → main** — promoción pequeña y reversible del bloque aprobado.
+15. **Main CI** — verificar el run post-merge de `push: main`.
+16. **QA visual real** — captura desde ASCENDA productivo con filtros relevantes.
+17. **Reconciliación** — comparar UI ↔ RPC ↔ tablas para cifras clave.
+18. **Observación** — revisar primera actividad real posterior al cambio cuando aplique.
+19. **Documentación** — registrar decisiones, casos ambiguos y deuda pendiente.
+20. **Rollback** — ante regresión visible, desactivar solo el enhancement y conservar datos/trazabilidad.
+
+## Gates obligatorios
+
+Un bloque no avanza al siguiente si falla cualquiera de estos gates:
+
+- **G1 Datos:** cifras reconciliadas con casos patrón.
+- **G2 Causalidad:** cero atribuciones anteriores al lead.
+- **G3 Runtime:** RPC ejecuta bajo el rol real del navegador.
+- **G4 Seguridad:** no se amplían permisos más allá de lo necesario.
+- **G5 Código:** diff acotado + sintaxis/CI verde.
+- **G6 Staging:** staging verde.
+- **G7 Producción:** main verde.
+- **G8 Visual:** captura productiva correcta.
+
+## Regla de despliegue por lotes
+
+Orden actual:
+
+1. Leads del período — aprobado visualmente.
+2. Histórico anual — siguiente bloque.
+3. LTV/cohortes.
+4. Top Anuncios.
+5. Campañas.
+6. Paginación/búsqueda avanzada.
+7. Intención → compra.
+8. Nuevos bloques de atribución/reactivación.
+9. Marketing Intelligence.
+
+No agrupar varios bloques de alto impacto en un mismo cutover.

--- a/supabase/migrations/20260812112000_marketing_historico_v2_public_gateway.sql
+++ b/supabase/migrations/20260812112000_marketing_historico_v2_public_gateway.sql
@@ -1,0 +1,37 @@
+create or replace function public.aos_marketing_historico_public_v2(p_anio integer)
+returns table(
+  mes integer,
+  anio integer,
+  leads bigint,
+  llamados bigint,
+  citas bigint,
+  asistieron bigint,
+  clientes bigint,
+  ventas bigint,
+  fact numeric,
+  fact_acumulado numeric,
+  conv numeric,
+  ingresos bigint,
+  reingresos bigint,
+  citas_tel bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if p_anio is null or p_anio < 2020 or p_anio > extract(year from current_date)::integer + 1 then
+    raise exception 'Año fuera de rango';
+  end if;
+
+  return query
+  select h.mes,h.anio,h.leads,h.llamados,h.citas,h.asistieron,h.clientes,h.ventas,
+         h.fact,h.fact_acumulado,h.conv,h.ingresos,h.reingresos,h.citas_tel
+  from public.aos_marketing_historico_aligned_v2(p_anio) h
+  order by h.mes;
+end;
+$$;
+
+revoke all on function public.aos_marketing_historico_public_v2(integer) from public;
+grant execute on function public.aos_marketing_historico_public_v2(integer) to anon, authenticated;


### PR DESCRIPTION
Promoción del Gate 2 ya validado en backend y staging. Cambios visibles limitados a Histórico anual y una aclaración de operaciones M0 en Ver Leads. Legacy permanece como fallback si la RPC falla. Incluye gateway agregado sin PII y loop canónico de release seguro.