### PR TITLE
CI: fix Zero-Cost policy runs-on false positives

### DIFF
--- a/scripts/ci/enforce-zero-cost-policy.py
+++ b/scripts/ci/enforce-zero-cost-policy.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WF = ROOT / '.github' / 'workflows'
 errors = []
 
-hosted_patterns = (
+HOSTED_PATTERNS = (
     'ubuntu-latest',
     'windows-latest',
     'macos-latest',
@@ -15,6 +15,54 @@ hosted_patterns = (
     'macos-14',
     'macos-15',
 )
+REQUIRED_LABELS = (
+    'self-hosted',
+    'linux',
+    'x64',
+    'ascenda-zero-cost-v2',
+)
+
+
+def runs_on_values(text: str) -> list[str]:
+    """Return only YAML runs-on declarations, including simple block-list forms.
+
+    Do not scan arbitrary workflow text for hosted-runner names: workflows may
+    legitimately mention forbidden runner tokens inside policy assertions or
+    documentation. The policy must judge scheduler declarations, not prose.
+    """
+    lines = text.splitlines()
+    values: list[str] = []
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        match = re.match(r'^(\s*)runs-on\s*:\s*(.*)$', raw, re.I)
+        if not match:
+            i += 1
+            continue
+
+        indent = len(match.group(1).replace('\t', '    '))
+        tail = match.group(2).strip()
+        if tail:
+            values.append(tail)
+            i += 1
+            continue
+
+        block: list[str] = []
+        i += 1
+        while i < len(lines):
+            child = lines[i]
+            stripped = child.strip()
+            if not stripped or stripped.startswith('#'):
+                i += 1
+                continue
+            child_indent = len(child) - len(child.lstrip(' \t'))
+            if child_indent <= indent:
+                break
+            block.append(stripped)
+            i += 1
+        values.append(' '.join(block))
+    return values
+
 
 workflow_files = sorted(list(WF.glob('*.yml')) + list(WF.glob('*.yaml')))
 if not workflow_files:
@@ -22,17 +70,22 @@ if not workflow_files:
 
 for path in workflow_files:
     text = path.read_text(encoding='utf-8')
-    lower = text.lower()
-    for token in hosted_patterns:
-        if token in lower:
-            errors.append(f'{path.relative_to(ROOT)} uses prohibited GitHub-hosted runner: {token}')
-
-    runs = [line.strip() for line in text.splitlines() if line.lstrip().startswith('runs-on:')]
+    runs = runs_on_values(text)
     if not runs:
         errors.append(f'{path.relative_to(ROOT)} has no runs-on declaration')
-    for line in runs:
-        if 'self-hosted' not in line or 'ascenda-zero-cost-v2' not in line:
-            errors.append(f'{path.relative_to(ROOT)} has non-canonical runs-on: {line}')
+        continue
+
+    for declaration in runs:
+        lower = declaration.lower()
+        for token in HOSTED_PATTERNS:
+            if token in lower:
+                errors.append(f'{path.relative_to(ROOT)} uses prohibited GitHub-hosted runner: {token}')
+        missing = [label for label in REQUIRED_LABELS if label not in lower]
+        if missing:
+            errors.append(
+                f'{path.relative_to(ROOT)} has non-canonical runs-on: {declaration} '
+                f'(missing {",".join(missing)})'
+            )
 
 sync = WF / 'sync-supabase.yml'
 if sync.exists():


### PR DESCRIPTION
## Scope
Repo-global Zero-Cost CI policy parser only. No runtime, database, product, Auth, provider, or production data changes.

## Finding
`enforce-zero-cost-policy.py` scanned arbitrary workflow text for `ubuntu-latest` / `windows-latest`. The CURRENT `phase3-products.yml` correctly runs on `[self-hosted, Linux, X64, ascenda-zero-cost-v2]` but contains those tokens inside its own negative grep assertion, causing a false policy failure and blocking unrelated certified releases such as CIA F16.

## Fix
Parse only actual YAML `runs-on` declarations (inline or simple block-list form), reject hosted runner tokens there, and require canonical labels: `self-hosted`, `Linux`, `X64`, `ascenda-zero-cost-v2`.

## Safety
- Zero-Cost policy becomes stricter on actual scheduler declarations.
- No hosted fallback introduced.
- No production mutation.
- Rollback: revert this PR.

## Gate
Merge only after self-hosted `Ascenda CI` is green on exact head SHA.