### PR TITLE
Infra: Zero-Cost V2 zero-residue Supabase cleanup

### DIFF
--- a/.github/workflows/cartera-phase2-final-release.yml
+++ b/.github/workflows/cartera-phase2-final-release.yml
@@ -16,6 +16,7 @@ on:
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
       - 'ci/phase2-cartera/**'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-final-release.yml'
   push:
     branches: ['agent/**','feature/**','fix/**','security/**','infra/**']
@@ -32,6 +33,7 @@ on:
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
       - 'ci/phase2-cartera/**'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-final-release.yml'
   workflow_dispatch:
 
@@ -53,6 +55,9 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: 2.101.0
+
+      - name: Clean stale ASCENDA Supabase resources
+        run: bash scripts/ci/cleanup-ascenda-supabase.sh
 
       - name: Configure isolated ports
         working-directory: ci/zero-cost-staging
@@ -172,7 +177,10 @@ jobs:
             supabase/migrations/20260814164500_restore_2fa_email_branding.sql \
             supabase/migrations/20260814195300_fix_auth_v3_btrim.sql
 
-      - name: Stop isolated Supabase
+      - name: Stop isolated Supabase and prove zero residue
         if: always()
-        working-directory: ci/zero-cost-staging
-        run: supabase stop --no-backup || true
+        run: |
+          cd ci/zero-cost-staging
+          supabase stop --no-backup || true
+          cd ../..
+          bash scripts/ci/cleanup-ascenda-supabase.sh

--- a/.github/workflows/cartera-phase2-hardening.yml
+++ b/.github/workflows/cartera-phase2-hardening.yml
@@ -18,6 +18,7 @@ on:
       - 'app/public/phase2-service-worker.js'
       - 'app/server-phase2.js'
       - 'app/railway.json'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-hardening.yml'
   push:
     branches: ['agent/**','feature/**','fix/**','security/**','infra/**']
@@ -36,6 +37,7 @@ on:
       - 'app/public/phase2-service-worker.js'
       - 'app/server-phase2.js'
       - 'app/railway.json'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-hardening.yml'
   workflow_dispatch:
 
@@ -58,6 +60,9 @@ jobs:
         with:
           version: 2.101.0
 
+      - name: Clean stale ASCENDA Supabase resources
+        run: bash scripts/ci/cleanup-ascenda-supabase.sh
+
       - name: Configure isolated Supabase ports
         working-directory: ci/zero-cost-staging
         run: |
@@ -69,10 +74,7 @@ jobs:
 
       - name: Start isolated Supabase
         working-directory: ci/zero-cost-staging
-        run: |
-          set -euo pipefail
-          supabase stop --no-backup || true
-          supabase db start
+        run: supabase db start
 
       - name: Build synthetic schema and prerequisites
         run: |
@@ -220,9 +222,11 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_admin_cambiar_password(uuid,text)','EXECUTE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_ventas','INSERT')")" = "f"
 
-      - name: Stop isolated Supabase
+      - name: Stop isolated Supabase and prove zero residue
         if: always()
         run: |
           if [ -f /tmp/phase2-proxy.pid ]; then kill $(cat /tmp/phase2-proxy.pid) 2>/dev/null || true; fi
           cd ci/zero-cost-staging
           supabase stop --no-backup || true
+          cd ../..
+          bash scripts/ci/cleanup-ascenda-supabase.sh

--- a/.github/workflows/cartera-phase2-hardening.yml
+++ b/.github/workflows/cartera-phase2-hardening.yml
@@ -148,7 +148,6 @@ jobs:
           from pathlib import Path
           audit=Path('supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql').read_text(encoding='utf-8')
           brand=Path('supabase/migrations/20260814164500_restore_2fa_email_branding.sql').read_text(encoding='utf-8')
-          btrim=Path('supabase/migrations/20260814195300_fix_auth_v3_btrim.sql').read_text(encoding='utf-8')
           assert "set search_path = ''" in audit
           assert 'public.aos_log_auditoria' in audit
           assert "AscendaOS <info@zivital.pe>" in brand
@@ -156,11 +155,14 @@ jobs:
           assert 'ascenda_branded_v1' in brand
           assert 'extensions.digest' in brand
           assert "set search_path=''" in brand
-          assert 'pg_catalog.btrim' in btrim and 'pg_catalog.trim' not in btrim
           print('PHASE2_AUTH_OUTAGE_REGRESSION_STATIC=PASS')
-          print('PHASE2_BRANDED_2FA_CONTRACT=PASS')
-          print('PHASE2_AUTH_BTRIM_P0=PASS')
+          print('PHASE2_BRANDED_2FA_SOURCE_CONTRACT=PASS')
           PY
+          AUTH_DEF="$(psql "$DB_URL" -X -qAt -c "select pg_get_functiondef('public.aos_login_v3(text,text)'::regprocedure)")"
+          grep -q 'pg_catalog.btrim' <<<"$AUTH_DEF"
+          ! grep -q 'pg_catalog.trim(' <<<"$AUTH_DEF"
+          grep -q 'ascenda_branded_v1' <<<"$AUTH_DEF"
+          echo 'PHASE2_AUTH_BTRIM_FINAL_DEFINITION=PASS'
 
       - name: UI and cutover contract
         run: |

--- a/app/server-phase2.js
+++ b/app/server-phase2.js
@@ -8,9 +8,12 @@ const https = require('https');
 const { spawn } = require('child_process');
 
 const EXTERNAL_PORT = parseInt(process.env.PORT || '4173', 10);
-const INTERNAL_PORT = EXTERNAL_PORT === 4187 ? 4188 : 4187;
+// Preserve production 4173→4187 and staging 4187→4188 exactly. Other explicit
+// ports are test/dev scopes and receive an adjacent isolated internal port so
+// sequential self-hosted CI cannot collide with a stale smoke process.
+const INTERNAL_PORT = EXTERNAL_PORT === 4173 ? 4187 : (EXTERNAL_PORT === 4187 ? 4188 : EXTERNAL_PORT + 1);
 const SB_URL = process.env.SUPABASE_URL || 'https://ituyqwstonmhnfshnaqz.supabase.co';
-const SB_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+const SB_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXNlIiwicmVmaWQiOiJpdHV5cXdzdG9ubWhuZnNobmFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
 
 const child = spawn(process.execPath, ['server.js'], {
   cwd: __dirname,

--- a/scripts/ci/cleanup-ascenda-supabase.sh
+++ b/scripts/ci/cleanup-ascenda-supabase.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dedicated ASCENDA runner hygiene. The repo-level runner executes one job at a
+# time, so no legitimate concurrent ASCENDA Supabase fixture should be running.
+# Remove only Supabase Docker resources whose names contain "ascenda".
+
+mapfile -t containers < <(docker ps -aq --filter 'name=supabase_' | while read -r id; do
+  [ -n "$id" ] || continue
+  name="$(docker inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')"
+  if [[ "$name" == supabase_*ascenda* ]]; then printf '%s\n' "$id"; fi
+done)
+
+if ((${#containers[@]})); then
+  docker rm -f "${containers[@]}" >/dev/null
+fi
+
+mapfile -t networks < <(docker network ls --format '{{.Name}}' | grep -E '^supabase_.*ascenda' || true)
+for n in "${networks[@]}"; do docker network rm "$n" >/dev/null 2>&1 || true; done
+
+mapfile -t volumes < <(docker volume ls --format '{{.Name}}' | grep -E '^supabase_.*ascenda' || true)
+for v in "${volumes[@]}"; do docker volume rm -f "$v" >/dev/null 2>&1 || true; done
+
+# Prove the common isolated DB ports used by ASCENDA are not held by a surviving
+# ASCENDA Supabase container. Do not kill arbitrary host processes.
+for port in 54322 55322 56322 57322 58322; do
+  if docker ps --format '{{.Ports}} {{.Names}}' | grep -E "0\.0\.0\.0:${port}->" | grep -q 'ascenda'; then
+    echo "ASCENDA_ZERO_RESIDUE=FAIL port=$port" >&2
+    exit 1
+  fi
+done
+
+echo "ASCENDA_ZERO_RESIDUE=PASS containers=${#containers[@]} networks=${#networks[@]} volumes=${#volumes[@]}"


### PR DESCRIPTION
## Objetivo
Cerrar dos fallos de higiene/testabilidad del self-hosted runner detectados después del merge de PR #97:
1. un contenedor Supabase ASCENDA stale podía retener un puerto y bloquear el siguiente job;
2. el proxy Phase2 fijaba el puerto interno en 4187 para smokes no productivos, permitiendo colisión con procesos residuales.

## Riesgo
MEDIUM — CI/infrastructure + override de puerto no productivo. **Los puertos normales no cambian:** producción mantiene `4173→4187`; staging mantiene `4187→4188`. Solo un `PORT` explícito diferente usa `PORT+1` internamente para aislamiento de smoke/dev.

## Cambios
- helper `scripts/ci/cleanup-ascenda-supabase.sh` limitado a recursos Docker/Supabase cuyos nombres contienen `ascenda`;
- cleanup antes de iniciar fixtures Phase2 Hardening/Final Release;
- cleanup `if: always()` al finalizar y prueba de zero-residue;
- validación Auth V3 sobre la definición SQL materializada, no sobre comentarios de migrations;
- aislamiento de puerto interno Phase2 para smokes no productivos;
- no fallback hosted ni infraestructura pagada.

## Evidencia que motivó el cambio
Final Release V2 falló al bindear `57322` porque sobrevivía `supabase_db_ascenda-k1-phase2`; todos los gates SQL previos eran válidos. Un run posterior de Hardening pasó migrations/lint/pgTAP y falló solo en runtime smoke. Este PR corrige higiene y aislamiento de prueba, sin reducir controles.

## Rollback
Revertir este PR restaura la limpieza/selección de puertos anterior. No hay DDL ni cambio de datos productivos.