### PR TITLE
F16 release sync: bring CURRENT main into v5

### DIFF
--- a/.github/workflows/cartera-phase2-hardening.yml
+++ b/.github/workflows/cartera-phase2-hardening.yml
@@ -18,6 +18,7 @@ on:
       - 'app/public/login.html'
       - 'app/public/phase2-service-worker.js'
       - 'app/server-phase2.js'
+      - 'app/server-f4.js'
       - 'app/railway.json'
       - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-hardening.yml'
@@ -38,6 +39,7 @@ on:
       - 'app/public/login.html'
       - 'app/public/phase2-service-worker.js'
       - 'app/server-phase2.js'
+      - 'app/server-f4.js'
       - 'app/railway.json'
       - 'scripts/ci/cleanup-ascenda-supabase.sh'
       - '.github/workflows/cartera-phase2-hardening.yml'
@@ -190,6 +192,7 @@ jobs:
           provider=Path('supabase/migrations/20260814062000_phase2_auth_provider_boundary.sql').read_text(encoding='utf-8')
           identity=Path('supabase/migrations/20260814063000_phase2_identity_admin_hardening.sql').read_text(encoding='utf-8')
           proxy=Path('app/server-phase2.js').read_text(encoding='utf-8')
+          f4_proxy=Path('app/server-f4.js').read_text(encoding='utf-8') if Path('app/server-f4.js').exists() else ''
           railway=Path('app/railway.json').read_text(encoding='utf-8')
           recovery=Path('supabase/rollbacks/20260814062000_phase2_emergency_recovery.sql').read_text(encoding='utf-8')
           assert 'aos_login_v3' in login and 'aos_verificar_2fa_v3' in login
@@ -203,7 +206,11 @@ jobs:
           assert '/api/send-2fa' in proxy and '/api/verify-turnstile' in proxy
           assert 'PHASE2_INTERNAL_PORT' in proxy
           assert 'LEGACY_AUTH_ENDPOINT_RETIRED' in proxy
-          assert 'node server-phase2.js' in railway and 'node staging-server.js' in railway
+          production_runtime=railway.split('"environments"')[0]
+          assert 'node staging-server.js' in railway
+          if 'node server-phase2.js' not in production_runtime:
+              assert 'node server-f4.js' in production_runtime
+              assert "spawn(process.execPath,['server-phase2.js']" in f4_proxy
           assert 'legacy_bypass' in recovery and 'not_restored' in recovery
           PY
 

--- a/.github/workflows/phase4-revenue-operations.yml
+++ b/.github/workflows/phase4-revenue-operations.yml
@@ -1,0 +1,176 @@
+name: ASCENDA Phase 4 Revenue Operations
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*f4_revenue*'
+      - 'supabase/migrations/*f4_cartera*'
+      - 'supabase/rollbacks/*f4_revenue*'
+      - 'ci/phase4-revenue/**'
+      - 'app/public/f4-revenue-ops.js'
+      - 'app/public/f4-kronia-revenue-bridge.js'
+      - 'app/public/phase2-service-worker.js'
+      - 'app/server-phase2.js'
+      - 'app/server-f4.js'
+      - 'app/railway.json'
+      - '.github/workflows/phase4-revenue-operations.yml'
+      - '.github/workflows/ascenda-ci.yml'
+      - 'scripts/ci/enforce-zero-cost-policy.py'
+  push:
+    branches: ['feature/**','fix/**','security/**','infra/**']
+    paths:
+      - 'supabase/migrations/*f4_revenue*'
+      - 'supabase/migrations/*f4_cartera*'
+      - 'supabase/rollbacks/*f4_revenue*'
+      - 'ci/phase4-revenue/**'
+      - 'app/public/f4-revenue-ops.js'
+      - 'app/public/f4-kronia-revenue-bridge.js'
+      - 'app/public/phase2-service-worker.js'
+      - 'app/server-phase2.js'
+      - 'app/server-f4.js'
+      - 'app/railway.json'
+      - '.github/workflows/phase4-revenue-operations.yml'
+      - '.github/workflows/ascenda-ci.yml'
+      - 'scripts/ci/enforce-zero-cost-policy.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phase4-revenue-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fast-contracts:
+    name: FAST runtime/UI contracts
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enforce self-hosted FAST lane
+        shell: powershell
+        run: |
+          if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'FAST lane must be self-hosted' }
+          Write-Host "Runner: $env:RUNNER_NAME"
+
+      - name: Runtime syntax contracts
+        shell: powershell
+        run: |
+          node --check app/public/f4-revenue-ops.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check app/public/f4-kronia-revenue-bridge.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check app/public/phase2-service-worker.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check app/server-phase2.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check app/server-f4.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  revenue-operations-contract:
+    name: DB/security contracts
+    needs: fast-contracts
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59322/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost DB runner policy
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: F4 UI/consumer contract
+        run: |
+          set -euo pipefail
+          python3 ci/phase4-revenue/ui_contract.py
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-phase4-revenue"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59321/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59322/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59320/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-phase4-revenue' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59322 -U postgres >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo 'F4 isolated Postgres did not become ready on 59322' >&2
+          docker ps -a --filter 'name=ascenda-phase4-revenue' || true
+          exit 1
+
+      - name: Build synthetic prerequisite schema
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase4-revenue/schema_contract.sql
+
+      - name: Apply exact additive F4 migrations
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814223000_f4_revenue_operations_core_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814223100_f4_cartera_candidates_v2.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: pgTAP F4 contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "create extension if not exists pgtap with schema extensions"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase4-revenue/tests/001_revenue_operations.sql | tee /tmp/f4-pgtap.txt
+          grep -q '1..38' /tmp/f4-pgtap.txt
+          if grep -q 'Looks like you planned' /tmp/f4-pgtap.txt; then exit 1; fi
+          if grep -q 'not ok' /tmp/f4-pgtap.txt; then exit 1; fi
+
+      - name: Apply cutover contract and verify legacy writes close
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260814223900_f4_revenue_operations_cutover.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_editar_venta(bigint,jsonb,text,text,text)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_importar_ventas(jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_grabar_venta_caja(text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_cartera_reconcile(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text)','EXECUTE')")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_importar_ventas_v4(text,jsonb)','EXECUTE')")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_cartera_reconcile_v2(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text,text)','EXECUTE')")" = "t"
+
+      - name: Recovery stays fail-closed
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260814223900_f4_revenue_operations_recovery.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_importar_ventas_v4(text,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_cartera_reconcile_v2(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text,text)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_sales_admin_gateway_v4(text,integer,integer,text,text,text)','EXECUTE')")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_importar_ventas_preview_v4(text,jsonb)','EXECUTE')")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_editar_venta(bigint,jsonb,text,text,text)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_importar_ventas(jsonb)','EXECUTE')")" = "f"
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/app/public/f4-kronia-revenue-bridge.js
+++ b/app/public/f4-kronia-revenue-bridge.js
@@ -1,0 +1,18 @@
+// ASCENDA OS — F4 KronIA revenue proof bridge.
+(function(){
+'use strict';
+if(window.__AOS_F4_KRONIA_REVENUE__)return;window.__AOS_F4_KRONIA_REVENUE__=true;
+var previousFetch=window.fetch.bind(window);
+function token(){try{return sessionStorage.getItem('aos_app_token')||''}catch(e){return ''}}
+function urlOf(input){return typeof input==='string'?input:(input&&input.url)||''}
+window.fetch=function(input,init){
+  var url=urlOf(input),method=String((init&&init.method)||((input&&input.method)||'GET')).toUpperCase();
+  try{
+    var u=new URL(url,location.href);
+    if(u.origin===location.origin&&u.pathname==='/api/kronia/chat'&&method==='POST'){
+      var next=Object.assign({},init||{});var h=new Headers((init&&init.headers)||((input&&input.headers)||{}));var t=token();if(t)h.set('X-AOS-App-Token',t);next.headers=h;return previousFetch(input,next);
+    }
+  }catch(e){}
+  return previousFetch(input,init);
+};
+})();

--- a/app/public/f4-revenue-ops.js
+++ b/app/public/f4-revenue-ops.js
@@ -1,0 +1,246 @@
+// ASCENDA OS — F4 Revenue Operations browser bridge.
+// Keeps existing panels intact while routing revenue/financial reads and writes
+// through tokenized F4 contracts and same-origin protected helpers.
+(function(){
+'use strict';
+if(window.__AOS_F4_REVENUE_OPS__)return;
+window.__AOS_F4_REVENUE_OPS__=true;
+
+var nativeFetch=window.fetch.bind(window);
+var carteraRows=[];
+var carteraCandidateByCase={};
+
+function token(){
+  try{return sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||''}catch(e){return ''}
+}
+function urlOf(input){return typeof input==='string'?input:(input&&input.url)||''}
+function parseBody(init){try{return JSON.parse((init&&init.body)||'{}')}catch(e){return {}}}
+function jsonResponse(obj,status){
+  return new Response(JSON.stringify(obj),{
+    status:status||200,
+    headers:{'Content-Type':'application/json','Cache-Control':'no-store','X-Ascenda-Revenue-Contract':'F4'}
+  });
+}
+function rpcUrl(url,name){return url.split('/rest/v1/')[0]+'/rest/v1/rpc/'+name}
+function postRpc(url,init,name,payload){
+  var h=new Headers((init&&init.headers)||{});
+  h.set('Content-Type','application/json');
+  return nativeFetch(rpcUrl(url,name),{
+    method:'POST',headers:h,body:JSON.stringify(payload||{}),cache:'no-store'
+  });
+}
+function missing(r){return r.status===404||r.status===400}
+function esc(s){
+  return String(s==null?'':s).replace(/[&<>"']/g,function(c){
+    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+  });
+}
+function money(n){return 'S/'+Number(n||0).toLocaleString('es-PE',{minimumFractionDigits:2,maximumFractionDigits:2})}
+
+function importApproval(preview){
+  return new Promise(function(resolve){
+    var old=document.getElementById('f4-import-preview');if(old)old.remove();
+    var ov=document.createElement('div');
+    ov.id='f4-import-preview';
+    ov.style.cssText='position:fixed;inset:0;background:rgba(7,29,74,.45);z-index:12000;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(5px)';
+    ov.innerHTML='<div style="width:min(560px,92vw);background:#fff;border-radius:16px;padding:20px;box-shadow:0 24px 70px rgba(7,29,74,.25);font-family:DM Sans,sans-serif">'+
+      '<div style="font:800 17px Exo 2,sans-serif;color:#0D1B3E">Validación previa · Importar ventas</div><div style="font-size:10px;color:#6B7BA8;margin:4px 0 14px">El lote todavía no ha modificado producción.</div>'+
+      '<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px">'+
+      [['Filas',preview.total],['Monto',money(preview.totalAmount)],['Adelantos',preview.advances],['Productos',preview.productLines],['Reconocidos',preview.productResolved],['A revisar',preview.productReviewRequired]].map(function(x){
+        return '<div style="border:1px solid #DDE4F5;border-radius:10px;padding:9px"><div style="font-size:8px;color:#8291B3;text-transform:uppercase">'+esc(x[0])+'</div><div style="font:800 16px Exo 2;color:#0D1B3E;margin-top:3px">'+esc(x[1])+'</div></div>';
+      }).join('')+'</div>'+
+      (preview.possibleExistingMatches?'<div style="margin-top:10px;padding:9px;border-radius:9px;background:#FFF9ED;color:#8A5A00;font-size:10px">⚠ '+preview.possibleExistingMatches+' coincidencia(s) posibles con ventas existentes. El importador conserva su deduplicación; revisa antes de confirmar.</div>':'')+
+      (preview.productReviewRequired?'<div style="margin-top:8px;padding:9px;border-radius:9px;background:#FFF3E1;color:#B96500;font-size:10px">⚠ '+preview.productReviewRequired+' producto(s) no tienen alias confirmado y quedarán en REVIEW_REQUIRED, sin inventar identidad.</div>':'')+
+      (preview.alreadyImported?'<div style="margin-top:8px;padding:9px;border-radius:9px;background:#FEE2E2;color:#B91C1C;font-size:10px">Este lote exacto ya fue procesado anteriormente.</div>':'')+
+      '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:16px"><button id="f4-imp-cancel" style="border:0;border-radius:9px;padding:8px 14px;background:#EEF3FA;color:#415270;font-weight:700;cursor:pointer">Cancelar</button><button id="f4-imp-ok" style="border:0;border-radius:9px;padding:8px 14px;background:#0A4FBF;color:#fff;font-weight:700;cursor:pointer" '+(preview.alreadyImported?'disabled':'')+'>Confirmar importación</button></div></div>';
+    document.body.appendChild(ov);
+    function done(v){ov.remove();resolve(v)}
+    document.getElementById('f4-imp-cancel').onclick=function(){done(false)};
+    var ok=document.getElementById('f4-imp-ok');if(ok&&!preview.alreadyImported)ok.onclick=function(){done(true)};
+  });
+}
+
+window.fetch=function(input,init){
+  var url=urlOf(input);
+  var method=String((init&&init.method)||((input&&input.method)||'GET')).toUpperCase();
+  var rm=url.match(/\/rest\/v1\/rpc\/([^?]+)/);
+  var name=rm&&rm[1];
+
+  if(name==='aos_ventas_admin'||name==='aos_ventas_admin_anio'){
+    var b=parseBody(init);
+    var payload={
+      p_token:token(),p_anio:b.p_anio,p_sede:b.p_sede||'',p_asesor:b.p_asesor||'',
+      p_mode:name==='aos_ventas_admin_anio'?'ANIO':'MES'
+    };
+    if(name==='aos_ventas_admin')payload.p_mes=b.p_mes;
+    return postRpc(url,init,'aos_sales_admin_gateway_v4',payload).then(function(r){
+      if(missing(r))return nativeFetch(input,init);
+      return r;
+    });
+  }
+
+  if(method==='GET'&&/\/rest\/v1\/aos_ventas\?/.test(url)){
+    try{
+      var u=new URL(url,location.href),id=(u.searchParams.get('id')||'');
+      if(/^eq\.\d+$/.test(id)&&u.searchParams.get('select')==='*'){
+        return postRpc(url,init,'aos_sales_admin_sale_v4',{p_token:token(),p_sale_id:Number(id.slice(3))}).then(function(r){
+          if(missing(r))return nativeFetch(input,init);
+          return r.json().then(function(d){return jsonResponse(d&&d.ok?[d.row]:d,r.ok?200:r.status)});
+        });
+      }
+    }catch(e){}
+  }
+
+  if(name==='aos_editar_venta'){
+    var eb=parseBody(init),expected='';
+    try{expected=(window.EV&&window.EV.ventaOriginal&&window.EV.ventaOriginal.updated_at)||eb.p_expected_updated_at||''}catch(e){}
+    return postRpc(url,init,'aos_editar_venta_v4',{
+      p_token:token(),p_venta_id:eb.p_venta_id,p_expected_updated_at:expected||null,
+      p_campos:eb.p_campos||{},p_origen:eb.p_origen||'panel_ventas_f4'
+    }).then(function(r){if(missing(r))return nativeFetch(input,init);return r});
+  }
+
+  if(name==='aos_importar_ventas'){
+    var ib=parseBody(init),ventas=ib.p_ventas||[];
+    return postRpc(url,init,'aos_importar_ventas_preview_v4',{p_token:token(),p_ventas:ventas}).then(function(pr){
+      if(missing(pr))return nativeFetch(input,init);
+      return pr.json().then(function(p){
+        if(!p||p.ok===false)return jsonResponse(p||{ok:false,error:'PREVIEW_FAILED'},403);
+        return importApproval(p).then(function(approved){
+          if(!approved)return jsonResponse({ok:false,cancelled:true,error:'IMPORT_CANCELLED_BY_USER'},409);
+          return postRpc(url,init,'aos_importar_ventas_v4',{p_token:token(),p_ventas:ventas});
+        });
+      });
+    });
+  }
+
+  if(name==='aos_grabar_venta_caja'){
+    var cb=parseBody(init);cb.p_token=token();
+    return postRpc(url,init,'aos_grabar_venta_caja_v4',cb).then(function(r){if(missing(r))return nativeFetch(input,init);return r});
+  }
+
+  if(name==='aos_cartera_gateway'){
+    return nativeFetch(input,init).then(function(r){
+      try{r.clone().json().then(function(d){if(d&&d.ok)carteraRows=d.rows||[]}).catch(function(){})}catch(e){}
+      return r;
+    });
+  }
+
+  if(name==='aos_cartera_reconcile'){
+    var rb=parseBody(init),sel=carteraCandidateByCase[rb.p_case_id]||null;
+    return postRpc(url,init,'aos_cartera_reconcile_v2',{
+      p_token:token(),p_case_id:rb.p_case_id,p_expected_updated_at:rb.p_expected_updated_at,
+      p_estado:rb.p_estado,p_confianza:rb.p_confianza,p_total_esperado:rb.p_total_esperado,
+      p_saldo_confirmado:rb.p_saldo_confirmado,p_candidate_type:sel?sel.type:null,
+      p_candidate_id:sel?sel.id:null,p_rol_pago:rb.p_rol_pago,p_observacion:rb.p_observacion
+    }).then(function(r){if(missing(r))return nativeFetch(input,init);return r});
+  }
+
+  return nativeFetch(input,init);
+};
+
+function patchSales(){
+  var box=document.getElementById('vs-top-prod');
+  if(!box||typeof window.renderCategoryRankings!=='function'||window.renderCategoryRankings.__f4)return;
+  var original=window.renderCategoryRankings;
+  function patched(rows){
+    original(rows);
+    var target=document.getElementById('vs-top-prod');if(!target)return;
+    var map={},base=0,productLines=0,resolved=0,review=0,excluded=0;
+    (rows||[]).forEach(function(v){
+      if((v.tipo||'')!=='PRODUCTO')return;
+      productLines++;
+      var m=Number(v.monto||0);base+=m;
+      var st=v.productResolutionStatus||'';
+      if(st==='EXCLUDED'){excluded++;return}
+      if(st!=='RESOLVED'||!v.canonicalProductName){review++;return}
+      resolved++;
+      var k=v.canonicalProductKey||v.canonicalProductName;
+      if(!map[k])map[k]={name:v.canonicalProductName,n:0,total:0,units:0,packs:0};
+      map[k].n++;map[k].total+=m;map[k].units+=Number(v.physicalQty||0);if(v.isPack)map[k].packs++;
+    });
+    var items=Object.keys(map).map(function(k){return map[k]}).sort(function(a,b){return b.total-a.total}).slice(0,8);
+    if(!items.length){target.innerHTML='<div class="ld">Sin productos canónicos resueltos</div>';return}
+    var max=items[0].total||1;
+    target.innerHTML=items.map(function(x,i){
+      var w=Math.max(4,Math.round(x.total/max*100)),share=base?Math.round(x.total/base*100):0;
+      return '<div class="rkx-row"><div><div class="rkx-name" title="'+esc(x.name)+'">'+(i+1)+'. '+esc(x.name)+'</div><div class="rkx-sub">'+x.n+' ventas · '+x.units.toLocaleString('es-PE',{maximumFractionDigits:2})+' u'+(x.packs?' · '+x.packs+' pack':'')+' · '+share+'% categoría</div></div><div class="rkx-bar"><div class="rkx-fill rkx-fill-prod" style="width:'+w+'%"></div></div><div class="rkx-val">'+money(x.total)+'</div></div>';
+    }).join('')+
+      '<div class="rkx-note">F4 canónico · '+resolved+'/'+productLines+' líneas resueltas'+(review?' · '+review+' por revisar':'')+(excluded?' · '+excluded+' excluidas':'')+'. La descripción original permanece auditable.</div>';
+  }
+  patched.__f4=true;patched.__original=original;window.renderCategoryRankings=patched;
+  try{if(window.VS&&window.VS.data)patched(window.VS.data.detalle||[])}catch(e){}
+}
+
+function candidateSummary(c){
+  var bits=[],r=c.reasons||{};
+  if(r.phoneMatch)bits.push('teléfono');
+  if(r.dniMatch)bits.push('DNI');
+  if(r.sameCanonicalProduct)bits.push('producto');else if(r.sameConcept)bits.push('concepto');
+  if(r.fullPayment)bits.push('pago completo');
+  if(r.amountNear)bits.push('monto');
+  return bits.join(' · ')||'coincidencia contextual';
+}
+
+function loadCandidates(caseRow){
+  var modal=document.getElementById('car-modal');
+  if(!modal||!caseRow)return;
+  var form=modal.querySelector('.car-form');
+  if(!form)return;
+
+  var old=document.getElementById('f4-car-candidates');if(old)old.remove();
+  var wrap=document.createElement('div');
+  wrap.id='f4-car-candidates';
+  wrap.style.cssText='grid-column:1/-1;border:1px solid #D9E2F1;border-radius:10px;padding:10px;background:#F8FAFE';
+  wrap.innerHTML='<div style="font-size:9px;font-weight:800;color:#415270">COINCIDENCIAS DEL SISTEMA</div><div style="font-size:9px;color:#8291B3;margin-top:3px">Buscando evidencia existente. Seleccionar una coincidencia no crea un pago nuevo.</div><div id="f4-car-list" style="margin-top:8px">Cargando...</div>';
+  form.appendChild(wrap);
+
+  nativeFetch('/api/f4/cartera-candidates',{
+    method:'POST',
+    headers:{'Content-Type':'application/json','X-AOS-App-Token':token()},
+    body:JSON.stringify({case_id:caseRow.id}),
+    cache:'no-store'
+  }).then(function(r){return r.json()}).then(function(d){
+    var list=document.getElementById('f4-car-list');
+    if(!list)return;
+    if(!d||!d.ok){list.textContent='No fue posible consultar coincidencias.';return}
+    var cs=d.candidates||[];
+    if(!cs.length){
+      list.innerHTML='<span style="font-size:9px;color:#8291B3">Sin coincidencias suficientemente fuertes. Puedes clasificar manualmente el caso, excepto PAGO_RECONCILIADO que exige evidencia vinculada.</span>';
+      return;
+    }
+    list.innerHTML=cs.map(function(c,i){
+      return '<button type="button" data-f4cand="'+i+'" style="display:block;width:100%;text-align:left;border:1px solid #DDE4F5;background:#fff;border-radius:8px;padding:8px;margin:5px 0;cursor:pointer"><b>'+esc(c.type)+' · '+esc(c.date||'')+' · '+money(c.totalAmount)+'</b><br><span style="font-size:9px;color:#6B7BA8">Score '+esc(c.score)+' · '+esc(c.confidence)+' · '+esc(candidateSummary(c))+'</span></button>';
+    }).join('');
+    Array.prototype.forEach.call(list.querySelectorAll('[data-f4cand]'),function(b){
+      b.onclick=function(){
+        var c=cs[Number(b.getAttribute('data-f4cand'))];
+        carteraCandidateByCase[caseRow.id]={type:c.type,id:c.id};
+        Array.prototype.forEach.call(list.children,function(x){x.style.borderColor='#DDE4F5';x.style.background='#fff'});
+        b.style.borderColor='#0A4FBF';b.style.background='#EBF2FF';
+        var total=document.getElementById('car-edit-total'),bal=document.getElementById('car-edit-balance');
+        if(c.type==='COTIZACION'){
+          if(total&&c.totalAmount!=null)total.value=c.totalAmount;
+          if(bal&&c.balanceAmount!=null)bal.value=c.balanceAmount;
+        }
+        var note=document.getElementById('car-edit-note');
+        if(note&&!note.value)note.value='F4: evidencia vinculada '+c.type+' '+c.id;
+      };
+    });
+  }).catch(function(){
+    var list=document.getElementById('f4-car-list');if(list)list.textContent='Error consultando coincidencias.';
+  });
+}
+
+document.addEventListener('click',function(ev){
+  var b=ev.target&&ev.target.closest?ev.target.closest('#car-body button[data-i]'):null;
+  if(!b)return;
+  var r=carteraRows[Number(b.getAttribute('data-i'))];if(!r)return;
+  setTimeout(function(){loadCandidates(r)},80);
+},true);
+
+var observer=new MutationObserver(function(){setTimeout(patchSales,40)});
+observer.observe(document.documentElement,{childList:true,subtree:true});
+setInterval(patchSales,1200);
+console.info('[ASCENDA F4] Revenue Operations bridge active');
+})();

--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -1,4 +1,4 @@
-// ASCENDA OS Phase 2 — app-wide controlled-write bridge.
+// ASCENDA OS Phase 2/F4 — app-wide controlled-write + revenue operations bridge.
 'use strict';
 self.addEventListener('install',function(){self.skipWaiting();});
 self.addEventListener('activate',function(e){e.waitUntil(self.clients.claim());});
@@ -8,48 +8,39 @@ var CAJA={aos_caja_abrir:'aos_caja_abrir_v2',aos_caja_cerrar:'aos_caja_cerrar_v2
 var IDENTITY={aos_admin_crear_usuario:'aos_admin_crear_usuario_v3',aos_admin_cambiar_password:'aos_admin_cambiar_password_v3',aos_cambiar_password:'aos_cambiar_password_v3'};
 
 async function getToken(){try{var c=await caches.open('aos-phase2-auth');var r=await c.match('/__aos_app_token');return r?await r.text():'';}catch(e){return '';}}
-function json(obj,status){return new Response(JSON.stringify(obj),{status:status||200,headers:{'Content-Type':'application/json'}});}
+function json(obj,status){return new Response(JSON.stringify(obj),{status:status||200,headers:{'Content-Type':'application/json','Cache-Control':'no-store'}});}
 function isMissing(r){return r.status===404||r.status===400;}
 function parseMatch(u){var out={};u.searchParams.forEach(function(v,k){if(k==='select'||k==='order'||k==='limit'||k==='offset')return;if(String(v).indexOf('eq.')!==0)throw new Error('FILTER_NOT_ALLOWED');out[k]=String(v).slice(3);});return out;}
 async function requestJson(req){try{return await req.clone().json();}catch(e){return {};}}
 async function rpcFrom(req,name,payload){var u=new URL(req.url);var target=u.origin+'/rest/v1/rpc/'+name;var h=new Headers(req.headers);h.set('Content-Type','application/json');return fetch(target,{method:'POST',headers:h,body:JSON.stringify(payload),credentials:req.credentials,mode:req.mode==='navigate'?'cors':req.mode,cache:'no-store'});}
 
+async function injectF4(req){
+  var r=await fetch(req,{cache:'no-store'});if(!r.ok)return r;
+  var type=(r.headers.get('content-type')||'').toLowerCase();if(type.indexOf('text/html')<0)return r;
+  var html=await r.text();
+  if(html.indexOf('/f4-revenue-ops.js')<0){
+    var tags='<script src="/f4-revenue-ops.js?v=20260814-f4"></script><script src="/f4-kronia-revenue-bridge.js?v=20260814-f4"></script>';
+    html=html.indexOf('</body>')>=0?html.replace('</body>',tags+'</body>'):html+tags;
+  }
+  var h=new Headers(r.headers);h.set('Cache-Control','no-store, no-cache, must-revalidate');h.delete('content-length');
+  return new Response(html,{status:r.status,statusText:r.statusText,headers:h});
+}
+
 self.addEventListener('fetch',function(event){
   var req=event.request,u;
   try{u=new URL(req.url);}catch(e){return;}
+  if(u.origin===self.location.origin&&req.method==='GET'&&(u.pathname==='/app'||u.pathname==='/app.html')){event.respondWith(injectF4(req));return;}
   if(u.hostname.indexOf('supabase.co')<0)return;
 
   var rm=u.pathname.match(/\/rest\/v1\/rpc\/([^/]+)$/);
   if(rm&&IDENTITY[rm[1]]){
-    event.respondWith((async function(){
-      var p=await requestJson(req);p.p_token=await getToken();
-      // The retired 4-argument admin password RPC is intentionally not compatible.
-      if(rm[1]==='aos_admin_cambiar_password'&&!p.p_usuario_id){return json({ok:false,error:'LEGACY_IDENTITY_FLOW_RETIRED'},403);}
-      if(rm[1]==='aos_cambiar_password'){
-        p={p_token:p.p_token,p_password_actual:p.p_password_actual,p_password_nuevo:p.p_password_nuevo};
-      }
-      var r=await rpcFrom(req,IDENTITY[rm[1]],p);
-      if(isMissing(r))return fetch(req);
-      return r;
-    })());return;
+    event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();if(rm[1]==='aos_admin_cambiar_password'&&!p.p_usuario_id){return json({ok:false,error:'LEGACY_IDENTITY_FLOW_RETIRED'},403);}if(rm[1]==='aos_cambiar_password')p={p_token:p.p_token,p_password_actual:p.p_password_actual,p_password_nuevo:p.p_password_nuevo};var r=await rpcFrom(req,IDENTITY[rm[1]],p);if(isMissing(r))return fetch(req);return r;})());return;
   }
-
   if(rm&&CAJA[rm[1]]){
-    event.respondWith((async function(){
-      var p=await requestJson(req);p.p_token=await getToken();delete p.p_usuario;
-      var r=await rpcFrom(req,CAJA[rm[1]],p);if(isMissing(r))return fetch(req);return r;
-    })());return;
+    event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();delete p.p_usuario;var r=await rpcFrom(req,CAJA[rm[1]],p);if(isMissing(r))return fetch(req);return r;})());return;
   }
-
   var tm=u.pathname.match(/\/rest\/v1\/([^/]+)$/),table=tm&&tm[1],method=req.method.toUpperCase();
   if(table&&PROTECTED[table]&&(method==='POST'||method==='PATCH'||method==='DELETE')){
-    event.respondWith((async function(){
-      var match;try{match=parseMatch(u);}catch(e){return json({ok:false,error:'FILTER_NOT_ALLOWED'},403);}
-      var payload={p_token:await getToken(),p_table:table,p_action:method==='POST'?'INSERT':method,p_match:match,p_data:method==='DELETE'?{}:await requestJson(req)};
-      var r=await rpcFrom(req,'aos_secure_write_v2',payload);if(isMissing(r))return fetch(req);
-      var d;try{d=await r.json();}catch(e){return json({ok:false,error:'WRITE_REJECTED'},500);}
-      if(!d||d.ok===false)return json(d||{ok:false,error:'WRITE_REJECTED'},403);
-      return json(d.rows||[],200);
-    })());
+    event.respondWith((async function(){var match;try{match=parseMatch(u);}catch(e){return json({ok:false,error:'FILTER_NOT_ALLOWED'},403);}var payload={p_token:await getToken(),p_table:table,p_action:method==='POST'?'INSERT':method,p_match:match,p_data:method==='DELETE'?{}:await requestJson(req)};var r=await rpcFrom(req,'aos_secure_write_v2',payload);if(isMissing(r))return fetch(req);var d;try{d=await r.json();}catch(e){return json({ok:false,error:'WRITE_REJECTED'},500);}if(!d||d.ok===false)return json(d||{ok:false,error:'WRITE_REJECTED'},403);return json(d.rows||[],200);})());
   }
 });

--- a/app/railway.json
+++ b/app/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "echo 'Skip build — serving static from public/'"
   },
   "deploy": {
-    "startCommand": "node server-phase2.js",
+    "startCommand": "node server-f4.js",
     "restartPolicyType": "ON_FAILURE"
   },
   "environments": {

--- a/app/server-f4.js
+++ b/app/server-f4.js
@@ -1,0 +1,62 @@
+// ASCENDA OS — F4 Revenue Operations front proxy.
+'use strict';
+const http=require('http');
+const https=require('https');
+const {spawn}=require('child_process');
+
+const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10);
+const INNER_PORT=EXTERNAL_PORT===4189?4190:4189;
+const SB_URL=process.env.SUPABASE_URL||'https://ituyqwstonmhnfshnaqz.supabase.co';
+const SB_ANON_KEY=process.env.SUPABASE_ANON_KEY||'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXNlIiwicmVmIjoiaXR1eXF3c3Rvbm1obmZzaG5hcXoiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc3NDc0NDIxOCwiZXhwIjoyMDkwMzIwMjE4fQ.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+
+const child=spawn(process.execPath,['server-phase2.js'],{cwd:__dirname,env:Object.assign({},process.env,{PORT:String(INNER_PORT)}),stdio:['ignore','inherit','inherit']});
+child.on('exit',(code,signal)=>{console.error('[F4-PROXY] backend exited',{code,signal});process.exit(code==null?1:code);});
+
+function writeJson(res,status,obj){res.writeHead(status,{'Content-Type':'application/json; charset=utf-8','Cache-Control':'no-store','X-Ascenda-Revenue-Route':'f4'});res.end(JSON.stringify(obj));}
+function readJson(req,maxBytes=1024*1024){return new Promise((resolve,reject)=>{let raw='',overflow=false;req.on('data',c=>{if(overflow)return;raw+=c;if(Buffer.byteLength(raw)>maxBytes)overflow=true;});req.on('end',()=>{if(overflow){reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413}));return;}try{resolve({raw,body:JSON.parse(raw||'{}')});}catch(e){reject(Object.assign(new Error('INVALID_JSON'),{status:400}));}});req.on('error',reject);});}
+function sbRpc(name,payload){
+  return new Promise((resolve,reject)=>{
+    let sb;try{sb=new URL(SB_URL);}catch(e){reject(e);return;}
+    const data=JSON.stringify(payload||{});
+    const req=https.request({hostname:sb.hostname,port:sb.port||443,path:'/rest/v1/rpc/'+name,method:'POST',headers:{apikey:SB_ANON_KEY,Authorization:'Bearer '+SB_ANON_KEY,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-F4-RevenueProxy/1.0'},timeout:12000},r=>{
+      let body='';r.on('data',c=>body+=c);r.on('end',()=>{let parsed={};try{parsed=body?JSON.parse(body):{};}catch(e){parsed={ok:false,error:'UPSTREAM_INVALID_JSON'};}resolve({status:r.statusCode||502,data:parsed});});
+    });
+    req.on('timeout',()=>req.destroy(new Error('UPSTREAM_TIMEOUT')));req.on('error',reject);req.write(data);req.end();
+  });
+}
+function strongToken(req){const t=String(req.headers['x-aos-app-token']||'').trim();return t.length>=32?t:'';}
+async function handleKroniaSaleEdit(req,res,body){
+  const appToken=strongToken(req);
+  if(!appToken){writeJson(res,403,{ok:true,respuesta:'🔒 La edición financiera requiere una sesión administrativa 2FA vigente.',provider:'f4-security',error:'F4_STRONG_SESSION_REQUIRED'});return;}
+  const action=body&&body.confirmar_accion;const params=action&&action.params||{};const saleId=Number(params.p_venta_id||0);
+  if(!saleId||!params.p_campos||typeof params.p_campos!=='object'){writeJson(res,400,{ok:false,error:'INVALID_SALE_EDIT'});return;}
+  try{
+    const current=await sbRpc('aos_sales_admin_sale_v4',{p_token:appToken,p_sale_id:saleId});
+    if(!current.data||current.data.ok!==true||!current.data.row){writeJson(res,403,{ok:true,respuesta:'🔒 No se pudo validar la venta o tu permiso de edición.',provider:'f4-security',resultado:current.data});return;}
+    const edited=await sbRpc('aos_editar_venta_v4',{p_token:appToken,p_venta_id:saleId,p_expected_updated_at:current.data.row.updated_at,p_campos:params.p_campos,p_origen:'kronia_f4'});
+    const result=edited.data||{};
+    if(result.ok===false){writeJson(res,200,{ok:true,respuesta:'⚠️ No pude ejecutar la edición: '+(result.error||'rechazada'),provider:'f4-ejecutor',resultado:result});return;}
+    writeJson(res,200,{ok:true,respuesta:'✅ Venta actualizada mediante el contrato seguro F4.',provider:'f4-ejecutor',resultado:result});
+  }catch(e){console.error('[F4-PROXY] KronIA sale edit',e.message);writeJson(res,502,{ok:true,respuesta:'⚠️ No fue posible completar la edición segura en este momento.',provider:'f4-ejecutor',error:'F4_UPSTREAM_UNAVAILABLE'});}
+}
+async function handleCandidates(req,res,body){
+  const appToken=strongToken(req);if(!appToken){writeJson(res,403,{ok:false,error:'F4_STRONG_SESSION_REQUIRED'});return;}
+  const caseId=String((body&&body.case_id)||'').trim();if(!caseId){writeJson(res,400,{ok:false,error:'CASE_ID_REQUIRED'});return;}
+  try{const out=await sbRpc('aos_cartera_candidates_v2',{p_token:appToken,p_case_id:caseId});writeJson(res,out.status>=200&&out.status<300?200:out.status,out.data||{ok:false,error:'UPSTREAM_EMPTY'});}catch(e){console.error('[F4-PROXY] candidates',e.message);writeJson(res,502,{ok:false,error:'F4_UPSTREAM_UNAVAILABLE'});}
+}
+
+const server=http.createServer(async(req,res)=>{
+  let pathname='/';try{pathname=new URL(req.url,'http://localhost').pathname;}catch(e){}
+  if(pathname==='/api/f4/cartera-candidates'&&req.method==='POST'){
+    try{const parsed=await readJson(req,128*1024);await handleCandidates(req,res,parsed.body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;
+  }
+  if(pathname==='/api/kronia/chat'&&req.method==='POST'){
+    try{const parsed=await readJson(req);if(parsed.body&&parsed.body.confirmar_accion&&parsed.body.confirmar_accion.rpc==='aos_editar_venta'){await handleKroniaSaleEdit(req,res,parsed.body);return;}proxyBuffered(req,res,parsed.raw);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;
+  }
+  proxyStream(req,res);
+});
+function proxyBuffered(req,res,raw){const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT,'content-length':Buffer.byteLength(raw)});const up=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{res.writeHead(r.statusCode||502,r.headers);r.pipe(res);});up.on('error',e=>{if(!res.headersSent)writeJson(res,502,{ok:false,error:'UPSTREAM_UNAVAILABLE'});else res.end();console.error('[F4-PROXY] buffered',e.message);});up.write(raw);up.end();}
+function proxyStream(req,res){const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT});const up=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{res.writeHead(r.statusCode||502,r.headers);r.pipe(res);});up.on('error',e=>{if(!res.headersSent)writeJson(res,502,{ok:false,error:'UPSTREAM_UNAVAILABLE'});else res.end();console.error('[F4-PROXY] stream',e.message);});req.pipe(up);}
+function shutdown(sig){console.log('[F4-PROXY] shutdown',sig);server.close(()=>process.exit(0));if(!child.killed)child.kill(sig);setTimeout(()=>process.exit(1),5000).unref();}
+process.on('SIGTERM',()=>shutdown('SIGTERM'));process.on('SIGINT',()=>shutdown('SIGINT'));
+server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[F4-PROXY] listening on :'+EXTERNAL_PORT+' -> :'+INNER_PORT));

--- a/ci/phase4-revenue/schema_contract.sql
+++ b/ci/phase4-revenue/schema_contract.sql
@@ -1,0 +1,102 @@
+\set ON_ERROR_STOP on
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+create table public.aos_usuarios(
+  id uuid primary key default extensions.gen_random_uuid(), codigo_asesor text unique, nombre text, rol text,
+  nivel_jerarquia integer, activo boolean default true, two_factor boolean default true,
+  paneles_acceso text[] default '{}', sedes_permitidas text[] default '{}'
+);
+create table public.aos_rrhh(codigo_asesor text primary key,nombre text,estado text default 'ACTIVO');
+create table public.aos_app_sessions_v3(
+  token_hash text primary key,user_id uuid,assurance_level text,expires_at timestamptz,revoked boolean default false,
+  last_used_at timestamptz default now()
+);
+create table public.aos_security_log(id bigserial primary key,usuario text,accion text,detalles jsonb,created_at timestamptz default now());
+
+create or replace function public.aos_app_actor_v3(p_token text,p_required_panel text default null,p_require_2fa boolean default false)
+returns uuid language sql stable security definer set search_path to '' as $$
+  select s.user_id from public.aos_app_sessions_v3 s join public.aos_usuarios u on u.id=s.user_id
+  where s.token_hash=encode(extensions.digest(p_token,'sha256'),'hex') and s.revoked=false and s.expires_at>now() and u.activo=true
+    and (not p_require_2fa or s.assurance_level='PASSWORD_2FA')
+    and (p_required_panel is null or coalesce(u.paneles_acceso,'{}') @> array[p_required_panel]::text[]) limit 1
+$$;
+
+create table public.aos_ventas(
+ id bigserial primary key,venta_id text,fecha date,nombres text,apellidos text,dni text,celular text,tratamiento text,descripcion text,
+ pago text,monto numeric,estado_pago text,asesor text,atendio text,sede text,tipo text,numero_limpio text,nro_doc text,estado_doc text,
+ tipo_comprobante text,created_at timestamptz default now(),updated_at timestamptz default now(),moneda text default 'PEN',cotizacion_id text
+);
+create table public.aos_product_identity_v1(product_key text primary key,canonical_name text,active boolean default true);
+create table public.aos_product_alias_v2(alias_key text primary key,alias_text text,product_key text,default_qty numeric default 1,default_is_pack boolean default false,active boolean default true);
+create table public.aos_product_sale_fact_v1(
+ sale_id bigint primary key,product_key text,raw_alias_key text,physical_qty numeric,is_pack boolean,resolution_status text,resolution_source text,locked boolean default false,note text,created_at timestamptz default now(),updated_at timestamptz default now()
+);
+create or replace function public.aos_product_normalize_alias_v2(p_value text) returns text language sql immutable set search_path to 'pg_catalog' as $$
+ select nullif(regexp_replace(translate(upper(btrim(coalesce(p_value,''))),'ÁÀÂÄÃÉÈÊËÍÌÎÏÓÒÔÖÕÚÙÛÜÑÇ','AAAAAEEEEIIIIOOOOOUUUUNC'),'[^A-Z0-9]+','','g'),'')
+$$;
+create or replace function public.aos_product_resolve_sale_test() returns trigger language plpgsql set search_path to '' as $$
+declare k text; a record;
+begin
+ if upper(trim(coalesce(new.tipo,'')))<>'PRODUCTO' and upper(trim(coalesce(new.tratamiento,''))) not like '%COMPRA%PRODUCTO%' then delete from public.aos_product_sale_fact_v1 where sale_id=new.id; return new; end if;
+ k:=public.aos_product_normalize_alias_v2(new.descripcion);
+ select * into a from public.aos_product_alias_v2 where alias_key=k and active=true limit 1;
+ insert into public.aos_product_sale_fact_v1(sale_id,product_key,raw_alias_key,physical_qty,is_pack,resolution_status,resolution_source,locked,updated_at)
+ values(new.id,a.product_key,k,case when a.product_key is null then null else coalesce(a.default_qty,1) end,case when a.product_key is null then null else coalesce(a.default_is_pack,false) end,case when a.product_key is null then 'REVIEW_REQUIRED' else 'RESOLVED' end,'TEST_ALIAS',false,now())
+ on conflict(sale_id) do update set product_key=excluded.product_key,raw_alias_key=excluded.raw_alias_key,physical_qty=excluded.physical_qty,is_pack=excluded.is_pack,resolution_status=excluded.resolution_status,updated_at=now();
+ return new;
+end$$;
+create trigger trg_aos_product_sync_sale_v1 after insert or update of tipo,tratamiento,descripcion on public.aos_ventas for each row execute function public.aos_product_resolve_sale_test();
+
+create table public.aos_import_ventas_batches(id bigserial primary key,batch_hash text unique,total_rows integer,resultado jsonb,created_at timestamptz default now());
+create table public.aos_caja_sesiones(id text primary key,sede text,estado text,abierto_por_user_id uuid,created_at timestamptz default now());
+create table public.aos_cotizaciones(id text primary key,numero_limpio text,nombre_paciente text,dni_paciente text,estado text,subtotal numeric,total_pagado numeric,saldo_pendiente numeric,sede text,asesor text,fecha_creacion date,updated_at timestamptz default now());
+create table public.aos_pagos(id text primary key default extensions.gen_random_uuid()::text,monto numeric default 0,created_at timestamptz default now());
+create table public.aos_cartera_reconciliacion(
+ id uuid primary key default extensions.gen_random_uuid(),source_type text,venta_row_id bigint,cotizacion_id text,pago_id text,grupo_pago_id uuid,rol_pago text,
+ estado_reconciliacion text,confianza text,monto_registrado numeric,total_compra_esperado numeric,saldo_confirmado numeric,source_active boolean default true,
+ evidencia jsonb default '{}',observacion text,confirmado_por uuid,confirmed_at timestamptz,created_at timestamptz default now(),updated_at timestamptz default now()
+);
+
+create or replace function public.aos_ventas_admin(p_mes integer,p_anio integer,p_sede text default '',p_asesor text default '') returns jsonb language sql security definer set search_path to '' as $$
+ with x as (select * from public.aos_ventas where extract(month from fecha)=p_mes and extract(year from fecha)=p_anio and (coalesce(p_sede,'')='' or upper(sede)=upper(p_sede)) and (coalesce(p_asesor,'')='' or upper(asesor)=upper(p_asesor)))
+ select jsonb_build_object('nVentas',count(*),'factTotal',coalesce(sum(monto),0),'nProd',count(*) filter(where tipo='PRODUCTO'),'factProd',coalesce(sum(monto) filter(where tipo='PRODUCTO'),0),'nServ',count(*) filter(where tipo<>'PRODUCTO'),'detalle',coalesce(jsonb_agg(to_jsonb(x) order by fecha desc,id desc),'[]'::jsonb)) from x
+$$;
+create or replace function public.aos_ventas_admin_anio(p_anio integer,p_sede text default '',p_asesor text default '') returns jsonb language sql security definer set search_path to '' as $$
+ with x as (select * from public.aos_ventas where extract(year from fecha)=p_anio and (coalesce(p_sede,'')='' or upper(sede)=upper(p_sede)) and (coalesce(p_asesor,'')='' or upper(asesor)=upper(p_asesor)))
+ select jsonb_build_object('nVentas',count(*),'factTotal',coalesce(sum(monto),0),'detalle',coalesce(jsonb_agg(to_jsonb(x) order by fecha desc,id desc),'[]'::jsonb)) from x
+$$;
+
+create or replace function public.aos_editar_venta(p_venta_id bigint,p_campos jsonb,p_editado_por text,p_rol text,p_origen text default 'test') returns jsonb language plpgsql security definer set search_path to '' as $$
+begin
+ update public.aos_ventas set
+  fecha=coalesce((p_campos->>'fecha')::date,fecha),
+  descripcion=case when p_campos?'descripcion' then p_campos->>'descripcion' else descripcion end,
+  tratamiento=case when p_campos?'tratamiento' then p_campos->>'tratamiento' else tratamiento end,
+  monto=case when p_campos?'monto' then (p_campos->>'monto')::numeric else monto end,
+  sede=case when p_campos?'sede' then p_campos->>'sede' else sede end,
+  tipo=case when p_campos?'tipo' then p_campos->>'tipo' else tipo end,
+  estado_pago=case when p_campos?'estado_pago' then p_campos->>'estado_pago' else estado_pago end,
+  updated_at=now()
+ where id=p_venta_id;
+ return jsonb_build_object('ok',found,'total',case when found then 1 else 0 end);
+end$$;
+
+create or replace function public.aos_importar_ventas(p_ventas jsonb) returns jsonb language plpgsql security definer set search_path to '' as $$
+declare r jsonb;n integer:=0;h text:=md5(p_ventas::text);v_num text;v_tipo text;v_res jsonb;
+begin
+ if exists(select 1 from public.aos_import_ventas_batches where batch_hash=h) then return jsonb_build_object('insertados',0,'duplicados',jsonb_array_length(p_ventas),'errores',0); end if;
+ for r in select value from jsonb_array_elements(p_ventas) loop
+   v_num:=regexp_replace(coalesce(r->>'celular',''),'[^0-9]','','g');if length(v_num)>9 then v_num:=right(v_num,9);end if;
+   v_tipo:=case when upper(coalesce(r->>'tratamiento','')) like '%COMPRA%' or upper(coalesce(r->>'tratamiento','')) like '%PRODUCTO%' or upper(coalesce(r->>'tratamiento',''))='OTROS' then 'PRODUCTO' else 'SERVICIO' end;
+   insert into public.aos_ventas(fecha,nombres,apellidos,dni,celular,numero_limpio,tratamiento,descripcion,pago,monto,estado_pago,asesor,atendio,sede,tipo)
+   values((r->>'fecha')::date,r->>'nombres',r->>'apellidos',r->>'dni',r->>'celular',v_num,r->>'tratamiento',r->>'descripcion',r->>'pago',(r->>'monto')::numeric,coalesce(r->>'estado_pago','PAGO COMPLETO'),r->>'asesor',r->>'atendio',upper(r->>'sede'),v_tipo);n:=n+1;
+ end loop;
+ v_res:=jsonb_build_object('insertados',n,'duplicados',0,'errores',0);insert into public.aos_import_ventas_batches(batch_hash,total_rows,resultado) values(h,jsonb_array_length(p_ventas),v_res);return v_res;
+end$$;
+
+create or replace function public.aos_grabar_venta_caja(p_sede text,p_usuario text,p_sesion_id text,p_numero_limpio text,p_nombres text,p_apellidos text,p_celular text,p_dni text,p_asesor text,p_doctor text,p_items jsonb,p_metodo_pago text,p_monto_total numeric,p_moneda text,p_tipo_comprobante text,p_nro_doc text,p_estado_pago text,p_nota text,p_tipo text,p_fecha text,p_razon_social_id text default null,p_monto_pagado numeric default null) returns jsonb language plpgsql security definer set search_path to '' as $$
+declare vid bigint;d text;begin d:=coalesce(p_items->0->>'descripcion',p_items->0->>'nombre','CAJA');insert into public.aos_ventas(fecha,nombres,apellidos,dni,celular,numero_limpio,tratamiento,descripcion,pago,monto,estado_pago,asesor,atendio,sede,tipo) values(p_fecha::date,p_nombres,p_apellidos,p_dni,p_celular,p_numero_limpio,case when upper(p_tipo)='PRODUCTO' then 'COMPRA DE PRODUCTO' else coalesce(p_items->0->>'nombre','SERVICIO') end,d,p_metodo_pago,p_monto_total,p_estado_pago,p_asesor,p_doctor,upper(p_sede),upper(p_tipo)) returning id into vid;return jsonb_build_object('ok',true,'venta_id',vid);end$$;
+
+create or replace function public.aos_cartera_reconcile(p_token text,p_case_id uuid,p_expected_updated_at timestamptz,p_estado text,p_confianza text default 'CONFIRMADA',p_total_esperado numeric default null,p_saldo_confirmado numeric default null,p_cotizacion_id text default null,p_rol_pago text default 'ADELANTO',p_observacion text default '') returns jsonb language plpgsql security definer set search_path to '' as $$
+declare c record;begin select * into c from public.aos_cartera_reconciliacion where id=p_case_id for update;if c.id is null then return jsonb_build_object('ok',false,'error','NOT_FOUND');end if;if c.updated_at<>p_expected_updated_at then return jsonb_build_object('ok',false,'error','STALE_CASE');end if;update public.aos_cartera_reconciliacion set estado_reconciliacion=p_estado,confianza=p_confianza,total_compra_esperado=p_total_esperado,saldo_confirmado=p_saldo_confirmado,cotizacion_id=coalesce(p_cotizacion_id,cotizacion_id),rol_pago=p_rol_pago,observacion=p_observacion,updated_at=now() where id=p_case_id;return jsonb_build_object('ok',true,'caseId',p_case_id);end$$;

--- a/ci/phase4-revenue/tests/001_revenue_operations.sql
+++ b/ci/phase4-revenue/tests/001_revenue_operations.sql
@@ -1,0 +1,84 @@
+\set ON_ERROR_STOP on
+begin;
+select plan(38);
+
+insert into public.aos_usuarios(id,codigo_asesor,nombre,rol,nivel_jerarquia,activo,two_factor,paneles_acceso,sedes_permitidas)
+values('00000000-0000-0000-0000-000000000001','ZIV-001','OWNER','admin',1,true,true,array['admin-sales','admin-import-ventas','admin-caja','admin-cartera'],'{}');
+insert into public.aos_rrhh(codigo_asesor,nombre,estado) values('ZIV-001','OWNER','ACTIVO');
+insert into public.aos_app_sessions_v3(token_hash,user_id,assurance_level,expires_at)
+values(encode(extensions.digest('F4-TEST-TOKEN','sha256'),'hex'),'00000000-0000-0000-0000-000000000001','PASSWORD_2FA',now()+interval '8 hours');
+
+insert into public.aos_product_identity_v1(product_key,canonical_name) values('F3:LIFTINGB30GR','LIFTING B 30GR'),('F3:SPRAYMINOX','SPRAY MINOX');
+insert into public.aos_product_alias_v2(alias_key,alias_text,product_key,default_qty,default_is_pack) values
+(public.aos_product_normalize_alias_v2('LIFTIN B'),'LIFTIN B','F3:LIFTINGB30GR',1,false),
+(public.aos_product_normalize_alias_v2('SPRAY MINOX'),'SPRAY MINOX','F3:SPRAYMINOX',2,true);
+
+insert into public.aos_ventas(fecha,nombres,celular,numero_limpio,tratamiento,descripcion,pago,monto,estado_pago,asesor,sede,tipo) values
+('2026-08-10','A','999111111','999111111','HIFU','HIFU','EFECTIVO',100,'PAGO COMPLETO','WILMER','SAN ISIDRO','SERVICIO'),
+('2026-08-11','B','999222222','999222222','COMPRA DE PRODUCTO','LIFTIN B','QR',200,'PAGO COMPLETO','WILMER','SAN ISIDRO','PRODUCTO'),
+('2026-08-12','C','999333333','999333333','COMPRA DE PRODUCTO','SPRAY MINOX','QR',300,'PAGO COMPLETO','WILMER','SAN ISIDRO','PRODUCTO'),
+('2026-08-12','D','999444444','999444444','COMPRA DE PRODUCTO','INDICACION ESPECIAL','QR',50,'PAGO COMPLETO','WILMER','SAN ISIDRO','PRODUCTO');
+update public.aos_product_sale_fact_v1 set resolution_status='EXCLUDED',resolution_source='OWNER_REVIEW',physical_qty=null,is_pack=false where sale_id=4;
+
+select ok(public.aos_f4_actor('F4-TEST-TOKEN','admin-sales') is not null,'1 strong actor accepted');
+select ok(public.aos_f4_actor('bad','admin-sales') is null,'2 bad actor rejected');
+select is((public.aos_sales_admin_gateway_v4('bad',8,2026,'SAN ISIDRO','WILMER','MES')->>'ok')::boolean,false,'3 unauthorized sales gateway rejected');
+select is((public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->>'ok')::boolean,true,'4 sales gateway authorized');
+select ok(exists(select 1 from jsonb_array_elements(public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->'detalle') e where e->>'rawDescription'='LIFTIN B' and e->>'canonicalProductName'='LIFTING B 30GR'),'5 raw description preserved beside canonical identity');
+select is(jsonb_array_length(public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->'canonicalProducts'),2,'6 two canonical products ranked');
+select is((public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->>'physicalUnits')::numeric,3::numeric,'7 physical units aggregated');
+select is((public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->>'productPackLines')::integer,1,'8 pack lines aggregated');
+select is((public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->'productResolution'->>'resolved')::integer,2,'9 resolution count');
+select is((public.aos_sales_admin_gateway_v4('F4-TEST-TOKEN',8,2026,'SAN ISIDRO','WILMER','MES')->'productResolution'->>'excluded')::integer,1,'10 excluded count');
+select is((public.aos_sales_admin_sale_v4('F4-TEST-TOKEN',2)->>'ok')::boolean,true,'11 secure sale read works');
+select is(public.aos_sales_admin_sale_v4('F4-TEST-TOKEN',2)->'row'->>'canonicalProductName','LIFTING B 30GR','12 secure sale read canonical identity');
+select is((public.aos_editar_venta_v4('bad',2,(select updated_at from public.aos_ventas where id=2),'{"descripcion":"SPRAY MINOX"}','test')->>'ok')::boolean,false,'13 unauthorized edit rejected');
+
+create temporary table f4_version(v timestamptz);insert into f4_version select updated_at from public.aos_ventas where id=2;
+select is((public.aos_editar_venta_v4('F4-TEST-TOKEN',2,(select v from f4_version),'{"descripcion":"SPRAY MINOX"}','test')->>'ok')::boolean,true,'14 tokenized edit succeeds');
+select is((select product_key from public.aos_product_sale_fact_v1 where sale_id=2),'F3:SPRAYMINOX','15 edit re-resolves product fact');
+-- Production RPC calls are separate DB transactions. This suite intentionally runs inside
+-- one pgTAP transaction, where now() is transaction-stable, so advance the row version
+-- with the wall clock to model the next request boundary deterministically.
+update public.aos_ventas set updated_at=clock_timestamp() where id=2;
+select is(public.aos_editar_venta_v4('F4-TEST-TOKEN',2,(select v from f4_version),'{"monto":201}','test')->>'error','STALE_SALE','16 stale edit rejected');
+select is(public.aos_editar_venta_v4('F4-TEST-TOKEN',2,(select updated_at from public.aos_ventas where id=2),'{"evil":"x"}','test')->>'error','FIELD_NOT_ALLOWED','17 unknown edit field rejected');
+
+create temporary table f4_count_before(n bigint);insert into f4_count_before select count(*) from public.aos_ventas;
+create temporary table f4_batch(j jsonb);insert into f4_batch values('[{"fecha":"2026-08-20","sede":"SAN ISIDRO","nombres":"E","celular":"999555555","tratamiento":"COMPRA DE PRODUCTO","descripcion":"LIFTIN B","pago":"QR","monto":"150","estado_pago":"ADELANTO","asesor":"WILMER","atendio":"DOC"},{"fecha":"2026-08-20","sede":"SAN ISIDRO","nombres":"F","celular":"999666666","tratamiento":"COMPRA DE PRODUCTO","descripcion":"NUEVO ALIAS","pago":"QR","monto":"180","estado_pago":"PAGO COMPLETO","asesor":"WILMER","atendio":"DOC"}]');
+create temporary table f4_preview(j jsonb);insert into f4_preview select public.aos_importar_ventas_preview_v4('F4-TEST-TOKEN',(select j from f4_batch));
+select is((select (j->>'ok')::boolean from f4_preview),true,'18 import preview valid');
+select is((select (j->>'mutates')::boolean from f4_preview),false,'19 preview read-only');
+select is((select (j->>'productResolved')::integer from f4_preview),1,'20 preview resolved count');
+select is((select (j->>'productReviewRequired')::integer from f4_preview),1,'21 preview review count');
+select is((select (j->>'advances')::integer from f4_preview),1,'22 preview advances count');
+select is((select count(*) from public.aos_ventas),(select n from f4_count_before),'23 preview creates no sales');
+create temporary table f4_import(j jsonb);insert into f4_import select public.aos_importar_ventas_v4('F4-TEST-TOKEN',(select j from f4_batch));
+select is((select (j->>'ok')::boolean from f4_import),true,'24 secure import succeeds');
+select is((select (j->>'insertados')::integer from f4_import),2,'25 secure import reports inserts');
+select is((select count(*) from public.aos_ventas),(select n+2 from f4_count_before),'26 secure import inserts expected rows');
+select is((select count(*) from public.aos_product_sale_fact_v1 where resolution_status='REVIEW_REQUIRED'),1::bigint,'27 unknown imported product fails closed');
+
+insert into public.aos_caja_sesiones(id,sede,estado,abierto_por_user_id) values('CAJA-1','SAN ISIDRO','ABIERTA','00000000-0000-0000-0000-000000000001');
+create temporary table f4_caja_before(n bigint);insert into f4_caja_before select count(*) from public.aos_ventas;
+select is(public.aos_grabar_venta_caja_v4('bad','SAN ISIDRO','spoof','CAJA-1','999777777','G','','999777777','77777777','WILMER','DOC','[{"nombre":"LIFTING B","descripcion":"LIFTIN B"}]','QR',200,'PEN','BOLETA','B1','PAGO COMPLETO','','PRODUCTO','2026-08-21',null,200)->>'error','UNAUTHORIZED','28 unauthorized caja rejected');
+select is((select count(*) from public.aos_ventas),(select n from f4_caja_before),'29 unauthorized caja creates no sale');
+select ok((public.aos_grabar_venta_caja_v4('F4-TEST-TOKEN','SAN ISIDRO','spoof','CAJA-1','999777777','G','','999777777','77777777','WILMER','DOC','[{"nombre":"LIFTING B","descripcion":"LIFTIN B"}]','QR',200,'PEN','BOLETA','B1','PAGO COMPLETO','','PRODUCTO','2026-08-21',null,200)->>'venta_id') is not null,'30 secure caja sale succeeds');
+select is((select count(*) from public.aos_ventas),(select n+1 from f4_caja_before),'31 caja exactly one sale');
+
+insert into public.aos_ventas(fecha,nombres,dni,celular,numero_limpio,tratamiento,descripcion,pago,monto,estado_pago,asesor,sede,tipo) values('2026-07-01','H','88888888','999888888','999888888','HIFU','HIFU','QR',300,'ADELANTO','WILMER','SAN ISIDRO','SERVICIO');
+insert into public.aos_ventas(fecha,nombres,dni,celular,numero_limpio,tratamiento,descripcion,pago,monto,estado_pago,asesor,sede,tipo) values('2026-07-12','H','88888888','999888888','999888888','HIFU','HIFU','QR',700,'PAGO COMPLETO','WILMER','SAN ISIDRO','SERVICIO');
+insert into public.aos_cotizaciones(id,numero_limpio,nombre_paciente,dni_paciente,estado,subtotal,total_pagado,saldo_pendiente,sede,asesor,fecha_creacion) values('Q-1','999888888','H','88888888','PAGADO_PARCIAL',1000,300,700,'SAN ISIDRO','WILMER','2026-07-01');
+insert into public.aos_cartera_reconciliacion(id,source_type,venta_row_id,rol_pago,estado_reconciliacion,confianza,monto_registrado,source_active,evidencia,updated_at) values('00000000-0000-0000-0000-000000000099','VENTA',(select max(id)-1 from public.aos_ventas),'ADELANTO','PENDIENTE_RECONCILIAR','NO_EVALUADA',300,true,'{}',now());
+create temporary table f4_pay_before(n bigint);insert into f4_pay_before select count(*) from public.aos_pagos;
+create temporary table f4_candidates(j jsonb);insert into f4_candidates select public.aos_cartera_candidates_v2('F4-TEST-TOKEN','00000000-0000-0000-0000-000000000099');
+select is((select (j->>'ok')::boolean from f4_candidates),true,'32 candidate lookup authorized');
+select ok((select jsonb_array_length(j->'candidates') from f4_candidates)>=2,'33 multiple evidence candidates surfaced');
+select is((select count(*) from public.aos_pagos),(select n from f4_pay_before),'34 candidate lookup creates no payments');
+select is(public.aos_cartera_reconcile_v2('F4-TEST-TOKEN','00000000-0000-0000-0000-000000000099',(select updated_at from public.aos_cartera_reconciliacion where id='00000000-0000-0000-0000-000000000099'),'PAGO_RECONCILIADO','ALTA',1000,0,null,null,'ADELANTO','test')->>'error','EVIDENCE_LINK_REQUIRED','35 payment reconciliation requires evidence');
+select is((public.aos_cartera_reconcile_v2('F4-TEST-TOKEN','00000000-0000-0000-0000-000000000099',(select updated_at from public.aos_cartera_reconciliacion where id='00000000-0000-0000-0000-000000000099'),'PAGO_RECONCILIADO','ALTA',1000,0,'VENTA',(select max(id)::text from public.aos_ventas),'ADELANTO','linked existing evidence')->>'ok')::boolean,true,'36 linked sale reconciliation succeeds');
+select is((select estado_reconciliacion from public.aos_cartera_reconciliacion where id='00000000-0000-0000-0000-000000000099'),'PAGO_RECONCILIADO','37 state persisted');
+select is((select evidencia#>>'{f4_link,type}' from public.aos_cartera_reconciliacion where id='00000000-0000-0000-0000-000000000099'),'VENTA','38 evidence linked without new payment');
+
+select * from finish();
+rollback;

--- a/ci/phase4-revenue/ui_contract.py
+++ b/ci/phase4-revenue/ui_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+bridge = (root / 'app/public/f4-revenue-ops.js').read_text(encoding='utf-8')
+kronia = (root / 'app/public/f4-kronia-revenue-bridge.js').read_text(encoding='utf-8')
+sw = (root / 'app/public/phase2-service-worker.js').read_text(encoding='utf-8')
+proxy = (root / 'app/server-f4.js').read_text(encoding='utf-8')
+railway = (root / 'app/railway.json').read_text(encoding='utf-8')
+core = (root / 'supabase/migrations/20260814223000_f4_revenue_operations_core_v1.sql').read_text(encoding='utf-8')
+
+required_bridge = [
+    'aos_sales_admin_gateway_v4', 'aos_sales_admin_sale_v4', 'aos_editar_venta_v4',
+    'aos_importar_ventas_preview_v4', 'aos_importar_ventas_v4', 'aos_grabar_venta_caja_v4',
+    '/api/f4/cartera-candidates', 'aos_cartera_reconcile_v2', 'canonicalProductName',
+    'physicalQty', 'productResolutionStatus', 'REVIEW_REQUIRED', 'PAGO_RECONCILIADO',
+    'importApproval', 'carteraCandidateByCase'
+]
+for marker in required_bridge:
+    assert marker in bridge, f'missing F4 bridge marker: {marker}'
+
+assert '/f4-revenue-ops.js' in sw, 'service worker must inject F4 revenue bridge'
+assert '/f4-kronia-revenue-bridge.js' in sw, 'service worker must inject KronIA revenue proof bridge'
+assert "'/api/kronia/chat'" in kronia and 'X-AOS-App-Token' in kronia
+assert "body.confirmar_accion.rpc==='aos_editar_venta'" in proxy
+assert 'F4_STRONG_SESSION_REQUIRED' in proxy
+assert 'aos_sales_admin_sale_v4' in proxy and 'aos_editar_venta_v4' in proxy
+assert "pathname==='/api/f4/cartera-candidates'" in proxy
+assert 'aos_cartera_candidates_v2' in proxy
+assert 'node server-f4.js' in railway
+assert 'node server-phase2.js' not in railway.split('"environments"')[0]
+
+# F4 never embeds service-role credentials in browser/runtime bridges.
+for text in (bridge, kronia, proxy):
+    assert 'service_role' not in text.lower()
+
+# Raw evidence preservation belongs to the DB read model. The browser consumes the
+# enriched payload transparently, so do not require a dead marker in the bridge.
+assert "'rawDescription',e->>'descripcion'" in core
+assert "'rawDescription',v.descripcion" in core
+assert "'canonicalProductName'" in core
+print('F4 UI/runtime contract PASS')

--- a/docs/control/F4_REVENUE_OPERATIONS_CHECKPOINT_CURRENT.md
+++ b/docs/control/F4_REVENUE_OPERATIONS_CHECKPOINT_CURRENT.md
@@ -1,0 +1,81 @@
+# ASCENDA OS — F4 Revenue Operations Integration V1 — CURRENT Checkpoint
+
+**Estado:** `IN_PROGRESS / BUILD COMPLETE / ZERO-COST CI GATE`  
+**Actualizado:** 2026-08-14  
+**Branch:** `feature/f4-revenue-operations-v1-20260814`  
+**PR:** `#110`  
+**Head al entrar al gate:** consultar PR/checks exact-SHA; no usar este valor como sustituto de GitHub live.
+
+## Input contract
+
+- F3 Producto Canónico certificado en producción.
+- `aos_product_identity_v1`, `aos_product_alias_v2`, `aos_product_sale_fact_v1` disponibles live.
+- F4 roadmap canónico: `docs/control/REVENUE_DATA_INTELLIGENCE_ROADMAP_CURRENT.md`.
+- Impact Report: `docs/control/F4_REVENUE_OPERATIONS_IMPACT_20260814.md`.
+
+## Baseline live previa al cutover
+
+- Producto facts: 395 total / 389 resolved / 6 excluded / 0 review / 419 unidades.
+- Ventas: 1,279 total en el corte de diseño; producción puede crecer normalmente durante el gate.
+- Cartera: 162 activos / sin auto-conversión de ADELANTO a deuda en el corte.
+- `aos_pagos`: no se considera ledger histórico completo; F4 jamás crea un pago al reconciliar evidencia.
+
+## Hallazgos resueltos por el build
+
+1. **Top Productos:** deja de depender de `descripcion` + aliases hardcodeados como autoridad y recibe identidad F3, ventas, facturación, unidades físicas, packs y cobertura.
+2. **Detalle Ventas:** conserva descripción raw y añade producto canónico/resolution metadata.
+3. **Edición Ventas:** nuevo `aos_editar_venta_v4` exige sesión Auth V3 + 2FA + `admin-sales`, actor server-side, sede válida, whitelist y optimistic lock.
+4. **Importar:** preview read-only + batch/idempotency visibility + resolución de productos + adelantos + posible coincidencia previa; commit por `aos_importar_ventas_v4` tokenizado.
+5. **Caja venta:** `aos_grabar_venta_caja_v4` exige 2FA + `admin-caja`, actor server-side, sede/sesión y montos válidos.
+6. **Cartera:** `aos_cartera_candidates_v2` propone evidencia sin mutar; `aos_cartera_reconcile_v2` exige evidencia para `PAGO_RECONCILIADO`, conserva optimistic lock y verifica que no se cree ningún `aos_pagos`.
+7. **KronIA financiero:** front proxy F4 exige `X-AOS-App-Token` fuerte para confirmar edición de venta; una sesión legacy sin prueba fuerte falla cerrado.
+8. **Runtime UI:** Service Worker inyecta el bridge F4 en `/app` sin reescribir la estructura operativa de Ventas/Cartera.
+9. **Cutover:** migración separada preparada para revocar execute público de `aos_editar_venta`, `aos_importar_ventas`, `aos_grabar_venta_caja` y `aos_cartera_reconcile` solo después de deploy/canary.
+10. **Recovery:** fail-closed; nunca restaura writes legacy débiles.
+
+## Artefactos del release
+
+- `supabase/migrations/20260814223000_f4_revenue_operations_core_v1.sql`
+- `supabase/migrations/20260814223100_f4_cartera_candidates_v2.sql`
+- `supabase/migrations/20260814223900_f4_revenue_operations_cutover.sql`
+- `supabase/rollbacks/20260814223900_f4_revenue_operations_recovery.sql`
+- `app/public/f4-revenue-ops.js`
+- `app/public/f4-kronia-revenue-bridge.js`
+- `app/server-f4.js`
+- `app/public/phase2-service-worker.js`
+- `ci/phase4-revenue/schema_contract.sql`
+- `ci/phase4-revenue/tests/001_revenue_operations.sql`
+- `ci/phase4-revenue/ui_contract.py`
+- `.github/workflows/phase4-revenue-operations.yml`
+
+## CI / Definition of Done pendiente
+
+El build no autoriza producción por sí mismo. Para cerrar F4 deben pasar, sobre el SHA exacto:
+
+1. Runtime syntax + UI contract.
+2. Supabase efímero Zero-Cost.
+3. Exact additive migrations replayables.
+4. DB lint.
+5. 38 pgTAP F4.
+6. Cutover ACL contract.
+7. Recovery fail-closed.
+8. Ascenda CI + Zero-Cost baseline sin regresión.
+9. Preflight read-only de producción.
+10. Merge/deploy Railway exact-SHA.
+11. Aplicación additive core.
+12. Owner canary Ventas + Importar preview + Cartera candidates + Caja no-mutating navigation.
+13. Aplicación de cutover ACL.
+14. Post-deploy smoke: no ventas/pagos ficticios, F3 intacta, Cartera sin deuda automática, legacy writes cerrados.
+15. Validation Report + Notion CURRENT.
+
+## Seguridad / deuda explícita no bloqueante
+
+Los legacy **read-only** `aos_ventas_admin*` continúan disponibles temporalmente porque el contexto KronIA legacy todavía los consume. F4 elimina su uso como autoridad en Ventas Admin y cierra los mutation paths de revenue. La migración del contexto read-only de KronIA queda para el workstream Intelligence/KronIA; no se falseará como deuda resuelta en F4.
+
+## Anti-scope
+
+F5 históricos/pacientes no empieza hasta F4 certificado. F6 BI avanzado y F7 automatización permanecen fuera de F4.
+
+## Next exact action
+
+**Esperar/inspeccionar Zero-Cost CI exact-SHA de PR #110; corregir cualquier fallo; después ejecutar production read-only preflight.**

--- a/docs/control/F4_REVENUE_OPERATIONS_IMPACT_20260814.md
+++ b/docs/control/F4_REVENUE_OPERATIONS_IMPACT_20260814.md
@@ -1,0 +1,279 @@
+# ASCENDA OS — F4 Revenue Operations Integration V1 — Impact Report
+
+**Estado:** CURRENT / PRE-IMPLEMENTATION  
+**Fecha:** 2026-08-14  
+**Rama:** `feature/f4-revenue-operations-v1-20260814`  
+**Base:** `main@1fbcb4ebc2573c7f6a5e84f9c4d83176d89f20e4`  
+**Riesgo:** HIGH con sub-bloque CRITICAL de autorización de writes  
+**Predecesor:** F3 Producto Canónico — `PRODUCTION CERTIFIED — 100%`
+
+## 1. Objetivo
+
+Integrar la verdad canónica de producto de F3 en la operación diaria y cerrar la brecha entre **venta registrada**, **producto real**, **pago existente**, **saldo real** e **importación Excel**, sin reescribir evidencia histórica ni crear pagos duplicados.
+
+F4 no importa todavía años históricos. Esa carga queda preservada como F5, una vez estabilizados estos contratos.
+
+## 2. Baseline live verificada
+
+### Producto F3
+- 395 hechos actuales en `aos_product_sale_fact_v1`.
+- 389 `RESOLVED`.
+- 6 `EXCLUDED`.
+- 0 `REVIEW_REQUIRED` actualmente.
+- 419 unidades físicas resueltas.
+- 43 registros promo/pack.
+- Venta post-workbook `sale_id=2340` resuelta como `F3:LIFTINGB30GR` con cantidad física 1.
+
+### Ventas / pagos / cartera
+- `aos_ventas`: 1,279 filas.
+- 394 filas actualmente tipadas `PRODUCTO`.
+- 123 filas con `estado_pago=ADELANTO`.
+- 0 ventas actuales con `cotizacion_id` poblado.
+- `aos_pagos`: 1 fila; 1 ligada a cotización. La evidencia histórica de cobro no vive principalmente en `aos_pagos`.
+- `aos_cartera_reconciliacion`: 162 casos activos; 162 pendientes; 0 saldo confirmado; 0 reconciliados; S/0 confirmado para cobranza en este corte.
+
+**Conclusión:** F4 no puede diseñar matching suponiendo que `aos_pagos` sea un ledger histórico completo. Debe considerar `aos_ventas`, cotizaciones y evidencia posterior existente, manteniendo la diferencia entre pago y deuda.
+
+## 3. Hallazgo A — Ventas Admin no consume F3 todavía
+
+`app/public/admin-sales.html` sigue construyendo `Top Productos` en el navegador a partir de `aos_ventas.descripcion` y una función hardcodeada `canonProductName()` con un conjunto parcial de aliases.
+
+La propia UI declara que muestra **ventas, no unidades físicas**.
+
+### Riesgo
+- variantes no previstas pueden fragmentar rankings;
+- el frontend duplica una lógica que F3 ya resolvió de forma gobernada en DB;
+- las unidades reales, packs y estado de resolución no llegan al panel;
+- un cambio futuro de aliases exigiría editar frontend en vez de actualizar una dimensión gobernada.
+
+### Decisión F4
+Eliminar la función ad-hoc como fuente de verdad. Crear un read-model/RPC token-gated que una:
+
+`aos_ventas → aos_product_sale_fact_v1 → aos_product_identity_v1`.
+
+Debe devolver por producto canónico:
+- `product_key`;
+- `canonical_name`;
+- número de líneas/ventas;
+- facturación;
+- unidades físicas;
+- promo/pack;
+- sede;
+- asesor;
+- estado de pago;
+- coverage/resolution status.
+
+El monto continúa procediendo de la venta original; la identidad y cantidad proceden de F3.
+
+## 4. Hallazgo B — Venta manual debe seleccionar catálogo, no depender de spelling
+
+F3 ya resuelve aliases después del INSERT/UPDATE de `aos_ventas`, pero el mejor control es prevenir errores cuando la venta nace manualmente.
+
+### Decisión F4
+- Para producto/servicio manual, preferir selector desde catálogo/identidad canónica.
+- Mantener texto libre solo donde sea necesario como evidencia/nota.
+- Si el catálogo tiene una relación F3 uno-a-uno, guardar el nombre canónico estable.
+- Si existen variantes ambiguas, obligar a seleccionar variante; no colapsar automáticamente.
+- Las importaciones legacy siguen usando aliases F3.
+- Alias desconocido → `REVIEW_REQUIRED`, nunca inferencia silenciosa.
+
+## 5. Hallazgo C — Importar es un write-path principal y debe ser first-class
+
+`aos_importar_ventas` ya implementa idempotencia por lote exacto y escribe en `aos_ventas`. Con el trigger F3, nuevas filas de producto pueden resolver su identidad automáticamente.
+
+Sin embargo, el sistema sigue usando Importar como canal operativo relevante; no se puede construir lógica que funcione solo desde Caja.
+
+### Contrato F4
+Caja e Importar deben converger en:
+1. `aos_ventas` como evidencia transaccional;
+2. resolver F3 para producto;
+3. bridge Cartera cuando `estado_pago=ADELANTO`;
+4. mismas reglas de auditoría/calidad.
+
+Debe existir preview previo a importación con:
+- total de filas;
+- periodo/sede;
+- monto total;
+- duplicados previstos;
+- productos `RESOLVED / REVIEW_REQUIRED` cuando sea determinable;
+- advertencias de identidad/reconciliación;
+- hash/idempotency key.
+
+## 6. Hallazgo D — Cartera tiene motor de enlace, pero UI incompleta
+
+`aos_cartera_reconcile(...)` ya acepta `p_cotizacion_id` para asociar un caso de venta a una cotización, implementa optimistic locking por `updated_at`, valida sede/identidad y registra before/after en `aos_security_log`.
+
+Pero `app/public/admin-cartera.html` actualmente envía `p_cotizacion_id:null`; por tanto el admin no tiene un buscador/selector real para vincular evidencia.
+
+### Decisión F4 — Reconciliation V2
+Construir una capa de **candidatos**, separada de la mutación:
+
+`aos_cartera_candidates_v2(token, case_id)` → read-only.
+
+Señales de candidato:
+- teléfono normalizado;
+- DNI cuando exista;
+- misma sede;
+- tratamiento o producto canónico;
+- monto registrado / total esperado;
+- ventana temporal;
+- pago completo posterior;
+- cotización parcial compatible.
+
+El resultado debe exponer `score/confidence + reasons`, nunca decidir deuda automáticamente.
+
+### Acción humana
+El admin puede:
+- vincular evidencia existente;
+- `PAGO_RECONCILIADO`;
+- `NO_ES_DEUDA`;
+- `REVISAR`;
+- confirmar `SALDO_CONFIRMADO` solo con total/saldo verificables.
+
+**Vincular no crea una nueva fila de pago.** Es una relación/auditoría sobre evidencia que ya existe.
+
+## 7. Hallazgo E — Seguridad del write-path de Ventas requiere corrección dentro de F4
+
+Preflight live detectó que varias RPC legacy relevantes siguen siendo ejecutables por `anon`/`authenticated`, entre ellas:
+- `aos_editar_venta`;
+- `aos_importar_ventas`;
+- `aos_grabar_venta_caja`;
+- RPC de lectura administrativa de ventas.
+
+El frontend de Ventas Admin además envía identidad/rol declarados por el navegador al editor legacy. Ese patrón no puede considerarse autorización suficiente.
+
+### Riesgo
+CRITICAL para mutaciones financieras: un rol enviado por navegador no debe otorgar autoridad.
+
+### Remediación F4 obligatoria
+Aplicar patrón additive-first:
+1. crear wrappers/gateways V3 tokenizados usando sesión fuerte y panel requerido (`admin-sales`, `admin-import-ventas`, `admin-caja` según acción);
+2. whitelist explícita de campos mutables;
+3. optimistic locking para edición de venta;
+4. actor derivado server-side, no `p_rol` confiado desde cliente;
+5. audit before/after;
+6. migrar consumidores UI;
+7. negative tests con token inválido/rol incorrecto/sede incorrecta;
+8. recién después revocar execute del legacy cuando todos los consumers estén migrados.
+
+No hacer big-bang revoke antes de probar Caja/Importar/Ventas Admin.
+
+## 8. Arquitectura propuesta
+
+### F4A — Canonical Sales Read Model
+`aos_sales_admin_gateway_v3(token, periodo, sede, asesor)`
+
+Debe conservar los KPIs actuales y añadir:
+- `canonicalProducts`;
+- `productResolutionCoverage`;
+- `physicalUnits`;
+- `reviewRequired`;
+- detalle con `raw_description + canonical_product`.
+
+### F4B — Secure sales writes
+- `aos_sales_edit_v3(...)` — `admin-sales` + 2FA.
+- `aos_importar_ventas_v3(...)` — `admin-import-ventas` + idempotencia.
+- wrapper seguro para grabación desde Caja — `admin-caja` + sesión de caja válida.
+
+Los nombres definitivos se cerrarán tras inventariar todos los consumers y evitar colisión con wrappers existentes.
+
+### F4C — Cartera Candidate Engine
+Read-only candidates + mutación de reconciliación separada. No introducir scoring opaco: cada score debe incluir razones determinísticas.
+
+### F4D — UI
+**Ventas Admin**
+- Top Productos canónico;
+- ventas + unidades;
+- badge de calidad/resolución;
+- editor sin authority declarada por browser.
+
+**Cartera**
+- `Buscar coincidencias`;
+- candidatos y razones;
+- `Vincular existente`;
+- `Ya pagado / No es deuda / Confirmar saldo / Revisar`;
+- timeline/audit del caso.
+
+**Importar**
+- preview profesional;
+- resultado del lote;
+- productos no reconocidos;
+- casos que entraron a Cartera;
+- no usar `window.confirm()` como gate final.
+
+## 9. Non-goals de F4
+
+No construir todavía:
+- merges masivos de pacientes históricos;
+- cargas multi-año;
+- geografía/demografía definitiva;
+- LTV/cohortes multi-año;
+- agentes de cobranza;
+- campañas automáticas.
+
+Esos outputs pertenecen a F5–F7.
+
+## 10. Tests Zero-Cost obligatorios
+
+### Producto
+- 4 spellings → 1 producto canónico;
+- facturación mantiene suma de `aos_ventas.monto`;
+- `physical_qty` suma unidades reales;
+- packs no multiplican venta monetaria;
+- unknown → `REVIEW_REQUIRED`.
+
+### Ventas / Import
+- token inválido no lee data admin ni muta;
+- asesor/admin sin panel correcto no muta;
+- lote repetido es idempotente;
+- import PRODUCTO dispara F3;
+- import ADELANTO dispara Cartera;
+- raw description permanece intacta.
+
+### Cartera
+- candidate read no muta;
+- stale case se rechaza;
+- sede incompatible se rechaza;
+- identidad incompatible se rechaza;
+- link válido no incrementa conteo de pagos/ventas;
+- `NO_ES_DEUDA` deja saldo 0;
+- `SALDO_CONFIRMADO` exige evidencia y total coherente;
+- auditoría before/after presente.
+
+### No regresión
+- Caja abre/cierra/ventas sigue operativa;
+- Ventas Admin mantiene totales del periodo;
+- Sales Intelligence V2 no cambia sus totales por activar F4;
+- F3 facts permanecen 1:1 por venta productiva.
+
+## 11. Rollout
+
+1. branch aislada + contratos sintéticos;
+2. Zero-Cost CI V2;
+3. preflight producción read-only;
+4. funciones/read-model aditivos;
+5. canary solo admin owner;
+6. validar Ventas Admin, Importar y Cartera sin transacciones ficticias;
+7. mover frontend a gateways nuevos;
+8. revocar legacy writes únicamente con evidence de paridad;
+9. post-deploy smoke;
+10. recovery que desactive gateways F4 sin reabrir paths anónimos inseguros.
+
+## 12. Gate de salida F4
+
+F4 = `PRODUCTION CERTIFIED — 100%` solo cuando:
+- Top Productos usa F3 y reporta venta + unidades correctamente;
+- selección manual reduce spelling libre;
+- Importar y Caja convergen en F3 + Cartera;
+- admin puede vincular evidencia existente sin crear pagos duplicados;
+- casos ambiguos fallan cerrado;
+- mutaciones financieras ya no confían en rol/actor enviado por navegador;
+- ACL/RLS/gateways negativos pasan;
+- Zero-Cost CI V2 verde sobre SHA exacto;
+- canary y smoke productivo pasan;
+- rollback/recovery probado;
+- checkpoint GitHub + Supabase + Notion actualizado.
+
+## 13. Siguiente fase preservada
+
+F5 — Historical Client & Sales Consolidation + Patient Identity permanece explícitamente en cola. No se elimina ni se sustituye. Su input contract será F4 certificado, para que años pasados entren por contratos operativos ya confiables.

--- a/supabase/migrations/20260814223000_f4_revenue_operations_core_v1.sql
+++ b/supabase/migrations/20260814223000_f4_revenue_operations_core_v1.sql
@@ -1,0 +1,451 @@
+-- ASCENDA OS — F4 Revenue Operations Integration V1
+-- Additive core. No legacy grants are revoked in this migration.
+
+create or replace function public.aos_f4_actor(p_token text, p_panel text)
+returns uuid
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  select au.id
+  from public.aos_usuarios au
+  join public.aos_rrhh r on r.codigo_asesor=au.codigo_asesor
+  where au.id=public.aos_app_actor_v3(p_token,p_panel,true)
+    and au.activo=true
+    and lower(coalesce(au.rol,''))='admin'
+    and au.nivel_jerarquia in (1,2)
+    and upper(trim(coalesce(r.estado,'')))='ACTIVO'
+  limit 1
+$function$;
+
+create or replace function public.aos_f4_sede_allowed(p_actor uuid, p_sede text)
+returns boolean
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  select case
+    when au.id is null then false
+    when upper(trim(coalesce(p_sede,''))) not in ('SAN ISIDRO','PUEBLO LIBRE') then false
+    when au.nivel_jerarquia=1 then true
+    else coalesce(upper(trim(p_sede))=any(
+      array(select upper(trim(s)) from unnest(coalesce(au.sedes_permitidas,'{}'::text[])) s)
+    ),false)
+  end
+  from public.aos_usuarios au
+  where au.id=p_actor
+$function$;
+
+create or replace function public.aos_sales_admin_gateway_v4(
+  p_token text,
+  p_mes integer default null,
+  p_anio integer default extract(year from (now() at time zone 'America/Lima'))::integer,
+  p_sede text default '',
+  p_asesor text default '',
+  p_mode text default 'MES'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_level integer;
+  v_mode text:=upper(trim(coalesce(p_mode,'MES')));
+  v_sede text:=upper(trim(coalesce(p_sede,'')));
+  v_asesor text:=upper(trim(coalesce(p_asesor,'')));
+  v_desde date;
+  v_hasta date;
+  v_base jsonb;
+  v_detail jsonb;
+  v_products jsonb;
+  v_product_lines integer:=0;
+  v_resolved integer:=0;
+  v_review integer:=0;
+  v_excluded integer:=0;
+  v_units numeric:=0;
+  v_packs integer:=0;
+  v_resolved_revenue numeric:=0;
+  v_unresolved_revenue numeric:=0;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-sales');
+  if v_actor is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  select nivel_jerarquia into v_level from public.aos_usuarios where id=v_actor;
+
+  if v_mode not in ('MES','ANIO') or p_anio not between 2020 and 2100 then
+    return jsonb_build_object('ok',false,'error','INVALID_PERIOD');
+  end if;
+  if v_mode='MES' and (p_mes is null or p_mes not between 1 and 12) then
+    return jsonb_build_object('ok',false,'error','INVALID_MONTH');
+  end if;
+  if v_sede<>'' and not public.aos_f4_sede_allowed(v_actor,v_sede) then
+    return jsonb_build_object('ok',false,'error','FORBIDDEN_SEDE');
+  end if;
+  if v_sede='' and v_level<>1 then
+    return jsonb_build_object('ok',false,'error','SEDE_REQUIRED');
+  end if;
+
+  if v_mode='ANIO' then
+    v_desde:=make_date(p_anio,1,1);
+    v_hasta:=make_date(p_anio,12,31);
+    v_base:=public.aos_ventas_admin_anio(p_anio,v_sede,v_asesor);
+  else
+    v_desde:=make_date(p_anio,p_mes,1);
+    v_hasta:=(v_desde+interval '1 month'-interval '1 day')::date;
+    v_base:=public.aos_ventas_admin(p_mes,p_anio,v_sede,v_asesor);
+  end if;
+
+  select coalesce(jsonb_agg(
+    e || jsonb_build_object(
+      'rawDescription',e->>'descripcion',
+      'canonicalProductKey',f.product_key,
+      'canonicalProductName',pi.canonical_name,
+      'physicalQty',f.physical_qty,
+      'isPack',f.is_pack,
+      'productResolutionStatus',f.resolution_status,
+      'productResolutionSource',f.resolution_source,
+      'updatedAt',v.updated_at
+    ) order by (e->>'fecha') desc,(e->>'id')::bigint desc
+  ),'[]'::jsonb)
+  into v_detail
+  from jsonb_array_elements(coalesce(v_base->'detalle','[]'::jsonb)) e
+  left join public.aos_ventas v on v.id=(e->>'id')::bigint
+  left join public.aos_product_sale_fact_v1 f on f.sale_id=v.id
+  left join public.aos_product_identity_v1 pi on pi.product_key=f.product_key;
+
+  select coalesce(jsonb_agg(to_jsonb(q) order by q.revenue desc,q.canonical_name),'[]'::jsonb)
+  into v_products
+  from (
+    select
+      f.product_key,
+      max(pi.canonical_name) as canonical_name,
+      count(*)::integer as sales_lines,
+      coalesce(sum(v.monto),0)::numeric as revenue,
+      coalesce(sum(f.physical_qty),0)::numeric as physical_units,
+      count(*) filter(where coalesce(f.is_pack,false))::integer as pack_lines
+    from public.aos_ventas v
+    join public.aos_product_sale_fact_v1 f on f.sale_id=v.id and f.resolution_status='RESOLVED'
+    join public.aos_product_identity_v1 pi on pi.product_key=f.product_key
+    where v.fecha between v_desde and v_hasta
+      and upper(trim(coalesce(v.tipo,'')))='PRODUCTO'
+      and (v_sede='' or upper(trim(coalesce(v.sede,'')))=v_sede)
+      and (v_asesor='' or upper(trim(coalesce(v.asesor,'')))=v_asesor)
+    group by f.product_key
+  ) q;
+
+  select
+    count(*)::integer,
+    count(*) filter(where f.resolution_status='RESOLVED')::integer,
+    count(*) filter(where f.resolution_status='REVIEW_REQUIRED' or f.sale_id is null)::integer,
+    count(*) filter(where f.resolution_status='EXCLUDED')::integer,
+    coalesce(sum(f.physical_qty) filter(where f.resolution_status='RESOLVED'),0),
+    count(*) filter(where f.resolution_status='RESOLVED' and coalesce(f.is_pack,false))::integer,
+    coalesce(sum(v.monto) filter(where f.resolution_status='RESOLVED'),0),
+    coalesce(sum(v.monto) filter(where f.resolution_status='REVIEW_REQUIRED' or f.sale_id is null),0)
+  into v_product_lines,v_resolved,v_review,v_excluded,v_units,v_packs,v_resolved_revenue,v_unresolved_revenue
+  from public.aos_ventas v
+  left join public.aos_product_sale_fact_v1 f on f.sale_id=v.id
+  where v.fecha between v_desde and v_hasta
+    and upper(trim(coalesce(v.tipo,'')))='PRODUCTO'
+    and (v_sede='' or upper(trim(coalesce(v.sede,'')))=v_sede)
+    and (v_asesor='' or upper(trim(coalesce(v.asesor,'')))=v_asesor);
+
+  update public.aos_app_sessions_v3 set last_used_at=now()
+  where user_id=v_actor and revoked=false;
+
+  return coalesce(v_base,'{}'::jsonb) || jsonb_build_object(
+    'ok',true,
+    'contract','F4_REVENUE_OPERATIONS_V1',
+    'detalle',v_detail,
+    'canonicalProducts',v_products,
+    'physicalUnits',v_units,
+    'productPackLines',v_packs,
+    'productResolution',jsonb_build_object(
+      'productLines',v_product_lines,
+      'resolved',v_resolved,
+      'reviewRequired',v_review,
+      'excluded',v_excluded,
+      'resolvedRevenue',v_resolved_revenue,
+      'unresolvedRevenue',v_unresolved_revenue,
+      'coveragePct',case when v_product_lines=0 then 100 else round((v_resolved::numeric/v_product_lines::numeric)*100,2) end
+    )
+  );
+end
+$function$;
+
+create or replace function public.aos_sales_admin_sale_v4(p_token text,p_sale_id bigint)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_sede text;
+  v_row jsonb;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-sales');
+  if v_actor is null or p_sale_id is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  select upper(trim(coalesce(sede,''))) into v_sede from public.aos_ventas where id=p_sale_id;
+  if v_sede is null then return jsonb_build_object('ok',false,'error','SALE_NOT_FOUND'); end if;
+  if not public.aos_f4_sede_allowed(v_actor,v_sede) then return jsonb_build_object('ok',false,'error','FORBIDDEN_SEDE'); end if;
+
+  select to_jsonb(v) || jsonb_build_object(
+    'rawDescription',v.descripcion,
+    'canonicalProductKey',f.product_key,
+    'canonicalProductName',pi.canonical_name,
+    'physicalQty',f.physical_qty,
+    'isPack',f.is_pack,
+    'productResolutionStatus',f.resolution_status
+  ) into v_row
+  from public.aos_ventas v
+  left join public.aos_product_sale_fact_v1 f on f.sale_id=v.id
+  left join public.aos_product_identity_v1 pi on pi.product_key=f.product_key
+  where v.id=p_sale_id;
+
+  return jsonb_build_object('ok',true,'row',v_row);
+end
+$function$;
+
+create or replace function public.aos_editar_venta_v4(
+  p_token text,
+  p_venta_id bigint,
+  p_expected_updated_at timestamptz,
+  p_campos jsonb,
+  p_origen text default 'panel_ventas_f4'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_actor_name text;
+  v_row record;
+  v_target_sede text;
+  v_allowed text[]:=array[
+    'fecha','nombres','apellidos','dni','celular','tratamiento','descripcion',
+    'pago','monto','estado_pago','asesor','atendio','sede','numero_limpio',
+    'nro_doc','estado_doc','tipo_comprobante','tipo'
+  ]::text[];
+  v_result jsonb;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-sales');
+  if v_actor is null or p_venta_id is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if p_expected_updated_at is null then return jsonb_build_object('ok',false,'error','EXPECTED_VERSION_REQUIRED'); end if;
+  if p_campos is null or jsonb_typeof(p_campos)<>'object' then return jsonb_build_object('ok',false,'error','INVALID_FIELDS'); end if;
+  if exists(select 1 from jsonb_object_keys(p_campos) k where not (k=any(v_allowed))) then
+    return jsonb_build_object('ok',false,'error','FIELD_NOT_ALLOWED');
+  end if;
+
+  select v.id,v.updated_at,upper(trim(coalesce(v.sede,''))) sede
+  into v_row
+  from public.aos_ventas v where v.id=p_venta_id for update;
+  if v_row.id is null then return jsonb_build_object('ok',false,'error','SALE_NOT_FOUND'); end if;
+  if v_row.updated_at<>p_expected_updated_at then
+    return jsonb_build_object('ok',false,'error','STALE_SALE','current_updated_at',v_row.updated_at);
+  end if;
+  if not public.aos_f4_sede_allowed(v_actor,v_row.sede) then return jsonb_build_object('ok',false,'error','FORBIDDEN_SEDE'); end if;
+
+  if p_campos ? 'sede' then
+    v_target_sede:=upper(trim(coalesce(p_campos->>'sede','')));
+    if not public.aos_f4_sede_allowed(v_actor,v_target_sede) then return jsonb_build_object('ok',false,'error','FORBIDDEN_TARGET_SEDE'); end if;
+  end if;
+
+  select au.nombre into v_actor_name from public.aos_usuarios au where au.id=v_actor;
+  v_result:=public.aos_editar_venta(p_venta_id,p_campos,coalesce(v_actor_name,'ADMIN'),'ADMIN',coalesce(nullif(trim(p_origen),''),'panel_ventas_f4'));
+
+  insert into public.aos_security_log(usuario,accion,detalles)
+  values(coalesce(v_actor_name,'ADMIN'),'F4_SALE_EDIT',jsonb_build_object(
+    'actor_id',v_actor,'sale_id',p_venta_id,'fields',(select coalesce(jsonb_agg(k),'[]'::jsonb) from jsonb_object_keys(p_campos) k),'origin',p_origen
+  ));
+
+  return coalesce(v_result,'{}'::jsonb) || jsonb_build_object(
+    'updated_at',(select updated_at from public.aos_ventas where id=p_venta_id),
+    'security_contract','F4_TOKEN_2FA_ADMIN_SALES'
+  );
+end
+$function$;
+
+create or replace function public.aos_importar_ventas_preview_v4(p_token text,p_ventas jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_row jsonb;
+  v_total integer;
+  v_errors integer:=0;
+  v_products integer:=0;
+  v_resolved integer:=0;
+  v_review integer:=0;
+  v_advances integer:=0;
+  v_existing integer:=0;
+  v_total_amount numeric:=0;
+  v_amount numeric;
+  v_trat text;
+  v_desc text;
+  v_alias text;
+  v_sede text;
+  v_num text;
+  v_fecha date;
+  v_hash text;
+  v_already boolean:=false;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-import-ventas');
+  if v_actor is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if p_ventas is null or jsonb_typeof(p_ventas)<>'array' then return jsonb_build_object('ok',false,'error','INVALID_BATCH'); end if;
+  v_total:=jsonb_array_length(p_ventas);
+  if v_total<1 or v_total>2000 then return jsonb_build_object('ok',false,'error','INVALID_BATCH_SIZE','total',v_total); end if;
+  v_hash:=md5(p_ventas::text);
+  select exists(select 1 from public.aos_import_ventas_batches where batch_hash=v_hash) into v_already;
+
+  for v_row in select value from jsonb_array_elements(p_ventas)
+  loop
+    begin
+      v_sede:=upper(trim(coalesce(v_row->>'sede','')));
+      if not public.aos_f4_sede_allowed(v_actor,v_sede) then v_errors:=v_errors+1; continue; end if;
+      v_fecha:=(v_row->>'fecha')::date;
+      v_amount:=coalesce(nullif(regexp_replace(coalesce(v_row->>'monto',''),'[^0-9.]','','g'),'')::numeric,0);
+      if v_amount<0 then v_errors:=v_errors+1; continue; end if;
+      v_total_amount:=v_total_amount+v_amount;
+      v_trat:=upper(trim(coalesce(v_row->>'tratamiento','')));
+      v_desc:=coalesce(v_row->>'descripcion','');
+      if upper(trim(coalesce(v_row->>'estado_pago','PAGO COMPLETO')))='ADELANTO' then v_advances:=v_advances+1; end if;
+      if v_trat like '%COMPRA%' or v_trat like '%PRODUCTO%' or v_trat='OTROS' then
+        v_products:=v_products+1;
+        v_alias:=public.aos_product_normalize_alias_v2(v_desc);
+        if exists(select 1 from public.aos_product_alias_v2 a where a.alias_key=v_alias and a.active=true) then v_resolved:=v_resolved+1; else v_review:=v_review+1; end if;
+      end if;
+      v_num:=regexp_replace(coalesce(v_row->>'celular',''),'[^0-9]','','g');
+      if length(v_num)>9 then v_num:=right(v_num,9); end if;
+      if exists(
+        select 1 from public.aos_ventas v
+        where v.fecha=v_fecha and v.numero_limpio=v_num
+          and upper(trim(coalesce(v.tratamiento,'')))=v_trat
+          and coalesce(v.monto,0)=v_amount
+          and upper(trim(coalesce(v.pago,'')))=upper(trim(coalesce(v_row->>'pago','')))
+          and upper(trim(coalesce(v.asesor,'')))=upper(trim(coalesce(v_row->>'asesor','')))
+      ) then v_existing:=v_existing+1; end if;
+    exception when others then
+      v_errors:=v_errors+1;
+    end;
+  end loop;
+
+  return jsonb_build_object(
+    'ok',v_errors=0,
+    'error',case when v_errors>0 then 'PREVIEW_VALIDATION_ERRORS' else null end,
+    'total',v_total,
+    'totalAmount',v_total_amount,
+    'batchHash',v_hash,
+    'alreadyImported',v_already,
+    'possibleExistingMatches',v_existing,
+    'productLines',v_products,
+    'productResolved',v_resolved,
+    'productReviewRequired',v_review,
+    'advances',v_advances,
+    'validationErrors',v_errors,
+    'mutates',false
+  );
+end
+$function$;
+
+create or replace function public.aos_importar_ventas_v4(p_token text,p_ventas jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_actor_name text;
+  v_preview jsonb;
+  v_result jsonb;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-import-ventas');
+  if v_actor is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  v_preview:=public.aos_importar_ventas_preview_v4(p_token,p_ventas);
+  if coalesce((v_preview->>'ok')::boolean,false)=false then return v_preview; end if;
+
+  v_result:=public.aos_importar_ventas(p_ventas);
+  select au.nombre into v_actor_name from public.aos_usuarios au where au.id=v_actor;
+  insert into public.aos_security_log(usuario,accion,detalles)
+  values(coalesce(v_actor_name,'ADMIN'),'F4_IMPORT_VENTAS',jsonb_build_object(
+    'actor_id',v_actor,'preview',v_preview,'result',v_result
+  ));
+
+  return coalesce(v_result,'{}'::jsonb) || jsonb_build_object('ok',true,'preview',v_preview,'security_contract','F4_TOKEN_2FA_ADMIN_IMPORT');
+end
+$function$;
+
+create or replace function public.aos_grabar_venta_caja_v4(
+  p_token text,
+  p_sede text, p_usuario text, p_sesion_id text, p_numero_limpio text,
+  p_nombres text, p_apellidos text, p_celular text, p_dni text,
+  p_asesor text, p_doctor text, p_items jsonb, p_metodo_pago text,
+  p_monto_total numeric, p_moneda text, p_tipo_comprobante text,
+  p_nro_doc text, p_estado_pago text, p_nota text, p_tipo text, p_fecha text,
+  p_razon_social_id text default null, p_monto_pagado numeric default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_actor_name text;
+  v_session record;
+  v_result jsonb;
+  v_sede text:=upper(trim(coalesce(p_sede,'')));
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-caja');
+  if v_actor is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if not public.aos_f4_sede_allowed(v_actor,v_sede) then return jsonb_build_object('ok',false,'error','FORBIDDEN_SEDE'); end if;
+  if p_items is null or jsonb_typeof(p_items)<>'array' or jsonb_array_length(p_items)=0 then return jsonb_build_object('ok',false,'error','ITEMS_REQUIRED'); end if;
+  if coalesce(p_monto_total,0)<0 or coalesce(p_monto_pagado,p_monto_total,0)<0 then return jsonb_build_object('ok',false,'error','INVALID_AMOUNT'); end if;
+
+  if nullif(trim(coalesce(p_sesion_id,'')),'') is not null then
+    select id,upper(trim(coalesce(sede,''))) sede,upper(trim(coalesce(estado,''))) estado
+    into v_session from public.aos_caja_sesiones where id=p_sesion_id;
+    if v_session.id is null then return jsonb_build_object('ok',false,'error','SESSION_NOT_FOUND'); end if;
+    if v_session.estado<>'ABIERTA' then return jsonb_build_object('ok',false,'error','SESSION_NOT_OPEN'); end if;
+    if v_session.sede<>v_sede then return jsonb_build_object('ok',false,'error','SESSION_SEDE_MISMATCH'); end if;
+  end if;
+
+  select au.nombre into v_actor_name from public.aos_usuarios au where au.id=v_actor;
+  v_result:=public.aos_grabar_venta_caja(
+    v_sede,coalesce(v_actor_name,'ADMIN'),p_sesion_id,p_numero_limpio,p_nombres,p_apellidos,p_celular,p_dni,
+    p_asesor,p_doctor,p_items,p_metodo_pago,p_monto_total,p_moneda,p_tipo_comprobante,p_nro_doc,
+    p_estado_pago,p_nota,p_tipo,p_fecha,p_razon_social_id,p_monto_pagado
+  );
+
+  insert into public.aos_security_log(usuario,accion,detalles)
+  values(coalesce(v_actor_name,'ADMIN'),'F4_CAJA_VENTA',jsonb_build_object(
+    'actor_id',v_actor,'sede',v_sede,'session_id',p_sesion_id,'result',v_result
+  ));
+  return coalesce(v_result,'{}'::jsonb) || jsonb_build_object('security_contract','F4_TOKEN_2FA_ADMIN_CAJA');
+end
+$function$;
+
+revoke all on function public.aos_f4_actor(text,text) from public;
+revoke all on function public.aos_f4_sede_allowed(uuid,text) from public;
+revoke all on function public.aos_sales_admin_gateway_v4(text,integer,integer,text,text,text) from public;
+revoke all on function public.aos_sales_admin_sale_v4(text,bigint) from public;
+revoke all on function public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text) from public;
+revoke all on function public.aos_importar_ventas_preview_v4(text,jsonb) from public;
+revoke all on function public.aos_importar_ventas_v4(text,jsonb) from public;
+revoke all on function public.aos_grabar_venta_caja_v4(text,text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric) from public;
+
+grant execute on function public.aos_sales_admin_gateway_v4(text,integer,integer,text,text,text) to anon,authenticated;
+grant execute on function public.aos_sales_admin_sale_v4(text,bigint) to anon,authenticated;
+grant execute on function public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text) to anon,authenticated;
+grant execute on function public.aos_importar_ventas_preview_v4(text,jsonb) to anon,authenticated;
+grant execute on function public.aos_importar_ventas_v4(text,jsonb) to anon,authenticated;
+grant execute on function public.aos_grabar_venta_caja_v4(text,text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric) to anon,authenticated;

--- a/supabase/migrations/20260814223100_f4_cartera_candidates_v2.sql
+++ b/supabase/migrations/20260814223100_f4_cartera_candidates_v2.sql
@@ -1,0 +1,235 @@
+-- ASCENDA OS — F4 Cartera Reconciliation V2
+-- Candidate discovery is read-only. Linking existing evidence never creates aos_pagos rows.
+
+create or replace function public.aos_cartera_candidates_v2(p_token text,p_case_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_case record;
+  v_phone text;
+  v_dni text;
+  v_sede text;
+  v_date date;
+  v_concept text;
+  v_amount numeric;
+  v_product_key text;
+  v_candidates jsonb;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-cartera');
+  if v_actor is null or p_case_id is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+
+  select cr.id,cr.source_type,cr.venta_row_id,cr.cotizacion_id,cr.monto_registrado,
+         upper(trim(coalesce(v.sede,c.sede,''))) sede,
+         coalesce(v.fecha,c.fecha_creacion) source_date,
+         regexp_replace(coalesce(v.numero_limpio,v.celular,c.numero_limpio,''),'\D','','g') phone,
+         regexp_replace(coalesce(v.dni,c.dni_paciente,''),'\D','','g') dni,
+         upper(trim(coalesce(v.tratamiento,''))) concept,
+         f.product_key
+    into v_case
+  from public.aos_cartera_reconciliacion cr
+  left join public.aos_ventas v on cr.source_type='VENTA' and v.id=cr.venta_row_id
+  left join public.aos_cotizaciones c on cr.cotizacion_id=c.id
+  left join public.aos_product_sale_fact_v1 f on f.sale_id=v.id and f.resolution_status='RESOLVED'
+  where cr.id=p_case_id and cr.source_active=true;
+
+  if v_case.id is null then return jsonb_build_object('ok',false,'error','CASE_NOT_FOUND'); end if;
+  if not public.aos_f4_sede_allowed(v_actor,v_case.sede) then return jsonb_build_object('ok',false,'error','FORBIDDEN_SEDE'); end if;
+
+  v_phone:=nullif(v_case.phone,'');
+  v_dni:=nullif(v_case.dni,'');
+  v_sede:=v_case.sede;
+  v_date:=v_case.source_date;
+  v_concept:=v_case.concept;
+  v_amount:=coalesce(v_case.monto_registrado,0);
+  v_product_key:=v_case.product_key;
+
+  if coalesce(length(v_phone),0)<6 and coalesce(length(v_dni),0)<6 then
+    return jsonb_build_object('ok',true,'caseId',p_case_id,'candidates','[]'::jsonb,'reason','IDENTITY_INSUFFICIENT','mutates',false);
+  end if;
+
+  with raw as (
+    select
+      'COTIZACION'::text candidate_type,
+      c.id::text candidate_id,
+      c.fecha_creacion candidate_date,
+      c.sede,
+      c.nombre_paciente label,
+      c.subtotal total_amount,
+      c.total_pagado paid_amount,
+      c.saldo_pendiente balance_amount,
+      c.estado status,
+      (
+        (case when length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(c.numero_limpio,''),'\D','','g')=v_phone then 45 else 0 end) +
+        (case when length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(c.dni_paciente,''),'\D','','g')=v_dni then 50 else 0 end) +
+        10 +
+        (case when abs(c.fecha_creacion-v_date)<=30 then 15 when abs(c.fecha_creacion-v_date)<=60 then 8 else 3 end) +
+        (case when v_amount>0 and abs(coalesce(c.total_pagado,0)-v_amount)<=1 then 10 else 0 end) +
+        (case when upper(trim(coalesce(c.estado,''))) in ('PAGADO_COMPLETO','PAGADO_PARCIAL') then 5 else 0 end)
+      )::integer score,
+      jsonb_strip_nulls(jsonb_build_object(
+        'phoneMatch',case when length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(c.numero_limpio,''),'\D','','g')=v_phone then true else null end,
+        'dniMatch',case when length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(c.dni_paciente,''),'\D','','g')=v_dni then true else null end,
+        'sameSede',true,
+        'daysApart',abs(c.fecha_creacion-v_date),
+        'amountNear',case when v_amount>0 then abs(coalesce(c.total_pagado,0)-v_amount)<=1 else null end
+      )) reasons
+    from public.aos_cotizaciones c
+    where upper(trim(coalesce(c.sede,'')))=v_sede
+      and c.fecha_creacion between v_date-90 and v_date+90
+      and (v_case.cotizacion_id is null or c.id<>v_case.cotizacion_id)
+      and (
+        (length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(c.numero_limpio,''),'\D','','g')=v_phone)
+        or (length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(c.dni_paciente,''),'\D','','g')=v_dni)
+      )
+
+    union all
+
+    select
+      'VENTA'::text candidate_type,
+      v.id::text candidate_id,
+      v.fecha candidate_date,
+      v.sede,
+      trim(coalesce(v.nombres,'')||' '||coalesce(v.apellidos,'')) label,
+      v.monto total_amount,
+      case when upper(trim(coalesce(v.estado_pago,'')))='PAGO COMPLETO' then v.monto else null end paid_amount,
+      null::numeric balance_amount,
+      v.estado_pago status,
+      (
+        (case when length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(v.numero_limpio,v.celular,''),'\D','','g')=v_phone then 45 else 0 end) +
+        (case when length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(v.dni,''),'\D','','g')=v_dni then 50 else 0 end) +
+        10 +
+        (case when abs(v.fecha-v_date)<=30 then 15 when abs(v.fecha-v_date)<=60 then 8 else 3 end) +
+        (case when v_product_key is not null and f2.product_key=v_product_key then 15 when v_concept<>'' and upper(trim(coalesce(v.tratamiento,'')))=v_concept then 12 else 0 end) +
+        (case when v_amount>0 and abs(coalesce(v.monto,0)-v_amount)<=1 then 8 else 0 end) +
+        (case when upper(trim(coalesce(v.estado_pago,'')))='PAGO COMPLETO' then 8 else 0 end)
+      )::integer score,
+      jsonb_strip_nulls(jsonb_build_object(
+        'phoneMatch',case when length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(v.numero_limpio,v.celular,''),'\D','','g')=v_phone then true else null end,
+        'dniMatch',case when length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(v.dni,''),'\D','','g')=v_dni then true else null end,
+        'sameSede',true,
+        'daysApart',abs(v.fecha-v_date),
+        'sameConcept',case when v_concept<>'' then upper(trim(coalesce(v.tratamiento,'')))=v_concept else null end,
+        'sameCanonicalProduct',case when v_product_key is not null then f2.product_key=v_product_key else null end,
+        'fullPayment',upper(trim(coalesce(v.estado_pago,'')))='PAGO COMPLETO',
+        'amountNear',case when v_amount>0 then abs(coalesce(v.monto,0)-v_amount)<=1 else null end
+      )) reasons
+    from public.aos_ventas v
+    left join public.aos_product_sale_fact_v1 f2 on f2.sale_id=v.id and f2.resolution_status='RESOLVED'
+    where upper(trim(coalesce(v.sede,'')))=v_sede
+      and v.fecha between v_date-90 and v_date+90
+      and (v_case.venta_row_id is null or v.id<>v_case.venta_row_id)
+      and (
+        (length(coalesce(v_phone,''))>=6 and regexp_replace(coalesce(v.numero_limpio,v.celular,''),'\D','','g')=v_phone)
+        or (length(coalesce(v_dni,''))>=6 and regexp_replace(coalesce(v.dni,''),'\D','','g')=v_dni)
+      )
+  ), ranked as (
+    select *,case when score>=85 then 'ALTA' when score>=65 then 'MEDIA' else 'BAJA' end confidence
+    from raw
+    where score>=55
+    order by score desc,candidate_date desc
+    limit 12
+  )
+  select coalesce(jsonb_agg(jsonb_build_object(
+    'type',candidate_type,'id',candidate_id,'date',candidate_date,'sede',sede,
+    'label',label,'totalAmount',total_amount,'paidAmount',paid_amount,'balanceAmount',balance_amount,
+    'status',status,'score',score,'confidence',confidence,'reasons',reasons
+  ) order by score desc,candidate_date desc),'[]'::jsonb)
+  into v_candidates from ranked;
+
+  return jsonb_build_object('ok',true,'caseId',p_case_id,'candidates',v_candidates,'mutates',false,'autoDecision',false);
+end
+$function$;
+
+create or replace function public.aos_cartera_reconcile_v2(
+  p_token text,
+  p_case_id uuid,
+  p_expected_updated_at timestamptz,
+  p_estado text,
+  p_confianza text default 'CONFIRMADA',
+  p_total_esperado numeric default null,
+  p_saldo_confirmado numeric default null,
+  p_candidate_type text default null,
+  p_candidate_id text default null,
+  p_rol_pago text default 'ADELANTO',
+  p_observacion text default ''
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_actor_name text;
+  v_type text:=upper(trim(coalesce(p_candidate_type,'')));
+  v_candidates jsonb;
+  v_valid boolean:=false;
+  v_quote_id text:=null;
+  v_result jsonb;
+  v_payments_before bigint;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-cartera');
+  if v_actor is null then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if (v_type='' and nullif(trim(coalesce(p_candidate_id,'')),'') is not null)
+     or (v_type<>'' and nullif(trim(coalesce(p_candidate_id,'')),'') is null)
+     or v_type not in ('','VENTA','COTIZACION') then
+    return jsonb_build_object('ok',false,'error','INVALID_CANDIDATE');
+  end if;
+
+  if v_type<>'' then
+    v_candidates:=public.aos_cartera_candidates_v2(p_token,p_case_id);
+    select exists(
+      select 1 from jsonb_array_elements(coalesce(v_candidates->'candidates','[]'::jsonb)) x
+      where x->>'type'=v_type and x->>'id'=p_candidate_id
+    ) into v_valid;
+    if not v_valid then return jsonb_build_object('ok',false,'error','CANDIDATE_NOT_ALLOWED'); end if;
+    if v_type='COTIZACION' then v_quote_id:=p_candidate_id; end if;
+  end if;
+
+  if upper(trim(coalesce(p_estado,'')))='PAGO_RECONCILIADO' and v_type='' then
+    return jsonb_build_object('ok',false,'error','EVIDENCE_LINK_REQUIRED');
+  end if;
+
+  select count(*) into v_payments_before from public.aos_pagos;
+  v_result:=public.aos_cartera_reconcile(
+    p_token,p_case_id,p_expected_updated_at,p_estado,p_confianza,
+    p_total_esperado,p_saldo_confirmado,v_quote_id,p_rol_pago,p_observacion
+  );
+  if coalesce((v_result->>'ok')::boolean,false)=false then return v_result; end if;
+
+  if v_type='VENTA' then
+    update public.aos_cartera_reconciliacion
+    set evidencia=coalesce(evidencia,'{}'::jsonb)||jsonb_build_object(
+      'f4_link',jsonb_build_object('type','VENTA','sale_id',p_candidate_id,'linked_at',now(),'linked_by',v_actor)
+    ),updated_at=now()
+    where id=p_case_id;
+  elsif v_type='COTIZACION' then
+    update public.aos_cartera_reconciliacion
+    set evidencia=coalesce(evidencia,'{}'::jsonb)||jsonb_build_object(
+      'f4_link',jsonb_build_object('type','COTIZACION','quote_id',p_candidate_id,'linked_at',now(),'linked_by',v_actor)
+    )
+    where id=p_case_id;
+  end if;
+
+  if (select count(*) from public.aos_pagos)<>v_payments_before then
+    raise exception 'F4_RECONCILIATION_MUST_NOT_CREATE_PAYMENTS';
+  end if;
+
+  select au.nombre into v_actor_name from public.aos_usuarios au where au.id=v_actor;
+  insert into public.aos_security_log(usuario,accion,detalles)
+  values(coalesce(v_actor_name,'ADMIN'),'F4_CARTERA_LINK',jsonb_build_object(
+    'actor_id',v_actor,'case_id',p_case_id,'candidate_type',nullif(v_type,''),'candidate_id',p_candidate_id,'status',p_estado
+  ));
+
+  return v_result || jsonb_build_object('candidateType',nullif(v_type,''),'candidateId',p_candidate_id,'createdPayment',false,'contract','F4_CARTERA_RECONCILIATION_V2');
+end
+$function$;
+
+revoke all on function public.aos_cartera_candidates_v2(text,uuid) from public;
+revoke all on function public.aos_cartera_reconcile_v2(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text,text) from public;
+grant execute on function public.aos_cartera_candidates_v2(text,uuid) to anon,authenticated;
+grant execute on function public.aos_cartera_reconcile_v2(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text,text) to anon,authenticated;

--- a/supabase/migrations/20260814223900_f4_revenue_operations_cutover.sql
+++ b/supabase/migrations/20260814223900_f4_revenue_operations_cutover.sql
@@ -1,0 +1,21 @@
+-- ASCENDA OS — F4 Revenue Operations controlled cutover.
+-- Apply only after F4 browser/proxy code is deployed and owner canary passes.
+-- Secure wrappers remain SECURITY DEFINER and can call the retired legacy functions internally.
+
+revoke execute on function public.aos_editar_venta(bigint,jsonb,text,text,text) from public,anon,authenticated;
+revoke execute on function public.aos_importar_ventas(jsonb) from public,anon,authenticated;
+revoke execute on function public.aos_grabar_venta_caja(text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric) from public,anon,authenticated;
+revoke execute on function public.aos_cartera_reconcile(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text) from public,anon,authenticated;
+
+-- Reads remain temporarily compatible because the legacy KronIA context still consumes
+-- aos_ventas_admin. F4 secures the operational UI and all revenue mutation paths; the
+-- remaining read-only legacy consumer is explicitly tracked for the Intelligence/KronIA stream.
+
+insert into public.aos_security_log(usuario,accion,detalles)
+values('SYSTEM','F4_REVENUE_CUTOVER',jsonb_build_object(
+  'legacy_sale_edit_execute',false,
+  'legacy_import_execute',false,
+  'legacy_caja_sale_execute',false,
+  'legacy_cartera_reconcile_execute',false,
+  'at',now()
+));

--- a/supabase/rollbacks/20260814223900_f4_revenue_operations_recovery.sql
+++ b/supabase/rollbacks/20260814223900_f4_revenue_operations_recovery.sql
@@ -1,0 +1,23 @@
+-- ASCENDA OS — F4 emergency recovery (fail closed).
+-- Do not restore weak legacy mutation paths. Keep read-only F4 visibility available,
+-- disable new revenue mutations/candidate reconciliation until a corrected release is ready.
+
+revoke execute on function public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text) from public,anon,authenticated;
+revoke execute on function public.aos_importar_ventas_v4(text,jsonb) from public,anon,authenticated;
+revoke execute on function public.aos_grabar_venta_caja_v4(text,text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric) from public,anon,authenticated;
+revoke execute on function public.aos_cartera_reconcile_v2(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text,text) from public,anon,authenticated;
+
+-- Read-only operations remain available for diagnosis.
+grant execute on function public.aos_sales_admin_gateway_v4(text,integer,integer,text,text,text) to anon,authenticated;
+grant execute on function public.aos_sales_admin_sale_v4(text,bigint) to anon,authenticated;
+grant execute on function public.aos_importar_ventas_preview_v4(text,jsonb) to anon,authenticated;
+grant execute on function public.aos_cartera_candidates_v2(text,uuid) to anon,authenticated;
+
+-- Legacy mutation functions intentionally remain revoked after recovery.
+revoke execute on function public.aos_editar_venta(bigint,jsonb,text,text,text) from public,anon,authenticated;
+revoke execute on function public.aos_importar_ventas(jsonb) from public,anon,authenticated;
+revoke execute on function public.aos_grabar_venta_caja(text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric) from public,anon,authenticated;
+revoke execute on function public.aos_cartera_reconcile(text,uuid,timestamptz,text,text,numeric,numeric,text,text,text) from public,anon,authenticated;
+
+insert into public.aos_security_log(usuario,accion,detalles)
+values('SYSTEM','F4_REVENUE_RECOVERY',jsonb_build_object('mode','FAIL_CLOSED','at',now()));


### PR DESCRIPTION
Synchronize the active F16 clean release with CURRENT main before exact-head certification. This PR is release-lineage only: head=main, base=release/cia-phase16-email-20260815-v5. It introduces the three commits that landed on main after the v5 base, including current deployment/runtime metadata. No production mutation. After merge, F16 Runtime/Contracts/Policy must be re-certified on the resulting exact release HEAD; no gate is waived.