### PR TITLE
WA-1: Secure WhatsApp Gateway

### DIFF
--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -39,6 +39,12 @@ jobs:
       DB_URL: postgresql://postgres:postgres@127.0.0.1:59622/postgres
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
 
       - name: Enforce Zero-Cost runner policy
         run: |

--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa1-secure-gateway/tests/001_wa1_security.sql | tee /tmp/wa1-pgtap.txt
-          grep -q '1..14' /tmp/wa1-pgtap.txt
+          grep -q '1..18' /tmp/wa1-pgtap.txt
           if grep -q 'Looks like you planned' /tmp/wa1-pgtap.txt; then exit 1; fi
           if grep -q 'not ok' /tmp/wa1-pgtap.txt; then exit 1; fi
 
@@ -112,7 +112,10 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_meta_config','SELECT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_meta_config','UPDATE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_meta_config'::regclass")" = "t"
 
       - name: Stop isolated Supabase
         if: always()

--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa1-secure-gateway/tests/001_wa1_security.sql | tee /tmp/wa1-pgtap.txt
-          grep -q '1..22' /tmp/wa1-pgtap.txt
+          grep -q '1..25' /tmp/wa1-pgtap.txt
           if grep -q 'Looks like you planned' /tmp/wa1-pgtap.txt; then exit 1; fi
           if grep -q 'not ok' /tmp/wa1-pgtap.txt; then exit 1; fi
 
@@ -114,10 +114,12 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_outbound_requests_v1','SELECT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_webhook_log','SELECT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_meta_config','SELECT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_meta_config','UPDATE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_outbound_requests_v1'::regclass")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_webhook_log'::regclass")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_meta_config'::regclass")" = "t"
 
       - name: Stop isolated Supabase

--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -11,6 +11,7 @@ on:
       - 'ci/wa1-secure-gateway/**'
       - 'docs/control/WHATSAPP_REVENUE_HUB_WA1_*'
       - '.github/workflows/wa1-secure-whatsapp-gateway.yml'
+      - 'ci/phase4-revenue/ui_contract.py'
   push:
     branches: ['security/**']
     paths:
@@ -21,6 +22,7 @@ on:
       - 'ci/wa1-secure-gateway/**'
       - 'docs/control/WHATSAPP_REVENUE_HUB_WA1_*'
       - '.github/workflows/wa1-secure-whatsapp-gateway.yml'
+      - 'ci/phase4-revenue/ui_contract.py'
   workflow_dispatch:
 
 permissions:
@@ -67,8 +69,20 @@ jobs:
           grep -q "SUPABASE_SERVICE_ROLE_KEY" app/server-f4.js
           grep -q "p_required_panel:'admin-chats'" app/server-f4.js
           grep -q "aos_wa_outbound_requests_v1" app/server-f4.js
+          grep -q "delete childEnv.SUPABASE_SERVICE_ROLE_KEY" app/server-f4.js
+          grep -q "delete childEnv.WHATSAPP_APP_SECRET" app/server-f4.js
+          grep -q "delete childEnv.WHATSAPP_ACCESS_TOKEN" app/server-f4.js
+          grep -q "delete childEnv.WHATSAPP_VERIFY_TOKEN" app/server-f4.js
+          grep -q "e.definite===true" app/server-f4.js
+          grep -q "ambiguous_pending" app/server-f4.js
+          grep -q "retry_safe:false" app/server-f4.js
           ! grep -Eq "WHATSAPP_(APP_SECRET|ACCESS_TOKEN|VERIFY_TOKEN)\s*=\s*['\"][^'\"]+['\"]" app/server-f4.js
           ! grep -Eq "Bearer [A-Za-z0-9_-]{20,}" app/server-f4.js app/wa-gateway.js
+
+      - name: Cross-workstream F4 compatibility contract
+        run: |
+          set -euo pipefail
+          python3 ci/phase4-revenue/ui_contract.py
 
       - name: Configure isolated Supabase ports
         working-directory: ci/zero-cost-staging

--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -60,6 +60,7 @@ jobs:
           grep -q "WHATSAPP_APP_SECRET" app/server-f4.js
           grep -q "SUPABASE_SERVICE_ROLE_KEY" app/server-f4.js
           grep -q "p_required_panel:'admin-chats'" app/server-f4.js
+          grep -q "aos_wa_outbound_requests_v1" app/server-f4.js
           ! grep -Eq "WHATSAPP_(APP_SECRET|ACCESS_TOKEN|VERIFY_TOKEN)\s*=\s*['\"][^'\"]+['\"]" app/server-f4.js
           ! grep -Eq "Bearer [A-Za-z0-9_-]{20,}" app/server-f4.js app/wa-gateway.js
 
@@ -101,7 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa1-secure-gateway/tests/001_wa1_security.sql | tee /tmp/wa1-pgtap.txt
-          grep -q '1..18' /tmp/wa1-pgtap.txt
+          grep -q '1..22' /tmp/wa1-pgtap.txt
           if grep -q 'Looks like you planned' /tmp/wa1-pgtap.txt; then exit 1; fi
           if grep -q 'not ok' /tmp/wa1-pgtap.txt; then exit 1; fi
 
@@ -111,10 +112,12 @@ jobs:
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_outbound_requests_v1','SELECT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_meta_config','SELECT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_meta_config','UPDATE')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_outbound_requests_v1'::regclass")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_meta_config'::regclass")" = "t"
 
       - name: Stop isolated Supabase

--- a/.github/workflows/wa1-secure-whatsapp-gateway.yml
+++ b/.github/workflows/wa1-secure-whatsapp-gateway.yml
@@ -1,0 +1,120 @@
+name: ASCENDA WA-1 Secure WhatsApp Gateway
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/server-f4.js'
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa1_secure_gateway*'
+      - 'supabase/rollbacks/*wa1_secure_gateway*'
+      - 'ci/wa1-secure-gateway/**'
+      - 'docs/control/WHATSAPP_REVENUE_HUB_WA1_*'
+      - '.github/workflows/wa1-secure-whatsapp-gateway.yml'
+  push:
+    branches: ['security/**']
+    paths:
+      - 'app/server-f4.js'
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa1_secure_gateway*'
+      - 'supabase/rollbacks/*wa1_secure_gateway*'
+      - 'ci/wa1-secure-gateway/**'
+      - 'docs/control/WHATSAPP_REVENUE_HUB_WA1_*'
+      - '.github/workflows/wa1-secure-whatsapp-gateway.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa1-secure-gateway-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: WA-1 Zero-Cost security certification
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59622/postgres
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce Zero-Cost runner policy
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Runtime syntax and regression tests
+        run: |
+          set -euo pipefail
+          node --check app/wa-gateway.js
+          node --check app/server-f4.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+
+      - name: Security source contracts
+        run: |
+          set -euo pipefail
+          grep -q "x-hub-signature-256" app/server-f4.js
+          grep -q "WHATSAPP_APP_SECRET" app/server-f4.js
+          grep -q "SUPABASE_SERVICE_ROLE_KEY" app/server-f4.js
+          grep -q "p_required_panel:'admin-chats'" app/server-f4.js
+          ! grep -Eq "WHATSAPP_(APP_SECRET|ACCESS_TOKEN|VERIFY_TOKEN)\s*=\s*['\"][^'\"]+['\"]" app/server-f4.js
+          ! grep -Eq "Bearer [A-Za-z0-9_-]{20,}" app/server-f4.js app/wa-gateway.js
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa1-secure-gateway"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59621/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59622/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59620/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa1-secure-gateway' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59622 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-1 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build synthetic prerequisite schema
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa1-secure-gateway/schema_contract.sql
+
+      - name: Apply exact WA-1 migration
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: pgTAP authorization contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa1-secure-gateway/tests/001_wa1_security.sql | tee /tmp/wa1-pgtap.txt
+          grep -q '1..14' /tmp/wa1-pgtap.txt
+          if grep -q 'Looks like you planned' /tmp/wa1-pgtap.txt; then exit 1; fi
+          if grep -q 'not ok' /tmp/wa1-pgtap.txt; then exit 1; fi
+
+      - name: Recovery remains fail-closed
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select relforcerowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass")" = "t"
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/app/server-f4.js
+++ b/app/server-f4.js
@@ -1,21 +1,32 @@
-// ASCENDA OS — F4 Revenue Operations front proxy.
+// ASCENDA OS — F4 Revenue Operations + WA-1 secure front proxy.
 'use strict';
 const http=require('http');
 const https=require('https');
 const {spawn}=require('child_process');
+const wa=require('./wa-gateway');
 
 const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10);
 const INNER_PORT=EXTERNAL_PORT===4189?4190:4189;
 const SB_URL=process.env.SUPABASE_URL||'https://ituyqwstonmhnfshnaqz.supabase.co';
-const SB_ANON_KEY=process.env.SUPABASE_ANON_KEY||'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXNlIiwicmVmIjoiaXR1eXF3c3Rvbm1obmZzaG5hcXoiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc3NDc0NDIxOCwiZXhwIjoyMDkwMzIwMjE4fQ.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+const SB_ANON_KEY=process.env.SUPABASE_ANON_KEY||'';
+const SB_SERVICE_KEY=process.env.SUPABASE_SERVICE_ROLE_KEY||'';
+const WA_VERIFY_TOKEN=process.env.WHATSAPP_VERIFY_TOKEN||'';
+const WA_APP_SECRET=process.env.WHATSAPP_APP_SECRET||'';
+const WA_ACCESS_TOKEN=process.env.WHATSAPP_ACCESS_TOKEN||'';
+const WA_PHONE_NUMBER_ID=process.env.WHATSAPP_PHONE_NUMBER_ID||'';
+const WA_GRAPH_VERSION=process.env.WHATSAPP_GRAPH_VERSION||'';
+const WA_CANARY_MODE=process.env.WA_CANARY_MODE||'true';
+const WA_CANARY_ALLOW_TO=process.env.WA_CANARY_ALLOW_TO||'';
 
 const child=spawn(process.execPath,['server-phase2.js'],{cwd:__dirname,env:Object.assign({},process.env,{PORT:String(INNER_PORT)}),stdio:['ignore','inherit','inherit']});
 child.on('exit',(code,signal)=>{console.error('[F4-PROXY] backend exited',{code,signal});process.exit(code==null?1:code);});
 
-function writeJson(res,status,obj){res.writeHead(status,{'Content-Type':'application/json; charset=utf-8','Cache-Control':'no-store','X-Ascenda-Revenue-Route':'f4'});res.end(JSON.stringify(obj));}
+function writeJson(res,status,obj,extra){res.writeHead(status,Object.assign({'Content-Type':'application/json; charset=utf-8','Cache-Control':'no-store','X-Ascenda-Revenue-Route':'f4','X-Ascenda-WA-Gateway':'v1'},extra||{}));res.end(JSON.stringify(obj));}
 function readJson(req,maxBytes=1024*1024){return new Promise((resolve,reject)=>{let raw='',overflow=false;req.on('data',c=>{if(overflow)return;raw+=c;if(Buffer.byteLength(raw)>maxBytes)overflow=true;});req.on('end',()=>{if(overflow){reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413}));return;}try{resolve({raw,body:JSON.parse(raw||'{}')});}catch(e){reject(Object.assign(new Error('INVALID_JSON'),{status:400}));}});req.on('error',reject);});}
+function readRaw(req,maxBytes=1024*1024){return new Promise((resolve,reject)=>{const chunks=[];let total=0,overflow=false;req.on('data',c=>{if(overflow)return;total+=c.length;if(total>maxBytes){overflow=true;return;}chunks.push(c);});req.on('end',()=>overflow?reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413})):resolve(Buffer.concat(chunks)));req.on('error',reject);});}
 function sbRpc(name,payload){
   return new Promise((resolve,reject)=>{
+    if(!SB_ANON_KEY){reject(new Error('SUPABASE_ANON_KEY_NOT_CONFIGURED'));return;}
     let sb;try{sb=new URL(SB_URL);}catch(e){reject(e);return;}
     const data=JSON.stringify(payload||{});
     const req=https.request({hostname:sb.hostname,port:sb.port||443,path:'/rest/v1/rpc/'+name,method:'POST',headers:{apikey:SB_ANON_KEY,Authorization:'Bearer '+SB_ANON_KEY,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-F4-RevenueProxy/1.0'},timeout:12000},r=>{
@@ -24,7 +35,19 @@ function sbRpc(name,payload){
     req.on('timeout',()=>req.destroy(new Error('UPSTREAM_TIMEOUT')));req.on('error',reject);req.write(data);req.end();
   });
 }
+function sbService(method,endpoint,body,prefer){
+  return new Promise((resolve,reject)=>{
+    if(!SB_SERVICE_KEY){reject(Object.assign(new Error('WA_SERVICE_ROLE_NOT_CONFIGURED'),{status:503}));return;}
+    let sb;try{sb=new URL(SB_URL);}catch(e){reject(e);return;}
+    const data=body==null?'':JSON.stringify(body);const headers={apikey:SB_SERVICE_KEY,Authorization:'Bearer '+SB_SERVICE_KEY,'Content-Type':'application/json','User-Agent':'AscendaOS-WA-Gateway/1.0'};
+    if(data)headers['Content-Length']=Buffer.byteLength(data);if(prefer)headers.Prefer=prefer;
+    const q=https.request({hostname:sb.hostname,port:sb.port||443,path:endpoint,method,headers,timeout:12000},r=>{let out='';r.on('data',c=>out+=c);r.on('end',()=>{let parsed=null;try{parsed=out?JSON.parse(out):null;}catch(e){}const result={status:r.statusCode||502,data:parsed,raw:out};if(result.status>=200&&result.status<300)resolve(result);else reject(Object.assign(new Error('WA_DB_WRITE_FAILED'),{status:502,upstreamStatus:result.status}));});});
+    q.on('timeout',()=>q.destroy(new Error('WA_DB_TIMEOUT')));q.on('error',reject);if(data)q.write(data);q.end();
+  });
+}
 function strongToken(req){const t=String(req.headers['x-aos-app-token']||'').trim();return t.length>=32?t:'';}
+async function authorizeWaSender(req){const token=strongToken(req);if(!token)return null;const out=await sbRpc('aos_app_actor_v3',{p_token:token,p_required_panel:'admin-chats',p_require_2fa:true});if(out.status<200||out.status>=300)return null;const actor=out.data;return typeof actor==='string'&&/^[0-9a-f-]{36}$/i.test(actor)?actor:null;}
+
 async function handleKroniaSaleEdit(req,res,body){
   const appToken=strongToken(req);
   if(!appToken){writeJson(res,403,{ok:true,respuesta:'🔒 La edición financiera requiere una sesión administrativa 2FA vigente.',provider:'f4-security',error:'F4_STRONG_SESSION_REQUIRED'});return;}
@@ -45,8 +68,68 @@ async function handleCandidates(req,res,body){
   try{const out=await sbRpc('aos_cartera_candidates_v2',{p_token:appToken,p_case_id:caseId});writeJson(res,out.status>=200&&out.status<300?200:out.status,out.data||{ok:false,error:'UPSTREAM_EMPTY'});}catch(e){console.error('[F4-PROXY] candidates',e.message);writeJson(res,502,{ok:false,error:'F4_UPSTREAM_UNAVAILABLE'});}
 }
 
+function waConfigReadyInbound(){return !!(WA_VERIFY_TOKEN&&WA_APP_SECRET&&SB_SERVICE_KEY);}
+function waConfigReadyOutbound(){return !!(waConfigReadyInbound()&&WA_ACCESS_TOKEN&&WA_PHONE_NUMBER_ID&&/^v\d+\.\d+$/.test(WA_GRAPH_VERSION));}
+function handleWaVerify(req,res){
+  if(!WA_VERIFY_TOKEN){writeJson(res,503,{ok:false,error:'WA_VERIFY_TOKEN_NOT_CONFIGURED'});return;}
+  const u=new URL(req.url,'http://localhost');const mode=u.searchParams.get('hub.mode');const token=u.searchParams.get('hub.verify_token');const challenge=u.searchParams.get('hub.challenge')||'';
+  if(mode==='subscribe'&&wa.safeEqualText(token,WA_VERIFY_TOKEN)){res.writeHead(200,{'Content-Type':'text/plain; charset=utf-8','Cache-Control':'no-store','X-Ascenda-WA-Gateway':'v1'});res.end(challenge);return;}
+  res.writeHead(403,{'Cache-Control':'no-store','X-Ascenda-WA-Gateway':'v1'});res.end('Forbidden');
+}
+async function persistWaEnvelope(envelope){
+  for(const m of envelope.messages){await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',m,'resolution=merge-duplicates,return=minimal');}
+  for(const st of envelope.statuses){
+    const patch={status:st.status,pricing_category:st.pricing_category,pricing_model:st.pricing_model,billable:st.billable,error_code:st.error_code,error_title:st.error_title,updated_at:new Date().toISOString()};
+    if(st.status==='sent')patch.sent_at=st.provider_timestamp;if(st.status==='delivered')patch.delivered_at=st.provider_timestamp;if(st.status==='read')patch.read_at=st.provider_timestamp;if(st.status==='failed')patch.failed_at=st.provider_timestamp;
+    await sbService('PATCH','/rest/v1/aos_wa_messages_v1?provider_message_id=eq.'+encodeURIComponent(st.provider_message_id),patch,'return=minimal');
+  }
+  for(const ev of envelope.events){await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',ev,'resolution=ignore-duplicates,return=minimal');}
+}
+async function handleWaWebhook(req,res){
+  if(!waConfigReadyInbound()){writeJson(res,503,{ok:false,error:'WA_GATEWAY_NOT_CONFIGURED'});return;}
+  try{
+    const raw=await readRaw(req,1024*1024);const signature=req.headers['x-hub-signature-256'];
+    if(!wa.verifyMetaSignature(raw,signature,WA_APP_SECRET)){writeJson(res,401,{ok:false,error:'INVALID_META_SIGNATURE'});return;}
+    let payload;try{payload=JSON.parse(raw.toString('utf8'));}catch(e){writeJson(res,400,{ok:false,error:'INVALID_JSON'});return;}
+    const envelope=wa.extractWebhook(payload);await persistWaEnvelope(envelope);
+    res.writeHead(200,{'Content-Type':'text/plain; charset=utf-8','Cache-Control':'no-store','X-Ascenda-WA-Gateway':'v1'});res.end('EVENT_RECEIVED');
+  }catch(e){console.error('[WA-GATEWAY] webhook',e.message);writeJson(res,e.status||503,{ok:false,error:e.message==='PAYLOAD_TOO_LARGE'?'PAYLOAD_TOO_LARGE':'WA_WEBHOOK_UNAVAILABLE'});}
+}
+function graphSend(payload){
+  return new Promise((resolve,reject)=>{
+    if(!waConfigReadyOutbound()){reject(Object.assign(new Error('WA_OUTBOUND_NOT_CONFIGURED'),{status:503}));return;}
+    const data=JSON.stringify(payload);const q=https.request({hostname:'graph.facebook.com',path:'/'+WA_GRAPH_VERSION+'/'+encodeURIComponent(WA_PHONE_NUMBER_ID)+'/messages',method:'POST',headers:{Authorization:'Bearer '+WA_ACCESS_TOKEN,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-WA-Gateway/1.0'},timeout:15000},r=>{let out='';r.on('data',c=>out+=c);r.on('end',()=>{let parsed={};try{parsed=out?JSON.parse(out):{};}catch(e){}if(r.statusCode>=200&&r.statusCode<300)resolve(parsed);else reject(Object.assign(new Error('META_SEND_REJECTED'),{status:502,metaStatus:r.statusCode}));});});q.on('timeout',()=>q.destroy(new Error('META_SEND_TIMEOUT')));q.on('error',reject);q.write(data);q.end();
+  });
+}
+async function handleWaSend(req,res,body){
+  if(!waConfigReadyOutbound()){writeJson(res,503,{ok:false,error:'WA_OUTBOUND_NOT_CONFIGURED'});return;}
+  const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}
+  if(!wa.validIdempotencyKey(body&&body.idempotency_key)){writeJson(res,400,{ok:false,error:'IDEMPOTENCY_KEY_REQUIRED'});return;}
+  let payload;try{payload=wa.buildOutboundPayload(body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message});return;}
+  if(!wa.canaryAllows(payload.to,WA_CANARY_MODE,WA_CANARY_ALLOW_TO)){writeJson(res,403,{ok:false,error:'WA_CANARY_RECIPIENT_BLOCKED'});return;}
+  try{
+    const existing=await sbService('GET','/rest/v1/aos_wa_messages_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key)+'&select=provider_message_id,status&limit=1',null);
+    if(Array.isArray(existing.data)&&existing.data[0]){writeJson(res,200,{ok:true,idempotent:true,message_id:existing.data[0].provider_message_id,status:existing.data[0].status});return;}
+    const meta=await graphSend(payload);const messageId=meta&&meta.messages&&meta.messages[0]&&meta.messages[0].id;
+    if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502});
+    await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',{
+      provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:payload.to,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,received_at:new Date().toISOString(),updated_at:new Date().toISOString()
+    },'resolution=merge-duplicates,return=minimal');
+    await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'outbound:'+String(messageId),event_type:'message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{actor_id:actor,message_type:payload.type}},'resolution=ignore-duplicates,return=minimal');
+    writeJson(res,200,{ok:true,idempotent:false,message_id:String(messageId),status:'accepted',canary:String(WA_CANARY_MODE).toLowerCase()==='true'});
+  }catch(e){console.error('[WA-GATEWAY] outbound',e.message);writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED'});}
+}
+async function handleWaStatus(req,res){
+  try{const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}writeJson(res,200,{ok:true,gateway:'v1',inbound_configured:waConfigReadyInbound(),outbound_configured:waConfigReadyOutbound(),canary:String(WA_CANARY_MODE).toLowerCase()==='true',allowlist_count:String(WA_CANARY_ALLOW_TO).split(',').filter(Boolean).length});}catch(e){writeJson(res,503,{ok:false,error:'WA_STATUS_UNAVAILABLE'});}
+}
+
 const server=http.createServer(async(req,res)=>{
   let pathname='/';try{pathname=new URL(req.url,'http://localhost').pathname;}catch(e){}
+  if((pathname==='/webhook'||pathname==='/webhook/')&&req.method==='GET'){handleWaVerify(req,res);return;}
+  if((pathname==='/webhook'||pathname==='/webhook/')&&req.method==='POST'){await handleWaWebhook(req,res);return;}
+  if(pathname==='/api/wa/send'&&req.method==='POST'){try{const parsed=await readJson(req,256*1024);await handleWaSend(req,res,parsed.body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;}
+  if(pathname==='/api/wa/status'&&req.method==='GET'){await handleWaStatus(req,res);return;}
+  if(pathname==='/api/wa/send'&&req.method==='OPTIONS'){res.writeHead(204,{'Access-Control-Allow-Methods':'POST,OPTIONS','Access-Control-Allow-Headers':'Content-Type,X-AOS-App-Token','Cache-Control':'no-store'});res.end();return;}
   if(pathname==='/api/f4/cartera-candidates'&&req.method==='POST'){
     try{const parsed=await readJson(req,128*1024);await handleCandidates(req,res,parsed.body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;
   }
@@ -59,4 +142,4 @@ function proxyBuffered(req,res,raw){const headers=Object.assign({},req.headers,{
 function proxyStream(req,res){const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT});const up=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{res.writeHead(r.statusCode||502,r.headers);r.pipe(res);});up.on('error',e=>{if(!res.headersSent)writeJson(res,502,{ok:false,error:'UPSTREAM_UNAVAILABLE'});else res.end();console.error('[F4-PROXY] stream',e.message);});req.pipe(up);}
 function shutdown(sig){console.log('[F4-PROXY] shutdown',sig);server.close(()=>process.exit(0));if(!child.killed)child.kill(sig);setTimeout(()=>process.exit(1),5000).unref();}
 process.on('SIGTERM',()=>shutdown('SIGTERM'));process.on('SIGINT',()=>shutdown('SIGINT'));
-server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[F4-PROXY] listening on :'+EXTERNAL_PORT+' -> :'+INNER_PORT));
+server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[F4-PROXY] listening on :'+EXTERNAL_PORT+' -> :'+INNER_PORT+' | WA gateway v1'));

--- a/app/server-f4.js
+++ b/app/server-f4.js
@@ -101,23 +101,39 @@ function graphSend(payload){
     const data=JSON.stringify(payload);const q=https.request({hostname:'graph.facebook.com',path:'/'+WA_GRAPH_VERSION+'/'+encodeURIComponent(WA_PHONE_NUMBER_ID)+'/messages',method:'POST',headers:{Authorization:'Bearer '+WA_ACCESS_TOKEN,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-WA-Gateway/1.0'},timeout:15000},r=>{let out='';r.on('data',c=>out+=c);r.on('end',()=>{let parsed={};try{parsed=out?JSON.parse(out):{};}catch(e){}if(r.statusCode>=200&&r.statusCode<300)resolve(parsed);else reject(Object.assign(new Error('META_SEND_REJECTED'),{status:502,metaStatus:r.statusCode}));});});q.on('timeout',()=>q.destroy(new Error('META_SEND_TIMEOUT')));q.on('error',reject);q.write(data);q.end();
   });
 }
+async function reserveOutbound(idempotencyKey,actor,payload){
+  const created=await sbService('POST','/rest/v1/aos_wa_outbound_requests_v1?on_conflict=idempotency_key',{
+    idempotency_key:String(idempotencyKey),actor_id:actor,to_number:payload.to,message_type:payload.type,state:'PENDING',updated_at:new Date().toISOString()
+  },'resolution=ignore-duplicates,return=representation');
+  if(Array.isArray(created.data)&&created.data.length===1)return {owner:true,row:created.data[0]};
+  const existing=await sbService('GET','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(idempotencyKey)+'&select=idempotency_key,state,provider_message_id,error_code&limit=1',null);
+  return {owner:false,row:Array.isArray(existing.data)?existing.data[0]||null:null};
+}
 async function handleWaSend(req,res,body){
   if(!waConfigReadyOutbound()){writeJson(res,503,{ok:false,error:'WA_OUTBOUND_NOT_CONFIGURED'});return;}
   const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}
   if(!wa.validIdempotencyKey(body&&body.idempotency_key)){writeJson(res,400,{ok:false,error:'IDEMPOTENCY_KEY_REQUIRED'});return;}
   let payload;try{payload=wa.buildOutboundPayload(body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message});return;}
   if(!wa.canaryAllows(payload.to,WA_CANARY_MODE,WA_CANARY_ALLOW_TO)){writeJson(res,403,{ok:false,error:'WA_CANARY_RECIPIENT_BLOCKED'});return;}
+  let reservation;
   try{
-    const existing=await sbService('GET','/rest/v1/aos_wa_messages_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key)+'&select=provider_message_id,status&limit=1',null);
-    if(Array.isArray(existing.data)&&existing.data[0]){writeJson(res,200,{ok:true,idempotent:true,message_id:existing.data[0].provider_message_id,status:existing.data[0].status});return;}
+    reservation=await reserveOutbound(body.idempotency_key,actor,payload);
+    if(!reservation.owner){
+      const row=reservation.row||{};
+      writeJson(res,row.state==='FAILED'?409:200,{ok:row.state!=='FAILED',idempotent:true,message_id:row.provider_message_id||null,status:row.state||'PENDING',error:row.state==='FAILED'?(row.error_code||'PREVIOUS_SEND_FAILED'):undefined});return;
+    }
     const meta=await graphSend(payload);const messageId=meta&&meta.messages&&meta.messages[0]&&meta.messages[0].id;
     if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502});
+    await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'ACCEPTED',provider_message_id:String(messageId),error_code:null,updated_at:new Date().toISOString()},'return=minimal');
     await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',{
       provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:payload.to,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,received_at:new Date().toISOString(),updated_at:new Date().toISOString()
     },'resolution=merge-duplicates,return=minimal');
     await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'outbound:'+String(messageId),event_type:'message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{actor_id:actor,message_type:payload.type}},'resolution=ignore-duplicates,return=minimal');
-    writeJson(res,200,{ok:true,idempotent:false,message_id:String(messageId),status:'accepted',canary:String(WA_CANARY_MODE).toLowerCase()==='true'});
-  }catch(e){console.error('[WA-GATEWAY] outbound',e.message);writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED'});}
+    writeJson(res,200,{ok:true,idempotent:false,message_id:String(messageId),status:'ACCEPTED',canary:String(WA_CANARY_MODE).toLowerCase()==='true'});
+  }catch(e){
+    if(reservation&&reservation.owner){try{await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'FAILED',error_code:String(e.message||'WA_SEND_FAILED').slice(0,128),updated_at:new Date().toISOString()},'return=minimal');}catch(_e){}}
+    console.error('[WA-GATEWAY] outbound',e.message);writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED'});
+  }
 }
 async function handleWaStatus(req,res){
   try{const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}writeJson(res,200,{ok:true,gateway:'v1',inbound_configured:waConfigReadyInbound(),outbound_configured:waConfigReadyOutbound(),canary:String(WA_CANARY_MODE).toLowerCase()==='true',allowlist_count:String(WA_CANARY_ALLOW_TO).split(',').filter(Boolean).length});}catch(e){writeJson(res,503,{ok:false,error:'WA_STATUS_UNAVAILABLE'});}

--- a/app/server-f4.js
+++ b/app/server-f4.js
@@ -18,7 +18,18 @@ const WA_GRAPH_VERSION=process.env.WHATSAPP_GRAPH_VERSION||'';
 const WA_CANARY_MODE=process.env.WA_CANARY_MODE||'true';
 const WA_CANARY_ALLOW_TO=process.env.WA_CANARY_ALLOW_TO||'';
 
-const child=spawn(process.execPath,['server-phase2.js'],{cwd:__dirname,env:Object.assign({},process.env,{PORT:String(INNER_PORT)}),stdio:['ignore','inherit','inherit']});
+// Least privilege: WA/service-role secrets belong only to this front proxy.
+// The legacy/product child does not need them and must never inherit them.
+const childEnv=Object.assign({},process.env,{PORT:String(INNER_PORT)});
+delete childEnv.SUPABASE_SERVICE_ROLE_KEY;
+delete childEnv.WHATSAPP_VERIFY_TOKEN;
+delete childEnv.WHATSAPP_APP_SECRET;
+delete childEnv.WHATSAPP_ACCESS_TOKEN;
+delete childEnv.WHATSAPP_PHONE_NUMBER_ID;
+delete childEnv.WHATSAPP_GRAPH_VERSION;
+delete childEnv.WA_CANARY_MODE;
+delete childEnv.WA_CANARY_ALLOW_TO;
+const child=spawn(process.execPath,['server-phase2.js'],{cwd:__dirname,env:childEnv,stdio:['ignore','inherit','inherit']});
 child.on('exit',(code,signal)=>{console.error('[F4-PROXY] backend exited',{code,signal});process.exit(code==null?1:code);});
 
 function writeJson(res,status,obj,extra){res.writeHead(status,Object.assign({'Content-Type':'application/json; charset=utf-8','Cache-Control':'no-store','X-Ascenda-Revenue-Route':'f4','X-Ascenda-WA-Gateway':'v1'},extra||{}));res.end(JSON.stringify(obj));}
@@ -97,8 +108,11 @@ async function handleWaWebhook(req,res){
 }
 function graphSend(payload){
   return new Promise((resolve,reject)=>{
-    if(!waConfigReadyOutbound()){reject(Object.assign(new Error('WA_OUTBOUND_NOT_CONFIGURED'),{status:503}));return;}
-    const data=JSON.stringify(payload);const q=https.request({hostname:'graph.facebook.com',path:'/'+WA_GRAPH_VERSION+'/'+encodeURIComponent(WA_PHONE_NUMBER_ID)+'/messages',method:'POST',headers:{Authorization:'Bearer '+WA_ACCESS_TOKEN,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-WA-Gateway/1.0'},timeout:15000},r=>{let out='';r.on('data',c=>out+=c);r.on('end',()=>{let parsed={};try{parsed=out?JSON.parse(out):{};}catch(e){}if(r.statusCode>=200&&r.statusCode<300)resolve(parsed);else reject(Object.assign(new Error('META_SEND_REJECTED'),{status:502,metaStatus:r.statusCode}));});});q.on('timeout',()=>q.destroy(new Error('META_SEND_TIMEOUT')));q.on('error',reject);q.write(data);q.end();
+    if(!waConfigReadyOutbound()){reject(Object.assign(new Error('WA_OUTBOUND_NOT_CONFIGURED'),{status:503,definite:true}));return;}
+    const data=JSON.stringify(payload);const q=https.request({hostname:'graph.facebook.com',path:'/'+WA_GRAPH_VERSION+'/'+encodeURIComponent(WA_PHONE_NUMBER_ID)+'/messages',method:'POST',headers:{Authorization:'Bearer '+WA_ACCESS_TOKEN,'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'User-Agent':'AscendaOS-WA-Gateway/1.0'},timeout:15000},r=>{let out='';r.on('data',c=>out+=c);r.on('end',()=>{let parsed={};try{parsed=out?JSON.parse(out):{};}catch(e){}if(r.statusCode>=200&&r.statusCode<300)resolve(parsed);else reject(Object.assign(new Error('META_SEND_REJECTED'),{status:502,metaStatus:r.statusCode,definite:true}));});});
+    q.on('timeout',()=>q.destroy(Object.assign(new Error('META_SEND_TIMEOUT'),{status:504,ambiguous:true})));
+    q.on('error',err=>reject(Object.assign(err,{status:err.status||502,ambiguous:err.definite!==true})));
+    q.write(data);q.end();
   });
 }
 async function reserveOutbound(idempotencyKey,actor,payload){
@@ -123,7 +137,7 @@ async function handleWaSend(req,res,body){
       writeJson(res,row.state==='FAILED'?409:200,{ok:row.state!=='FAILED',idempotent:true,message_id:row.provider_message_id||null,status:row.state||'PENDING',error:row.state==='FAILED'?(row.error_code||'PREVIOUS_SEND_FAILED'):undefined});return;
     }
     const meta=await graphSend(payload);const messageId=meta&&meta.messages&&meta.messages[0]&&meta.messages[0].id;
-    if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502});
+    if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502,ambiguous:true});
     await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'ACCEPTED',provider_message_id:String(messageId),error_code:null,updated_at:new Date().toISOString()},'return=minimal');
     await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',{
       provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:payload.to,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,received_at:new Date().toISOString(),updated_at:new Date().toISOString()
@@ -131,8 +145,10 @@ async function handleWaSend(req,res,body){
     await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'outbound:'+String(messageId),event_type:'message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{actor_id:actor,message_type:payload.type}},'resolution=ignore-duplicates,return=minimal');
     writeJson(res,200,{ok:true,idempotent:false,message_id:String(messageId),status:'ACCEPTED',canary:String(WA_CANARY_MODE).toLowerCase()==='true'});
   }catch(e){
-    if(reservation&&reservation.owner){try{await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'FAILED',error_code:String(e.message||'WA_SEND_FAILED').slice(0,128),updated_at:new Date().toISOString()},'return=minimal');}catch(_e){}}
-    console.error('[WA-GATEWAY] outbound',e.message);writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED'});
+    if(reservation&&reservation.owner&&e.definite===true){try{await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'FAILED',error_code:String(e.message||'WA_SEND_FAILED').slice(0,128),updated_at:new Date().toISOString()},'return=minimal');}catch(_e){}}
+    const ambiguous=!!(reservation&&reservation.owner&&e.definite!==true);
+    console.error('[WA-GATEWAY] outbound',e.message,ambiguous?'ambiguous_pending':'definite_failure');
+    writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED',status:ambiguous?'PENDING':'FAILED',retry_safe:false});
   }
 }
 async function handleWaStatus(req,res){

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -1,0 +1,99 @@
+'use strict';
+const crypto=require('crypto');
+
+function safeEqualText(a,b){
+  const aa=Buffer.from(String(a||''));const bb=Buffer.from(String(b||''));
+  if(aa.length!==bb.length)return false;
+  return crypto.timingSafeEqual(aa,bb);
+}
+
+function verifyMetaSignature(rawBody,signatureHeader,appSecret){
+  if(!appSecret||!signatureHeader)return false;
+  const header=String(signatureHeader).trim();
+  if(!/^sha256=[a-f0-9]{64}$/i.test(header))return false;
+  const digest='sha256='+crypto.createHmac('sha256',appSecret).update(Buffer.isBuffer(rawBody)?rawBody:Buffer.from(String(rawBody||''))).digest('hex');
+  return safeEqualText(header.toLowerCase(),digest.toLowerCase());
+}
+
+function normalizePhone(v){return String(v||'').replace(/\D/g,'').slice(0,20);}
+function isoFromUnix(v){const n=Number(v);return Number.isFinite(n)&&n>0?new Date(n*1000).toISOString():new Date().toISOString();}
+function trimText(v,max){return String(v==null?'':v).slice(0,max||4000);}
+
+function messageBody(msg){
+  if(msg.text&&msg.text.body)return trimText(msg.text.body,8000);
+  if(msg.button&&msg.button.text)return trimText(msg.button.text,2000);
+  if(msg.interactive){
+    const i=msg.interactive;
+    if(i.button_reply)return trimText(i.button_reply.title||i.button_reply.id,2000);
+    if(i.list_reply)return trimText(i.list_reply.title||i.list_reply.id,2000);
+  }
+  if(msg.image&&msg.image.caption)return trimText(msg.image.caption,4000);
+  if(msg.document&&msg.document.caption)return trimText(msg.document.caption,4000);
+  return '';
+}
+function mediaId(msg){
+  const t=msg.type;const obj=t&&msg[t];return obj&&obj.id?trimText(obj.id,256):null;
+}
+
+function extractWebhook(payload){
+  const messages=[];const statuses=[];const events=[];
+  if(!payload||payload.object!=='whatsapp_business_account'||!Array.isArray(payload.entry))return {messages,statuses,events};
+  payload.entry.forEach(entry=>{
+    (entry.changes||[]).forEach(change=>{
+      if(change.field!=='messages')return;
+      const value=change.value||{};const meta=value.metadata||{};const contacts=value.contacts||[];
+      (value.messages||[]).forEach(msg=>{
+        const from=normalizePhone(msg.from);const contact=contacts.find(c=>normalizePhone(c.wa_id)===from)||{};
+        const referral=msg.referral||{};
+        const row={
+          provider_message_id:trimText(msg.id,256),direction:'INBOUND',from_number:from,to_number:normalizePhone(meta.display_phone_number),
+          phone_number_id:trimText(meta.phone_number_id,128)||null,contact_name:trimText(contact.profile&&contact.profile.name,256)||null,
+          message_type:trimText(msg.type||'unknown',64),message_body:messageBody(msg)||null,media_id:mediaId(msg),status:'received',
+          campaign_source:trimText(referral.headline||referral.source_type||'',512)||null,ad_id:trimText(referral.source_id||'',256)||null,
+          raw_referral:Object.keys(referral).length?{
+            source_id:trimText(referral.source_id,256)||null,source_type:trimText(referral.source_type,64)||null,
+            headline:trimText(referral.headline,512)||null,body:trimText(referral.body,1000)||null
+          }:null,provider_timestamp:isoFromUnix(msg.timestamp),received_at:new Date().toISOString()
+        };
+        if(!row.provider_message_id)return;
+        messages.push(row);
+        events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral}});
+      });
+      (value.statuses||[]).forEach(st=>{
+        const id=trimText(st.id,256);if(!id)return;
+        const pricing=st.pricing||{};const state=trimText(st.status||'unknown',64);
+        const row={provider_message_id:id,status:state,recipient_id:normalizePhone(st.recipient_id),provider_timestamp:isoFromUnix(st.timestamp),
+          pricing_category:trimText(pricing.category||'',64)||null,pricing_model:trimText(pricing.pricing_model||'',64)||null,
+          billable:typeof pricing.billable==='boolean'?pricing.billable:null,error_code:null,error_title:null};
+        if(Array.isArray(st.errors)&&st.errors[0]){row.error_code=trimText(st.errors[0].code,64)||null;row.error_title=trimText(st.errors[0].title||st.errors[0].message,512)||null;}
+        statuses.push(row);
+        events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,pricing_category:row.pricing_category,pricing_model:row.pricing_model,billable:row.billable,error_code:row.error_code}});
+      });
+    });
+  });
+  return {messages,statuses,events};
+}
+
+function buildOutboundPayload(input){
+  const d=input||{};const to=normalizePhone(d.to);if(to.length<8||to.length>15)throw Object.assign(new Error('INVALID_RECIPIENT'),{status:400});
+  const type=String(d.type||'text').toLowerCase();const out={messaging_product:'whatsapp',recipient_type:'individual',to,type};
+  if(type==='text'){
+    const body=trimText(d.text,4096);if(!body)throw Object.assign(new Error('TEXT_REQUIRED'),{status:400});out.text={preview_url:false,body};
+  }else if(type==='template'){
+    const name=trimText(d.template_name,512);const language=trimText(d.language||'es',32);if(!name)throw Object.assign(new Error('TEMPLATE_NAME_REQUIRED'),{status:400});
+    out.template={name,language:{code:language}};if(Array.isArray(d.components))out.template.components=d.components;
+  }else if(['image','document','audio'].includes(type)){
+    const link=trimText(d.link,2048);if(!/^https:\/\//i.test(link))throw Object.assign(new Error('HTTPS_MEDIA_LINK_REQUIRED'),{status:400});
+    out[type]={link};if(type!=='audio'&&d.caption)out[type].caption=trimText(d.caption,1024);if(type==='document'&&d.filename)out.document.filename=trimText(d.filename,255);
+  }else throw Object.assign(new Error('UNSUPPORTED_MESSAGE_TYPE'),{status:400});
+  return out;
+}
+
+function validIdempotencyKey(v){return /^[A-Za-z0-9._:-]{16,120}$/.test(String(v||''));}
+function canaryAllows(to,mode,allowCsv){
+  if(String(mode||'true').toLowerCase()!=='true')return true;
+  const allowed=new Set(String(allowCsv||'').split(',').map(normalizePhone).filter(Boolean));
+  return allowed.has(normalizePhone(to));
+}
+
+module.exports={verifyMetaSignature,extractWebhook,buildOutboundPayload,normalizePhone,validIdempotencyKey,canaryAllows,safeEqualText};

--- a/ci/phase4-revenue/ui_contract.py
+++ b/ci/phase4-revenue/ui_contract.py
@@ -29,9 +29,25 @@ assert 'aos_cartera_candidates_v2' in proxy
 assert 'node server-f4.js' in railway
 assert 'node server-phase2.js' not in railway.split('"environments"')[0]
 
-# F4 never embeds service-role credentials in browser/runtime bridges.
-for text in (bridge, kronia, proxy):
+# Browser/runtime bridges must never know service-role credentials.
+for text in (bridge, kronia):
     assert 'service_role' not in text.lower()
+
+# WA-1 is allowed to consume the service role only at the server-side front boundary.
+# Least privilege requires stripping that credential and all WA secrets before spawning
+# the legacy/product child process.
+assert 'SUPABASE_SERVICE_ROLE_KEY' in proxy
+assert 'delete childEnv.SUPABASE_SERVICE_ROLE_KEY' in proxy
+for marker in (
+    'delete childEnv.WHATSAPP_VERIFY_TOKEN',
+    'delete childEnv.WHATSAPP_APP_SECRET',
+    'delete childEnv.WHATSAPP_ACCESS_TOKEN',
+    'delete childEnv.WHATSAPP_PHONE_NUMBER_ID',
+    'delete childEnv.WHATSAPP_GRAPH_VERSION',
+    'delete childEnv.WA_CANARY_MODE',
+    'delete childEnv.WA_CANARY_ALLOW_TO',
+):
+    assert marker in proxy, f'missing secret isolation marker: {marker}'
 
 # Raw evidence preservation belongs to the DB read model. The browser consumes the
 # enriched payload transparently, so do not require a dead marker in the bridge.

--- a/ci/wa1-secure-gateway/schema_contract.sql
+++ b/ci/wa1-secure-gateway/schema_contract.sql
@@ -1,0 +1,11 @@
+create extension if not exists pgcrypto;
+create table if not exists public.aos_whatsapp_mensajes (
+  id uuid primary key default gen_random_uuid(),
+  wa_message_id text,
+  from_number text not null,
+  message_type text,
+  message_body text,
+  estado text,
+  created_at timestamptz default now()
+);
+grant all on table public.aos_whatsapp_mensajes to anon, authenticated, service_role;

--- a/ci/wa1-secure-gateway/schema_contract.sql
+++ b/ci/wa1-secure-gateway/schema_contract.sql
@@ -9,3 +9,11 @@ create table if not exists public.aos_whatsapp_mensajes (
   created_at timestamptz default now()
 );
 grant all on table public.aos_whatsapp_mensajes to anon, authenticated, service_role;
+
+create table if not exists public.aos_meta_config (
+  id uuid primary key default gen_random_uuid(),
+  key text not null,
+  value text not null,
+  updated_at timestamptz default now()
+);
+grant all on table public.aos_meta_config to anon, authenticated, service_role;

--- a/ci/wa1-secure-gateway/schema_contract.sql
+++ b/ci/wa1-secure-gateway/schema_contract.sql
@@ -10,6 +10,16 @@ create table if not exists public.aos_whatsapp_mensajes (
 );
 grant all on table public.aos_whatsapp_mensajes to anon, authenticated, service_role;
 
+create table if not exists public.aos_webhook_log (
+  id uuid primary key default gen_random_uuid(),
+  source text,
+  payload jsonb,
+  processed boolean default false,
+  error text,
+  created_at timestamptz default now()
+);
+grant all on table public.aos_webhook_log to anon, authenticated, service_role;
+
 create table if not exists public.aos_meta_config (
   id uuid primary key default gen_random_uuid(),
   key text not null,

--- a/ci/wa1-secure-gateway/tests/001_wa1_security.sql
+++ b/ci/wa1-secure-gateway/tests/001_wa1_security.sql
@@ -1,6 +1,6 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(18);
+select plan(22);
 
 select ok(to_regclass('public.aos_wa_messages_v1') is not null,'messages table exists');
 select ok(to_regclass('public.aos_wa_events_v1') is not null,'events table exists');
@@ -20,6 +20,10 @@ select ok((select relrowsecurity from pg_class where oid='public.aos_meta_config
 select ok((select relforcerowsecurity from pg_class where oid='public.aos_meta_config'::regclass),'Meta config FORCE RLS enabled');
 select ok(not has_table_privilege('anon','public.aos_meta_config','SELECT'),'anon cannot read Meta credentials');
 select ok(not has_table_privilege('authenticated','public.aos_meta_config','UPDATE'),'authenticated cannot mutate Meta credentials');
+select ok(to_regclass('public.aos_wa_outbound_requests_v1') is not null,'outbound idempotency ledger exists');
+select ok((select relforcerowsecurity from pg_class where oid='public.aos_wa_outbound_requests_v1'::regclass),'outbound ledger FORCE RLS enabled');
+select ok(not has_table_privilege('anon','public.aos_wa_outbound_requests_v1','SELECT'),'anon cannot inspect outbound reservations');
+select ok(has_table_privilege('service_role','public.aos_wa_outbound_requests_v1','INSERT'),'service role can reserve outbound idempotency key');
 
 select * from finish();
 rollback;

--- a/ci/wa1-secure-gateway/tests/001_wa1_security.sql
+++ b/ci/wa1-secure-gateway/tests/001_wa1_security.sql
@@ -1,6 +1,6 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(22);
+select plan(25);
 
 select ok(to_regclass('public.aos_wa_messages_v1') is not null,'messages table exists');
 select ok(to_regclass('public.aos_wa_events_v1') is not null,'events table exists');
@@ -24,6 +24,9 @@ select ok(to_regclass('public.aos_wa_outbound_requests_v1') is not null,'outboun
 select ok((select relforcerowsecurity from pg_class where oid='public.aos_wa_outbound_requests_v1'::regclass),'outbound ledger FORCE RLS enabled');
 select ok(not has_table_privilege('anon','public.aos_wa_outbound_requests_v1','SELECT'),'anon cannot inspect outbound reservations');
 select ok(has_table_privilege('service_role','public.aos_wa_outbound_requests_v1','INSERT'),'service role can reserve outbound idempotency key');
+select ok((select relrowsecurity from pg_class where oid='public.aos_webhook_log'::regclass),'raw webhook log RLS enabled');
+select ok((select relforcerowsecurity from pg_class where oid='public.aos_webhook_log'::regclass),'raw webhook log FORCE RLS enabled');
+select ok(not has_table_privilege('anon','public.aos_webhook_log','SELECT'),'anon cannot read raw webhook payloads');
 
 select * from finish();
 rollback;

--- a/ci/wa1-secure-gateway/tests/001_wa1_security.sql
+++ b/ci/wa1-secure-gateway/tests/001_wa1_security.sql
@@ -1,6 +1,6 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(14);
+select plan(18);
 
 select ok(to_regclass('public.aos_wa_messages_v1') is not null,'messages table exists');
 select ok(to_regclass('public.aos_wa_events_v1') is not null,'events table exists');
@@ -16,6 +16,10 @@ select ok(not has_table_privilege('anon','public.aos_wa_events_v1','SELECT'),'an
 select ok(has_table_privilege('service_role','public.aos_wa_events_v1','INSERT'),'service role can append WA events');
 select ok(not has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT'),'legacy anon insert closed');
 select ok(not has_table_privilege('authenticated','public.aos_whatsapp_mensajes','UPDATE'),'legacy authenticated update closed');
+select ok((select relrowsecurity from pg_class where oid='public.aos_meta_config'::regclass),'Meta config RLS enabled');
+select ok((select relforcerowsecurity from pg_class where oid='public.aos_meta_config'::regclass),'Meta config FORCE RLS enabled');
+select ok(not has_table_privilege('anon','public.aos_meta_config','SELECT'),'anon cannot read Meta credentials');
+select ok(not has_table_privilege('authenticated','public.aos_meta_config','UPDATE'),'authenticated cannot mutate Meta credentials');
 
 select * from finish();
 rollback;

--- a/ci/wa1-secure-gateway/tests/001_wa1_security.sql
+++ b/ci/wa1-secure-gateway/tests/001_wa1_security.sql
@@ -1,0 +1,21 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(14);
+
+select ok(to_regclass('public.aos_wa_messages_v1') is not null,'messages table exists');
+select ok(to_regclass('public.aos_wa_events_v1') is not null,'events table exists');
+select ok((select relrowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass),'messages RLS enabled');
+select ok((select relforcerowsecurity from pg_class where oid='public.aos_wa_messages_v1'::regclass),'messages FORCE RLS enabled');
+select ok((select relrowsecurity from pg_class where oid='public.aos_wa_events_v1'::regclass),'events RLS enabled');
+select ok((select relforcerowsecurity from pg_class where oid='public.aos_wa_events_v1'::regclass),'events FORCE RLS enabled');
+select ok(not has_table_privilege('anon','public.aos_wa_messages_v1','SELECT'),'anon cannot read canonical WA messages');
+select ok(not has_table_privilege('anon','public.aos_wa_messages_v1','INSERT'),'anon cannot insert canonical WA messages');
+select ok(not has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE'),'authenticated cannot update canonical WA messages');
+select ok(has_table_privilege('service_role','public.aos_wa_messages_v1','INSERT'),'service role can ingest canonical WA messages');
+select ok(not has_table_privilege('anon','public.aos_wa_events_v1','SELECT'),'anon cannot read WA events');
+select ok(has_table_privilege('service_role','public.aos_wa_events_v1','INSERT'),'service role can append WA events');
+select ok(not has_table_privilege('anon','public.aos_whatsapp_mensajes','INSERT'),'legacy anon insert closed');
+select ok(not has_table_privilege('authenticated','public.aos_whatsapp_mensajes','UPDATE'),'legacy authenticated update closed');
+
+select * from finish();
+rollback;

--- a/ci/wa1-secure-gateway/wa-gateway.test.js
+++ b/ci/wa1-secure-gateway/wa-gateway.test.js
@@ -1,0 +1,58 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const crypto=require('crypto');
+const wa=require('../../app/wa-gateway');
+
+function sig(secret,raw){return 'sha256='+crypto.createHmac('sha256',secret).update(raw).digest('hex');}
+
+test('accepts authentic Meta signature',()=>{
+  const raw=Buffer.from('{"object":"whatsapp_business_account","entry":[]}');
+  assert.equal(wa.verifyMetaSignature(raw,sig('secret-x',raw),'secret-x'),true);
+});
+
+test('rejects missing, malformed and forged signatures',()=>{
+  const raw=Buffer.from('{"ok":true}');
+  assert.equal(wa.verifyMetaSignature(raw,'','secret-x'),false);
+  assert.equal(wa.verifyMetaSignature(raw,'sha256=abc','secret-x'),false);
+  assert.equal(wa.verifyMetaSignature(raw,sig('attacker',raw),'secret-x'),false);
+});
+
+test('signature is bound to exact raw bytes',()=>{
+  const raw=Buffer.from('{"a":1}');const changed=Buffer.from('{"a": 1}');
+  assert.equal(wa.verifyMetaSignature(changed,sig('secret-x',raw),'secret-x'),false);
+});
+
+test('normalizes inbound click-to-whatsapp message without raw payload retention',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn1'},contacts:[{wa_id:'51999111222',profile:{name:'Paciente Demo'}}],messages:[{id:'wamid.1',from:'51999111222',timestamp:'1786807000',type:'text',text:{body:'Hola'},referral:{source_id:'ad-77',source_type:'ad',headline:'HIFU'}}]}}]}]};
+  const e=wa.extractWebhook(p);
+  assert.equal(e.messages.length,1);assert.equal(e.messages[0].from_number,'51999111222');assert.equal(e.messages[0].ad_id,'ad-77');assert.equal(e.messages[0].message_body,'Hola');
+  assert.deepEqual(Object.keys(e.messages[0].raw_referral).sort(),['body','headline','source_id','source_type']);
+  assert.equal(e.events[0].event_key,'message:wamid.1');
+});
+
+test('normalizes status pricing and error metadata',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{statuses:[{id:'wamid.out',status:'delivered',timestamp:'1786807100',recipient_id:'51999999999',pricing:{category:'utility',pricing_model:'PMP',billable:false}}]}}]}]};
+  const e=wa.extractWebhook(p);assert.equal(e.statuses.length,1);assert.equal(e.statuses[0].status,'delivered');assert.equal(e.statuses[0].pricing_category,'utility');assert.equal(e.statuses[0].billable,false);
+});
+
+test('builds governed text/template/media outbound payloads',()=>{
+  const text=wa.buildOutboundPayload({to:'+51 999 999 999',type:'text',text:'Hola'});assert.equal(text.to,'51999999999');assert.equal(text.text.body,'Hola');
+  const tpl=wa.buildOutboundPayload({to:'51999999999',type:'template',template_name:'recordatorio',language:'es_PE'});assert.equal(tpl.template.name,'recordatorio');
+  const img=wa.buildOutboundPayload({to:'51999999999',type:'image',link:'https://example.test/a.jpg',caption:'Demo'});assert.equal(img.image.link,'https://example.test/a.jpg');
+});
+
+test('rejects unsupported payloads and non-https media',()=>{
+  assert.throws(()=>wa.buildOutboundPayload({to:'51999999999',type:'video',link:'https://example.test/v.mp4'}),/UNSUPPORTED_MESSAGE_TYPE/);
+  assert.throws(()=>wa.buildOutboundPayload({to:'51999999999',type:'image',link:'http://example.test/a.jpg'}),/HTTPS_MEDIA_LINK_REQUIRED/);
+});
+
+test('requires high entropy shaped idempotency key',()=>{
+  assert.equal(wa.validIdempotencyKey('short'),false);assert.equal(wa.validIdempotencyKey('wa:conv:1234567890:01'),true);
+});
+
+test('canary blocks recipients outside explicit allowlist',()=>{
+  assert.equal(wa.canaryAllows('51911111111','true','51911111111,51922222222'),true);
+  assert.equal(wa.canaryAllows('51933333333','true','51911111111,51922222222'),false);
+  assert.equal(wa.canaryAllows('51933333333','false',''),true);
+});

--- a/docs/control/WHATSAPP_REVENUE_HUB_WA1_IMPACT_REPORT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_WA1_IMPACT_REPORT.md
@@ -1,0 +1,123 @@
+# ASCENDA Conversations — WA-1 Secure WhatsApp Gateway — Impact Report
+
+**Estado:** IMPLEMENTED / PRE-CERTIFICATION  
+**Riesgo:** CRITICAL  
+**Baseline inicial:** `f05982e7a6af6a85d158693dffa6a693b27df54f`  
+**Branch:** `security/wa1-secure-whatsapp-gateway`
+
+## Objetivo
+Cerrar la frontera WhatsApp/Meta antes de construir inbox, routing o IA: autenticar webhooks, hacer idempotente el ingreso, crear almacenamiento privado normalizado, habilitar outbound gobernado y conservar un canary fail-closed.
+
+## Vulnerable path revalidado
+El backend legado aceptaba `POST /webhook`, respondía `200`, parseaba y persistía el payload sin validar `X-Hub-Signature-256`. El verify token del flujo histórico también quedó expuesto en código y por tanto debe considerarse comprometido/retirado.
+
+## Security invariants
+1. Ningún POST WhatsApp se procesa sin HMAC SHA-256 válido sobre los bytes exactos.
+2. `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`, `WHATSAPP_ACCESS_TOKEN` y `SUPABASE_SERVICE_ROLE_KEY` existen solo como secretos de runtime.
+3. Si falta configuración de seguridad, el gateway falla cerrado; no proxifica al webhook legado.
+4. Payload máximo inbound: 1 MiB.
+5. La base canónica WA no es accesible por `anon` ni `authenticated`.
+6. `provider_message_id`, `event_key` e `idempotency_key` evitan duplicidad/replay operativo.
+7. Outbound requiere sesión administrativa 2FA válida y panel `admin-chats`.
+8. Canary outbound bloquea números fuera de `WA_CANARY_ALLOW_TO` mientras `WA_CANARY_MODE=true`.
+9. El gateway no almacena raw webhook completo; solo hechos normalizados y metadata sanitizada.
+10. Recovery nunca reabre escritura legacy ni el POST unsigned.
+
+## Código
+- `app/server-f4.js`: enforcement boundary productivo; intercepta `/webhook` y `/api/wa/*` antes del backend.
+- `app/wa-gateway.js`: HMAC, normalización, parsing y validación outbound.
+- `ci/wa1-secure-gateway/*`: regresiones y contratos DB.
+- `.github/workflows/wa1-secure-whatsapp-gateway.yml`: certificación Zero-Cost.
+
+## Datos
+### Nuevas tablas aditivas
+- `aos_wa_messages_v1`: mensaje normalizado, estado delivery/read/failure, attribution mínima y ledger económico.
+- `aos_wa_events_v1`: eventos idempotentes/sanitizados.
+
+Ambas usan RLS + FORCE RLS y no tienen acceso `anon/authenticated`; writes del gateway requieren `service_role` server-side.
+
+### Legacy
+`aos_whatsapp_mensajes` se conserva para compatibilidad/historia, pero sus writes directos `anon/authenticated` quedan revocados. No se toca `aos_webhook_log`, porque es compartida por integraciones no inventariadas completamente y WA-1 ya no la usa como store raw.
+
+## Contratos externos
+### Inbound
+- `GET /webhook`: challenge Meta; token solo desde `WHATSAPP_VERIFY_TOKEN`.
+- `POST /webhook`: `X-Hub-Signature-256` obligatorio; 401 ante firma inválida; 413 >1 MiB; 503 si security config falta.
+
+### Outbound
+- `POST /api/wa/send`
+- Header: `X-AOS-App-Token` de sesión administrativa 2FA.
+- Payload soportado WA-1: `text`, `template`, `image`, `document`, `audio` mediante link HTTPS.
+- `idempotency_key` obligatorio.
+- Canary allowlist obligatorio por defecto.
+
+### Status
+- `GET /api/wa/status`: admin+2FA; expone solo booleanos de configuración y estado canary, nunca secretos.
+
+## Variables runtime requeridas
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `WHATSAPP_VERIFY_TOKEN` — **nuevo valor rotado**, no reutilizar el valor histórico del repo.
+- `WHATSAPP_APP_SECRET`
+- `WHATSAPP_ACCESS_TOKEN`
+- `WHATSAPP_PHONE_NUMBER_ID`
+- `WHATSAPP_GRAPH_VERSION`
+- `WA_CANARY_MODE=true`
+- `WA_CANARY_ALLOW_TO=<números de canary autorizados>`
+
+No registrar los valores en GitHub, Notion, logs, prompts ni documentación.
+
+## Pruebas
+### Runtime
+- `node --check app/wa-gateway.js`
+- `node --check app/server-f4.js`
+- `node --test ci/wa1-secure-gateway/wa-gateway.test.js`
+- firma válida/forjada/malformed;
+- bytes exactos;
+- CTWA/referral;
+- status/pricing;
+- payload outbound permitido/prohibido;
+- idempotency key;
+- canary allowlist.
+
+### Database
+- migración exacta en Supabase local efímero;
+- lint;
+- pgTAP RLS/GRANT positivo y negativo;
+- recovery fail-closed;
+- zero-residue al finalizar.
+
+## Production read-only preflight
+Antes del primer release productivo:
+1. confirmar `main` exacto y ausencia de drift en `server-f4.js`/Railway start command;
+2. confirmar tabla legacy sin tráfico productivo no explicado durante la ventana;
+3. confirmar names/configuración Meta sin leer ni imprimir secretos;
+4. confirmar que las variables requeridas existen en Railway mediante un mecanismo autorizado;
+5. confirmar WABA subscription/callback target.
+
+## Canary
+1. `WA_CANARY_MODE=true`.
+2. allowlist mínima del propietario/admin de prueba.
+3. inbound: evento real firmado llega una sola vez y queda persistido en `aos_wa_messages_v1`/`aos_wa_events_v1`.
+4. replay del mismo payload no duplica mensajes/eventos.
+5. firma alterada obtiene 401 y genera cero rows.
+6. outbound texto al número allowlisted produce `provider_message_id` y retry con mismo `idempotency_key` no reenvía.
+7. recibir al menos un status `sent/delivered/read` y actualizar la misma fila.
+8. número fuera de allowlist obtiene 403 sin llamada a Meta.
+
+## Rollback / recovery
+- Nunca volver al POST unsigned.
+- Mantener inbound firmado.
+- Para incidente outbound: conservar `WA_CANARY_MODE=true` y retirar/deshabilitar `WHATSAPP_ACCESS_TOKEN`; resultado esperado: 503 fail-closed sin envíos.
+- La migration es aditiva y recovery conserva las tablas/evidencia; no borra chats.
+- La tabla legacy conserva lecturas, pero no recupera writes anónimos.
+
+## Gate de certificación
+WA-1 solo puede declararse `100_COMPLETE / PRODUCTION CERTIFIED` cuando:
+- Zero-Cost exact-SHA está verde;
+- no quedan findings HIGH/CRITICAL WA-1 abiertos;
+- production preflight read-only está verde;
+- secretos activos han sido rotados/configurados fuera del repo;
+- canary real firmado + outbound allowlisted + delivery status están probados;
+- post-deploy smoke y reconciliación no muestran regresiones.

--- a/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+++ b/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
@@ -64,7 +64,15 @@ grant select, insert on table public.aos_wa_events_v1 to service_role;
 -- Legacy WhatsApp table remains available for historical reads, but direct client writes close.
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
+-- Meta credential/config store was historically exposed with RLS disabled and broad client grants.
+-- No CURRENT runtime consumer reads it directly; WA-1 moves active secrets to server-side environment.
+alter table public.aos_meta_config enable row level security;
+alter table public.aos_meta_config force row level security;
+revoke all on table public.aos_meta_config from public, anon, authenticated;
+grant select, insert, update, delete on table public.aos_meta_config to service_role;
+
 do $$ begin
   comment on table public.aos_wa_messages_v1 is 'WA-1 canonical normalized WhatsApp message store. Server/service-role only; no raw webhook payloads.';
   comment on table public.aos_wa_events_v1 is 'WA-1 idempotent WhatsApp event/status ledger. Server/service-role only; sanitized payload only.';
+  comment on table public.aos_meta_config is 'Legacy Meta configuration store. WA-1 closes all browser/client access; active secrets belong in server-side runtime environment.';
 exception when others then null; end $$;

--- a/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+++ b/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
@@ -61,6 +61,26 @@ alter table public.aos_wa_events_v1 force row level security;
 revoke all on table public.aos_wa_events_v1 from public, anon, authenticated;
 grant select, insert on table public.aos_wa_events_v1 to service_role;
 
+-- Atomic idempotency reservation for outbound sends.
+-- A retry that encounters PENDING/ACCEPTED/FAILED does not send again automatically.
+create table if not exists public.aos_wa_outbound_requests_v1 (
+  idempotency_key text primary key,
+  actor_id uuid not null,
+  to_number text not null,
+  message_type text not null,
+  state text not null default 'PENDING' check (state in ('PENDING','ACCEPTED','FAILED')),
+  provider_message_id text,
+  error_code text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists aos_wa_outbound_requests_v1_state_idx on public.aos_wa_outbound_requests_v1(state, created_at desc);
+alter table public.aos_wa_outbound_requests_v1 enable row level security;
+alter table public.aos_wa_outbound_requests_v1 force row level security;
+revoke all on table public.aos_wa_outbound_requests_v1 from public, anon, authenticated;
+grant select, insert, update on table public.aos_wa_outbound_requests_v1 to service_role;
+
 -- Legacy WhatsApp table remains available for historical reads, but direct client writes close.
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
@@ -74,5 +94,6 @@ grant select, insert, update, delete on table public.aos_meta_config to service_
 do $$ begin
   comment on table public.aos_wa_messages_v1 is 'WA-1 canonical normalized WhatsApp message store. Server/service-role only; no raw webhook payloads.';
   comment on table public.aos_wa_events_v1 is 'WA-1 idempotent WhatsApp event/status ledger. Server/service-role only; sanitized payload only.';
+  comment on table public.aos_wa_outbound_requests_v1 is 'WA-1 atomic outbound idempotency ledger. Reservation occurs before provider send; ambiguous PENDING never auto-resends.';
   comment on table public.aos_meta_config is 'Legacy Meta configuration store. WA-1 closes all browser/client access; active secrets belong in server-side runtime environment.';
 exception when others then null; end $$;

--- a/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+++ b/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
@@ -1,0 +1,70 @@
+-- WA-1 Secure WhatsApp Gateway V1 — additive, fail-closed storage.
+
+create table if not exists public.aos_wa_messages_v1 (
+  id uuid primary key default gen_random_uuid(),
+  provider_message_id text not null unique,
+  idempotency_key text unique,
+  direction text not null check (direction in ('INBOUND','OUTBOUND')),
+  from_number text,
+  to_number text,
+  phone_number_id text,
+  contact_name text,
+  message_type text not null,
+  message_body text,
+  media_id text,
+  status text not null default 'received',
+  campaign_source text,
+  ad_id text,
+  lead_id text,
+  raw_referral jsonb,
+  actor_id uuid,
+  pricing_category text,
+  pricing_model text,
+  billable boolean,
+  error_code text,
+  error_title text,
+  provider_timestamp timestamptz,
+  received_at timestamptz,
+  sent_at timestamptz,
+  delivered_at timestamptz,
+  read_at timestamptz,
+  failed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists aos_wa_messages_v1_to_number_idx on public.aos_wa_messages_v1(to_number, created_at desc);
+create index if not exists aos_wa_messages_v1_from_number_idx on public.aos_wa_messages_v1(from_number, created_at desc);
+create index if not exists aos_wa_messages_v1_status_idx on public.aos_wa_messages_v1(status, created_at desc);
+create index if not exists aos_wa_messages_v1_ad_idx on public.aos_wa_messages_v1(ad_id, created_at desc) where ad_id is not null;
+
+alter table public.aos_wa_messages_v1 enable row level security;
+alter table public.aos_wa_messages_v1 force row level security;
+revoke all on table public.aos_wa_messages_v1 from public, anon, authenticated;
+grant select, insert, update on table public.aos_wa_messages_v1 to service_role;
+
+create table if not exists public.aos_wa_events_v1 (
+  id uuid primary key default gen_random_uuid(),
+  event_key text not null unique,
+  event_type text not null,
+  provider_message_id text,
+  status text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists aos_wa_events_v1_message_idx on public.aos_wa_events_v1(provider_message_id, created_at desc);
+create index if not exists aos_wa_events_v1_type_idx on public.aos_wa_events_v1(event_type, created_at desc);
+
+alter table public.aos_wa_events_v1 enable row level security;
+alter table public.aos_wa_events_v1 force row level security;
+revoke all on table public.aos_wa_events_v1 from public, anon, authenticated;
+grant select, insert on table public.aos_wa_events_v1 to service_role;
+
+-- Legacy WhatsApp table remains available for historical reads, but direct client writes close.
+revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
+
+do $$ begin
+  comment on table public.aos_wa_messages_v1 is 'WA-1 canonical normalized WhatsApp message store. Server/service-role only; no raw webhook payloads.';
+  comment on table public.aos_wa_events_v1 is 'WA-1 idempotent WhatsApp event/status ledger. Server/service-role only; sanitized payload only.';
+exception when others then null; end $$;

--- a/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+++ b/supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
@@ -84,6 +84,13 @@ grant select, insert, update on table public.aos_wa_outbound_requests_v1 to serv
 -- Legacy WhatsApp table remains available for historical reads, but direct client writes close.
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
+-- Raw legacy webhook store has no live rows and no CURRENT consumer except the bypassed WA legacy handler.
+-- It must not remain a client-readable/client-writable payload sink.
+alter table public.aos_webhook_log enable row level security;
+alter table public.aos_webhook_log force row level security;
+revoke all on table public.aos_webhook_log from public, anon, authenticated;
+grant select, insert, update on table public.aos_webhook_log to service_role;
+
 -- Meta credential/config store was historically exposed with RLS disabled and broad client grants.
 -- No CURRENT runtime consumer reads it directly; WA-1 moves active secrets to server-side environment.
 alter table public.aos_meta_config enable row level security;
@@ -95,5 +102,6 @@ do $$ begin
   comment on table public.aos_wa_messages_v1 is 'WA-1 canonical normalized WhatsApp message store. Server/service-role only; no raw webhook payloads.';
   comment on table public.aos_wa_events_v1 is 'WA-1 idempotent WhatsApp event/status ledger. Server/service-role only; sanitized payload only.';
   comment on table public.aos_wa_outbound_requests_v1 is 'WA-1 atomic outbound idempotency ledger. Reservation occurs before provider send; ambiguous PENDING never auto-resends.';
+  comment on table public.aos_webhook_log is 'Legacy raw webhook log. WA-1 closes browser/client access; canonical WhatsApp ingress no longer writes raw payloads here.';
   comment on table public.aos_meta_config is 'Legacy Meta configuration store. WA-1 closes all browser/client access; active secrets belong in server-side runtime environment.';
 exception when others then null; end $$;

--- a/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
+++ b/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
@@ -15,11 +15,15 @@ revoke all on table public.aos_wa_outbound_requests_v1 from public, anon, authen
 
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
+alter table if exists public.aos_webhook_log enable row level security;
+alter table if exists public.aos_webhook_log force row level security;
+revoke all on table public.aos_webhook_log from public, anon, authenticated;
+
 alter table if exists public.aos_meta_config enable row level security;
 alter table if exists public.aos_meta_config force row level security;
 revoke all on table public.aos_meta_config from public, anon, authenticated;
 
 -- Runtime recovery: disable outbound by removing/invalidating WHATSAPP_ACCESS_TOKEN or keeping WA_CANARY_MODE=true.
 -- Inbound must remain signature-validating; do not roll back to the legacy unsigned /webhook path.
--- Credential stores remain closed during recovery; a rollback must never re-expose Meta secrets to clients.
+-- Credential and raw webhook stores remain closed during recovery.
 -- Idempotency reservations are preserved so ambiguous provider sends cannot be replayed accidentally.

--- a/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
+++ b/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
@@ -11,5 +11,10 @@ revoke all on table public.aos_wa_events_v1 from public, anon, authenticated;
 
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
+alter table if exists public.aos_meta_config enable row level security;
+alter table if exists public.aos_meta_config force row level security;
+revoke all on table public.aos_meta_config from public, anon, authenticated;
+
 -- Runtime recovery: disable outbound by removing/invalidating WHATSAPP_ACCESS_TOKEN or keeping WA_CANARY_MODE=true.
 -- Inbound must remain signature-validating; do not roll back to the legacy unsigned /webhook path.
+-- Credential stores remain closed during recovery; a rollback must never re-expose Meta secrets to clients.

--- a/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
+++ b/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
@@ -9,6 +9,10 @@ alter table if exists public.aos_wa_events_v1 enable row level security;
 alter table if exists public.aos_wa_events_v1 force row level security;
 revoke all on table public.aos_wa_events_v1 from public, anon, authenticated;
 
+alter table if exists public.aos_wa_outbound_requests_v1 enable row level security;
+alter table if exists public.aos_wa_outbound_requests_v1 force row level security;
+revoke all on table public.aos_wa_outbound_requests_v1 from public, anon, authenticated;
+
 revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
 
 alter table if exists public.aos_meta_config enable row level security;
@@ -18,3 +22,4 @@ revoke all on table public.aos_meta_config from public, anon, authenticated;
 -- Runtime recovery: disable outbound by removing/invalidating WHATSAPP_ACCESS_TOKEN or keeping WA_CANARY_MODE=true.
 -- Inbound must remain signature-validating; do not roll back to the legacy unsigned /webhook path.
 -- Credential stores remain closed during recovery; a rollback must never re-expose Meta secrets to clients.
+-- Idempotency reservations are preserved so ambiguous provider sends cannot be replayed accidentally.

--- a/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
+++ b/supabase/rollbacks/20260815160000_wa1_secure_gateway_recovery.sql
@@ -1,0 +1,15 @@
+-- WA-1 recovery is intentionally fail-closed.
+-- Preserve captured WA evidence; disable all non-service access and never reopen legacy anon writes.
+
+alter table if exists public.aos_wa_messages_v1 enable row level security;
+alter table if exists public.aos_wa_messages_v1 force row level security;
+revoke all on table public.aos_wa_messages_v1 from public, anon, authenticated;
+
+alter table if exists public.aos_wa_events_v1 enable row level security;
+alter table if exists public.aos_wa_events_v1 force row level security;
+revoke all on table public.aos_wa_events_v1 from public, anon, authenticated;
+
+revoke insert, update, delete, truncate, references, trigger on table public.aos_whatsapp_mensajes from anon, authenticated;
+
+-- Runtime recovery: disable outbound by removing/invalidating WHATSAPP_ACCESS_TOKEN or keeping WA_CANARY_MODE=true.
+-- Inbound must remain signature-validating; do not roll back to the legacy unsigned /webhook path.


### PR DESCRIPTION
## WA-1 — Secure WhatsApp Gateway

CRITICAL security/integration release for ASCENDA Conversations.

### Scope
- Intercept WhatsApp `/webhook` at the productive `server-f4.js` boundary.
- Validate Meta `X-Hub-Signature-256` against runtime app secret before processing.
- Fail closed when required runtime security configuration is missing.
- Add normalized/private WA message + event stores with FORCE RLS.
- Add atomic outbound reservation ledger: idempotency key is reserved **before** the Meta call; ambiguous `PENDING` is never auto-replayed.
- Close direct `anon`/`authenticated` writes to legacy `aos_whatsapp_mensajes`.
- Close legacy raw `aos_webhook_log` to browser/client roles; canonical WA ingress stores sanitized facts only.
- Close legacy `aos_meta_config` with RLS + FORCE RLS after discovering it had broad client grants while containing Meta credentials.
- Add governed outbound `/api/wa/send` requiring admin 2FA + `admin-chats`, idempotency and canary allowlist.
- Track delivery/read/failure/pricing status events.
- Add fail-closed recovery contract.
- Add Zero-Cost V2 runtime, 25 pgTAP authorization contracts, negative security and recovery tests.

### Additional hardening from security review
- WA/service-role secrets are stripped from the spawned legacy/product child process; they exist only at the WA/F4 server boundary.
- Explicit Meta rejection can close a reservation as `FAILED`; timeout/network/ambiguous provider outcomes remain `PENDING` and `retry_safe:false`, preventing duplicate auto-send.
- F4 compatibility contract was updated narrowly: browser bridges remain forbidden from service-role knowledge, while the server-only WA boundary is explicitly certified for least-privilege use.

### Current exact candidate
`94bb68d5ab6c7796efa7aa064d6c2679e5ea8753`

### Production preflight completed read-only
- WA canonical tables are absent before migration, as expected.
- Legacy WhatsApp messages: 0.
- WhatsApp/raw webhook logs: 0.
- `aos_meta_config`: 11 populated configuration rows; secret values were not read or copied.
- Live preflight confirms legacy `anon/authenticated` WA writes and raw Meta/webhook access are currently open and RLS is disabled; this migration intentionally closes that exposure.
- SQL dependency search found no public functions dependent on the three legacy WA/config tables being hardened.

### Safety
No production DB migration or Meta/Railway secret mutation has been performed by this PR yet. Production release remains blocked until exact-SHA Zero-Cost certification is green, current-main preflight is rechecked, migration/cutover is controlled, deployment smoke is green, and signed inbound + allowlisted outbound canary can be demonstrated.

### Required external runtime variables
Names only are documented in the Impact Report. Secret values must never be pasted into GitHub/Notion/chat.

### Rollback invariant
Recovery never reopens the unsigned legacy webhook, public credential stores, raw webhook payload access, or anonymous WhatsApp writes.