### PR TITLE
P0 CURRENT: secure_write JSONB fix on stabilized main

### DIFF
--- a/.github/workflows/cartera-phase2-final-release.yml
+++ b/.github/workflows/cartera-phase2-final-release.yml
@@ -15,6 +15,7 @@ on:
       - 'supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql'
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'ci/phase2-cartera/**'
       - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-final-release.yml'
@@ -32,6 +33,7 @@ on:
       - 'supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql'
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'ci/phase2-cartera/**'
       - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-final-release.yml'
@@ -99,7 +101,8 @@ jobs:
             20260814064000_phase2_owner_canary_access.sql \
             20260814163000_p0_auth_audit_trigger_search_path_fix.sql \
             20260814164500_restore_2fa_email_branding.sql \
-            20260814195300_fix_auth_v3_btrim.sql; do
+            20260814195300_fix_auth_v3_btrim.sql \
+            20260814201500_fix_secure_write_v2_jsonb_match_count.sql; do
               psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
           done
 
@@ -108,15 +111,8 @@ jobs:
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
           create table if not exists public.aos_log_auditoria (
-            id bigserial primary key,
-            ts timestamptz,
-            tabla text,
-            accion text,
-            asesor text,
-            registro_id text,
-            datos_new jsonb,
-            datos_old jsonb,
-            metadata jsonb
+            id bigserial primary key, ts timestamptz, tabla text, accion text,
+            asesor text, registro_id text, datos_new jsonb, datos_old jsonb, metadata jsonb
           );
           alter table public.aos_log_auditoria add column if not exists ts timestamptz;
           alter table public.aos_log_auditoria add column if not exists tabla text;
@@ -127,14 +123,18 @@ jobs:
           alter table public.aos_log_auditoria add column if not exists datos_old jsonb;
           alter table public.aos_log_auditoria add column if not exists metadata jsonb;
           drop trigger if exists trg_brain_audit on public.aos_rrhh;
-          create trigger trg_brain_audit
-            after update on public.aos_rrhh
-            for each row execute function public.fn_audit_trigger();
+          create trigger trg_brain_audit after update on public.aos_rrhh for each row execute function public.fn_audit_trigger();
           set search_path='';
           update public.aos_rrhh set updated_at=pg_catalog.now() where codigo_asesor='CAROWNER';
           SQL
           test "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_log_auditoria where tabla='aos_rrhh' and accion='UPDATE'")" -ge "1"
           echo 'PHASE2_P0_AUDIT_TRIGGER_REGRESSION=PASS'
+
+      - name: Secure write P0 exact regression
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.txt
+          grep -q 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' /tmp/secure-write-p0.txt
 
       - name: Final release invariants
         run: |
@@ -151,8 +151,8 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select position('ascenda_branded_v1' in pg_get_functiondef('public.aos_login_v3(text,text)'::regprocedure))>0")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select position('pg_catalog.btrim' in pg_get_functiondef('public.aos_login_v3(text,text)'::regprocedure))>0")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select position('pg_catalog.trim' in pg_get_functiondef('public.aos_login_v3(text,text)'::regprocedure))=0")" = "t"
-          echo 'PHASE2_BRANDED_2FA_FINAL=PASS'
-          echo 'PHASE2_AUTH_BTRIM_P0=PASS'
+          test "$(psql "$DB_URL" -X -qAt -c "select position('jsonb_object_length' in pg_get_functiondef('public.aos_secure_write_v2(text,text,text,jsonb,jsonb)'::regprocedure))=0")" = "t"
+          echo 'PHASE2_FINAL_INVARIANTS=PASS'
 
       - name: Final database lint
         working-directory: ci/zero-cost-staging
@@ -160,6 +160,8 @@ jobs:
           set -euo pipefail
           supabase db lint --local --schema public --level error | tee /tmp/db-lint.txt
           ! grep -q 'pg_catalog.trim' /tmp/db-lint.txt
+          ! grep -q 'jsonb_object_length' /tmp/db-lint.txt
+          ! grep -q '"level": "error"' /tmp/db-lint.txt
 
       - name: Release digest
         run: |
@@ -175,7 +177,9 @@ jobs:
             supabase/migrations/20260814064000_phase2_owner_canary_access.sql \
             supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql \
             supabase/migrations/20260814164500_restore_2fa_email_branding.sql \
-            supabase/migrations/20260814195300_fix_auth_v3_btrim.sql
+            supabase/migrations/20260814195300_fix_auth_v3_btrim.sql \
+            supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+          echo 'PHASE2_FINAL_RELEASE_DIGEST=PASS'
 
       - name: Stop isolated Supabase and prove zero residue
         if: always()

--- a/.github/workflows/cartera-phase2-hardening.yml
+++ b/.github/workflows/cartera-phase2-hardening.yml
@@ -12,6 +12,7 @@ on:
       - 'supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql'
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'supabase/rollbacks/20260814062000_phase2_emergency_recovery.sql'
       - 'ci/phase2-cartera/**'
       - 'app/public/login.html'
@@ -31,6 +32,7 @@ on:
       - 'supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql'
       - 'supabase/migrations/20260814164500_restore_2fa_email_branding.sql'
       - 'supabase/migrations/20260814195300_fix_auth_v3_btrim.sql'
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
       - 'supabase/rollbacks/20260814062000_phase2_emergency_recovery.sql'
       - 'ci/phase2-cartera/**'
       - 'app/public/login.html'
@@ -89,26 +91,32 @@ jobs:
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/schema_hardening_contract.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/fixture_pre_migration.sql
 
-      - name: Compile exact Phase 2 hardened auth release chain
+      - name: Compile exact Phase 2 hardened release chain including P0
         run: |
           set -euo pipefail
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814030000_phase2_auth_v3_additive.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814034401_cartera_phase2_reconciliation.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814050000_cartera_phase2_security_cleanup.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814060000_phase2_production_hardening.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814061000_phase2_secure_write_defaults_fix.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814062000_phase2_auth_provider_boundary.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814063000_phase2_identity_admin_hardening.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814163000_p0_auth_audit_trigger_search_path_fix.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814164500_restore_2fa_email_branding.sql
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814195300_fix_auth_v3_btrim.sql
+          for f in \
+            20260814030000_phase2_auth_v3_additive.sql \
+            20260814034401_cartera_phase2_reconciliation.sql \
+            20260814050000_cartera_phase2_security_cleanup.sql \
+            20260814060000_phase2_production_hardening.sql \
+            20260814061000_phase2_secure_write_defaults_fix.sql \
+            20260814062000_phase2_auth_provider_boundary.sql \
+            20260814063000_phase2_identity_admin_hardening.sql \
+            20260814163000_p0_auth_audit_trigger_search_path_fix.sql \
+            20260814164500_restore_2fa_email_branding.sql \
+            20260814195300_fix_auth_v3_btrim.sql \
+            20260814201500_fix_secure_write_v2_jsonb_match_count.sql; do
+              psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
 
-      - name: Database lint
+      - name: Database lint must be clean
         working-directory: ci/zero-cost-staging
         run: |
           set -euo pipefail
           supabase db lint --local --schema public --level error | tee /tmp/db-lint.txt
+          ! grep -q 'jsonb_object_length' /tmp/db-lint.txt
           ! grep -q 'pg_catalog.trim' /tmp/db-lint.txt
+          ! grep -q '"level": "error"' /tmp/db-lint.txt
 
       - name: pgTAP Phase 2 base contract
         run: |
@@ -141,6 +149,12 @@ jobs:
           ! grep -q 'not ok' /tmp/identity.txt
           ! grep -q 'Looks like you planned' /tmp/identity.txt
 
+      - name: Secure write P0 regression
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.txt
+          grep -q 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' /tmp/secure-write-p0.txt
+
       - name: Auth outage and branded-email regression contract
         run: |
           set -euo pipefail
@@ -154,7 +168,6 @@ jobs:
           assert 'Código de Verificación' in brand
           assert 'ascenda_branded_v1' in brand
           assert 'extensions.digest' in brand
-          assert "set search_path=''" in brand
           print('PHASE2_AUTH_OUTAGE_REGRESSION_STATIC=PASS')
           print('PHASE2_BRANDED_2FA_SOURCE_CONTRACT=PASS')
           PY
@@ -173,7 +186,7 @@ jobs:
           login=Path('app/public/login.html').read_text(encoding='utf-8')
           sw=Path('app/public/phase2-service-worker.js').read_text(encoding='utf-8')
           hard=Path('supabase/migrations/20260814060000_phase2_production_hardening.sql').read_text(encoding='utf-8')
-          fix=Path('supabase/migrations/20260814061000_phase2_secure_write_defaults_fix.sql').read_text(encoding='utf-8')
+          fix=Path('supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql').read_text(encoding='utf-8')
           provider=Path('supabase/migrations/20260814062000_phase2_auth_provider_boundary.sql').read_text(encoding='utf-8')
           identity=Path('supabase/migrations/20260814063000_phase2_identity_admin_hardening.sql').read_text(encoding='utf-8')
           proxy=Path('app/server-phase2.js').read_text(encoding='utf-8')
@@ -184,34 +197,48 @@ jobs:
           assert "register('/phase2-service-worker.js'" in login
           assert 'aos_secure_write_v2' in sw and 'aos_caja_abrir_v2' in sw
           assert 'aos_admin_crear_usuario_v3' in sw and 'aos_admin_cambiar_password_v3' in sw
-          assert 'aos_planes_trabajo' in sw and 'aos_catalogo_servicios' in sw
-          assert 'revoke execute on function public.aos_login_v2' in hard.lower()
-          assert 'revoke insert,update,delete' in hard.lower()
-          assert 'v_cols' in fix and 'jsonb_populate_record' in fix
+          assert 'jsonb_object_keys' in fix and 'jsonb_object_length' not in fix
           assert 'anon_integ_read_non_auth_provider' in provider and 'resend' in provider.lower()
           assert 'revoke execute on function public.aos_login(text,text)' in identity.lower()
-          assert 'owner_admin_2fa_required' in identity.lower()
           assert '/api/send-2fa' in proxy and '/api/verify-turnstile' in proxy
+          assert 'PHASE2_INTERNAL_PORT' in proxy
           assert 'LEGACY_AUTH_ENDPOINT_RETIRED' in proxy
-          assert 'node server-phase2.js' in railway
-          assert 'node staging-server.js' in railway
+          assert 'node server-phase2.js' in railway and 'node staging-server.js' in railway
           assert 'legacy_bypass' in recovery and 'not_restored' in recovery
           PY
 
-      - name: Runtime auth retirement smoke
+      - name: Runtime auth retirement smoke on dynamically free ports
         run: |
           set -euo pipefail
-          PORT=4190 node app/server-phase2.js >/tmp/phase2-proxy.log 2>&1 &
+          read -r EXT_PORT INT_PORT < <(python3 - <<'PY'
+          import socket
+          ports=[]
+          for _ in range(2):
+              s=socket.socket(); s.bind(('127.0.0.1',0)); ports.append(s.getsockname()[1]); s.close()
+          while ports[0] == ports[1]:
+              s=socket.socket(); s.bind(('127.0.0.1',0)); ports[1]=s.getsockname()[1]; s.close()
+          print(*ports)
+          PY
+          )
+          PORT="$EXT_PORT" PHASE2_INTERNAL_PORT="$INT_PORT" node app/server-phase2.js >/tmp/phase2-proxy.log 2>&1 &
           echo $! >/tmp/phase2-proxy.pid
+          ok=0
           for i in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:4190/login >/tmp/login.html; then break; fi
+            if curl -fsS "http://127.0.0.1:${EXT_PORT}/login" >/tmp/login.html; then ok=1; break; fi
+            if ! kill -0 "$(cat /tmp/phase2-proxy.pid)" 2>/dev/null; then break; fi
             sleep 1
           done
+          if [ "$ok" != 1 ]; then
+            echo 'PHASE2_RUNTIME_SMOKE_STARTUP=FAIL' >&2
+            cat /tmp/phase2-proxy.log >&2 || true
+            exit 1
+          fi
           grep -q 'aos_login_v3' /tmp/login.html
-          test "$(curl -sS -o /tmp/legacy2fa.json -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:4190/api/send-2fa)" = "410"
+          test "$(curl -sS -o /tmp/legacy2fa.json -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' "http://127.0.0.1:${EXT_PORT}/api/send-2fa")" = "410"
           grep -q 'LEGACY_AUTH_ENDPOINT_RETIRED' /tmp/legacy2fa.json
-          test "$(curl -sS -o /tmp/turnstile.json -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:4190/api/verify-turnstile)" = "410"
-          kill $(cat /tmp/phase2-proxy.pid) || true
+          test "$(curl -sS -o /tmp/turnstile.json -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' "http://127.0.0.1:${EXT_PORT}/api/verify-turnstile")" = "410"
+          kill "$(cat /tmp/phase2-proxy.pid)" || true
+          echo 'PHASE2_RUNTIME_SMOKE=PASS'
 
       - name: Emergency recovery contract
         run: |
@@ -221,13 +248,12 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_caja_abrir_v2(text,text,numeric,numeric,numeric,date)','EXECUTE')")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_login_v3(text,text)','EXECUTE')")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_login_v2(text,text)','EXECUTE')")" = "f"
-          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_admin_cambiar_password(uuid,text)','EXECUTE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_ventas','INSERT')")" = "f"
 
       - name: Stop isolated Supabase and prove zero residue
         if: always()
         run: |
-          if [ -f /tmp/phase2-proxy.pid ]; then kill $(cat /tmp/phase2-proxy.pid) 2>/dev/null || true; fi
+          if [ -f /tmp/phase2-proxy.pid ]; then kill "$(cat /tmp/phase2-proxy.pid)" 2>/dev/null || true; fi
           cd ci/zero-cost-staging
           supabase stop --no-backup || true
           cd ../..

--- a/.github/workflows/phase2-secure-write-p0.yml
+++ b/.github/workflows/phase2-secure-write-p0.yml
@@ -1,0 +1,126 @@
+name: Phase2 Secure Write JSONB P0
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
+      - 'supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql'
+      - 'ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql'
+      - 'scripts/ci/cleanup-ascenda-supabase.sh'
+      - '.github/workflows/phase2-secure-write-p0.yml'
+  push:
+    branches: ['fix/phase2-secure-write-jsonb-*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phase2-secure-write-p0-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zero-cost-p0:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 25
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:58322/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Clean stale ASCENDA Supabase resources
+        run: bash scripts/ci/cleanup-ascenda-supabase.sh
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-secure-write-p0"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 58321/' supabase/config.toml
+          sed -i 's/port = 54322/port = 58322/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 58320/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: supabase db start
+
+      - name: Build production-shaped Phase 2 baseline
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/zero-cost-staging/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813164711_fix_otros_service_type.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813173000_sales_intelligence_v2_summary.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260813174500_sales_intelligence_v2_summary_optimize.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814021609_fix_2fa_context_canary.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814024619_sales_intelligence_admin_activation.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/schema_hardening_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/fixture_pre_migration.sql
+          for f in \
+            20260814030000_phase2_auth_v3_additive.sql \
+            20260814034401_cartera_phase2_reconciliation.sql \
+            20260814050000_cartera_phase2_security_cleanup.sql \
+            20260814060000_phase2_production_hardening.sql \
+            20260814061000_phase2_secure_write_defaults_fix.sql \
+            20260814062000_phase2_auth_provider_boundary.sql \
+            20260814063000_phase2_identity_admin_hardening.sql \
+            20260814064000_phase2_owner_canary_access.sql \
+            20260814163000_p0_auth_audit_trigger_search_path_fix.sql \
+            20260814164500_restore_2fa_email_branding.sql \
+            20260814195300_fix_auth_v3_btrim.sql \
+            20260814201500_fix_secure_write_v2_jsonb_match_count.sql; do
+              psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+
+      - name: Secure write P0 contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.txt
+          grep -q 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' /tmp/secure-write-p0.txt
+
+      - name: Phase 2 regression contracts
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "create extension if not exists pgtap with schema extensions"
+          for t in 004_cartera_phase2.sql 005_phase2_hardening.sql 006_phase2_provider_boundary.sql 007_phase2_identity_admin.sql; do
+            psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f "ci/phase2-cartera/tests/$t" | tee "/tmp/$t.txt"
+            ! grep -q 'not ok' "/tmp/$t.txt"
+            ! grep -q 'Looks like you planned' "/tmp/$t.txt"
+          done
+
+      - name: Database lint must be clean
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase db lint --local --schema public --level error | tee /tmp/db-lint.txt
+          ! grep -q 'jsonb_object_length' /tmp/db-lint.txt
+          ! grep -q 'pg_catalog.trim' /tmp/db-lint.txt
+
+      - name: Fail-closed recovery and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('authenticated','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('service_role','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "t"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_secure_write_v2(text,text,text,jsonb,jsonb)','EXECUTE')")" = "t"
+          echo 'PHASE2_SECURE_WRITE_RECOVERY=PASS'
+
+      - name: Release digest
+        run: |
+          set -euo pipefail
+          sha256sum supabase/migrations/20260814195300_fix_auth_v3_btrim.sql supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql | tee /tmp/secure-write-p0.sha256
+          echo 'PHASE2_SECURE_WRITE_ZERO_COST_CERTIFIED=PASS'
+
+      - name: Stop isolated Supabase and prove zero residue
+        if: always()
+        run: |
+          cd ci/zero-cost-staging
+          supabase stop --no-backup || true
+          cd ../..
+          bash scripts/ci/cleanup-ascenda-supabase.sh

--- a/app/server-phase2.js
+++ b/app/server-phase2.js
@@ -8,12 +8,20 @@ const https = require('https');
 const { spawn } = require('child_process');
 
 const EXTERNAL_PORT = parseInt(process.env.PORT || '4173', 10);
-// Preserve production 4173→4187 and staging 4187→4188 exactly. Other explicit
-// ports are test/dev scopes and receive an adjacent isolated internal port so
-// sequential self-hosted CI cannot collide with a stale smoke process.
-const INTERNAL_PORT = EXTERNAL_PORT === 4173 ? 4187 : (EXTERNAL_PORT === 4187 ? 4188 : EXTERNAL_PORT + 1);
+// Preserve production 4173→4187 and staging 4187→4188 exactly. CI/dev may
+// explicitly allocate a free internal port to eliminate self-hosted runner
+// collisions without changing production defaults.
+const defaultInternalPort = EXTERNAL_PORT === 4173 ? 4187 : (EXTERNAL_PORT === 4187 ? 4188 : EXTERNAL_PORT + 1);
+const INTERNAL_PORT = parseInt(process.env.PHASE2_INTERNAL_PORT || String(defaultInternalPort), 10);
 const SB_URL = process.env.SUPABASE_URL || 'https://ituyqwstonmhnfshnaqz.supabase.co';
-const SB_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXNlIiwicmVmaWQiOiJpdHV5cXdzdG9ubWhuZnNobmFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+const SB_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+
+if (!Number.isInteger(EXTERNAL_PORT) || EXTERNAL_PORT < 1 || EXTERNAL_PORT > 65535 ||
+    !Number.isInteger(INTERNAL_PORT) || INTERNAL_PORT < 1 || INTERNAL_PORT > 65535 ||
+    EXTERNAL_PORT === INTERNAL_PORT) {
+  console.error('[PHASE2-PROXY] invalid port configuration');
+  process.exit(1);
+}
 
 const child = spawn(process.execPath, ['server.js'], {
   cwd: __dirname,
@@ -126,8 +134,6 @@ const proxy = http.createServer((req, res) => {
   let pathname = '/';
   try { pathname = new URL(req.url, 'http://localhost').pathname; } catch (_) {}
 
-  // Same-origin Auth V3 transport. This removes browser/network dependency on
-  // direct Supabase RPC access while preserving the exact database auth contract.
   if (pathname === '/api/auth/v3/login') return authRpcProxy(req, res, 'aos_login_v3');
   if (pathname === '/api/auth/v3/verify') return authRpcProxy(req, res, 'aos_verificar_2fa_v3');
 
@@ -145,21 +151,13 @@ const proxy = http.createServer((req, res) => {
       'Content-Type': 'application/json; charset=utf-8',
       'Cache-Control': 'no-store'
     });
-    res.end(JSON.stringify({
-      ok: false,
-      error: 'LEGACY_AUTH_ENDPOINT_RETIRED',
-      auth_version: 'v3'
-    }));
+    res.end(JSON.stringify({ ok: false, error: 'LEGACY_AUTH_ENDPOINT_RETIRED', auth_version: 'v3' }));
     return;
   }
 
   const headers = Object.assign({}, req.headers, { host: '127.0.0.1:' + INTERNAL_PORT });
   const upstream = http.request({
-    hostname: '127.0.0.1',
-    port: INTERNAL_PORT,
-    path: req.url,
-    method: req.method,
-    headers
+    hostname: '127.0.0.1', port: INTERNAL_PORT, path: req.url, method: req.method, headers
   }, upstreamRes => {
     res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
     upstreamRes.pipe(res);
@@ -170,13 +168,10 @@ const proxy = http.createServer((req, res) => {
     res.end(JSON.stringify({ ok: false, error: 'UPSTREAM_UNAVAILABLE' }));
     console.error('[PHASE2-PROXY] upstream error', err.message);
   });
-
   req.pipe(upstream);
 });
 
-proxy.on('clientError', (err, socket) => {
-  socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
-});
+proxy.on('clientError', (err, socket) => socket.end('HTTP/1.1 400 Bad Request\r\n\r\n'));
 
 function shutdown(signal) {
   console.log('[PHASE2-PROXY] shutting down', signal);

--- a/ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql
+++ b/ci/phase2-cartera/tests/008_secure_write_jsonb_fix.sql
@@ -1,0 +1,53 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+-- Synthetic authority only; fixture contains no production identity/PII.
+update public.aos_usuarios
+set paneles_acceso = case when paneles_acceso @> array['admin-config']::text[] then paneles_acceso else array_append(paneles_acceso,'admin-config') end
+where codigo_asesor='CAROWNER';
+
+insert into public.aos_app_sessions_v3(token_hash,user_id,assurance_level,expires_at)
+select encode(extensions.digest('secure-write-p0-token-0000000000000000001','sha256'),'hex'),id,'PASSWORD_2FA',now()+interval '1 hour'
+from public.aos_usuarios where codigo_asesor='CAROWNER'
+on conflict (token_hash) do update set revoked=false,expires_at=excluded.expires_at;
+
+do $$
+declare
+  j jsonb;
+  def text;
+begin
+  def:=pg_get_functiondef('public.aos_secure_write_v2(text,text,text,jsonb,jsonb)'::regprocedure);
+  if position('jsonb_object_length' in def)>0 then
+    raise exception 'P0-SW-01 invalid jsonb_object_length survived';
+  end if;
+  if position('jsonb_object_keys' in def)=0 then
+    raise exception 'P0-SW-02 expected jsonb_object_keys guard missing';
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'secure-write-p0-token-0000000000000000001',
+    'aos_catalogo_categorias','DELETE','{}'::jsonb,'{}'::jsonb
+  );
+  if j->>'error'<>'MATCH_REQUIRED' then
+    raise exception 'P0-SW-03 empty DELETE match must fail MATCH_REQUIRED, got %',j;
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'secure-write-p0-token-0000000000000000001',
+    'aos_tabla_no_permitida','DELETE',jsonb_build_object('id','x'),'{}'::jsonb
+  );
+  if j->>'error'<>'TABLE_NOT_ALLOWED' then
+    raise exception 'P0-SW-04 allowlist boundary changed: %',j;
+  end if;
+
+  j:=public.aos_secure_write_v2(
+    'invalid-token','aos_catalogo_categorias','DELETE',jsonb_build_object('id','x'),'{}'::jsonb
+  );
+  if j->>'error'<>'UNAUTHORIZED' then
+    raise exception 'P0-SW-05 invalid token boundary changed: %',j;
+  end if;
+end $$;
+
+select 'PHASE2_SECURE_WRITE_JSONB_P0=PASS' as certificate;
+rollback;

--- a/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
+++ b/docs/control/PHASE2_SECURE_WRITE_JSONB_P0_IMPACT_20260814.md
@@ -1,0 +1,41 @@
+# ASCENDA OS — Phase 2 `aos_secure_write_v2` JSONB P0 Impact Report
+
+**Fecha:** 2026-08-14  
+**Riesgo:** HIGH — gateway de escritura protegido / compatibilidad operativa  
+**Estado:** PREPRODUCTION ONLY
+
+## Objetivo
+Corregir un fallo de runtime detectado por Zero-Cost CI: `aos_secure_write_v2` usa `jsonb_object_length(jsonb)`, función inexistente en PostgreSQL, al validar `p_match` para `PATCH`/`DELETE`.
+
+## Código / datos
+- migration nueva: `supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`;
+- recovery: `supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql`;
+- función: `public.aos_secure_write_v2(text,text,text,jsonb,jsonb)`;
+- no cambia tablas, datos productivos, allowlists, roles ni contrato de retorno.
+
+## Consumidores
+El gateway protege escrituras allowlisted sobre catálogo y planes de trabajo. La corrección mantiene exactamente el mismo comportamiento esperado: `PATCH`/`DELETE` sin match devuelven `MATCH_REQUIRED`; los matches no vacíos continúan por el flujo existente.
+
+## Seguridad
+- conserva `SECURITY DEFINER` + `search_path=''`;
+- conserva autoridad derivada de `aos_app_actor_v3`;
+- conserva allowlists de tablas/campos/match;
+- no amplía grants en operación normal;
+- no usa PII/PHI ni secretos en CI.
+
+## Plan de prueba
+1. construir fixture sintético Phase 2/Auth V3;
+2. aplicar cadena exacta hasta `20260814195300_fix_auth_v3_btrim.sql`;
+3. demostrar que el hotfix elimina la referencia inválida;
+4. sesión sintética autorizada: `DELETE` con `p_match={}` debe devolver `MATCH_REQUIRED`, no `WRITE_REJECTED`;
+5. tabla fuera de allowlist debe seguir devolviendo `TABLE_NOT_ALLOWED`;
+6. `supabase db lint --level error` sin el finding de `aos_secure_write_v2`;
+7. ejecutar contratos Phase 2 relevantes;
+8. ejecutar recovery fail-closed y demostrar que `anon/authenticated` pierden EXECUTE mientras `service_role` lo conserva;
+9. reaplicar la migration y verificar recuperación del contrato normal.
+
+## Rollback / recovery
+No se restaura la definición defectuosa. El recovery es **security-preserving / fail-closed**: revoca temporalmente `EXECUTE` a `anon` y `authenticated`, conserva `service_role` y permite recuperar el servicio reejecutando la migration validada. Se prioriza degradación temporal del gateway sobre reintroducir una función inválida.
+
+## Gate productivo
+No aplicar directamente en producción. Branch → Zero-Cost V2 → PR → integración → preflight read-only → autorización conforme a gobernanza HIGH.

--- a/scripts/ci/cleanup-ascenda-supabase.sh
+++ b/scripts/ci/cleanup-ascenda-supabase.sh
@@ -30,4 +30,20 @@ for port in 54322 55322 56322 57322 58322; do
   fi
 done
 
+# GitHub's self-hosted runner already ships a Node runtime under `externals` for
+# Actions. The service account does not expose it in the interactive shell PATH.
+# Reuse that bundled runtime for later CI smoke/static steps instead of installing
+# a second Node distribution or using paid hosted infrastructure.
+if [[ -n "${GITHUB_PATH:-}" && -n "${RUNNER_WORKSPACE:-}" ]]; then
+  runner_root="$(cd "$(dirname "$RUNNER_WORKSPACE")/.." && pwd)"
+  node_dir="${runner_root}/externals/node24/bin"
+  if [[ -x "${node_dir}/node" ]]; then
+    printf '%s\n' "$node_dir" >> "$GITHUB_PATH"
+    echo "ASCENDA_RUNNER_NODE=PASS runtime=node24"
+  else
+    echo "ASCENDA_RUNNER_NODE=FAIL bundled node24 not found" >&2
+    exit 1
+  fi
+fi
+
 echo "ASCENDA_ZERO_RESIDUE=PASS containers=${#containers[@]} networks=${#networks[@]} volumes=${#volumes[@]}"

--- a/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,4 +1,5 @@
--- P0/HIGH: PostgreSQL has jsonb_object_keys(jsonb), not jsonb_object_length(jsonb).
+-- P0/HIGH: PostgreSQL validates JSONB object presence via jsonb_object_keys(jsonb);
+-- the legacy object-length helper was not a valid PostgreSQL function.
 -- Preserve the existing secure-write contract while making PATCH/DELETE match
 -- validation executable and lint-clean.
 begin;

--- a/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,0 +1,94 @@
+-- P0/HIGH: PostgreSQL has jsonb_object_keys(jsonb), not jsonb_object_length(jsonb).
+-- Preserve the existing secure-write contract while making PATCH/DELETE match
+-- validation executable and lint-clean.
+begin;
+
+create or replace function public.aos_secure_write_v2(
+  p_token text,
+  p_table text,
+  p_action text,
+  p_match jsonb default '{}'::jsonb,
+  p_data jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $function$
+declare
+  v_uid uuid; v_user record; v_family text;
+  v_action text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_action,'')));
+  v_allowed_match text[]; v_key text;
+  v_where text:=''; v_set text:=''; v_cols text:=''; v_vals text:='';
+  v_rows jsonb:='[]'::jsonb; v_sql text;
+  v_all_keys integer; v_real_keys integer;
+begin
+  v_uid:=public.aos_app_actor_v3(p_token,null,false);
+  if v_uid is null then return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  select id,rol,nivel_jerarquia,paneles_acceso into v_user from public.aos_usuarios where id=v_uid and activo=true;
+
+  if p_table in ('aos_catalogo_categorias','aos_catalogo_servicios','aos_catalogo_toppings','aos_catalogo_productos_detalle') then
+    v_family:='CATALOG';
+    if pg_catalog.lower(coalesce(v_user.rol,''))<>'admin' or not (coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-config']::text[]) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','CATALOG_ADMIN_REQUIRED');
+    end if;
+    v_allowed_match:=case when p_table='aos_catalogo_servicios' then array['id','categoria','tipo']::text[] else array['id']::text[] end;
+  elsif p_table in ('aos_planes_trabajo','aos_plan_trabajo_items') then
+    v_family:='PLAN';
+    if not (coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['advisor-attendance']::text[] or coalesce(v_user.paneles_acceso,'{}'::text[]) @> array['admin-agenda']::text[]) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','PLAN_ACCESS_REQUIRED');
+    end if;
+    v_allowed_match:=case when p_table='aos_planes_trabajo' then array['id','numero_limpio','fecha']::text[] else array['id','plan_id','numero_limpio','fecha']::text[] end;
+  else
+    return pg_catalog.jsonb_build_object('ok',false,'error','TABLE_NOT_ALLOWED');
+  end if;
+
+  if v_action not in ('INSERT','PATCH','DELETE') then return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_NOT_ALLOWED'); end if;
+  if v_action in ('PATCH','DELETE') and not exists (
+    select 1 from pg_catalog.jsonb_object_keys(coalesce(p_match,'{}'::jsonb))
+  ) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_REQUIRED'); end if;
+
+  for v_key in select pg_catalog.jsonb_object_keys(coalesce(p_match,'{}'::jsonb)) loop
+    if not (v_key=any(v_allowed_match)) then return pg_catalog.jsonb_build_object('ok',false,'error','MATCH_NOT_ALLOWED','field',v_key); end if;
+    if v_where<>'' then v_where:=v_where||' and '; end if;
+    v_where:=v_where||pg_catalog.format('%I::text=%L',v_key,p_match->>v_key);
+  end loop;
+
+  if v_action in ('INSERT','PATCH') then
+    select pg_catalog.count(*) into v_all_keys from pg_catalog.jsonb_object_keys(coalesce(p_data,'{}'::jsonb));
+    select pg_catalog.count(*) into v_real_keys from pg_catalog.jsonb_object_keys(coalesce(p_data,'{}'::jsonb)) k
+      join information_schema.columns c on c.table_schema='public' and c.table_name=p_table and c.column_name=k;
+    if v_all_keys=0 or v_all_keys<>v_real_keys then return pg_catalog.jsonb_build_object('ok',false,'error','FIELD_NOT_ALLOWED'); end if;
+  end if;
+
+  if v_action='INSERT' then
+    for v_key in select pg_catalog.jsonb_object_keys(p_data) loop
+      if v_cols<>'' then v_cols:=v_cols||',';v_vals:=v_vals||','; end if;
+      v_cols:=v_cols||pg_catalog.format('%I',v_key);
+      v_vals:=v_vals||pg_catalog.format('(jsonb_populate_record(null::public.%I,$1)).%I',p_table,v_key);
+    end loop;
+    v_sql:=pg_catalog.format('with ins as (insert into public.%I as t (%s) select %s returning t.*) select coalesce(jsonb_agg(to_jsonb(ins)),''[]''::jsonb) from ins',p_table,v_cols,v_vals);
+    execute v_sql using p_data into v_rows;
+  elsif v_action='PATCH' then
+    for v_key in select pg_catalog.jsonb_object_keys(p_data) loop
+      if v_set<>'' then v_set:=v_set||','; end if;
+      v_set:=v_set||pg_catalog.format('%I=(jsonb_populate_record(t,$1)).%I',v_key,v_key);
+    end loop;
+    v_sql:=pg_catalog.format('with upd as (update public.%I as t set %s where %s returning t.*) select coalesce(jsonb_agg(to_jsonb(upd)),''[]''::jsonb) from upd',p_table,v_set,v_where);
+    execute v_sql using p_data into v_rows;
+  else
+    v_sql:=pg_catalog.format('with del as (delete from public.%I as t where %s returning t.*) select coalesce(jsonb_agg(to_jsonb(del)),''[]''::jsonb) from del',p_table,v_where);
+    execute v_sql into v_rows;
+  end if;
+
+  insert into public.aos_security_log(usuario,accion,detalles)
+  select au.nombre,'SECURED_WRITE_V2',pg_catalog.jsonb_build_object('family',v_family,'table',p_table,'action',v_action,'rows',pg_catalog.jsonb_array_length(v_rows)) from public.aos_usuarios au where au.id=v_uid;
+  return pg_catalog.jsonb_build_object('ok',true,'rows',v_rows);
+exception when others then
+  return pg_catalog.jsonb_build_object('ok',false,'error','WRITE_REJECTED','detail',sqlstate);
+end
+$function$;
+
+revoke all on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) from public;
+grant execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) to anon,authenticated,service_role;
+
+commit;

--- a/supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/rollbacks/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,0 +1,8 @@
+-- Security-preserving recovery for 20260814201500.
+-- Do not restore the invalid jsonb_object_length implementation.
+begin;
+revoke execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) from anon,authenticated;
+grant execute on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) to service_role;
+comment on function public.aos_secure_write_v2(text,text,text,jsonb,jsonb) is
+  'RECOVERY_FAIL_CLOSED: browser execution disabled pending validated redeploy; service_role preserved.';
+commit;


### PR DESCRIPTION
## Objetivo
Reaplicar sobre CURRENT `main` el P0 ya certificado de `aos_secure_write_v2`, evitando el conflicto add/add del helper de cleanup de PR #105.

## Base
Incluye `main` con PR #107 zero-residue ya integrado. Conserva el helper de cleanup más nuevo y añade únicamente los cinco artefactos P0 válidos: migration, recovery fail-closed, regresión, workflow dedicado e Impact Report.

## Riesgo
HIGH — gateway de escritura protegido. Sin cambio de datos, allowlists, roles ni contrato de retorno.

## Evidencia previa
El candidato original #105 pasó el gate dedicado `Phase2 Secure Write JSONB P0` y el Final Release exacto. Este PR exige repetir el certificado en el SHA CURRENT antes de merge.

## Producción
No aplica DDL productivo por sí mismo. Merge solo tras CI exact-SHA verde; aplicación productiva queda sujeta al gate K1/producción autorizado.