### PR TITLE
Fix Comisiones: desacoplar tipo de venta de elegibilidad de comisión

### DIFF
--- a/app/public/admin-comisiones.html
+++ b/app/public/admin-comisiones.html
@@ -151,11 +151,11 @@ function renderDet(rows){
   tb.innerHTML=filtered.map(function(v){
     var cli=((v.nombres||'')+' '+(v.apellidos||'')).trim();var c=parseFloat(v.comision||0);
     var epC=v.estado_pago==='PAGO COMPLETO'?'ep-ok':v.estado_pago==='ADELANTO'?'ep-ad':'ep-pen';
-    var tbC=v.asesor==='NO APLICA'?'tb-na':(v.tipo==='PRODUCTO'?'tb-p':'tb-s');
+    var tbC=v.tipo==='PRODUCTO'?'tb-p':'tb-s';
     var sedeCol=(v.sede||'').indexOf('PUEBLO')>=0?'background:#FFFBEB;color:#D97706':'background:#F0FDF4;color:#059669';
     return '<tr><td><div style="font-weight:700;font-size:10px">'+h((cli||'--').substring(0,22))+'</div><div style="font-size:8px;color:#9AAAC8">'+h(v.numero_limpio||'')+'</div></td>'+
       '<td style="font-size:9px;color:#6B7BA8">'+h((v.tratamiento||'').substring(0,16))+'</td>'+
-      '<td><span class="tb '+tbC+'">'+(v.asesor==='NO APLICA'?'N/A':v.tipo==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+
+      '<td><span class="tb '+tbC+'">'+(v.tipo==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+
       '<td style="font-weight:700">S/'+parseFloat(v.monto||0).toFixed(2)+'</td>'+
       '<td><span class="com-v">S/'+c.toFixed(2)+'</span></td>'+
       '<td><span style="font-size:8px;font-weight:700;padding:2px 6px;border-radius:4px;'+sedeCol+'">'+h((v.sede||'').substring(0,10))+'</span></td>'+


### PR DESCRIPTION
## Problema
La columna **Tipo** del panel Comisiones mostraba `N/A` cuando `asesor='NO APLICA'`, aunque `aos_ventas.tipo` y los RPC devolvieran correctamente `SERVICIO` o `PRODUCTO`.

Ejemplo validado: ventas de Paul Sablich con BIOESTIMULADOR y MESOTERAPIA CAPILAR tienen `tipo=SERVICIO`, pero la UI mostraba `N/A` por usar el asesor para decidir el badge.

## Cambio
- El estilo del badge depende solo de `v.tipo`.
- El texto del badge depende solo de `v.tipo`: `SERV` / `PROD`.
- `NO APLICA` continúa visible en la columna Asesor y continúa implicando comisión S/0; no se modifica la lógica financiera.

## Validación
- DB: tipos de las ventas ejemplo correctos.
- RPC `aos_comisiones_admin_anio`: devuelve `tipo=SERVICIO` para las cinco ventas ejemplo.
- Diff semántico: solo 2 expresiones en `renderDet`.
- No modifica Supabase, ventas, reglas ni importes históricos.

## Hallazgo separado
El motor de comisiones todavía hardcodea las tasas aunque existe `aos_tabla_comisiones` con vigencia. Se simuló un motor dinámico que preserva exactamente Ene–Jul (diferencia S/0.00 en los 7 meses), pero ese cambio queda separado para no mezclar riesgos con este bug visual.