### PR TITLE
P0: secure_write JSONB fix on CURRENT main

### DIFF
--- a/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
+++ b/supabase/migrations/20260814201500_fix_secure_write_v2_jsonb_match_count.sql
@@ -1,5 +1,4 @@
--- P0/HIGH: PostgreSQL validates JSONB object presence via jsonb_object_keys(jsonb);
--- the legacy object-length helper was not a valid PostgreSQL function.
+-- P0/HIGH: PostgreSQL has jsonb_object_keys(jsonb), not jsonb_object_length(jsonb).
 -- Preserve the existing secure-write contract while making PATCH/DELETE match
 -- validation executable and lint-clean.
 begin;


### PR DESCRIPTION
## Objetivo
Reanclar el P0 de `aos_secure_write_v2` sobre el `main` CURRENT sin arrastrar la rama histórica divergida de PR #105.

## Riesgo
HIGH — protected write gateway compatibility.

## Cambios
- misma migration `20260814201500_fix_secure_write_v2_jsonb_match_count.sql` ya validada en el certificado dedicado de #105;
- mismo recovery fail-closed;
- mismo test de regresión `008_secure_write_jsonb_fix.sql`;
- mismo workflow Zero-Cost P0;
- sin datos, PII/PHI ni secretos;
- baseline exacta: `main` f05982e7a6af6a85d158693dffa6a693b27df54f, que ya incluye zero-residue #107 y cambios CURRENT posteriores.

## Gate
No fusionar hasta que el SHA exacto pase CI self-hosted Zero-Cost V2, DB lint, regresiones, recovery/reapply y zero-residue.