### PR TITLE
P0: fix secure_write JSONB match validation

### DIFF
--- a/.github/workflows/phase2-secure-write-p0.yml
+++ b/.github/workflows/phase2-secure-write-p0.yml
@@ -1,0 +1,110 @@
+name: Phase2 Secure Write JSONB P0
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
+      - 'ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql'
+      - '.github/workflows/phase2-secure-write-p0.yml'
+  push:
+    branches: ['fix/phase2-secure-write-jsonb-*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phase2-secure-write-p0-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zero-cost-p0:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 25
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:58322/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-secure-write-p0"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 58321/' supabase/config.toml
+          sed -i 's/port = 54322/port = 58322/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 58320/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          supabase db start
+
+      - name: Build production-shaped Phase 2 baseline
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/zero-cost-staging/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813164711_fix_otros_service_type.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813173000_sales_intelligence_v2_summary.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813174500_sales_intelligence_v2_summary_optimize.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814021609_fix_2fa_context_canary.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814024619_sales_intelligence_admin_activation.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/schema_hardening_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/fixture_pre_migration.sql
+          for f in \
+            20260814030000_phase2_auth_v3_additive.sql \
+            20260814034401_cartera_phase2_reconciliation.sql \
+            20260814050000_cartera_phase2_security_cleanup.sql \
+            20260814060000_phase2_production_hardening.sql \
+            20260814061000_phase2_secure_write_defaults_fix.sql \
+            20260814062000_phase2_auth_provider_boundary.sql \
+            20260814063000_phase2_identity_admin_hardening.sql \
+            20260814064000_phase2_owner_canary_access.sql \
+            20260814163000_p0_auth_audit_trigger_search_path_fix.sql \
+            20260814164500_restore_2fa_email_branding.sql \
+            20260814195300_fix_auth_v3_btrim.sql \
+            20260814201500_fix_secure_write_v2_jsonb_match_count.sql; do
+              psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+
+      - name: Secure write P0 contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.txt
+          grep -q 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' /tmp/secure-write-p0.txt
+
+      - name: Phase 2 regression contracts
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "create extension if not exists pgtap with schema extensions"
+          for t in 004_cartera_phase2.sql 005_phase2_hardening.sql 006_phase2_provider_boundary.sql 007_phase2_identity_admin.sql; do
+            psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "ci/phase2-cartera/tests/$t" | tee "/tmp/$t.txt"
+            ! grep -q 'not ok' "/tmp/$t.txt"
+            ! grep -q 'Looks like you planned' "/tmp/$t.txt"
+          done
+
+      - name: Database lint must be clean
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase db lint --local --schema public --level error | tee /tmp/db-lint.txt
+          ! grep -q 'jsonb_object_length' /tmp/db-lint.txt
+          ! grep -q 'pg_catalog.trim' /tmp/db-lint.txt
+
+      - name: Release digest
+        run: |
+          set -euo pipefail
+          sha256sum supabase/migrations/20260814195300_fix_auth_v3_btrim.sql supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.sha256
+          echo 'PHASE2_SECURE_WRITE_ZERO_COST_CERTIFIED=PASS'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/.github/workflows/phase2-secure-write-p0.yml
+++ b/.github/workflows/phase2-secure-write-p0.yml
@@ -7,6 +7,7 @@ on:
       - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/phase2-secure-write-p0.yml'
   push:
     branches: ['fix/phase2-secure-write-jsonb-*']
@@ -31,6 +32,9 @@ jobs:
         with:
           version: 2.101.0
 
+      - name: Clean stale ASCENDA Supabase resources
+        run: bash scripts/ci/cleanup-ascenda-supabase.sh
+
       - name: Configure isolated Supabase ports
         working-directory: ci/zero-cost-staging
         run: |
@@ -42,10 +46,7 @@ jobs:
 
       - name: Start isolated Supabase
         working-directory: ci/zero-cost-staging
-        run: |
-          set -euo pipefail
-          supabase stop --no-backup || true
-          supabase db start
+        run: supabase db start
 
       - name: Build production-shaped Phase 2 baseline
         run: |
@@ -116,7 +117,10 @@ jobs:
           sha256sum supabase/migrations/20260814195300_fix_auth_v3_btrim.sql supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.sha256
           echo 'PHASE2_SECURE_WRITE_ZERO_COST_CERTIFIED=PASS'
 
-      - name: Stop isolated Supabase
+      - name: Stop isolated Supabase and prove zero residue
         if: always()
-        working-directory: ci/zero-cost-staging
-        run: supabase stop --no-backup || true
+        run: |
+          cd ci/zero-cost-staging
+          supabase stop --no-backup || true
+          cd ../..
+          bash scripts/ci/cleanup-ascenda-supabase.sh

--- a/.github/workflows/phase2-secure-write-p0.yml
+++ b/.github/workflows/phase2-secure-write-p0.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
+      - 'supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql'
       - '.github/workflows/phase2-secure-write-p0.yml'
   push:
@@ -98,10 +99,21 @@ jobs:
           ! grep -q 'jsonb_object_length' /tmp/db-lint.txt
           ! grep -q 'pg_catalog.trim' /tmp/db-lint.txt
 
+      - name: Fail-closed recovery and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('authenticated','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('service_role','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "t"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "t"
+          echo 'PHASE2_SECURE_WRITE_RECOVERY=PASS'
+
       - name: Release digest
         run: |
           set -euo pipefail
-          sha256sum supabase/migrations/20260814195300_fix_auth_v3_btrim.sql supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.sha256
+          sha256sum supabase/migrations/20260814195300_fix_auth_v3_btrim.sql supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.sha256
           echo 'PHASE2_SECURE_WRITE_ZERO_COST_CERTIFIED=PASS'
 
       - name: Stop isolated Supabase

--- a/ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql
+++ b/ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql
@@ -1,0 +1,53 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+-- Synthetic authority only; fixture contains no production identity/PII.
+update public.aos_usuarios
+set paneles_acceso = case when paneles_acceso @> array['admin-config']::text[] then paneles_acceso else array_append(paneles_acceso,'admin-config') end
+where codigo_asesor='CAROWNER';
+
+insert into public.aos_app_sessions_v3(token_hash,user_id,assurance_level,expires_at)
+select encode(extensions.digest('secure-write-p0-token-0000000000000000001','sha256'),'hex'),id,'PASSWORD_2FA',now()+interval '1 hour'
+from public.aos_usuarios where codigo_asesor='CAROWNER'
+on conflict (token_hash) do update set revoked=false,expires_at=excluded.expires_at;
+
+do $$
+declare
+  j jsonb;
+  def text;
+begin
+  def:=pg_get_functiondef('public.aos_secure_write_v2(text,text,text,jsonb,jsonb)'::regprocedure);
+  if position('jsonb_object_length' in def)>0 then
+    raise exception 'P0-SW-01 invalid jsonb_object_length survived';
+  end if;
+  if position('jsonb_object_keys' in def)=0 then
+    raise exception 'P0-SW-02 expected jsonb_object_keys guard missing';
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'secure-write-p0-token-0000000000000000001',
+    'aos_catalogo_categorias','DELETE','{}'::jsonb,'{}'::jsonb
+  );
+  if j->>'error'<>'MATCH_REQUIRED' then
+    raise exception 'P0-SW-03 empty DELETE match must fail MATCH_REQUIRED, got %',j;
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'secure-write-p0-token-0000000000000000001',
+    'aos_tabla_no_permitida','DELETE',jsonb_build_object('id','x'),'{}'::jsonb
+  );
+  if j->>'error'<>'TABLE_NOT_ALLOWED' then
+    raise exception 'P0-SW-04 allowlist boundary changed: %',j;
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'invalid-token','aos_catalogo_categorias','DELETE',jsonb_build_object('id','x'),'{}'::jsonb
+  );
+  if j->>'error'<>'UNAUTHORIZED' then
+    raise exception 'P0-SW-05 invalid token boundary changed: %',j;
+  end if;
+end $$;
+
+select 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' as certificate;
+rollback;

--- a/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
+++ b/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
@@ -1,0 +1,38 @@
+# ASCENDA OS — Phase 2 `aos_secure_write_v2` JSONB P0 Impact Report
+
+**Fecha:** 2026-08-14  
+**Riesgo:** HIGH — gateway de escritura protegido / compatibilidad operativa  
+**Estado:** PREPRODUCTION ONLY
+
+## Objetivo
+Corregir un fallo de runtime detectado por Zero-Cost CI: `aos_secure_write_v2` usa `jsonb_object_length(jsonb)`, función inexistente en PostgreSQL, al validar `p_match` para `PATCH`/`DELETE`.
+
+## Código / datos
+- migration nueva: `supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`
+- función: `public.aos_secure_write_v2(text,text,text,jsonb,jsonb)`
+- no cambia tablas, datos productivos, allowlists, roles ni contrato de retorno.
+
+## Consumidores
+El gateway protege escrituras allowlisted sobre catálogo y planes de trabajo. La corrección mantiene exactamente el mismo comportamiento esperado: `PATCH`/`DELETE` sin match devuelven `MATCH_REQUIRED`; los matches no vacíos continúan por el flujo existente.
+
+## Seguridad
+- conserva `SECURITY DEFINER` + `search_path=''`;
+- conserva autoridad derivada de `aos_app_actor_v3`;
+- conserva allowlists de tablas/campos/match;
+- no amplía grants;
+- no usa PII/PHI ni secretos en CI.
+
+## Plan de prueba
+1. construir fixture sintético Phase 2/Auth V3;
+2. aplicar cadena exacta hasta `20260814195300_fix_auth_v3_btrim.sql`;
+3. demostrar que el hotfix elimina la referencia inválida;
+4. sesión sintética autorizada: `DELETE` con `p_match={}` debe devolver `MATCH_REQUIRED`, no `WRITE_REJECTED`;
+5. tabla fuera de allowlist debe seguir devolviendo `TABLE_NOT_ALLOWED`;
+6. `supabase db lint --level error` sin el finding de `aos_secure_write_v2`;
+7. ejecutar contratos Phase 2 relevantes.
+
+## Rollback / recovery
+La migration solo redefine la función. Recovery: restaurar la definición inmediatamente anterior si apareciera regresión, pero **no** restaurar `jsonb_object_length`; en emergencia se puede degradar temporalmente el gateway antes que reintroducir una función inválida.
+
+## Gate productivo
+No aplicar directamente en producción. Branch → Zero-Cost V2 → PR → integración → preflight read-only → autorización conforme a gobernanza HIGH.

--- a/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
+++ b/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
@@ -8,8 +8,9 @@
 Corregir un fallo de runtime detectado por Zero-Cost CI: `aos_secure_write_v2` usa `jsonb_object_length(jsonb)`, función inexistente en PostgreSQL, al validar `p_match` para `PATCH`/`DELETE`.
 
 ## Código / datos
-- migration nueva: `supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`
-- función: `public.aos_secure_write_v2(text,text,text,jsonb,jsonb)`
+- migration nueva: `supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`;
+- recovery: `supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`;
+- función: `public.aos_secure_write_v2(text,text,text,jsonb,jsonb)`;
 - no cambia tablas, datos productivos, allowlists, roles ni contrato de retorno.
 
 ## Consumidores
@@ -19,7 +20,7 @@ El gateway protege escrituras allowlisted sobre catálogo y planes de trabajo. L
 - conserva `SECURITY DEFINER` + `search_path=''`;
 - conserva autoridad derivada de `aos_app_actor_v3`;
 - conserva allowlists de tablas/campos/match;
-- no amplía grants;
+- no amplía grants en operación normal;
 - no usa PII/PHI ni secretos en CI.
 
 ## Plan de prueba
@@ -29,10 +30,12 @@ El gateway protege escrituras allowlisted sobre catálogo y planes de trabajo. L
 4. sesión sintética autorizada: `DELETE` con `p_match={}` debe devolver `MATCH_REQUIRED`, no `WRITE_REJECTED`;
 5. tabla fuera de allowlist debe seguir devolviendo `TABLE_NOT_ALLOWED`;
 6. `supabase db lint --level error` sin el finding de `aos_secure_write_v2`;
-7. ejecutar contratos Phase 2 relevantes.
+7. ejecutar contratos Phase 2 relevantes;
+8. ejecutar recovery fail-closed y demostrar que `anon/authenticated` pierden EXECUTE mientras `service_role` lo conserva;
+9. reaplicar la migration y verificar recuperación del contrato normal.
 
 ## Rollback / recovery
-La migration solo redefine la función. Recovery: restaurar la definición inmediatamente anterior si apareciera regresión, pero **no** restaurar `jsonb_object_length`; en emergencia se puede degradar temporalmente el gateway antes que reintroducir una función inválida.
+No se restaura la definición defectuosa. El recovery es **security-preserving / fail-closed**: revoca temporalmente `EXECUTE` a `anon` y `authenticated`, conserva `service_role` y permite recuperar el servicio reejecutando la migration validada. Se prioriza degradación temporal del gateway sobre reintroducir una función inválida.
 
 ## Gate productivo
 No aplicar directamente en producción. Branch → Zero-Cost V2 → PR → integración → preflight read-only → autorización conforme a gobernanza HIGH.

--- a/scripts/ci/cleanup-ascenda-supabase.sh
+++ b/scripts/ci/cleanup-ascenda-supabase.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t containers < <(docker ps -aq --filter 'name=supabase_' | while read -r id; do
+  [ -n "$id" ] || continue
+  name="$(docker inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')"
+  if [[ "$name" == supabase_*ascenda* ]]; then printf '%s\n' "$id"; fi
+done)
+if ((${#containers[@]})); then docker rm -f "${containers[@]}" >/dev/null; fi
+
+mapfile -t networks < <(docker network ls --format '{{.Name}}' | grep -E '^supabase_.*ascenda' || true)
+for n in "${networks[@]}"; do docker network rm "$n" >/dev/null 2>&1 || true; done
+
+mapfile -t volumes < <(docker volume ls --format '{{.Name}}' | grep -E '^supabase_.*ascenda' || true)
+for v in "${volumes[@]}"; do docker volume rm -f "$v" >/dev/null 2>&1 || true; done
+
+for port in 54322 55322 56322 57322 58322; do
+  if docker ps --format '{{.Ports}} {{.Names}}' | grep -E "0\.0\.0\.0:${port}->" | grep -q 'ascenda'; then
+    echo "ASCENDA_ZERO_RESIDUE=FAIL port=$port" >&2
+    exit 1
+  fi
+done
+
+echo "ASCENDA_ZERO_RESIDUE=PASS containers=${#containers[@]} networks=${#networks[@]} volumes=${#volumes[@]}"

--- a/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,0 +1,94 @@
+-- P0/HIGH: PostgreSQL has jsonb_object_keys(jsonb), not jsonb_object_length(jsonb).
+-- Preserve the existing secure-write contract while making PATCH/DELETE match
+-- validation executable and lint-clean.
+begin;
+
+create or replace function public.aos_secure_write_v2(
+  p_token text,
+  p_table text,
+  p_action text,
+  p_match jsonb default '{}'::jsonb,
+  p_data jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $function$
+declare
+  v_uid uuid; v_user record; v_family text;
+  v_action text:=pg_catalog.upper(pg_catalog.btrim(pg_catalog.coalesce(p_action,'')));
+  v_allowed_match text[]; v_key text;
+  v_where text:=''; v_set text:=''; v_cols text:=''; v_vals text:='';
+  v_rows jsonb:='[]'::jsonb; v_sql text;
+  v_all_keys integer; v_real_keys integer;
+begin
+  v_uid:=public.aos_app_actor_v3(p_token,null,false);
+  if v_uid is null then return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  select id,rol,nivel_jerarquia,paneles_acceso into v_user from public.aos_usuarios where id=v_uid and activo=true;
+
+  if p_table in ('aos_catalogo_categorias','aos_catalogo_servicios','aos_catalogo_toppings','aos_catalogo_productos_detalle') then
+    v_family:='CATALOG';
+    if pg_catalog.lower(pg_catalog.coalesce(v_user.rol,''))<>'admin' or not (pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-config']::text[]) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','CATALOG_ADMIN_REQUIRED');
+    end if;
+    v_allowed_match:=case when p_table='aos_catalogo_servicios' then array['id','categoria','tipo']::text[] else array['id']::text[] end;
+  elsif p_table in ('aos_planes_trabajo','aos_plan_trabajo_items') then
+    v_family:='PLAN';
+    if not (pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['advisor-attendance']::text[] or pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-agenda']::text[]) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','PLAN_ACCESS_REQUIRED');
+    end if;
+    v_allowed_match:=case when p_table='aos_planes_trabajo' then array['id','numero_limpio','fecha']::text[] else array['id','plan_id','numero_limpio','fecha']::text[] end;
+  else
+    return pg_catalog.jsonb_build_object('ok',false,'error','TABLE_NOT_ALLOWED');
+  end if;
+
+  if v_action not in ('INSERT','PATCH','DELETE') then return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_NOT_ALLOWED'); end if;
+  if v_action in ('PATCH','DELETE') and not exists (
+    select 1 from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_match,'{}'::jsonb))
+  ) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_REQUIRED'); end if;
+
+  for v_key in select pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_match,'{}'::jsonb)) loop
+    if not (v_key=any(v_allowed_match)) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_NOT_ALLOWED','field',v_key); end if;
+    if v_where<>'' then v_where:=v_where||' and '; end if;
+    v_where:=v_where||pg_catalog.format('%I::text=%L',v_key,p_match->>v_key);
+  end loop;
+
+  if v_action in ('INSERT','PATCH') then
+    select pg_catalog.count(*) into v_all_keys from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_data,'{}'::jsonb));
+    select pg_catalog.count(*) into v_real_keys from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_data,'{}'::jsonb)) k
+      join information_schema.columns c on c.table_schema='public' and c.table_name=p_table and c.column_name=k;
+    if v_all_keys=0 or v_all_keys<>v_real_keys then return pg_catalog.jsonb_build_object('ok',false,'error','FIELD_NOT_ALLOWED'); end if;
+  end if;
+
+  if v_action='INSERT' then
+    for v_key in select pg_catalog.jsonb_object_keys(p_data) loop
+      if v_cols<>'' then v_cols:=v_cols||',';v_vals:=v_vals||','; end if;
+      v_cols:=v_cols||pg_catalog.format('%I',v_key);
+      v_vals:=v_vals||pg_catalog.format('(jsonb_populate_record(null::public.%I,$1)).%I',p_table,v_key);
+    end loop;
+    v_sql:=pg_catalog.format('with ins as (insert into public.%I as t (%s) select %s returning t.*) select coalesce(jsonb_agg(to_jsonb(ins)),''[]''::jsonb) from ins',p_table,v_cols,v_vals);
+    execute v_sql using p_data into v_rows;
+  elsif v_action='PATCH' then
+    for v_key in select pg_catalog.jsonb_object_keys(p_data) loop
+      if v_set<>'' then v_set:=v_set||','; end if;
+      v_set:=v_set||pg_catalog.format('%I=(jsonb_populate_record(t,$1)).%I',v_key,v_key);
+    end loop;
+    v_sql:=pg_catalog.format('with upd as (update public.%I as t set %s where %s returning t.*) select coalesce(jsonb_agg(to_jsonb(upd)),''[]''::jsonb) from upd',p_table,v_set,v_where);
+    execute v_sql using p_data into v_rows;
+  else
+    v_sql:=pg_catalog.format('with del as (delete from public.%I as t where %s returning t.*) select coalesce(jsonb_agg(to_jsonb(del)),''[]''::jsonb) from del',p_table,v_where);
+    execute v_sql into v_rows;
+  end if;
+
+  insert into public.aos_security_log(usuario,accion,detalles)
+  select au.nombre,'SECURED_WRITE_V2',pg_catalog.jsonb_build_object('family',v_family,'table',p_table,'action',v_action,'rows',pg_catalog.jsonb_array_length(v_rows)) from public.aos_usuarios au where au.id=v_uid;
+  return pg_catalog.jsonb_build_object('ok',true,'rows',v_rows);
+exception when others then
+  return pg_catalog.jsonb_build_object('ok',false,'error','WRITE_REJECTED','detail',sqlstate);
+end
+$function$;
+
+revoke all on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) from public;
+grant execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) to anon,authenticated,service_role;
+
+commit;

--- a/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -16,7 +16,7 @@ set search_path=''
 as $function$
 declare
   v_uid uuid; v_user record; v_family text;
-  v_action text:=pg_catalog.upper(pg_catalog.btrim(pg_catalog.coalesce(p_action,'')));
+  v_action text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_action,'')));
   v_allowed_match text[]; v_key text;
   v_where text:=''; v_set text:=''; v_cols text:=''; v_vals text:='';
   v_rows jsonb:='[]'::jsonb; v_sql text;
@@ -28,13 +28,13 @@ begin
 
   if p_table in ('aos_catalogo_categorias','aos_catalogo_servicios','aos_catalogo_toppings','aos_catalogo_productos_detalle') then
     v_family:='CATALOG';
-    if pg_catalog.lower(pg_catalog.coalesce(v_user.rol,''))<>'admin' or not (pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-config']::text[]) then
+    if pg_catalog.lower(coalesce(v_user.rol,''))<>'admin' or not (coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-config']::text[]) then
       return pg_catalog.jsonb_build_object('ok',false,'error','CATALOG_ADMIN_REQUIRED');
     end if;
     v_allowed_match:=case when p_table='aos_catalogo_servicios' then array['id','categoria','tipo']::text[] else array['id']::text[] end;
   elsif p_table in ('aos_planes_trabajo','aos_plan_trabajo_items') then
     v_family:='PLAN';
-    if not (pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['advisor-attendance']::text[] or pg_catalog.coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-agenda']::text[]) then
+    if not (coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['advisor-attendance']::text[] or coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-agenda']::text[]) then
       return pg_catalog.jsonb_build_object('ok',false,'error','PLAN_ACCESS_REQUIRED');
     end if;
     v_allowed_match:=case when p_table='aos_planes_trabajo' then array['id','numero_limpio','fecha']::text[] else array['id','plan_id','numero_limpio','fecha']::text[] end;
@@ -44,18 +44,18 @@ begin
 
   if v_action not in ('INSERT','PATCH','DELETE') then return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_NOT_ALLOWED'); end if;
   if v_action in ('PATCH','DELETE') and not exists (
-    select 1 from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_match,'{}'::jsonb))
+    select 1 from pg_catalog.jsonb_object_keys(coalesce(p_match,'{}'::jsonb))
   ) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_REQUIRED'); end if;
 
-  for v_key in select pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_match,'{}'::jsonb)) loop
+  for v_key in select pg_catalog.jsonb_object_keys(coalesce(p_match,'{}'::jsonb)) loop
     if not (v_key=any(v_allowed_match)) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_NOT_ALLOWED','field',v_key); end if;
     if v_where<>'' then v_where:=v_where||' and '; end if;
     v_where:=v_where||pg_catalog.format('%I::text=%L',v_key,p_match->>v_key);
   end loop;
 
   if v_action in ('INSERT','PATCH') then
-    select pg_catalog.count(*) into v_all_keys from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_data,'{}'::jsonb));
-    select pg_catalog.count(*) into v_real_keys from pg_catalog.jsonb_object_keys(pg_catalog.coalesce(p_data,'{}'::jsonb)) k
+    select pg_catalog.count(*) into v_all_keys from pg_catalog.jsonb_object_keys(coalesce(p_data,'{}'::jsonb));
+    select pg_catalog.count(*) into v_real_keys from pg_catalog.jsonb_object_keys(coalesce(p_data,'{}'::jsonb)) k
       join information_schema.columns c on c.table_schema='public' and c.table_name=p_table and c.column_name=k;
     if v_all_keys=0 or v_all_keys<>v_real_keys then return pg_catalog.jsonb_build_object('ok',false,'error','FIELD_NOT_ALLOWED'); end if;
   end if;

--- a/supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,0 +1,8 @@
+-- Security-preserving recovery for 20260814201500.
+-- Do not restore the invalid jsonb_object_length implementation.
+begin;
+revoke execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) from anon,authenticated;
+grant execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) to service_role;
+comment on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) is
+  'RECOVERY_FAIL_CLOSED: browser execution disabled pending validated redeploy; service_role preserved.';
+commit;


### PR DESCRIPTION
SUPERSEDED / CLOSED. Este P0 fue reconstruido sobre la línea CURRENT y fusionado posteriormente mediante PR #111 (`P0 CURRENT: secure_write JSONB fix on stabilized main`). La migración, regresión Secure Write y gates endurecidos ya forman parte de la historia canónica de `main`. Mantener #105 abierto duplicaba una solución ya absorbida y podía inducir a ejecutar una rama antigua (113 commits detrás del `main` actual). No realizar despliegues desde este PR.