### PR TITLE
Stabilize Marketing V4.2 annual analytics and KPI formatting

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -1,40 +1,344 @@
-/* ASCENDA OS — Marketing V4 recovery controller
- * One remount-safe owner for Summary, Trace, History, LTV, Attribution and Intent.
- * Read-only: no business-data writes.
+/* ASCENDA OS — Marketing V4.2 stability controller
+ * Single remount-safe owner for Summary, Trace, History, LTV, Attribution and Intent.
+ * Read-only. Annual RPCs are intentionally serialized to avoid anon timeout contention.
  */
 (function(){
 'use strict';
-var RELEASE='2026-08-12-v4.1';
-if(window.__AOS_MKT4&&window.__AOS_MKT4.destroy){try{window.__AOS_MKT4.destroy();}catch(e){}}
-var alive=true,cycle=0,ctl=null,timers=[],wraps={},S={kpi:null,summary:null,history:[],ltv:[],attr:null};
-function $id(x){return document.getElementById(x)}
-function N(v){var x=Number(v);return Number.isFinite(x)?x:0}
-function M(v){return'S/'+Math.round(N(v)).toLocaleString('es-PE')}
-function E(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
-function A(v){if(Array.isArray(v))return v;if(v&&Array.isArray(v.ltv))return v.ltv;if(typeof v==='string'){try{return A(JSON.parse(v))}catch(e){}}return[]}
-function O(v){if(v&&typeof v==='object'&&!Array.isArray(v))return v;if(Array.isArray(v)&&v.length===1){var k=Object.keys(v[0]||{});if(k.length===1&&v[0][k[0]]&&typeof v[0][k[0]]==='object')return v[0][k[0]]}return v||{}}
-function C(){var a=N($id('mk-anio').value),m=N($id('mk-mes').value),d=new Date(a,m,0).getDate();return{a:a,m:m,d:a+'-'+String(m).padStart(2,'0')+'-01',h:a+'-'+String(m).padStart(2,'0')+'-'+String(d).padStart(2,'0')}}
-function month(){return !window.MK||MK.modo!=='anio'}
-function L(fn,ms){var t=setTimeout(function(){if(alive)fn()},ms||0);timers.push(t)}
-function clearT(){timers.forEach(clearTimeout);timers=[]}
-function U(fn){var i=0;while(fn&&fn.__mkt4base&&i++<4)fn=fn.__mkt4base;return fn}
-var B={mkL:U(window.mkL),rKPI:U(window.rKPI),rEmb:U(window.rEmb),rHist:U(window.rHist),rLTV:U(window.rLTV)};
-function call(fn,args){try{if(typeof fn==='function')return fn.apply(window,args||[])}catch(e){console.warn('[MKT4] legacy',e)}}
-function hook(n,fn){fn.__mkt4base=B[n];wraps[n]=fn;window[n]=fn}
-function rpc(fn,p,sig){return fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{apikey:SK,Authorization:'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(p||{}),signal:sig}).then(function(r){if(!r.ok)return r.text().then(function(t){throw new Error(fn+' HTTP '+r.status+' '+t.slice(0,180))});return r.json()})}
-function error(id,title,e){var b=$id(id);if(b)b.innerHTML='<div style="padding:10px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:9px"><b>'+E(title)+'</b><br>'+E(e.message||e)+'<br><button onclick="window.__AOS_MKT4.reload()" style="margin-top:5px;border:0;border-radius:6px;padding:5px 8px;background:#B91C1C;color:white;cursor:pointer">Reintentar</button></div>'}
-function traceBox(){var c=$id('mk4-trace')||$id('mk-v3-trace');if(c){c.id='mk4-trace';var g=$id('mk-v3-trace-grid');if(g)g.id='mk4-trace-grid';var n=$id('mk-v3-trace-note');if(n)n.id='mk4-trace-note';return c}var x=$id('mk-gest');if(!x)return null;c=document.createElement('div');c.id='mk4-trace';c.className='crd';c.style.padding='8px 12px';c.innerHTML='<div class="ct">🧭 Trazabilidad del período <span class="tag tag-b">V4</span></div><div id="mk4-trace-grid"><div class="ld">Cargando…</div></div><div id="mk4-trace-note" style="font-size:8px;color:#6B7BA8;margin-top:6px"></div>';x.insertAdjacentElement('afterend',c);return c}
-function insights(){var a=$id('mk4-insights')||$id('mk-v3-insights');if(a){a.id='mk4-insights';[['mk-v3-attr-card','mk4-attr-card'],['mk-v3-attr','mk4-attr'],['mk-v3-intent-card','mk4-intent-card'],['mk-v3-intent','mk4-intent']].forEach(function(x){var e=$id(x[0]);if(e)e.id=x[1]});return a}var l=$id('mk-ltv');if(!l)return null;var card=l.closest('.crd');a=document.createElement('div');a.id='mk4-insights';a.style.cssText='display:flex;gap:10px;flex-wrap:wrap';a.innerHTML='<div class="crd" id="mk4-attr-card" style="flex:1 1 420px"><div class="ct">🧠 Atribución y reingresos <span class="tag tag-b">V4</span></div><div id="mk4-attr"><div class="ld">Cargando…</div></div></div><div class="crd" id="mk4-intent-card" style="flex:1 1 420px"><div class="ct">🧩 Intención → Compra <span class="tag tag-c">auditable</span></div><div id="mk4-intent"><div class="ld">Cargando…</div></div></div>';card.insertAdjacentElement('afterend',a);return a}
-function loading(){traceBox();insights();var g=$id('mk4-trace-grid');if(g)g.innerHTML='<div class="ld">Cargando trazabilidad…</div>';var h=$id('mk-hist');if(h)h.innerHTML='<div class="ld">Cargando histórico anual…</div>';var l=$id('mk-ltv');if(l)l.innerHTML='<div class="ld">Cargando LTV…</div>';var t=$id('mk-ltv-tag');if(t)t.textContent='cargando…';var a=$id('mk4-attr');if(a)a.innerHTML='<div class="ld">Cargando atribución…</div>';var i=$id('mk4-intent');if(i)i.innerHTML='<div class="ld">Cargando intención…</div>'}
-function renderTrace(s){var c=traceBox();if(!c)return;c.style.display=month()?'':'none';if(!month())return;var v=[[s.ingresos,'INGRESOS','#0A4FBF'],[s.personasUnicas,'PERSONAS ÚNICAS','#0D9488'],[s.reingresos,'REINGRESOS','#7C3AED'],[s.personasGestionadas,'GESTIÓN POST-INGRESO','#059669'],[s.personasCitaTel,'CITAS TEL.','#D97706'],[s.personasConCita,'CITAS AGENDA','#7C3AED'],[s.clientesM0,'CLIENTES M0','#059669']];$id('mk4-trace-grid').innerHTML='<div class="g-row">'+v.map(function(x){return'<div class="g-c" style="background:#F8FAFF;border:1px solid #EEF2F8"><div class="g-v" style="color:'+x[2]+'">'+N(x[0])+'</div><div class="g-l">'+x[1]+'</div></div>'}).join('')+'</div>';$id('mk4-trace-note').innerHTML='Personas únicas y gestión posterior al ingreso. Citas Tel. = Call Center; Citas Agenda = agenda real; Clientes M0 = compradores atribuidos dentro del mes.'}
-function renderTop(){if(!S.summary||!month())return;var s=S.summary,k={},old=S.kpi||{},inv=N(old.invTotal);Object.keys(old).forEach(function(x){k[x]=old[x]});k.leads=N(s.personasUnicas);k.llamados=N(s.personasGestionadas);k.citas=N(s.personasCitaTel);k.asistieron=N(s.personasAsistieron);k.clientes=N(s.clientesM0);k.nVentas=N(s.ventasM0);k.factTotal=N(s.factM0);k.pctLlamados=k.leads?k.llamados/k.leads*100:0;k.roas=inv?k.factTotal/inv:0;k.cac=k.clientes&&inv?inv/k.clientes:null;k.cpl=k.leads&&inv?inv/k.leads:null;call(B.rKPI,[k]);call(B.rEmb,[{leads:k.leads,llamados:k.llamados,citas:k.citas,asistieron:k.asistieron,clientes:k.clientes,ventas:k.nVentas,factTotal:k.factTotal,tasas:{llamados:k.leads?k.llamados/k.leads*100:0,citas:k.llamados?k.citas/k.llamados*100:0,asist:k.citas?k.asistieron/k.citas*100:0,clientes:k.asistieron?k.clientes/k.asistieron*100:0,ventas:k.clientes?k.nVentas/k.clientes*100:0}}]);renderTrace(s);var e=$id('mk-emb'),o=$id('mk4-fnote');if(o)o.remove();if(e){o=document.createElement('div');o.id='mk4-fnote';o.style.cssText='font-size:8px;color:#6B7BA8;margin-top:5px';o.innerHTML='<b>Nota:</b> Ventas = operaciones. El último ratio puede superar 100%; no es conversión de personas.';e.appendChild(o)}}
-function renderHistory(rows){rows=A(rows).sort(function(a,b){return N(a.mes)-N(b.mes)});S.history=rows;var b=$id('mk-hist');if(!b)return;if(!rows.length){b.innerHTML='<div class="ld">Sin datos</div>';return}var sel=month()?C().m:null,mf=Math.max.apply(null,rows.map(function(x){return N(x.fact_acumulado)})),ml=Math.max.apply(null,rows.map(function(x){return N(x.leads)}));var ch='<div style="display:flex;gap:3px;align-items:flex-end;height:55px;margin-bottom:6px">'+rows.map(function(x){var a=sel===N(x.mes),hf=mf?N(x.fact_acumulado)/mf*42:0,hl=ml?N(x.leads)/ml*42:0;return'<div style="flex:1;text-align:center;'+(a?'background:#F0F7FF;border-radius:4px':'')+'"><div style="height:44px;display:flex;align-items:flex-end;justify-content:center;gap:1px"><div style="width:8px;height:'+hf+'px;background:#0A4FBF"></div><div style="width:8px;height:'+hl+'px;background:#00C9A7"></div></div><div style="font-size:6px;color:#6B7BA8;font-weight:700">'+MF[N(x.mes)].slice(0,3).toUpperCase()+'</div></div>'}).join('')+'</div>';var tb='<table class="vt"><thead><tr><th>MES</th><th>LEADS</th><th>LLAM.</th><th>CITAS</th><th>ASIST.</th><th>CLIENTES M0</th><th>OPS M0</th><th>FACT M0</th><th>LTV ACUM.</th><th>CONV%</th></tr></thead><tbody>'+rows.map(function(x){return'<tr'+(sel===N(x.mes)?' style="background:#F0F7FF;outline:1px solid #D9E8FF"':'')+'><td><b>'+MF[N(x.mes)].slice(0,3).toUpperCase()+' '+N(x.anio)+'</b></td><td>'+N(x.leads)+'</td><td>'+(N(x.llamados)===0&&N(x.citas)>0?'—':N(x.llamados))+'</td><td>'+N(x.citas)+'</td><td>'+N(x.asistieron)+'</td><td class="hi hi-g">'+N(x.clientes)+'</td><td>'+N(x.ventas)+'</td><td class="hi hi-b">'+M(x.fact)+'</td><td class="hi hi-c">'+M(x.fact_acumulado)+'</td><td>'+N(x.conv).toFixed(2)+'%</td></tr>'}).join('')+'</tbody></table>';b.innerHTML=ch+tb+'<div style="font-size:8px;color:#6B7BA8;margin-top:6px"><b>Histórico anual fijo:</b> cambiar el mes solo resalta la cohorte; no recorta ENE→mes actual.</div>'}
-function cell(v,st,c){if(v==null||st==='FUTURE')return'<span style="color:#CBD5E1">—</span>';return'<b style="color:'+c+'">'+M(v)+'</b>'+(st==='PARTIAL'?'<div style="font-size:7px;color:#D97706">parcial</div>':'')}
-function renderLtv(raw){var rows=A(raw).sort(function(a,b){return N(a.mes)-N(b.mes)});S.ltv=rows;var b=$id('mk-ltv'),tag=$id('mk-ltv-tag');if(!rows.length){b.innerHTML='<div class="ld">Sin LTV</div>';return}var f=month()?rows.find(function(x){return N(x.mes)===C().m}):null;if(!f){var inv=0,m0=0,lt=0,ac=0;rows.forEach(function(x){inv+=N(x.inversion);m0+=N(x.m0);lt+=N(x.ltv_total);ac+=N(x.clientes_adquiridos)});f={m0:m0,ltv_total:lt,inversion:inv,clientes_adquiridos:ac,roas_ltv:inv?lt/inv:0,cac_adquisicion:ac?inv/ac:0,m1:0,m2:0,m3:0,m4plus:0}}var mult=N(f.m0)?N(f.ltv_total)/N(f.m0):0;tag.textContent='LTV '+(mult?mult.toFixed(1)+'x':'—')+' · '+rows.length+' cohortes';var h='<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px"><div style="flex:1;background:#F5F3FF;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#7C3AED">LTV / M0</div><div style="font-size:24px;font-weight:800;color:#7C3AED">'+(mult?mult.toFixed(1)+'x':'—')+'</div></div><div style="flex:1;background:#F0FDF4;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#059669">ROAS LTV</div><div style="font-size:24px;font-weight:800;color:#059669">'+N(f.roas_ltv).toFixed(2)+'x</div></div><div style="flex:1;background:#FFF7ED;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#D97706">CAC ADQUISICIÓN</div><div style="font-size:24px;font-weight:800;color:#D97706">'+M(f.cac_adquisicion)+'</div></div></div>';h+='<div style="overflow:auto"><table class="vt"><thead><tr><th>COHORTE</th><th>PERSONAS</th><th>ADQUIRIDOS</th><th>M0 CLIENTES</th><th>INV.</th><th>M0</th><th>M+1</th><th>M+2</th><th>M+3</th><th>M+4+</th><th>LTV TOTAL</th><th>ROAS LTV</th></tr></thead><tbody>'+rows.map(function(x){return'<tr'+(month()&&N(x.mes)===C().m?' style="background:#F0F7FF;outline:1px solid #D9E8FF"':'')+'><td><b>'+MF[N(x.mes)].slice(0,3).toUpperCase()+'</b></td><td>'+N(x.personas_unicas)+'</td><td>'+N(x.clientes_adquiridos)+'</td><td>'+N(x.clientes_adquiridos_m0)+'</td><td>'+M(x.inversion)+'</td><td>'+cell(x.m0,x.m0_estado,'#0A4FBF')+'</td><td>'+cell(x.m1,x.m1_estado,'#00C9A7')+'</td><td>'+cell(x.m2,x.m2_estado,'#7C3AED')+'</td><td>'+cell(x.m3,x.m3_estado,'#D97706')+'</td><td>'+cell(x.m4plus,x.m4plus==null?'FUTURE':'COMPLETE','#6B7BA8')+'</td><td class="hi hi-g">'+M(x.ltv_total)+'</td><td class="hi hi-g">'+N(x.roas_ltv).toFixed(2)+'x</td></tr>'}).join('')+'</tbody></table></div><div style="font-size:8px;color:#6B7BA8;margin-top:6px">M0 y LTV son magnitudes distintas. LTV acumula compras posteriores del cliente adquirido.</div>';b.innerHTML=h}
-function renderAttr(raw){var s=O(raw);S.attr=s;insights();var b=$id('mk4-attr');if(!b)return;var ac=N(s.clientesAdquiridosM0||s.clientesAdquiridos||s.clientesAdquiridosAtribuidos),v=[[s.personasUnicas,'PERSONAS ÚNICAS','#0A4FBF'],[s.touchpointsEfectivos,'TOUCHPOINTS EFECTIVOS','#0D9488'],[s.duplicadosTecnicosProbables,'DUPLICADOS TÉCNICOS','#DC2626'],[s.reingresosProspectoHistorico,'REINGRESOS HISTÓRICOS','#7C3AED'],[s.reingresosProspectoMismoMes,'REINGRESOS MISMO MES','#7C3AED'],[s.reingresosClienteExistente,'CLIENTES QUE REINGRESAN','#D97706'],[ac,month()?'CLIENTES M0':'CLIENTES ADQUIRIDOS','#059669'],[s.reactivacionesConfirmadas,'REACTIVACIONES CONF.','#00C9A7'],[s.anomaliasHigh,'REVISIÓN ALTA','#DC2626'],[s.anomaliasMedium,'REVISIÓN MEDIA','#D97706']];b.innerHTML='<div class="g-row">'+v.map(function(x){return'<div class="g-c" style="background:#F8FAFF;border:1px solid #EEF2F8"><div class="g-v" style="color:'+x[2]+'">'+N(x[0])+'</div><div class="g-l">'+x[1]+'</div></div>'}).join('')+'</div><div style="font-size:8px;color:#6B7BA8;margin-top:6px">Reingreso ≠ reactivación. Los duplicados técnicos son candidatos de revisión; no se eliminan automáticamente.</div>'}
-function renderIntent(r,d){insights();var card=$id('mk4-intent-card'),b=$id('mk4-intent');if(!month()){card.style.display='none';return}card.style.display='';r=A(r);d=A(d);if(!r.length){b.innerHTML='<div class="ld">Sin compras atribuibles</div>';return}var a='<table class="vt"><thead><tr><th>INTENCIÓN</th><th>COMPRA REAL</th><th>CLIENTES</th><th>OPS.</th><th>FACT.</th><th>%</th></tr></thead><tbody>'+r.map(function(x){return'<tr><td><b>'+E(x.tratamiento_interes)+'</b></td><td>'+E(x.tratamiento_compra)+'</td><td>'+N(x.clientes)+'</td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td><td>'+N(x.porcentaje_facturacion_intencion).toFixed(1)+'%</td></tr>'}).join('')+'</tbody></table>';var z=d.length?'<div style="margin-top:9px;border-top:1px solid #EEF2F8;padding-top:7px"><b style="font-size:9px">Auditoría por cliente</b><table class="vt"><thead><tr><th>CLIENTE</th><th>LEAD / ANUNCIO</th><th>COMPRA / DETALLE</th><th>OPS.</th><th>FACT.</th></tr></thead><tbody>'+d.map(function(x){return'<tr title="'+E(x.venta_ids||'')+'"><td><b>'+E(x.cliente)+'</b><div style="font-size:7px;color:#9AAAC8">•••• '+E(x.telefono_ult4||'—')+'</div></td><td><b>#'+E(x.lead_id)+'</b> · '+E(x.lead_fecha)+'<div style="font-size:7px;color:#6B7BA8">'+E(x.lead_anuncio)+'</div></td><td><b>'+E(x.tratamiento_compra)+'</b><div style="font-size:7px;color:#6B7BA8">'+E(x.descripciones)+'</div></td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td></tr>'}).join('')+'</tbody></table></div>':'';b.innerHTML=a+z+'<div style="font-size:8px;color:#6B7BA8;margin-top:6px">El teléfono se muestra solo con últimos 4 dígitos. Varias líneas de compra no se tratan como duplicados automáticamente.</div>'}
-function loadAll(){if(!alive)return;cycle++;var my=cycle;if(ctl)ctl.abort();ctl=new AbortController();clearT();loading();var c=C(),s=ctl.signal,tr=traceBox(),ic=$id('mk4-intent-card');if(tr)tr.style.display=month()?'':'none';if(ic)ic.style.display=month()?'':'none';if(month())L(function(){rpc('aos_marketing_period_summary_v2',{p_fecha_desde:c.d,p_fecha_hasta:c.h},s).then(function(x){if(my!==cycle)return;S.summary=O(x);renderTop()}).catch(function(e){if(e.name!=='AbortError')error('mk4-trace-grid','Trazabilidad',e)})},10);L(function(){rpc('aos_marketing_historico_public_v2',{p_anio:c.a},s).then(function(x){if(my===cycle)renderHistory(x)}).catch(function(e){if(e.name!=='AbortError')error('mk-hist','Histórico',e)})},30);L(function(){rpc('aos_marketing_ltv_public_v2',{p_anio:c.a},s).then(function(x){if(my===cycle)renderLtv(x)}).catch(function(e){if(e.name!=='AbortError')error('mk-ltv','LTV',e)})},80);L(function(){var fn=month()?'aos_marketing_attribution_public_v3':'aos_marketing_attribution_public_v2_anio',p=month()?{p_mes:c.m,p_anio:c.a}:{p_anio:c.a};rpc(fn,p,s).then(function(x){if(my===cycle)renderAttr(x)}).catch(function(e){if(e.name!=='AbortError')error('mk4-attr','Atribución',e)})},130);if(month())L(function(){Promise.all([rpc('aos_marketing_intent_public_v2',{p_mes:c.m,p_anio:c.a},s),rpc('aos_marketing_intent_detail_public_v3',{p_mes:c.m,p_anio:c.a},s)]).then(function(x){if(my===cycle)renderIntent(x[0],x[1])}).catch(function(e){if(e.name!=='AbortError')error('mk4-intent','Intención → Compra',e)})},180)}
-hook('rKPI',function(k){S.kpi=k||{};call(B.rKPI,[k]);if(S.summary)renderTop()});hook('rEmb',function(e){call(B.rEmb,[e]);if(S.summary)L(renderTop,5)});hook('rHist',function(){L(loadAll,5)});hook('rLTV',function(){L(loadAll,5)});hook('mkL',function(){var r=call(B.mkL,arguments);L(loadAll,10);return r});
-function destroy(){alive=false;clearT();if(ctl)ctl.abort();Object.keys(wraps).forEach(function(n){if(window[n]===wraps[n])window[n]=B[n]})}
-window.__AOS_MKT4={release:RELEASE,reload:loadAll,destroy:destroy,state:S};window.__AOS_MARKETING_V3_ACTIVE=false;window.__AOS_MARKETING_V3_CONSISTENCY_PATCH=false;traceBox();insights();L(loadAll,40);console.log('[ASCENDA] Marketing V4 recovery '+RELEASE+' mounted');
+
+var RELEASE='2026-08-12-v4.2';
+if(window.__AOS_MKT4&&window.__AOS_MKT4.destroy){
+  try{window.__AOS_MKT4.destroy();}catch(e){}
+}
+
+var alive=true, cycle=0, ctl=null, timers=[], wraps={};
+var S={kpi:null,summary:null,history:[],ltv:[],attr:null,intent:[],intentDetail:[]};
+
+function $id(x){return document.getElementById(x);}
+function N(v){var x=Number(v);return Number.isFinite(x)?x:0;}
+function R2(v){return Math.round(N(v)*100)/100;}
+function M(v){return 'S/'+Math.round(N(v)).toLocaleString('es-PE');}
+function E(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
+function A(v){
+  if(Array.isArray(v))return v;
+  if(v&&Array.isArray(v.ltv))return v.ltv;
+  if(typeof v==='string'){try{return A(JSON.parse(v));}catch(e){}}
+  return [];
+}
+function O(v){
+  if(v&&typeof v==='object'&&!Array.isArray(v))return v;
+  if(Array.isArray(v)&&v.length===1){
+    var k=Object.keys(v[0]||{});
+    if(k.length===1&&v[0][k[0]]&&typeof v[0][k[0]]==='object')return v[0][k[0]];
+  }
+  return v||{};
+}
+function C(){
+  var y=$id('mk-anio'),m=$id('mk-mes');
+  var a=N(y&&y.value),mm=N(m&&m.value),last=new Date(a,mm,0).getDate();
+  return {a:a,m:mm,d:a+'-'+String(mm).padStart(2,'0')+'-01',h:a+'-'+String(mm).padStart(2,'0')+'-'+String(last).padStart(2,'0')};
+}
+function month(){return !window.MK||MK.modo!=='anio';}
+function L(fn,ms){var t=setTimeout(function(){if(alive)fn();},ms||0);timers.push(t);}
+function clearT(){timers.forEach(clearTimeout);timers=[];}
+function U(fn){var i=0;while(fn&&fn.__mkt4base&&i++<6)fn=fn.__mkt4base;return fn;}
+
+var B={
+  mkL:U(window.mkL),
+  rKPI:U(window.rKPI),
+  rEmb:U(window.rEmb),
+  rHist:U(window.rHist),
+  rLTV:U(window.rLTV)
+};
+
+function call(fn,args){
+  try{if(typeof fn==='function')return fn.apply(window,args||[]);}
+  catch(e){console.warn('[MKT4.2] legacy:',e);}
+}
+function hook(n,fn){fn.__mkt4base=B[n];wraps[n]=fn;window[n]=fn;}
+
+function rpc(fn,p,sig){
+  return fetch(SB+'/rest/v1/rpc/'+fn,{
+    method:'POST',
+    headers:{apikey:SK,Authorization:'Bearer '+SK,'Content-Type':'application/json'},
+    body:JSON.stringify(p||{}),
+    signal:sig
+  }).then(function(r){
+    if(!r.ok)return r.text().then(function(t){
+      var er=new Error(fn+' HTTP '+r.status);
+      er.detail=t.slice(0,220);
+      throw er;
+    });
+    return r.json();
+  });
+}
+
+function err(id,title,e){
+  console.warn('[MKT4.2] '+title,e&&e.message,e&&e.detail);
+  var b=$id(id);if(!b)return;
+  b.innerHTML='<div style="padding:10px;background:#FFF7ED;border:1px solid #FED7AA;border-radius:8px;color:#9A3412;font-size:9px;line-height:1.45"><b>'+E(title)+'</b><br>No se pudo completar esta lectura. Los demás bloques continúan operativos.<br><button onclick="window.__AOS_MKT4.reload()" style="margin-top:6px;border:0;border-radius:6px;padding:5px 9px;background:#C2410C;color:white;cursor:pointer">Reintentar</button></div>';
+}
+
+function traceBox(){
+  var c=$id('mk4-trace')||$id('mk-v3-trace');
+  if(c){
+    c.id='mk4-trace';
+    var g=$id('mk-v3-trace-grid');if(g)g.id='mk4-trace-grid';
+    var n=$id('mk-v3-trace-note');if(n)n.id='mk4-trace-note';
+    return c;
+  }
+  var x=$id('mk-gest');if(!x)return null;
+  c=document.createElement('div');
+  c.id='mk4-trace';c.className='crd';c.style.padding='8px 12px';
+  c.innerHTML='<div class="ct">🧭 Trazabilidad del período <span class="tag tag-b">V4.2</span></div><div id="mk4-trace-grid"><div class="ld">Cargando…</div></div><div id="mk4-trace-note" style="font-size:8px;color:#6B7BA8;margin-top:6px"></div>';
+  x.insertAdjacentElement('afterend',c);
+  return c;
+}
+
+function insights(){
+  var a=$id('mk4-insights')||$id('mk-v3-insights');
+  if(a){
+    a.id='mk4-insights';
+    [['mk-v3-attr-card','mk4-attr-card'],['mk-v3-attr','mk4-attr'],['mk-v3-intent-card','mk4-intent-card'],['mk-v3-intent','mk4-intent']].forEach(function(x){
+      var e=$id(x[0]);if(e)e.id=x[1];
+    });
+    return a;
+  }
+  var l=$id('mk-ltv');if(!l)return null;
+  var card=l.closest('.crd');if(!card)return null;
+  a=document.createElement('div');a.id='mk4-insights';a.style.cssText='display:flex;gap:10px;flex-wrap:wrap';
+  a.innerHTML='<div class="crd" id="mk4-attr-card" style="flex:1 1 420px"><div class="ct">🧠 Atribución y reingresos <span class="tag tag-b">V4.2</span></div><div id="mk4-attr"><div class="ld">Cargando…</div></div></div><div class="crd" id="mk4-intent-card" style="flex:1 1 420px"><div class="ct">🧩 Intención → Compra <span class="tag tag-c">auditable</span></div><div id="mk4-intent"><div class="ld">Cargando…</div></div></div>';
+  card.insertAdjacentElement('afterend',a);
+  return a;
+}
+
+function loading(){
+  traceBox();insights();
+  var g=$id('mk4-trace-grid');if(g)g.innerHTML='<div class="ld">Cargando trazabilidad…</div>';
+  var h=$id('mk-hist');if(h)h.innerHTML='<div class="ld">Cargando histórico anual…</div>';
+  var l=$id('mk-ltv');if(l)l.innerHTML='<div class="ld">Esperando histórico para cargar LTV…</div>';
+  var t=$id('mk-ltv-tag');if(t)t.textContent='en cola…';
+  var a=$id('mk4-attr');if(a)a.innerHTML='<div class="ld">Cargando atribución…</div>';
+  var i=$id('mk4-intent');if(i)i.innerHTML='<div class="ld">Cargando intención…</div>';
+}
+
+function renderTrace(s){
+  var c=traceBox();if(!c)return;
+  c.style.display=month()?'':'none';if(!month())return;
+  var v=[
+    [s.ingresos,'INGRESOS','#0A4FBF'],
+    [s.personasUnicas,'PERSONAS ÚNICAS','#0D9488'],
+    [s.reingresos,'REINGRESOS','#7C3AED'],
+    [s.personasGestionadas,'GESTIÓN POST-INGRESO','#059669'],
+    [s.personasCitaTel,'CITAS TEL.','#D97706'],
+    [s.personasConCita,'CITAS AGENDA','#7C3AED'],
+    [s.clientesM0,'CLIENTES M0','#059669']
+  ];
+  $id('mk4-trace-grid').innerHTML='<div class="g-row">'+v.map(function(x){
+    return '<div class="g-c" style="background:#F8FAFF;border:1px solid #EEF2F8"><div class="g-v" style="color:'+x[2]+'">'+N(x[0])+'</div><div class="g-l">'+x[1]+'</div></div>';
+  }).join('')+'</div>';
+  $id('mk4-trace-note').innerHTML='Personas únicas y gestión posterior al ingreso. Citas Tel. = Call Center; Citas Agenda = agenda real; Clientes M0 = compradores atribuidos dentro del mes.';
+}
+
+function renderTop(){
+  if(!S.summary||!month())return;
+  var s=S.summary,k={},old=S.kpi||{},inv=N(old.invTotal);
+  Object.keys(old).forEach(function(x){k[x]=old[x];});
+  k.leads=N(s.personasUnicas);
+  k.llamados=N(s.personasGestionadas);
+  k.citas=N(s.personasCitaTel);
+  k.asistieron=N(s.personasAsistieron);
+  k.clientes=N(s.clientesM0);
+  k.nVentas=N(s.ventasM0);
+  k.factTotal=N(s.factM0);
+  k.pctLlamados=k.leads?R2(k.llamados/k.leads*100):0;
+  k.roas=inv?R2(k.factTotal/inv):0;
+  k.cac=k.clientes&&inv?Math.round(inv/k.clientes):null;
+  k.cpl=k.leads&&inv?R2(inv/k.leads):null;
+  call(B.rKPI,[k]);
+
+  var tasas={
+    llamados:k.leads?R2(k.llamados/k.leads*100):0,
+    citas:k.llamados?R2(k.citas/k.llamados*100):0,
+    asist:k.citas?R2(k.asistieron/k.citas*100):0,
+    clientes:k.asistieron?R2(k.clientes/k.asistieron*100):0,
+    ventas:k.clientes?R2(k.nVentas/k.clientes*100):0
+  };
+  call(B.rEmb,[{leads:k.leads,llamados:k.llamados,citas:k.citas,asistieron:k.asistieron,clientes:k.clientes,ventas:k.nVentas,factTotal:k.factTotal,tasas:tasas}]);
+  renderTrace(s);
+
+  var e=$id('mk-emb'),o=$id('mk4-fnote');if(o)o.remove();
+  if(e){
+    o=document.createElement('div');o.id='mk4-fnote';o.style.cssText='font-size:8px;color:#6B7BA8;margin-top:5px';
+    o.innerHTML='<b>Nota:</b> Ventas = operaciones. El último ratio puede superar 100%; no es conversión de personas.';
+    e.appendChild(o);
+  }
+}
+
+function renderHistory(raw){
+  var rows=A(raw).sort(function(a,b){return N(a.mes)-N(b.mes);});
+  S.history=rows;
+  var b=$id('mk-hist');if(!b)return;
+  if(!rows.length){b.innerHTML='<div class="ld">Sin datos</div>';return;}
+
+  var sel=month()?C().m:null;
+  var mf=Math.max.apply(null,rows.map(function(x){return N(x.fact_acumulado);}));
+  var ml=Math.max.apply(null,rows.map(function(x){return N(x.leads);}));
+  var ch='<div style="display:flex;gap:3px;align-items:flex-end;height:55px;margin-bottom:6px">'+rows.map(function(x){
+    var active=sel===N(x.mes),hf=mf?N(x.fact_acumulado)/mf*42:0,hl=ml?N(x.leads)/ml*42:0;
+    return '<div style="flex:1;text-align:center;'+(active?'background:#F0F7FF;border-radius:4px':'')+'"><div style="height:44px;display:flex;align-items:flex-end;justify-content:center;gap:1px"><div style="width:8px;height:'+hf+'px;background:#0A4FBF"></div><div style="width:8px;height:'+hl+'px;background:#00C9A7"></div></div><div style="font-size:6px;color:#6B7BA8;font-weight:700">'+MF[N(x.mes)].slice(0,3).toUpperCase()+'</div></div>';
+  }).join('')+'</div>';
+
+  var tb='<table class="vt"><thead><tr><th>MES</th><th>LEADS</th><th>LLAM.</th><th>CITAS</th><th>ASIST.</th><th>CLIENTES M0</th><th>OPS M0</th><th>FACT M0</th><th>LTV ACUM.</th><th>CONV%</th></tr></thead><tbody>'+rows.map(function(x){
+    return '<tr'+(sel===N(x.mes)?' style="background:#F0F7FF;outline:1px solid #D9E8FF"':'')+'><td><b>'+MF[N(x.mes)].slice(0,3).toUpperCase()+' '+N(x.anio)+'</b></td><td>'+N(x.leads)+'</td><td>'+(N(x.llamados)===0&&N(x.citas)>0?'—':N(x.llamados))+'</td><td>'+N(x.citas)+'</td><td>'+N(x.asistieron)+'</td><td class="hi hi-g">'+N(x.clientes)+'</td><td>'+N(x.ventas)+'</td><td class="hi hi-b">'+M(x.fact)+'</td><td class="hi hi-c">'+M(x.fact_acumulado)+'</td><td>'+N(x.conv).toFixed(2)+'%</td></tr>';
+  }).join('')+'</tbody></table>';
+
+  b.innerHTML=ch+tb+'<div style="font-size:8px;color:#6B7BA8;margin-top:6px"><b>Histórico anual fijo:</b> cambiar el mes solo resalta la cohorte; no recorta ENE → mes actual.</div>';
+}
+
+function cell(v,st,c){
+  if(v==null||st==='FUTURE')return '<span style="color:#CBD5E1">—</span>';
+  return '<b style="color:'+c+'">'+M(v)+'</b>'+(st==='PARTIAL'?'<div style="font-size:7px;color:#D97706">parcial</div>':'');
+}
+
+function renderLtv(raw){
+  var rows=A(raw).sort(function(a,b){return N(a.mes)-N(b.mes);});
+  S.ltv=rows;
+  var b=$id('mk-ltv'),tag=$id('mk-ltv-tag');if(!b||!tag)return;
+  if(!rows.length){b.innerHTML='<div class="ld">Sin LTV</div>';tag.textContent='sin datos';return;}
+
+  var f=month()?rows.find(function(x){return N(x.mes)===C().m;}):null;
+  if(!f){
+    var inv=0,m0=0,lt=0,ac=0,m1=0,m2=0,m3=0,m4=0;
+    rows.forEach(function(x){inv+=N(x.inversion);m0+=N(x.m0);lt+=N(x.ltv_total);ac+=N(x.clientes_adquiridos);m1+=N(x.m1);m2+=N(x.m2);m3+=N(x.m3);m4+=N(x.m4plus);});
+    f={m0:m0,ltv_total:lt,inversion:inv,clientes_adquiridos:ac,roas_ltv:inv?lt/inv:0,cac_adquisicion:ac?inv/ac:0,m1:m1,m2:m2,m3:m3,m4plus:m4};
+  }
+
+  var mult=N(f.m0)?N(f.ltv_total)/N(f.m0):0;
+  tag.textContent='LTV '+(mult?mult.toFixed(1)+'x':'—')+' · '+rows.length+' cohortes';
+
+  var h='<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px"><div style="flex:1;background:#F5F3FF;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#7C3AED">LTV / M0</div><div style="font-size:24px;font-weight:800;color:#7C3AED">'+(mult?mult.toFixed(1)+'x':'—')+'</div></div><div style="flex:1;background:#F0FDF4;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#059669">ROAS LTV</div><div style="font-size:24px;font-weight:800;color:#059669">'+N(f.roas_ltv).toFixed(2)+'x</div></div><div style="flex:1;background:#FFF7ED;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#D97706">CAC ADQUISICIÓN</div><div style="font-size:24px;font-weight:800;color:#D97706">'+M(f.cac_adquisicion)+'</div></div></div>';
+
+  h+='<div style="overflow:auto"><table class="vt"><thead><tr><th>COHORTE</th><th>PERSONAS</th><th>ADQUIRIDOS</th><th>M0 CLIENTES</th><th>INV.</th><th>M0</th><th>M+1</th><th>M+2</th><th>M+3</th><th>M+4+</th><th>LTV TOTAL</th><th>ROAS LTV</th></tr></thead><tbody>'+rows.map(function(x){
+    return '<tr'+(month()&&N(x.mes)===C().m?' style="background:#F0F7FF;outline:1px solid #D9E8FF"':'')+'><td><b>'+MF[N(x.mes)].slice(0,3).toUpperCase()+'</b></td><td>'+N(x.personas_unicas)+'</td><td>'+N(x.clientes_adquiridos)+'</td><td>'+N(x.clientes_adquiridos_m0)+'</td><td>'+M(x.inversion)+'</td><td>'+cell(x.m0,x.m0_estado,'#0A4FBF')+'</td><td>'+cell(x.m1,x.m1_estado,'#00C9A7')+'</td><td>'+cell(x.m2,x.m2_estado,'#7C3AED')+'</td><td>'+cell(x.m3,x.m3_estado,'#D97706')+'</td><td>'+cell(x.m4plus,x.m4plus==null?'FUTURE':'COMPLETE','#6B7BA8')+'</td><td class="hi hi-g">'+M(x.ltv_total)+'</td><td class="hi hi-g">'+N(x.roas_ltv).toFixed(2)+'x</td></tr>';
+  }).join('')+'</tbody></table></div><div style="font-size:8px;color:#6B7BA8;margin-top:6px">M0 y LTV son magnitudes distintas. LTV acumula compras posteriores del cliente adquirido.</div>';
+  b.innerHTML=h;
+}
+
+function renderAttr(raw){
+  var s=O(raw);S.attr=s;insights();
+  var b=$id('mk4-attr');if(!b)return;
+  var ac=N(s.clientesAdquiridosM0||s.clientesAdquiridos||s.clientesAdquiridosAtribuidos);
+  var v=[
+    [s.personasUnicas,'PERSONAS ÚNICAS','#0A4FBF'],
+    [s.touchpointsEfectivos,'TOUCHPOINTS EFECTIVOS','#0D9488'],
+    [s.duplicadosTecnicosProbables,'DUPLICADOS TÉCNICOS','#DC2626'],
+    [s.reingresosProspectoHistorico,'REINGRESOS HISTÓRICOS','#7C3AED'],
+    [s.reingresosProspectoMismoMes,'REINGRESOS MISMO MES','#7C3AED'],
+    [s.reingresosClienteExistente,'CLIENTES QUE REINGRESAN','#D97706'],
+    [ac,month()?'CLIENTES M0':'CLIENTES ADQUIRIDOS','#059669'],
+    [s.reactivacionesConfirmadas,'REACTIVACIONES CONF.','#00C9A7'],
+    [s.anomaliasHigh,'REVISIÓN ALTA','#DC2626'],
+    [s.anomaliasMedium,'REVISIÓN MEDIA','#D97706']
+  ];
+  b.innerHTML='<div class="g-row">'+v.map(function(x){
+    return '<div class="g-c" style="background:#F8FAFF;border:1px solid #EEF2F8"><div class="g-v" style="color:'+x[2]+'">'+N(x[0])+'</div><div class="g-l">'+x[1]+'</div></div>';
+  }).join('')+'</div><div style="font-size:8px;color:#6B7BA8;margin-top:6px">Reingreso ≠ reactivación. Los duplicados técnicos son candidatos de revisión; no se eliminan automáticamente.</div>';
+}
+
+function renderIntent(r,d){
+  insights();
+  var card=$id('mk4-intent-card'),b=$id('mk4-intent');if(!card||!b)return;
+  if(!month()){card.style.display='none';return;}
+  card.style.display='';
+  r=A(r);d=A(d);S.intent=r;S.intentDetail=d;
+  if(!r.length){b.innerHTML='<div class="ld">Sin compras atribuibles</div>';return;}
+
+  var agg='<table class="vt"><thead><tr><th>INTENCIÓN</th><th>COMPRA REAL</th><th>CLIENTES</th><th>OPS.</th><th>FACT.</th><th>%</th></tr></thead><tbody>'+r.map(function(x){
+    return '<tr><td><b>'+E(x.tratamiento_interes)+'</b></td><td>'+E(x.tratamiento_compra)+'</td><td>'+N(x.clientes)+'</td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td><td>'+N(x.porcentaje_facturacion_intencion).toFixed(1)+'%</td></tr>';
+  }).join('')+'</tbody></table>';
+
+  var det=d.length?'<div style="margin-top:9px;border-top:1px solid #EEF2F8;padding-top:7px"><b style="font-size:9px">Auditoría por cliente</b><table class="vt"><thead><tr><th>CLIENTE</th><th>LEAD / ANUNCIO</th><th>COMPRA / DETALLE</th><th>OPS.</th><th>FACT.</th></tr></thead><tbody>'+d.map(function(x){
+    return '<tr title="'+E(x.venta_ids||'')+'"><td><b>'+E(x.cliente)+'</b><div style="font-size:7px;color:#9AAAC8">•••• '+E(x.telefono_ult4||'—')+'</div></td><td><b>#'+E(x.lead_id)+'</b> · '+E(x.lead_fecha)+'<div style="font-size:7px;color:#6B7BA8">'+E(x.lead_anuncio)+'</div></td><td><b>'+E(x.tratamiento_compra)+'</b><div style="font-size:7px;color:#6B7BA8">'+E(x.descripciones)+'</div></td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td></tr>';
+  }).join('')+'</tbody></table></div>':'';
+
+  b.innerHTML=agg+det+'<div style="font-size:8px;color:#6B7BA8;margin-top:6px">El teléfono se muestra solo con últimos 4 dígitos. Varias líneas de compra no se tratan como duplicados automáticamente.</div>';
+}
+
+function stale(my){return !alive||my!==cycle;}
+
+function loadAll(){
+  if(!alive)return;
+  cycle++;var my=cycle;
+  if(ctl)ctl.abort();
+  ctl=new AbortController();
+  clearT();loading();
+
+  var c=C(),s=ctl.signal,tr=traceBox(),ic=$id('mk4-intent-card');
+  if(tr)tr.style.display=month()?'':'none';
+  if(ic)ic.style.display=month()?'':'none';
+
+  var chain=Promise.resolve();
+
+  if(month()){
+    chain=chain.then(function(){
+      return rpc('aos_marketing_period_summary_v2',{p_fecha_desde:c.d,p_fecha_hasta:c.h},s)
+        .then(function(x){if(stale(my))return;S.summary=O(x);renderTop();})
+        .catch(function(e){if(e.name!=='AbortError'&&!stale(my))err('mk4-trace-grid','Trazabilidad',e);});
+    });
+  }
+
+  chain=chain.then(function(){
+    var fn=month()?'aos_marketing_attribution_public_v3':'aos_marketing_attribution_public_v2_anio';
+    var p=month()?{p_mes:c.m,p_anio:c.a}:{p_anio:c.a};
+    return rpc(fn,p,s)
+      .then(function(x){if(!stale(my))renderAttr(x);})
+      .catch(function(e){if(e.name!=='AbortError'&&!stale(my))err('mk4-attr','Atribución y reingresos',e);});
+  });
+
+  if(month()){
+    chain=chain.then(function(){
+      return Promise.all([
+        rpc('aos_marketing_intent_public_v2',{p_mes:c.m,p_anio:c.a},s),
+        rpc('aos_marketing_intent_detail_public_v3',{p_mes:c.m,p_anio:c.a},s)
+      ]).then(function(x){if(!stale(my))renderIntent(x[0],x[1]);})
+        .catch(function(e){if(e.name!=='AbortError'&&!stale(my))err('mk4-intent','Intención → Compra',e);});
+    });
+  }
+
+  chain=chain.then(function(){
+    return rpc('aos_marketing_historico_public_v2',{p_anio:c.a},s)
+      .then(function(x){if(!stale(my))renderHistory(x);})
+      .catch(function(e){if(e.name!=='AbortError'&&!stale(my))err('mk-hist','Histórico mensual',e);});
+  });
+
+  chain=chain.then(function(){
+    var tag=$id('mk-ltv-tag');if(tag&&!stale(my))tag.textContent='cargando…';
+    return rpc('aos_marketing_ltv_public_v2',{p_anio:c.a},s)
+      .then(function(x){if(!stale(my))renderLtv(x);})
+      .catch(function(e){if(e.name!=='AbortError'&&!stale(my))err('mk-ltv','Valor del Lead (LTV)',e);});
+  });
+
+  chain.catch(function(e){if(e&&e.name!=='AbortError')console.warn('[MKT4.2] pipeline',e);});
+}
+
+hook('rKPI',function(k){S.kpi=k||{};call(B.rKPI,[k]);if(S.summary)renderTop();});
+hook('rEmb',function(e){call(B.rEmb,[e]);if(S.summary)L(renderTop,5);});
+hook('rHist',function(){if(S.history.length)renderHistory(S.history);});
+hook('rLTV',function(){if(S.ltv.length)renderLtv(S.ltv);});
+hook('mkL',function(){
+  var r=call(B.mkL,arguments);
+  L(loadAll,20);
+  return r;
+});
+
+function destroy(){
+  alive=false;clearT();if(ctl)ctl.abort();
+  Object.keys(wraps).forEach(function(n){if(window[n]===wraps[n])window[n]=B[n];});
+}
+
+window.__AOS_MKT4={release:RELEASE,reload:loadAll,destroy:destroy,state:S};
+window.__AOS_MARKETING_V3_ACTIVE=false;
+window.__AOS_MARKETING_V3_CONSISTENCY_PATCH=false;
+traceBox();insights();L(loadAll,50);
+console.log('[ASCENDA] Marketing V4.2 mounted — serialized annual analytics');
 })();


### PR DESCRIPTION
Fixes the remaining Marketing regression observed in production.

Changes:
- serializes Summary/Attribution/Intent/History/LTV instead of firing all heavy RPCs concurrently under anon's 3s statement timeout;
- preserves full-year History while changing month;
- rounds KPI/embudo percentages, ROAS, CAC and CPL before legacy render;
- keeps remount-safe cancellation and stale-request protection;
- replaces raw backend error blobs with a user-facing retry state while keeping technical details in console.

Database-side prerequisites already applied and validated in production:
- composite lookup indexes for leads/calls/agenda/sales;
- function-local 8s timeout only for annual History and LTV public gateways.

No frontend writes to business data. CI branch SUCCESS.