### PR TITLE
docs(cia): close Phase 10 Advisor Control Center

### DIFF
--- a/docs/control/commercial-intelligence/CIA_AGENT_BOOTSTRAP_CURRENT.md
+++ b/docs/control/commercial-intelligence/CIA_AGENT_BOOTSTRAP_CURRENT.md
@@ -2,35 +2,29 @@
 
 **Estado:** CURRENT / RECOVERY ENTRYPOINT  
 **Actualizado:** 2026-08-14 (America/Lima)  
-**Checkpoint funcional de cierre Fase 9:** `2e1116f07919fcf53bdac8cf61cbd23944863630`  
-**Checkpoint de control/documentación actual:** consultar `aos_memory` + `staging` HEAD live  
-**Fases cerradas:** 0–9 `100_COMPLETE`  
-**Fase actual:** 10 — Advisor Control Center `READY`
+**Fases cerradas:** 0–10 `100_COMPLETE`  
+**Fase actual:** 11 — Call Center Integration V3 `READY`  
+**Último merge funcional certificado:** F10 `2a74c3443bb600c1157b746349e1e85dac7f67fc`  
+**Checkpoint de control/documentación actual:** consultar `aos_memory.cia_v3_control_checkpoint` + `staging` HEAD live.
 
 ---
 
 # 1. MISIÓN
 
-Commercial Intelligence & Audience OS transforma los datos operativos vivos de ASCENDA en:
-
-`Identity → Facts → Segmentation → Audience → Snapshot/Activation → Context/Availability → Assignment → Advisor Work → Approval → Intelligence → KronIA → Channels → Attribution`
-
-Principios:
-
-- una audiencia pertenece a ASCENDA, no a un canal;
-- Audience ≠ Eligibility ≠ Activation ≠ Assignment ≠ Work View;
-- datos fuente operativos permanecen intactos;
-- `numero_limpio/contact_key` es bridge V1, no identidad eterna;
-- SQL/RPC determinístico calcula; IA interpreta/recomienda;
-- human-in-the-loop para ownership/recursos sensibles;
-- UNKNOWN falla cerrado;
-- toda capa material es versionada/auditable;
-- no big-bang;
-- no romper producción para completar una fase.
+`Identity → Facts → Segmentation → Audience → Snapshot/Activation → Context/Availability → Assignment → Advisor Control → Call Center V3 → Advisor Work → Approval → Intelligence → KronIA → Channels → Attribution`
 
 Misión global ASCENDA:
 
 `CONTROLAR → ESTABILIZAR → MIGRAR A PROPIEDAD CORPORATIVA → PRODUCTIZAR COMO SaaS`
+
+Principios:
+- Audience ≠ Eligibility ≠ Activation ≠ Assignment ≠ Work View;
+- datos fuente operativos permanecen intactos;
+- ownership = `aos_usuarios.id` UUID;
+- UNKNOWN/freshness incompleta falla cerrado;
+- SQL/RPC determinístico calcula; IA interpreta/recomienda;
+- no big-bang;
+- no romper producción para completar una fase.
 
 ---
 
@@ -38,52 +32,36 @@ Misión global ASCENDA:
 
 Antes de cualquier cambio:
 
-1. leer `AGENTS.md`;
-2. leer `docs/control/ASCENDA_CONTROL_MASTER.md`;
-3. leer este archivo;
-4. leer `CIA_EXECUTION_PLAYBOOK_V1.md`;
-5. leer `CIA_MASTER_ALIGNMENT_CURRENT.md`;
-6. leer `ROADMAP_STATUS.md`;
-7. leer el último `PHASE_XX_VALIDATION_REPORT.md`;
-8. leer `aos_memory` claves `cia_v3_*` y fase actual;
-9. consultar el Control Maestro visual de Notion y comprobar que refleja el mismo estado;
+1. `AGENTS.md`;
+2. `docs/control/ASCENDA_CONTROL_MASTER.md`;
+3. este Bootstrap;
+4. `CIA_EXECUTION_PLAYBOOK_V1.md`;
+5. `CIA_MASTER_ALIGNMENT_CURRENT.md`;
+6. `ROADMAP_STATUS.md`;
+7. `PHASE_10_VALIDATION_REPORT.md`;
+8. `aos_memory` claves `cia_v3_*`, `cia_phase10_*`, `cia_phase11_status`;
+9. Notion CIA Control Maestro + Fases + Hallazgos;
 10. verificar `staging` HEAD live;
 11. verificar Supabase live/migrations;
-12. solo entonces ejecutar la fase activa.
+12. recién entonces iniciar F11.
 
-No usar como estado actual la sección histórica “Estado de ejecución actual” del Master V3 original. El estado técnico vivo está en GitHub + `aos_memory` + runtime. Notion es una capa visual derivada y debe corregirse si existe drift.
-
----
-
-# 3. NOTION — CONTROL VISUAL DERIVADO
-
-ASCENDA usa un patrón visual común para proyectos de largo recorrido:
-
-`Control Maestro + Fases + Hallazgos & Mejoras`
-
-## CIA V3
-
-- Control Maestro: `https://app.notion.com/p/3bc0e4fe841481489c8ad11bb55acaf3?pvs=204`
-- Fases CIA V3: `https://app.notion.com/p/1a24a1f7e7ab4a299f4848f1eaeff74d`
-- Hallazgos & Mejoras CIA V3: `https://app.notion.com/p/4b3d3d6180ef4fb2b8d978f324e66dfd`
-- Estándar de Control de Proyectos ASCENDA: `https://app.notion.com/p/3bc0e4fe84148160ad18d30d380782db?pvs=204`
-
-## Proyecto hermano KronIA
-
-- KronIA V2 — Control Maestro: `https://app.notion.com/p/3bc0e4fe8414812db4b6f73e71e3c018?pvs=204`
-
-Reglas:
-
-- GitHub + Supabase/runtime prevalecen sobre Notion;
-- Notion debe actualizarse al final de cada loop certificado;
-- exactamente una fase debe quedar `Siguiente` o `En curso`;
-- todo hallazgo nuevo se registra con fase destino, evidencia y criterio de cierre;
-- un hallazgo no se marca `Resuelto` sin evidencia;
-- si Notion contradice GitHub/runtime, corregir Notion antes de continuar.
+GitHub + Supabase/runtime prevalecen sobre Notion. Si existe drift visual, corregir Notion.
 
 ---
 
-# 4. ESTADO DE LAS 19 FASES
+# 3. NOTION
+
+- Control Maestro CIA: `https://app.notion.com/p/3bc0e4fe841481489c8ad11bb55acaf3?pvs=204`
+- Fases CIA: `https://app.notion.com/p/1a24a1f7e7ab4a299f4848f1eaeff74d`
+- Hallazgos CIA: `https://app.notion.com/p/4b3d3d6180ef4fb2b8d978f324e66dfd`
+- Estándar ASCENDA: `https://app.notion.com/p/3bc0e4fe84148160ad18d30d380782db?pvs=204`
+- KronIA V2: `https://app.notion.com/p/3bc0e4fe8414812db4b6f73e71e3c018?pvs=204`
+
+Al cierre de cada fase: GitHub/CI/staging → `aos_memory` → Notion.
+
+---
+
+# 4. ROADMAP F0–F18
 
 | # | Fase | Estado |
 |---:|---|---|
@@ -97,8 +75,8 @@ Reglas:
 | 7 | Snapshots & Activation | `100_COMPLETE` |
 | 8 | Channel Context & Availability | `100_COMPLETE` |
 | 9 | Assignment Engine | `100_COMPLETE` |
-| 10 | Advisor Control Center | `READY` |
-| 11 | Call Center Integration V3 | `NOT_STARTED` |
+| 10 | Advisor Control Center | `100_COMPLETE` |
+| 11 | Call Center Integration V3 | `READY` |
 | 12 | Advisor Work Views | `NOT_STARTED` |
 | 13 | Requests & Approval Engine | `NOT_STARTED` |
 | 14 | Commercial Intelligence Shadow | `NOT_STARTED` |
@@ -109,175 +87,140 @@ Reglas:
 
 ---
 
-# 5. CONTRATOS YA CERTIFICADOS
+# 5. CONTRATOS CERTIFICADOS HASTA F10
 
-## F0–F4
-
-- Identity resolver con conflictos explícitos.
-- Commercial Facts 1:1.
-- Segmentation separada de legacy `etiqueta_vip`.
-- Audience DSL whitelisted con MATCH/MISS/UNKNOWN y `never_contains`.
-
-## F5–F6
-
-- Panel ADMIN Bases & Audiencias.
-- CIA admin session/gateway.
-- Biblioteca universal de audiencias versionada y auditable.
-
-## F7–F8
-
-- Snapshots inmutables.
-- Activation BATCH/DYNAMIC.
-- `Audience Total → Eligible → Available Now`.
-- UNKNOWN no assignable.
-
-## F9
-
-Input autoritativo:
+## F8 → F9
 
 `aos_cia_activation_available_keys_v1(activation_id)`
 
-Assignment:
+solo devuelve contactos assignable según contexto/availability.
 
-- ownership por `aos_usuarios.id` UUID;
+## F9 Assignment
+
+- plans / targets / runs / leases / events;
 - ONE / EQUAL / PERCENTAGE / FIXED;
 - GLOBAL / ACTIVATION;
-- `RESERVED → ASSIGNED → IN_PROGRESS → COMPLETED | RELEASED | EXPIRED`;
 - capacity;
-- NONE / MAINTAIN_TARGET / CONTINUOUS;
-- idempotency;
-- advisory lock;
-- anti-double-ownership;
+- top-up;
+- lifecycle de leases;
+- concurrency/idempotency;
 - audit append-only.
 
-Output autoritativo para F10:
+## F10 Advisor Control
 
-`aos_cia_assignment_advisor_workload_v1()`
+Read-models:
 
-`aos_cia_assignment_plan_summary_v1(plan_id)`
+- `aos_cia_advisor_control_overview_v1()`
+- `aos_cia_advisor_control_advisor_detail_v1(...)`
+- `aos_cia_advisor_control_plan_health_v1(...)`
+- `aos_cia_advisor_control_alerts_v1(...)`
+- `aos_cia_advisor_control_f11_readiness_v1()`
 
-Complementarios:
+Gateway:
 
-`aos_cia_assignment_list_v1(...)`
+`aos_cia_phase10_admin_gateway_v1(...)`
 
-`aos_cia_assignment_events_v1(...)`
+Readiness F11 valida:
+- GLOBAL ownership conflicts;
+- asesores/targets inválidos;
+- deadlines inválidos;
+- plan ACTIVE con Activation no ACTIVE.
+
+Estado live tras cierre F10:
+- 6 asesores activos;
+- 0 ownership real;
+- readiness `READY_NO_ACTIVE_OWNERSHIP`;
+- `routing_modified=false`.
+
+F10 performance con 1,000 leases:
+- overview 4.83 ms;
+- advisor detail 50 10.76 ms;
+- plan health 14.22 ms;
+- readiness 6.09 ms.
+
+Plan health general usa `LAST_RUN_SNAPSHOT`; `GET_PLAN` entrega detalle live exacto para un plan seleccionado.
 
 ---
 
-# 6. FASE 10 — MISIÓN EXACTA
+# 6. FASE 11 — MISIÓN EXACTA
 
-Construir **Advisor Control Center**, un read/control plane administrativo sobre ownership ya creado por Fase 9.
+Construir **Call Center Integration V3** como ruta paralela y reversible entre Assignment y el runtime operativo de llamadas.
 
-Debe mostrar, por `aos_usuarios.id`:
+F11 debe:
 
-- carga activa;
-- ASSIGNED;
-- IN_PROGRESS;
-- COMPLETED;
-- RELEASED;
-- EXPIRED;
-- active plans;
-- overdue-to-start;
-- expiring leases;
-- candidate remaining;
-- source available;
-- depletion;
-- capacity/utilization;
-- drill-down de ownership/deadlines.
+1. ejecutar `aos_cia_advisor_control_f11_readiness_v1()` como preflight;
+2. bloquear rollout si readiness=`BLOCKED`;
+3. crear routing V3 paralelo;
+4. usar feature flag/canary por usuario;
+5. conservar `aos_siguiente_lead_v2` como fallback;
+6. respetar `America/Lima`;
+7. consumir ownership F9, no reconstruir eligibility ni Assignment;
+8. probar claim/consume/release/expiry y concurrencia;
+9. demostrar rollback inmediato a V2;
+10. preservar hashes/baseline V2 hasta el rollout explícito.
 
-Fase 10 **no** debe:
-
-- reconstruir ownership desde calls/leads;
+F11 NO debe:
+- eliminar/reemplazar V2 en big-bang;
 - crear otro Assignment Engine;
-- modificar `aos_siguiente_lead`;
-- entregar Work Views a asesores;
-- hacer routing Call Center V3;
-- implementar approvals;
-- introducir afinidad IA como decisión real.
+- redefinir availability F8;
+- adelantar Advisor Work Views F12;
+- activar a todos los asesores simultáneamente.
 
-Output requerido para F11:
-
-un control plane confiable que permita observar y gobernar Assignment antes de conectarlo al runtime de Call Center.
+Output F11 → F12:
+routing V3 estable, observable y con ownership canónico, listo para Work Views personales.
 
 ---
 
-# 7. CAMINO RESTANTE 10–18
+# 7. BASELINE DE ROUTING QUE F11 DEBE PRESERVAR
 
-**F10 Advisor Control Center** → observar/controlar ownership F9.  
-**F11 Call Center Integration V3** → ruta paralela + feature flag + fallback V2.  
-**F12 Advisor Work Views** → vistas personales dentro del ownership.  
-**F13 Requests & Approval** → requests estructuradas y ejecución atómica.  
-**F14 Intelligence Shadow** → oportunidades/afinidad/agotamiento sin autoacción.  
-**F15 KronIA + Multiagent** → tools estructuradas + Policy Gate.  
-**F16 Email** → consumir Audience/Activation central conservando flows actuales.  
-**F17 SMS/WhatsApp** → mismos contratos, provider específico.  
-**F18 Attribution/Learning/Hardening** → outcomes end-to-end, resiliencia, observabilidad y paquete reusable.
+Antes de tocar Call Center verificar nuevamente:
 
-No adelantar capacidades entre fases salvo deuda bloqueante demostrada; si se adelanta una corrección, documentar por qué y mantener la frontera funcional.
+- `aos_siguiente_lead` hash: `76412bac81e20ec6cfdc4f8c0db89e8c`
+- `aos_siguiente_lead_v2` hash: `cb69781d1457ed73de8f8d52f0f83a00`
+
+Cierre F10 no modificó:
+- `calls.js`;
+- `aos_siguiente_lead*`;
+- `aos_cola_config`;
+- `aos_leads_en_curso`.
+
+Semántica diaria V3 debe ser `America/Lima`, no `CURRENT_DATE` server implícito.
 
 ---
 
-# 8. GUARDRAILS ADQUIRIDOS
+# 8. GUARDRAILS PERMANENTES
 
-Antes de tocar una tabla operativa:
-
-- revisar write-path;
-- revisar funciones usadas por índices/triggers;
-- probar INSERT/UPDATE como rol real;
-- confirmar tráfico real posterior.
-
-Antes de optimizar:
-
-- EXPLAIN/benchmark;
-- no subir timeout como solución;
-- no mega-join de dominios innecesarios.
-
-Antes de certificar:
-
-- migration replayability;
-- grants reales;
-- timezone Lima;
-- cache coverage/freshness;
-- QA rollback-only;
+- write-path safety obligatorio antes de tocar tablas/routing operativo;
+- QA mutante rollback-only cuando sea posible;
 - zero residue;
-- handshake fase anterior;
-- output siguiente fase;
-- PR + CI + staging smoke;
-- docs + `aos_memory` + Notion.
+- migrations Git ↔ `schema_migrations` coherentes;
+- ACL reales post-DDL;
+- no subir timeout para ocultar una arquitectura lenta;
+- freshness explícita;
+- una sola fuente autoritativa de audit events;
+- handshake fase anterior + output fase siguiente antes de `100_COMPLETE`;
+- PR + CI + staging smoke + Validation Report + `aos_memory` + Notion.
 
 ---
 
-# 9. INCIDENTES QUE TODO AGENTE DEBE RECORDAR
+# 9. INCIDENTES/LECCIONES QUE SIGUEN VIGENTES
 
-1. Mega-view del resolver llegó a ~30.4 s → Resolver V2 domain-aware.
-2. Índices CIA con función privada rompieron INSERT de Call Center con 401 → write-path safety obligatorio.
-3. Default EXECUTE de funciones fue más amplio de lo supuesto → revisar ACL post-DDL.
-4. Auth KronIA existente no era apta para panel ADMIN → no reutilizar auth sin auditoría.
-5. Drift de timestamps de migrations → Git ↔ `schema_migrations` debe ser 1:1.
-6. Segment/Email caches quedaron detrás del universo → absence no es FALSE si freshness no cuadra.
-7. Snapshot BATCH falló por `digest()` sin schema → calificar extensiones y probar handshake real.
-8. Event emitter DB + RPC manual duplicaba potencialmente eventos → una sola fuente de audit.
-9. `CURRENT_DATE` server divergió de Lima → timezone explícita.
-10. CONTINUOUS top-up inicial se desbalanceó → probar ciclo completo, no solo primera asignación.
-
-Sentry está registrado en Notion como mejora planificada de observabilidad; no asumir integración completada hasta que exista confirmación y evidencia técnica.
+1. Mega-view ~30.4 s → resolver por dominios.
+2. Índices CIA privados rompieron Call Center 401 → write-path test real.
+3. ACL defaults inesperados → auditar privileges.
+4. Auth heredada no se reutiliza sin auditoría.
+5. Drift de migrations → ledger Git/live 1:1.
+6. Cache stale → UNKNOWN/freshness fail-closed.
+7. `digest()` sin schema → extensiones schema-qualified.
+8. Doble audit source → una sola fuente DB.
+9. UTC vs Lima → timezone explícita.
+10. CONTINUOUS top-up → probar ciclo completo.
+11. F10 plan health N+1 → lista snapshot ligera + drill-down exacto live.
 
 ---
 
-# 10. CHECKPOINTS
+# 10. SIGUIENTE ACCIÓN
 
-Checkpoint funcional/closure Fase 9:
+**Iniciar F11 únicamente después de recovery/preflight completo.**
 
-`2e1116f07919fcf53bdac8cf61cbd23944863630`
-
-Checkpoint de control/documentación actual:
-
-consultar `staging` HEAD live y `aos_memory` clave `cia_v3_control_checkpoint`.
-
-Último cierre funcional:
-
-`docs/control/commercial-intelligence/PHASE_09_VALIDATION_REPORT.md`
-
-Siguiente acción:
-
-**Iniciar Fase 10 únicamente después de recovery/preflight y comprobar que Notion visual coincide con GitHub/runtime.**
+Primer paso F11: baseline exhaustivo del Call Center V2 + readiness F10 + Impact Report CRITICAL antes de modificar routing.

--- a/docs/control/commercial-intelligence/PHASE_10_ADVISOR_CONTROL_CENTER.md
+++ b/docs/control/commercial-intelligence/PHASE_10_ADVISOR_CONTROL_CENTER.md
@@ -1,34 +1,39 @@
 # FASE 10 — ADVISOR CONTROL CENTER
 
-**Estado:** IN_PROGRESS / PRE-DDL IMPACT REPORT  
+**Estado:** `100_COMPLETE`  
 **Fecha:** 2026-08-14 (America/Lima)  
-**Branch:** `feature/commercial-intelligence-phase10-advisor-control-20260814`  
-**Base staging:** `859954ab6d99b4b273b993daaeab4aebb017d035`  
-**Input funcional F9:** `2e1116f07919fcf53bdac8cf61cbd23944863630`
+**Functional branch:** `feature/commercial-intelligence-phase10-advisor-control-20260814`  
+**Baseline staging:** `859954ab6d99b4b273b993daaeab4aebb017d035`  
+**Input funcional F9:** `2e1116f07919fcf53bdac8cf61cbd23944863630`  
+**Functional merge staging:** `2a74c3443bb600c1157b746349e1e85dac7f67fc`  
+**PR:** #82  
+**CI:** #701 `SUCCESS`
 
 ---
 
-## 1. Objetivo
+## 1. Objetivo cumplido
 
-Construir el **Advisor Control Center** como control plane administrativo sobre ownership ya producido por Fase 9.
+F10 construyó el **Advisor Control Center** como control plane administrativo sobre ownership F9, sin reinterpretar calls/leads y sin modificar routing.
 
-Debe permitir observar y gobernar, sin reinterpretar calls/leads:
+Entrega:
 
 - carga activa por `aos_usuarios.id`;
 - ASSIGNED / IN_PROGRESS / COMPLETED / RELEASED / EXPIRED;
-- planes abiertos/activos;
+- planes abiertos;
 - overdue-to-start;
-- leases que expiran próximamente;
-- capacidad y utilización con semántica explícita;
-- source available, candidate remaining y depletion por plan;
-- drill-down de ownership y deadlines;
-- readiness estructural para F11.
+- leases próximos a expirar;
+- capacity/utilization con semántica explícita;
+- health de planes;
+- drill-down;
+- readiness F11.
 
 ---
 
 ## 2. INPUT CONTRACT — F9 → F10
 
-Autoritativos:
+F10 consume ownership y contratos certificados F9.
+
+Fuentes canónicas:
 
 - `aos_cia_assignment_advisor_workload_v1()`
 - `aos_cia_assignment_plan_summary_v1(plan_id)`
@@ -36,152 +41,137 @@ Autoritativos:
 - `aos_cia_assignment_list_v1(...)`
 - `aos_cia_assignment_events_v1(...)`
 
-Ownership continúa siendo exclusivamente F9.
+F10 no crea una segunda fuente de ownership.
 
 ---
 
 ## 3. OUTPUT CONTRACT — F10 → F11
 
-F10 entregará un contrato read-only de readiness con, al menos:
+Nuevo preflight:
 
-- asesores activos;
-- planes open/active/paused;
-- leases activos;
-- overdue-to-start;
-- expiring leases;
-- conflictos GLOBAL activos;
-- leases activos con asesor inválido/inactivo;
-- leases activos sin deadline requerido;
-- planes activos cuyo Activation ya no está ACTIVE;
-- estado `READY`, `READY_NO_ACTIVE_OWNERSHIP` o `BLOCKED`.
+`aos_cia_advisor_control_f11_readiness_v1()`
 
-F11 deberá usar este control plane como preflight antes de conectar routing V3.
+Estados:
 
----
+- `READY`
+- `READY_NO_ACTIVE_OWNERSHIP`
+- `BLOCKED`
 
-## 4. ANTI-SCOPE
+Valida:
 
-F10 **NO**:
+- GLOBAL active conflicts;
+- owner inválido/inactivo/no asesor;
+- targets inválidos;
+- deadlines inválidos;
+- plan ACTIVE con Activation no ACTIVE.
 
-- modifica `aos_siguiente_lead` ni `aos_siguiente_lead_v2`;
-- modifica `calls.js`, `aos_cola_config` o `aos_leads_en_curso`;
-- reconstruye ownership desde llamadas/leads;
-- crea otro Assignment Engine;
-- crea Work Views personales para asesores;
-- implementa routing Call Center V3;
-- implementa approvals;
-- usa afinidad IA como decisión real.
+F11 debe usar este contrato antes de habilitar routing V3.
 
 ---
 
-# 5. IMPACT REPORT
+## 4. Anti-scope preservado
 
-**Riesgo:** HIGH
+F10 no modificó:
 
-### Código
+- `aos_siguiente_lead`;
+- `aos_siguiente_lead_v2`;
+- `calls.js`;
+- `aos_cola_config`;
+- `aos_leads_en_curso`;
+- tablas operativas calls/leads/agenda/ventas.
 
-Previsto:
+No construyó:
 
-- `app/public/admin-activaciones.html`
-- nuevo `app/public/admin-activaciones-control.js`
-- nuevo `app/public/admin-activaciones-control.css`
-- migrations F10 read contracts + gateway.
+- routing V3;
+- Work Views F12;
+- approvals;
+- IA de afinidad.
 
-No tocar `app/public/calls.js`.
+---
 
-### Datos
-
-Lectura sobre:
-
-- `aos_cia_assignment_plans`
-- `aos_cia_assignment_targets`
-- `aos_cia_assignment_assignments` / tabla real `aos_cia_assignments`
-- `aos_cia_assignment_events`
-- `aos_usuarios`
-- Activation/context F7/F8 solo para health/readiness.
-
-Persistencia nueva de negocio: **ninguna prevista**.
-
-### RPC
-
-Nuevos contratos F10 propuestos:
+## 5. Read-models entregados
 
 - `aos_cia_advisor_control_overview_v1()`
 - `aos_cia_advisor_control_advisor_detail_v1(...)`
+- `aos_cia_advisor_control_plan_health_v1(...)`
+- `aos_cia_advisor_control_alerts_v1(...)`
 - `aos_cia_advisor_control_f11_readiness_v1()`
-- `aos_cia_phase10_admin_gateway_v1(token, action, payload)`
+- `aos_cia_phase10_admin_gateway_v1(...)`
 
-El gateway F10 reutilizará mutaciones F9 certificadas; no escribirá directamente ownership.
-
-### Seguridad
-
-- browser solo vía gateway F10 con CIA admin token;
-- read-models internos revocados a PUBLIC/anon/authenticated;
-- `SECURITY DEFINER` solo en gateway si es necesario;
-- `search_path=public` explícito;
-- ninguna superficie asesor en F10.
-
-### Performance
-
-Targets:
-
-- Overview P95 < 1.5 s;
-- advisor detail 50 filas P95 < 1.5 s;
-- F11 readiness P95 < 1.5 s;
-- UI normal < 2.5 s incluso con planes múltiples.
-
-### No-regresión operacional
-
-Obligatorio verificar:
-
-- hashes/definiciones de `aos_siguiente_lead*` sin cambios;
-- `calls.js` sin diff;
-- Call Center continúa guardando llamadas;
-- 0 cambios en tablas operativas de calls/leads/agenda/ventas.
-
-### Rollback
-
-1. retirar módulo frontend F10;
-2. revocar/drop únicamente RPC F10 nuevos si fuese necesario;
-3. F9 permanece intacta;
-4. no existe migración de datos fuente ni routing que revertir.
+Plan health general usa `LAST_RUN_SNAPSHOT`; `GET_PLAN` mantiene exactitud live por plan seleccionado.
 
 ---
 
-## 6. Semántica de capacidad
+## 6. Capacidad
 
-No presentar `0%` cuando la capacidad no está definida.
+Semántica:
 
-Por asesor:
+- `NO_OPEN_PLANS`
+- `BOUNDED`
+- `UNBOUNDED`
+- `MIXED`
 
-- `BOUNDED`: todos sus targets abiertos tienen `capacity_limit` y se puede calcular utilization %;
-- `UNBOUNDED`: ningún target abierto tiene capacity;
-- `MIXED`: existen targets bounded + unbounded; utilization % global será `NULL`/no aplicable.
+Utilization global solo existe para `BOUNDED`.
 
-Capacidad conocida = suma de `capacity_limit` de targets en planes ACTIVE/PAUSED.
+No se presenta 0% cuando la capacidad es desconocida/no limitada.
 
 ---
 
-## 7. Gates F10
+## 7. QA / seguridad / rendimiento
 
-- P10-G01 recovery/preflight — IN_PROGRESS
-- P10-G02 baseline F9/live — PASS (ownership live vacío)
-- P10-G03 Impact Report / scope — PASS
-- P10-G04 read-model overview — PENDING
-- P10-G05 capacity/utilization semantics — PENDING
-- P10-G06 advisor drill-down — PENDING
-- P10-G07 plan health/depletion — PENDING
-- P10-G08 deadline alerts — PENDING
-- P10-G09 F11 readiness contract — PENDING
-- P10-G10 gateway/admin authorization — PENDING
-- P10-G11 empty-state real — PENDING
-- P10-G12 populated QA rollback-only — PENDING
-- P10-G13 security/ACL — PENDING
-- P10-G14 performance — PENDING
-- P10-G15 frontend/responsive/a11y — PENDING
-- P10-G16 no-regression Call Center — PENDING
-- P10-G17 replayability Git↔Supabase — PENDING
-- P10-G18 PR/CI/staging smoke — PENDING
-- P10-G19 docs/aos_memory/Notion — PENDING
+Evidencia completa:
 
-**100_COMPLETE requiere P10-G01..G19 PASS.**
+`docs/control/commercial-intelligence/PHASE_10_VALIDATION_REPORT.md`
+
+Resumen:
+
+- empty-state real PASS;
+- populated QA rollback-only PASS;
+- adversarial BLOCKED readiness PASS;
+- zero residue PASS;
+- ACL/RLS PASS;
+- gateway invalid token → UNAUTHORIZED;
+- 1,000 ownership: overview 4.83 ms, detail 10.76 ms, health 14.22 ms, readiness 6.09 ms;
+- Call Center hashes intactos.
+
+---
+
+## 8. Replayability
+
+Canónicas Git/live:
+
+1. `20260814064201_cia_phase10_advisor_control_read_contracts_v1.sql`
+2. `20260814064219_cia_phase10_admin_gateway_v1.sql`
+3. `20260814065732_cia_phase10_plan_health_scaling_fix_v1.sql`
+
+Provisionales anteriores = comment-only `SUPERSEDED / NEVER APPLIED`.
+
+---
+
+## 9. Gates F10
+
+- P10-G01 recovery/preflight — PASS
+- P10-G02 baseline F9/live — PASS
+- P10-G03 Impact Report/scope — PASS
+- P10-G04 read-model overview — PASS
+- P10-G05 capacity/utilization semantics — PASS
+- P10-G06 advisor drill-down — PASS
+- P10-G07 plan health/depletion — PASS
+- P10-G08 deadline alerts — PASS
+- P10-G09 F11 readiness contract — PASS
+- P10-G10 gateway/admin authorization — PASS
+- P10-G11 empty-state real — PASS
+- P10-G12 populated QA rollback-only — PASS
+- P10-G13 security/ACL — PASS
+- P10-G14 performance — PASS
+- P10-G15 frontend/responsive/a11y — PASS
+- P10-G16 no-regression Call Center — PASS
+- P10-G17 replayability Git↔Supabase — PASS
+- P10-G18 PR/CI/staging smoke — PASS
+- P10-G19 docs/aos_memory/Notion — PASS al completar cierre documental y sincronización final.
+
+## Veredicto
+
+**FASE 10 — ADVISOR CONTROL CENTER = `100_COMPLETE`.**
+
+**FASE 11 — CALL CENTER INTEGRATION V3 = `READY`.**

--- a/docs/control/commercial-intelligence/PHASE_10_VALIDATION_REPORT.md
+++ b/docs/control/commercial-intelligence/PHASE_10_VALIDATION_REPORT.md
@@ -1,44 +1,32 @@
 # ASCENDA OS — FASE 10 VALIDATION REPORT
 
 **Fase:** Advisor Control Center  
-**Estado:** `VALIDATING`  
+**Estado:** `100_COMPLETE`  
 **Fecha:** 2026-08-14 (America/Lima)  
-**Branch:** `feature/commercial-intelligence-phase10-advisor-control-20260814`  
-**Baseline staging real:** `859954ab6d99b4b273b993daaeab4aebb017d035`  
-**Input funcional F9:** `2e1116f07919fcf53bdac8cf61cbd23944863630`
+**Branch funcional:** `feature/commercial-intelligence-phase10-advisor-control-20260814`  
+**Baseline staging:** `859954ab6d99b4b273b993daaeab4aebb017d035`  
+**Input funcional F9:** `2e1116f07919fcf53bdac8cf61cbd23944863630`  
+**Functional PR:** #82  
+**Ascenda CI funcional:** #701 `SUCCESS`  
+**Merge funcional staging:** `2a74c3443bb600c1157b746349e1e85dac7f67fc`
 
 ---
 
-## 1. Resultado funcional
+## 1. Resultado certificado
 
-F10 construye un **Advisor Control Center** administrativo sobre ownership ya producido por F9.
+F10 implementa el **Advisor Control Center** como control plane administrativo sobre ownership ya producido por F9.
 
-Cadena certificada:
+Cadena:
 
-`F9 Assignment → Advisor workload / plan summary / leases / events → F10 Control Center → F11 readiness preflight`
+`F9 Assignment → F10 Advisor Control Center → F11 Readiness Preflight`
 
-F10 **no reconstruye ownership** desde calls/leads y **no modifica routing**.
-
----
-
-## 2. Estado live de entrada
-
-Al iniciar F10:
-
-- assignment plans = 0;
-- targets = 0;
-- runs = 0;
-- assignments = 0;
-- events = 0;
-- asesores activos live = 6.
-
-El estado vacío real fue tratado como contrato de primera clase, no como error.
+F10 no reconstruye ownership desde calls/leads y no modifica routing Call Center.
 
 ---
 
-## 3. Read-models F10
+## 2. Contratos F10
 
-Nuevos contratos privados:
+Read-models privados:
 
 - `aos_cia_advisor_control_overview_v1()`
 - `aos_cia_advisor_control_advisor_detail_v1(...)`
@@ -46,261 +34,223 @@ Nuevos contratos privados:
 - `aos_cia_advisor_control_alerts_v1(...)`
 - `aos_cia_advisor_control_f11_readiness_v1()`
 
-Gateway browser:
+Gateway:
 
 - `aos_cia_phase10_admin_gateway_v1(token, action, payload)`
 
-No se crearon tablas nuevas de negocio ni un segundo Assignment Engine.
+No se crearon tablas nuevas de ownership ni un segundo Assignment Engine.
 
 ---
 
-## 4. Estado vacío real
+## 3. Empty-state live
 
-Sobre producción live sin ownership:
+Estado productivo al cierre:
 
-- asesores = 6;
+- asesores activos = 6;
 - active ownership = 0;
-- assigned = 0;
-- in progress = 0;
 - plans open = 0;
 - alerts = 0;
-- todos los asesores → `capacity_mode=NO_OPEN_PLANS`;
-- utilization = `NULL`, no 0% inventado.
+- capacity mode = `NO_OPEN_PLANS` para los seis asesores;
+- utilization = NULL, no 0% inventado.
 
 F11 readiness:
 
 - `f11_engineering_ready=true`;
 - `status=READY_NO_ACTIVE_OWNERSHIP`;
-- global conflicts = 0;
-- invalid ownership advisor = 0;
-- invalid open targets = 0;
-- deadline errors = 0;
-- active-plan/activation mismatch = 0;
+- 0 conflictos GLOBAL;
+- 0 ownership con asesor inválido;
+- 0 targets inválidos;
+- 0 deadline errors;
+- 0 plan/Activation mismatch;
 - `routing_modified=false`.
 
 PASS.
 
 ---
 
-## 5. Capacity / utilization semantics
+## 4. Capacity semantics
 
-F10 distingue explícitamente:
+Estados explícitos:
 
 - `NO_OPEN_PLANS`
 - `BOUNDED`
 - `UNBOUNDED`
 - `MIXED`
 
-Solo `BOUNDED` produce utilization global `%`.
+Solo `BOUNDED` produce utilization global porcentual.
 
-QA poblado rollback-only:
+QA rollback-only:
 
-- JHORDANO → `MIXED`, utilization `NULL`;
-- JOSELO → `UNBOUNDED`, utilization `NULL`;
-- MIREYA → `BOUNDED`, capacity 2, active 1, utilization 50%.
+- JHORDANO → MIXED / utilization NULL;
+- JOSELO → UNBOUNDED / utilization NULL;
+- MIREYA → BOUNDED, capacity 2, active 1, utilization 50%.
 
 PASS.
 
 ---
 
-## 6. QA poblado rollback-only
+## 5. Populated QA rollback-only
 
-Se creó dentro de una subtransacción una cadena temporal completa usando:
+Se construyó una cadena temporal real usando:
 
-- preset real `LEADS_UNWORKED`;
-- Audience/version F6;
-- dos Activations DYNAMIC F7;
-- policy `CALL_GENERAL` F8;
-- available keys reales F8;
+- preset `LEADS_UNWORKED`;
+- Audience/version;
+- dos Activations DYNAMIC;
+- `CALL_GENERAL` F8;
+- available_keys reales;
 - dos planes F9;
-- targets seleccionados desde `aos_usuarios` live;
-- 7 leases con estados/deadlines distintos.
+- tres asesores tomados desde `aos_usuarios` live;
+- siete leases con distintos estados/deadlines.
 
-Resultados F10:
+Resultados:
 
-- active ownership = 4;
-- assigned = 3;
-- in progress = 1;
-- completed = 1;
-- released = 1;
-- expired = 1;
-- overdue-to-start = 1;
-- expiring ≤60m = 2;
-- alerts = 2;
-- plan health rows = 2;
-- advisor detail rows = 2;
-- F11 readiness = `READY`.
-
-Todos los asserts PASS.
+- active ownership 4;
+- assigned 3;
+- in progress 1;
+- completed 1;
+- released 1;
+- expired 1;
+- overdue-to-start 1;
+- expiring ≤60m 2;
+- alerts 2;
+- plan health rows 2;
+- advisor detail rows 2;
+- readiness `READY`.
 
 Después del rollback:
 
-- plans = 0;
-- targets = 0;
-- runs = 0;
-- assignments = 0;
-- events = 0;
-- audiences QA = 0;
-- activations QA = 0.
+- plans 0;
+- targets 0;
+- runs 0;
+- assignments 0;
+- events 0;
+- audiences QA 0;
+- activations QA 0.
 
 **Zero residue PASS.**
 
 ---
 
-## 7. Deadline alerts
-
-F10 identifica:
-
-- `OVERDUE_TO_START`: ASSIGNED cuyo `must_start_before` ya venció;
-- `EXPIRING_60M`: ASSIGNED/IN_PROGRESS cuyo lease expira en ≤60 min.
+## 6. F11 readiness adversarial
 
 QA:
 
-1. ASSIGNED overdue + expiring;
-2. IN_PROGRESS expiring.
-
-Alert rows = 2.
-
-PASS.
-
----
-
-## 8. F11 readiness contract
-
-Readiness valida estructuralmente:
-
-- duplicate GLOBAL active ownership;
-- ownership activo con usuario inexistente/inactivo/no asesor;
-- target de plan abierto inválido;
-- deadlines ausentes o incoherentes;
-- plan F9 ACTIVE cuya Activation ya no está ACTIVE.
-
-QA adversarial rollback-only:
-
-- Activation ACTIVE + F9 plan ACTIVE;
-- Activation cambia a PAUSED;
+- Activation ACTIVE;
+- F9 plan ACTIVE;
+- Activation pasa a PAUSED;
 - readiness → `BLOCKED`;
 - `f11_engineering_ready=false`;
 - `active_plan_activation_not_active=1`;
 - `routing_modified=false`.
 
-Rollback dejó 0 residuos.
+Rollback 0 residuos.
 
 PASS.
 
 ---
 
-## 9. Plan health: defecto encontrado y corrección
+## 7. Plan health scaling correction
 
-La primera versión de `plan_health` llamaba a `aos_cia_assignment_plan_summary_v1()` por cada plan.
+La primera versión del health list llamaba a `aos_cia_assignment_plan_summary_v1()` para cada plan, generando un patrón N+1 sobre F8.
 
-Eso obligaba a re-resolver F8 repetidamente y producía un patrón N+1 potencialmente caro. Un benchmark poblado detectó `statement_timeout` durante montaje + health.
+Un benchmark detectó el riesgo mediante timeout durante montaje + health.
 
-**No se aumentó el timeout.**
+No se aumentó el timeout.
 
 Corrección:
 
 `20260814065732_cia_phase10_plan_health_scaling_fix_v1.sql`
 
-Semántica final:
+Contrato final:
 
-- lista general = `LAST_RUN_SNAPSHOT`;
-- usa último run + estados actuales de leases;
-- health/deadlines son actuales;
-- source/candidate/depletion de la lista se etiquetan como estimación del último run;
-- `GET_PLAN` sigue siendo el drill-down exacto live de F9 y revalida F8 para un plan seleccionado.
-
-Así se evita N+1 sin fingir freshness.
+- lista general → `LAST_RUN_SNAPSHOT`;
+- counts/deadlines actuales;
+- availability/depletion de lista claramente marcados como snapshot/estimación del último run;
+- detalle `GET_PLAN` → exacto live y revalida F8/F9 para un solo plan seleccionado.
 
 PASS.
 
 ---
 
-## 10. Performance
+## 8. Performance
 
-QA rollback-only con **1,000 ownership activos** sobre 3 asesores.
-
-Resultados F10 después del scaling fix:
+QA rollback-only con **1,000 ownership activos**:
 
 - Overview: **4.83 ms**;
 - Advisor Detail 50: **10.76 ms**;
 - Plan Health: **14.22 ms**;
 - F11 Readiness: **6.09 ms**.
 
-Asserts:
+Todos <1.5 s.
 
-- active ownership = 1,000;
-- advisor detail = 50 rows;
-- plan health = `LAST_RUN_SNAPSHOT`;
-- readiness = `READY`;
-- todos los read-models <1.5 s.
+Assertions:
 
-Después del rollback: 0 plans/assignments/events/audiences QA.
+- active ownership 1,000;
+- detail rows 50;
+- health mode `LAST_RUN_SNAPSHOT`;
+- readiness `READY`.
 
-El detalle exacto `GET_PLAN` permanece sobre el contrato F9 ya certificado (~903 ms con 1,000 assignments).
+Rollback dejó 0 plans/assignments/events/audiences QA.
 
 PASS.
 
 ---
 
-## 11. Seguridad
+## 9. Seguridad
 
-Read-models F10:
+Read-models:
 
-- `SECURITY INVOKER`;
+- SECURITY INVOKER;
 - `search_path=public`;
-- anon EXECUTE = false;
-- authenticated EXECUTE = false;
-- service_role EXECUTE = true.
+- anon EXECUTE false;
+- authenticated EXECUTE false;
+- service_role EXECUTE true.
 
-Gateway F10:
+Gateway:
 
-- `SECURITY DEFINER`;
+- SECURITY DEFINER;
 - `search_path=public`;
-- ejecutable por browser roles;
 - CIA admin token obligatorio;
 - invalid token → `UNAUTHORIZED`;
 - payload ≤65,536 bytes.
 
 F9 persistence:
 
-- 5/5 tablas con RLS=true;
+- 5/5 tablas RLS=true;
 - 0 policies permisivas.
 
-Server limits:
+Server caps:
 
-- advisor detail ≤100;
-- plan health ≤50;
-- alerts ≤100.
+- advisor detail 100;
+- plan health 50;
+- alerts 100.
 
 PASS.
 
 ---
 
-## 12. Control actions permitidas en F10
+## 10. Controles permitidos
 
-Gateway F10 puede reutilizar únicamente contratos certificados F9 para:
+F10 reutiliza funciones F9 únicamente para:
 
-- `PAUSE` / `RESUME` plan;
-- `RECONCILE`;
-- `TOPUP`;
-- `RELEASE_ASSIGNMENT`.
+- PAUSE / RESUME;
+- RECONCILE;
+- TOPUP;
+- RELEASE_ASSIGNMENT.
 
 No ofrece:
 
 - CREATE_PLAN;
 - ACTIVATE_PLAN;
 - CLOSE/CANCEL;
-- START/COMPLETE lease;
+- START/COMPLETE;
 - routing Call Center.
-
-F10 no se convierte en un segundo Assignment Engine ni adelanta Work Views.
 
 PASS.
 
 ---
 
-## 13. Frontend
+## 11. Frontend
 
 Activaciones incorpora quinta pestaña:
 
@@ -308,102 +258,126 @@ Activaciones incorpora quinta pestaña:
 
 Archivos:
 
-- `admin-activaciones-control.css`
-- `admin-activaciones-control.js`
-- actualización aditiva de `admin-activaciones.html`.
+- `app/public/admin-activaciones-control.css`
+- `app/public/admin-activaciones-control.js`
+- `app/public/admin-activaciones.html`
 
-La UI muestra:
+Funciones visuales:
 
-- KPIs de ownership;
-- readiness F11;
-- carga por asesor UUID;
-- capacity mode/utilization;
+- KPIs ownership;
+- F11 readiness;
+- carga/capacidad por asesor UUID;
 - drill-down de leases;
 - deadlines;
-- health de planes;
-- exact live detail por plan;
+- plan health;
+- detalle exacto live;
 - alertas;
-- controles administrativos limitados.
+- controles limitados.
 
-Controller audit:
+Static audit:
 
 - 0 `alert()`;
 - 0 `confirm()`;
 - 0 `prompt()`;
-- 0 direct `/rest/v1/aos_*` table reads.
+- 0 direct `/rest/v1/aos_*` reads.
 
-Responsive:
+Responsive CSS: desktop/tablet/mobile + table overflow.
 
-- desktop;
-- tablet;
-- mobile;
-- tables con overflow horizontal.
-
-CI/staging todavía pendientes al momento de crear este informe.
-
----
-
-## 14. Replayability
-
-Supabase live registra:
-
-1. `20260814064201_cia_phase10_advisor_control_read_contracts_v1`
-2. `20260814064219_cia_phase10_admin_gateway_v1`
-3. `20260814065732_cia_phase10_plan_health_scaling_fix_v1`
-
-Git contiene exactamente esos tres timestamps con el SQL ejecutado live.
-
-Los nombres provisionales pre-aplicación permanecen únicamente como archivos comentario:
-
-`SUPERSEDED / NEVER APPLIED`.
+Ascenda CI #701 validó JavaScript público y archivos críticos.
 
 PASS.
 
 ---
 
-## 15. Call Center / legacy compatibility
+## 12. Replayability
 
-Hashes live F10 vs cierre F9:
+Supabase live y Git canónico:
 
-- `aos_siguiente_lead` = `76412bac81e20ec6cfdc4f8c0db89e8c` — idéntico;
-- `aos_siguiente_lead_v2` = `cb69781d1457ed73de8f8d52f0f83a00` — idéntico.
+1. `20260814064201_cia_phase10_advisor_control_read_contracts_v1.sql`
+2. `20260814064219_cia_phase10_admin_gateway_v1.sql`
+3. `20260814065732_cia_phase10_plan_health_scaling_fix_v1.sql`
 
-Último día operacional completo 2026-08-13:
+Los tres timestamps coinciden con `schema_migrations` live.
+
+Los filenames provisionales anteriores son comment-only `SUPERSEDED / NEVER APPLIED`.
+
+PASS.
+
+---
+
+## 13. Call Center compatibility
+
+Hashes pre/post F10:
+
+- `aos_siguiente_lead` = `76412bac81e20ec6cfdc4f8c0db89e8c`;
+- `aos_siguiente_lead_v2` = `cb69781d1457ed73de8f8d52f0f83a00`.
+
+Ambos idénticos al cierre F9.
+
+Último día operacional completo 13/08:
 
 - llamadas guardadas = **349**;
-- última actividad observada incluye escrituras reales de WILMER/MIREYA antes del cambio de día Lima.
+- actividad real observada de WILMER/MIREYA antes del cambio de día Lima.
 
-A las ~01:32 Lima del 14/08 todavía había 0 llamadas del nuevo día, coherente con la hora y no indicativo de fallo.
+A ~01:32 Lima del 14/08 todavía había 0 llamadas del nuevo día, coherente con la hora.
 
-Diff F10 no toca:
+F10 no modifica:
 
 - `calls.js`;
 - `aos_siguiente_lead*`;
 - `aos_cola_config`;
 - `aos_leads_en_curso`;
-- tablas operativas de calls/leads/agenda/ventas.
+- tablas operativas Calls/Leads/Agenda/Ventas.
+
+Post-merge hashes nuevamente idénticos.
 
 PASS.
 
 ---
 
-## 16. Handoff F10 → F11
+## 14. Integración GitHub / staging
 
-Output autoritativo nuevo:
+Functional PR #82: **MERGED**.
+
+Ascenda CI #701: **SUCCESS**.
+
+Merge funcional staging:
+
+`2a74c3443bb600c1157b746349e1e85dac7f67fc`
+
+Post-merge smoke:
+
+- controller F10 presente en staging;
+- read-model empty state PASS;
+- readiness `READY_NO_ACTIVE_OWNERSHIP`;
+- gateway invalid token `UNAUTHORIZED`;
+- 0 data QA residual;
+- Call Center hashes intactos.
+
+PASS.
+
+---
+
+## 15. F10 → F11 output contract
+
+Output autoritativo:
 
 `aos_cia_advisor_control_f11_readiness_v1()`
 
-F11 deberá:
+F11 debe:
 
-1. ejecutar este readiness como preflight;
-2. permanecer bloqueada si `status=BLOCKED`;
-3. construir routing V3 **paralelo**, no reemplazo big-bang;
-4. usar feature flag / rollout controlado por usuarios;
-5. conservar fallback V2;
-6. mantener timezone `America/Lima`;
-7. no reconstruir eligibility/ownership.
+1. ejecutar readiness antes de habilitar V3;
+2. bloquear rollout si `status=BLOCKED`;
+3. construir routing V3 paralelo;
+4. usar feature flag/canary por usuarios;
+5. conservar V2 como fallback;
+6. mantener `America/Lima`;
+7. consumir ownership F9, no reconstruirlo;
+8. demostrar rollback inmediato.
 
-F10 deja explícitamente `routing_modified=false`.
+F10 certifica explícitamente:
+
+`routing_modified=false`.
 
 ---
 
@@ -415,7 +389,7 @@ F10 deja explícitamente `routing_modified=false`.
 - P10-G04 read-model overview — PASS
 - P10-G05 capacity/utilization semantics — PASS
 - P10-G06 advisor drill-down — PASS
-- P10-G07 plan health/depletion — PASS after scaling fix
+- P10-G07 plan health/depletion — PASS after scaling correction
 - P10-G08 deadline alerts — PASS
 - P10-G09 F11 readiness contract — PASS
 - P10-G10 gateway/admin authorization — PASS
@@ -423,14 +397,14 @@ F10 deja explícitamente `routing_modified=false`.
 - P10-G12 populated QA rollback-only — PASS
 - P10-G13 security/ACL — PASS
 - P10-G14 performance — PASS
-- P10-G15 frontend/responsive/a11y contract — PASS static / CI pending
+- P10-G15 frontend/responsive/a11y contract — PASS
 - P10-G16 no-regression Call Center — PASS
 - P10-G17 replayability Git↔Supabase — PASS
-- P10-G18 PR/CI/staging smoke — PENDING
-- P10-G19 docs/aos_memory/Notion — PENDING
+- P10-G18 PR/CI/staging smoke — PASS
+- P10-G19 docs/aos_memory/Notion — PASS al fusionar cierre y sincronizar fuentes visual/técnica.
 
-## Veredicto actual
+## Veredicto
 
-**FASE 10 = VALIDATING.**
+**FASE 10 — ADVISOR CONTROL CENTER = `100_COMPLETE`.**
 
-Solo faltan integración PR/CI/staging y cierre documental/memory/Notion. No hay feature funcional pendiente.
+**FASE 11 — CALL CENTER INTEGRATION V3 = `READY`.**

--- a/docs/control/commercial-intelligence/ROADMAP_STATUS.md
+++ b/docs/control/commercial-intelligence/ROADMAP_STATUS.md
@@ -1,9 +1,9 @@
 # ASCENDA OS — COMMERCIAL INTELLIGENCE & AUDIENCE OS
 ## ROADMAP / PHASE STATUS
 
-**Última actualización:** 2026-08-13 (America/Lima)  
+**Última actualización:** 2026-08-14 (America/Lima)  
 **Baseline inicial:** `82d5115fe240b97464850d942b368a982e8e2258`  
-**Staging funcional tras Fase 9:** `57445a0863350c1989d8398157308783bdaf3905`  
+**Staging funcional tras Fase 10:** `2a74c3443bb600c1157b746349e1e85dac7f67fc`  
 **Master:** `docs/control/COMMERCIAL_INTELLIGENCE_AUDIENCE_OS_V3_MASTER.md`
 
 ---
@@ -19,7 +19,7 @@ Una fase solo es `100_COMPLETE` cuando:
 - CI pasa;
 - smoke post-merge pasa;
 - Validation Report final existe;
-- GitHub y `aos_memory` guardan el checkpoint.
+- GitHub, `aos_memory` y Notion guardan el checkpoint.
 
 ---
 
@@ -37,8 +37,8 @@ Una fase solo es `100_COMPLETE` cuando:
 | 7 | Snapshots & Activation | `100_COMPLETE` | 100% |
 | 8 | Channel Context & Availability | `100_COMPLETE` | 100% |
 | 9 | Assignment Engine | `100_COMPLETE` | 100% |
-| 10 | Advisor Control Center | `READY` | 0% |
-| 11 | Call Center Integration V3 | `NOT_STARTED` | 0% |
+| 10 | Advisor Control Center | `100_COMPLETE` | 100% |
+| 11 | Call Center Integration V3 | `READY` | 0% |
 | 12 | Advisor Work Views | `NOT_STARTED` | 0% |
 | 13 | Requests & Approvals | `NOT_STARTED` | 0% |
 | 14 | Commercial Intelligence Shadow | `NOT_STARTED` | 0% |
@@ -51,191 +51,172 @@ Una fase solo es `100_COMPLETE` cuando:
 
 # CIERRES CERTIFICADOS
 
-## Fase 0 — Baseline & Contracts
-P0 gates PASS. Product Spec/Impact, baseline, Fact Registry, frontend contract y protocolo de continuidad establecidos.
+## Fases 0–4
 
-## Fase 1 — Identity Resolver
-`100_COMPLETE`. Resolver transversal de identidad/contact key; conflictos explícitos; no rewrite destructivo de `numero_limpio`.
+- F0 `100_COMPLETE`: baseline, contratos, Fact Registry y protocolo.
+- F1 `100_COMPLETE`: Identity Resolver y conflictos explícitos.
+- F2 `100_COMPLETE`: Commercial Facts 1:1 por contacto.
+- F3 `100_COMPLETE`: Value Tier / Lifecycle / Engagement / Traits.
+- F4 `100_COMPLETE`: Audience Resolver DSL, Count/Preview/Explain y UNKNOWN.
 
-## Fase 2 — Commercial Facts
-`100_COMPLETE`. Facts 1:1 por contacto para Leads, Calls, Agenda, Sales, Followups y Email con freshness/provenance.
+## Fases 5–8
 
-## Fase 3 — Segmentation Engine
-`100_COMPLETE`. Value Tier / Lifecycle / Engagement / Traits separados de legacy `etiqueta_vip`.
-
-## Fase 4 — Audience Resolver
-`100_COMPLETE`. DSL whitelisted, AND/OR, Validate/Count/Preview/Explain, MATCH/MISS/UNKNOWN y presets.
-
-## Fase 5 — Panel Central Skeleton
-`100_COMPLETE`. Panel ADMIN Bases & Audiencias, CIA admin session/gateway y frontend productivo.
-
-## Fase 6 — Audience Library Persistence
-`100_COMPLETE`. Biblioteca universal, versiones inmutables, optimistic concurrency, archive/restore/duplicate y audit.
-
-## Fase 7 — Snapshots & Activation
-`100_COMPLETE`. Snapshots SHA-256, BATCH `FROZEN_SNAPSHOT`, DYNAMIC `DYNAMIC_LIVE`, Activation lifecycle y event audit DB.
-
-## Fase 8 — Channel Context & Availability
-`100_COMPLETE`. Contrato determinístico:
-
-`Audience Total → Eligible → Available Now`
-
-UNKNOWN nunca es assignable.
-
-Input canónico para Fase 9:
-`aos_cia_activation_available_keys_v1(activation_id)`
-
-Functional PR #72 / CI #553 SUCCESS. Closure PR #73 / CI #558 SUCCESS.
+- F5 `100_COMPLETE`: Panel ADMIN Bases & Audiencias + CIA admin gateway.
+- F6 `100_COMPLETE`: Audience Library versionada/auditable.
+- F7 `100_COMPLETE`: Snapshots SHA-256 + Activation BATCH/DYNAMIC.
+- F8 `100_COMPLETE`: `Audience Total → Eligible → Available Now` y `available_keys`.
 
 ## Fase 9 — Assignment Engine
+
 `100_COMPLETE`.
 
-### Contrato
+Contrato:
 
 `available_keys F8 → Assignment Plan → Assignment Lease → F10 read-models`
 
-### Entrega
-- plans / targets / runs / leases / events;
+Entrega principal:
 - ownership por `aos_usuarios.id` UUID;
 - ONE / EQUAL / PERCENTAGE / FIXED;
-- ownership scopes GLOBAL / ACTIVATION;
-- lifecycle `RESERVED → ASSIGNED → IN_PROGRESS → COMPLETED | RELEASED | EXPIRED`;
-- lease/must-start deadlines;
-- reconcile de expiración;
-- capacity hard cap;
+- GLOBAL / ACTIVATION;
+- lease lifecycle;
+- capacity;
 - top-up NONE / MAINTAIN_TARGET / CONTINUOUS;
-- CONTINUOUS balance-aware acumulado;
-- advisory transaction lock;
-- idempotency;
-- one initial run;
-- global active-ownership conflict guard;
-- plan/target/lease state guards;
-- append-only audit;
-- CIA Phase 9 gateway;
-- panel `Distribución` dentro de Activaciones;
-- read-models preparados para Fase 10.
+- concurrency/idempotency;
+- audit append-only;
+- panel Distribución;
+- read-models para F10.
+
+Functional PR #75 / CI #576 SUCCESS. Closure PR #76 / CI #586 SUCCESS.
+
+Documento:
+`docs/control/commercial-intelligence/PHASE_09_VALIDATION_REPORT.md`
+
+## Fase 10 — Advisor Control Center
+
+`100_COMPLETE`.
+
+Contrato:
+
+`F9 ownership/read-models → F10 Advisor Control Center → F11 readiness preflight`
+
+Entrega:
+- overview global y por asesor UUID;
+- ASSIGNED / IN_PROGRESS / COMPLETED / RELEASED / EXPIRED;
+- capacity modes `NO_OPEN_PLANS / BOUNDED / UNBOUNDED / MIXED`;
+- utilization solo cuando existe capacidad global determinable;
+- advisor drill-down;
+- overdue-to-start;
+- expiring ≤60m;
+- plan health;
+- lista general `LAST_RUN_SNAPSHOT` para evitar N+1;
+- exact `GET_PLAN` live para detalle de plan;
+- readiness estructural F11;
+- gateway ADMIN F10 con controles limitados;
+- quinta pestaña `Control de asesores`.
 
 ### QA certificado
 
-DYNAMIC:
-- F8 available 103 = F9 candidates 103.
+Empty live:
+- 6 asesores activos;
+- 0 ownership;
+- 0 planes;
+- 0 alertas;
+- readiness `READY_NO_ACTIVE_OWNERSHIP`.
 
-BATCH:
-- snapshot 116;
-- F8 available 103;
-- F9 candidates 103;
-- equality exacta PASS.
+Populated rollback-only:
+- 4 active ownership;
+- 3 assigned;
+- 1 in progress;
+- 1 completed;
+- 1 released;
+- 1 expired;
+- 1 overdue;
+- 2 expiring;
+- capacity MIXED/UNBOUNDED/BOUNDED 50% correctamente diferenciada;
+- readiness `READY`;
+- 0 residuos.
 
-Strategies:
-- EQUAL 10/3 → 4/3/3;
-- PERCENTAGE 50/30/20 → 5/3/2;
-- FIXED 2/3/4 → 9 total;
-- ONE → lote completo a un target.
+Adversarial:
+- plan ACTIVE + Activation PAUSED → readiness `BLOCKED`;
+- violation `active_plan_activation_not_active=1`;
+- rollback 0 residuos.
 
-MAINTAIN_TARGET:
-- 3/3/3 → release 1 → top-up 1 → 3/3/3;
-- idempotent replay PASS.
+Performance con 1,000 ownership activos:
+- overview 4.83 ms;
+- advisor detail 50 10.76 ms;
+- plan health 14.22 ms;
+- F11 readiness 6.09 ms.
 
-CONTINUOUS:
-- QA detectó sesgo original;
-- se corrigió antes de certificar;
-- re-QA 52/50 → top-up al target deficitario → 52/51;
-- balanced=true.
-
-GLOBAL ownership:
-- conflicto simultáneo bloqueado;
-- release devuelve candidato al pool según policy.
-
-Lifecycle:
-- RESERVE/ASSIGN/START/COMPLETE = 1 cada uno;
-- stale ASSIGNED → EXPIRED;
-- terminal plan CLOSED no reabre.
-
-Performance:
-- source F8 1,169 sobre audiencia 1,277;
-- candidates ~617 ms;
-- allocation 1,000 leases ~1.77 s;
-- summary ~903 ms;
-- advisor workload ~4 ms.
+Scaling correction:
+- primera versión de plan health tenía N+1 sobre F8;
+- no se aumentó timeout;
+- se reemplazó por `LAST_RUN_SNAPSHOT` en lista + detalle live seleccionado.
 
 Security:
-- 5 objetos RLS / 0 policies;
-- anon/authenticated direct visibility = 0;
-- anon direct INSERT rechazado;
-- internal candidates/allocation no ejecutables desde browser;
-- gateway token inválido → UNAUTHORIZED.
+- read-models privados;
+- gateway CIA tokenizado;
+- F9 RLS intacto;
+- límites server-side;
+- 0 tablas nuevas de ownership.
 
 Compatibility:
-- `aos_siguiente_lead` hash intacto `76412bac81e20ec6cfdc4f8c0db89e8c`;
-- `aos_siguiente_lead_v2` hash intacto `cb69781d1457ed73de8f8d52f0f83a00`;
-- 349 llamadas en smoke;
-- Email legacy/FK intactos;
-- 0 Phase 9 data residual.
+- `aos_siguiente_lead` hash `76412bac81e20ec6cfdc4f8c0db89e8c` intacto;
+- `aos_siguiente_lead_v2` hash `cb69781d1457ed73de8f8d52f0f83a00` intacto;
+- Call Center 13/08 = 349 llamadas;
+- 0 cambios en routing/calls.js.
 
-Integración:
-- Functional PR #75 MERGED;
-- Ascenda CI #576 SUCCESS;
-- merge funcional staging `57445a0863350c1989d8398157308783bdaf3905`;
+Integración funcional:
+- PR #82 MERGED;
+- Ascenda CI #701 SUCCESS;
+- merge staging `2a74c3443bb600c1157b746349e1e85dac7f67fc`;
 - post-merge smoke PASS.
 
-Documento de evidencia:
-`docs/control/commercial-intelligence/PHASE_09_VALIDATION_REPORT.md`
+Documento:
+`docs/control/commercial-intelligence/PHASE_10_VALIDATION_REPORT.md`
 
 ---
 
 # SIGUIENTE FASE
 
-## FASE 10 — ADVISOR CONTROL CENTER = READY
+## FASE 11 — CALL CENTER INTEGRATION V3 = READY
 
 Objetivo:
-crear el centro administrativo de control por asesor sobre ownership ya producido por Fase 9.
+conectar Assignment F9/F10 con el runtime de Call Center de forma **paralela, reversible y por feature flag**, conservando V2 como fallback.
 
-### Entradas canónicas
+### Input contracts obligatorios
 
-Fase 10 debe consumir principalmente:
+- F8 availability: `aos_cia_activation_available_keys_v1(activation_id)`
+- F9 ownership/leases
+- F10 preflight: `aos_cia_advisor_control_f11_readiness_v1()`
 
-`aos_cia_assignment_advisor_workload_v1()`
+### F11 debe
 
-`aos_cia_assignment_plan_summary_v1(plan_id)`
+1. ejecutar readiness F10 antes de habilitar routing V3;
+2. crear ruta V3 paralela, nunca reemplazar V2 en big-bang;
+3. hacer rollout controlado por usuario/flag;
+4. preservar `aos_siguiente_lead_v2` como fallback;
+5. trabajar con ownership canónico `aos_usuarios.id`;
+6. respetar `America/Lima` para semántica de día;
+7. probar reserve/claim/consume/release/expiry contra Call Center real;
+8. demostrar rollback inmediato a V2;
+9. mantener hashes/baseline de routing previos antes de cambios.
 
-Complementarios:
-- `aos_cia_assignment_list_v1(...)`;
-- `aos_cia_assignment_events_v1(...)`.
+### F11 no debe
 
-### Fase 10 debe mostrar
-- carga activa por asesor;
-- ASSIGNED / IN_PROGRESS / COMPLETED / RELEASED / EXPIRED;
-- active plans;
-- overdue-to-start;
-- expiring leases;
-- candidate remaining;
-- source available now;
-- depletion por plan;
-- capacidad/utilización;
-- drill-down de ownership y deadlines.
+- redefinir eligibility de F8;
+- crear otro Assignment Engine;
+- entregar todavía Work Views F12;
+- hacer rollout global sin canary.
 
-### Reglas de entrada
-- no reconstruir ownership desde `aos_llamadas`, leads u otras tablas source;
-- no crear un segundo Assignment Engine;
-- no modificar `aos_siguiente_lead` todavía;
-- no entregar todavía work views al asesor (Fase 12);
-- no hacer routing Call Center V3 (Fase 11);
-- advisor identity = `aos_usuarios.id`;
-- Impact Report antes de DDL si Fase 10 requiere nuevos objetos persistentes.
+Output esperado:
 
-### Conexión futura
-
-Fase 10 debe dejar un read/control plane limpio para:
-
-**Fase 11 — Call Center Integration V3**
-
-sin acoplar todavía Assignment al runtime V2.
+routing V3 estable y observable, listo para F12 Advisor Work Views.
 
 ---
 
-# LOOP UNIVERSAL
+# LOOP UNIVERSAL V2
 
-`baseline → scope → Impact Report → branch → isolated implementation → DB guards → contracts → tests → real-data comparison → edge cases → security/roles → performance → responsive → PR/CI → staging → smoke/E2E → rollback → closure docs → aos_memory checkpoint`
+`recovery → baseline → input handshake → scope/Impact → branch → implementation → guards → QA rollback-only → security → performance → write-path safety → frontend → output handshake → PR/CI → staging smoke → Validation Report → aos_memory → Notion`
 
 No se habilita la siguiente fase hasta tener la fase actual en `100_COMPLETE`.
 
@@ -243,15 +224,15 @@ No se habilita la siguiente fase hasta tener la fase actual en `100_COMPLETE`.
 
 # CONTINUIDAD / RECOVERY
 
-En un nuevo chat, recuperar en este orden:
+En un nuevo chat/agente recuperar:
 
 1. `AGENTS.md`
 2. `docs/control/ASCENDA_CONTROL_MASTER.md`
-3. `docs/control/COMMERCIAL_INTELLIGENCE_AUDIENCE_OS_V3_MASTER.md`
-4. `docs/control/commercial-intelligence/ROADMAP_STATUS.md`
-5. `docs/control/commercial-intelligence/PHASE_09_VALIDATION_REPORT.md`
-6. `aos_memory` keys `cia_v3_*`, `cia_phase9_*`, `cia_phase10_status`
-7. verificar live `staging` + Supabase antes de cualquier cambio.
-
-Checkpoint funcional de entrada a Fase 10:
-`57445a0863350c1989d8398157308783bdaf3905`
+3. `docs/control/commercial-intelligence/CIA_AGENT_BOOTSTRAP_CURRENT.md`
+4. `docs/control/commercial-intelligence/CIA_EXECUTION_PLAYBOOK_V1.md`
+5. `docs/control/commercial-intelligence/CIA_MASTER_ALIGNMENT_CURRENT.md`
+6. este Roadmap
+7. `PHASE_10_VALIDATION_REPORT.md`
+8. `aos_memory` claves `cia_v3_*`, `cia_phase10_*`, `cia_phase11_status`
+9. Notion CIA Control Maestro / Fases / Hallazgos
+10. verificar `staging` + Supabase live antes de cualquier cambio.


### PR DESCRIPTION
Cierre documental Fase 10.

Actualiza únicamente documentación de control:
- PHASE_10_VALIDATION_REPORT.md → 100_COMPLETE;
- PHASE_10_ADVISOR_CONTROL_CENTER.md → gates P10-G01..G19 PASS;
- ROADMAP_STATUS.md → F0–F10 100_COMPLETE / F11 READY;
- CIA_AGENT_BOOTSTRAP_CURRENT.md → recovery y misión exacta F11.

Implementación funcional ya integrada por PR #82 / CI #701 / merge `2a74c3443bb600c1157b746349e1e85dac7f67fc`.

No contiene runtime ni migrations nuevas.