### PR TITLE
Hotfix admin home: authoritative Lima business date

### DIFF
--- a/.github/workflows/hotfix-admin-sales-read.yml
+++ b/.github/workflows/hotfix-admin-sales-read.yml
@@ -36,15 +36,15 @@ jobs:
           findstr /C:"if(!r.ok||!b||b.code||b.error)" app\public\admin-sales.html
           findstr /C:"timeZone:'America/Lima'" app\public\admin-sales.html
       - name: Commit materialized frontend only when changed
-        shell: bash
+        shell: cmd
         run: |
-          set -euo pipefail
-          if git diff --quiet -- app/public/admin-sales.html; then
-            echo 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
-            exit 0
-          fi
-          git config user.name 'ascenda-ci'
-          git config user.email 'ascenda-ci@users.noreply.github.com'
+          git diff --quiet -- app/public/admin-sales.html
+          if not errorlevel 1 (
+            echo ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT
+            exit /b 0
+          )
+          git config user.name ascenda-ci
+          git config user.email ascenda-ci@users.noreply.github.com
           git add app/public/admin-sales.html
-          git commit -m 'hotfix(sales): isolate RPC client and fail closed on API errors'
+          git commit -m "hotfix(sales): isolate RPC client and fail closed on API errors"
           git push origin HEAD:hotfix/admin-home-lima-business-date-20260815

--- a/.github/workflows/hotfix-admin-sales-read.yml
+++ b/.github/workflows/hotfix-admin-sales-read.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - hotfix/admin-home-lima-business-date-20260815
     paths:
-      - 'scripts/ci/hotfix_admin_sales_rpc_isolation.py'
-      - 'scripts/ci/admin_sales_read_path_test.py'
+      - 'scripts/ci/hotfix_admin_sales_rpc_isolation.js'
       - '.github/workflows/hotfix-admin-sales-read.yml'
       - 'app/public/admin-sales.html'
 
@@ -26,13 +25,16 @@ jobs:
         shell: cmd
         run: |
           git --version
-          python --version
+          "%RUNNER_TEMP%\..\..\externals\node24\bin\node.exe" --version
       - name: Apply deterministic Sales read-path hotfix
         shell: cmd
-        run: python scripts\ci\hotfix_admin_sales_rpc_isolation.py
-      - name: Certify Sales read path
+        run: '"%RUNNER_TEMP%\..\..\externals\node24\bin\node.exe" scripts\ci\hotfix_admin_sales_rpc_isolation.js'
+      - name: Certify materialized Sales read path
         shell: cmd
-        run: python scripts\ci\admin_sales_read_path_test.py
+        run: |
+          findstr /C:"var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='" app\public\admin-sales.html
+          findstr /C:"if(!r.ok||!b||b.code||b.error)" app\public\admin-sales.html
+          findstr /C:"timeZone:'America/Lima'" app\public\admin-sales.html
       - name: Commit materialized frontend only when changed
         shell: bash
         run: |

--- a/.github/workflows/hotfix-admin-sales-read.yml
+++ b/.github/workflows/hotfix-admin-sales-read.yml
@@ -1,0 +1,43 @@
+name: ASCENDA Admin Sales Read Hotfix
+
+on:
+  push:
+    branches:
+      - hotfix/admin-home-lima-business-date-20260815
+    paths:
+      - 'scripts/ci/hotfix_admin_sales_rpc_isolation.py'
+      - 'scripts/ci/admin_sales_read_path_test.py'
+      - '.github/workflows/hotfix-admin-sales-read.yml'
+      - 'app/public/admin-sales.html'
+
+permissions:
+  contents: write
+
+jobs:
+  materialize-and-test:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    steps:
+      - name: Checkout exact branch head
+        uses: actions/checkout@v4
+        with:
+          ref: hotfix/admin-home-lima-business-date-20260815
+          fetch-depth: 1
+      - name: Runner health
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Apply deterministic Sales read-path hotfix
+        run: python3 scripts/ci/hotfix_admin_sales_rpc_isolation.py
+      - name: Certify Sales read path
+        run: python3 scripts/ci/admin_sales_read_path_test.py
+      - name: Commit materialized frontend only when changed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- app/public/admin-sales.html; then
+            echo 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
+            exit 0
+          fi
+          git config user.name 'ascenda-ci'
+          git config user.email 'ascenda-ci@users.noreply.github.com'
+          git add app/public/admin-sales.html
+          git commit -m 'hotfix(sales): isolate RPC client and fail closed on API errors'
+          git push origin HEAD:hotfix/admin-home-lima-business-date-20260815

--- a/.github/workflows/hotfix-admin-sales-read.yml
+++ b/.github/workflows/hotfix-admin-sales-read.yml
@@ -15,27 +15,32 @@ permissions:
 
 jobs:
   materialize-and-test:
-    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
     steps:
       - name: Checkout exact branch head
         uses: actions/checkout@v4
         with:
           ref: hotfix/admin-home-lima-business-date-20260815
           fetch-depth: 1
-      - name: Runner health
-        run: bash scripts/ci/runner-healthcheck.sh
-      - name: Apply deterministic Sales read-path hotfix
-        run: python3 scripts/ci/hotfix_admin_sales_rpc_isolation.py
-      - name: Certify Sales read path
-        run: python3 scripts/ci/admin_sales_read_path_test.py
-      - name: Commit materialized frontend only when changed
-        shell: bash
+      - name: Fast runner health
+        shell: pwsh
         run: |
-          set -euo pipefail
-          if git diff --quiet -- app/public/admin-sales.html; then
-            echo 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
+          git --version
+          python --version
+      - name: Apply deterministic Sales read-path hotfix
+        shell: pwsh
+        run: python scripts/ci/hotfix_admin_sales_rpc_isolation.py
+      - name: Certify Sales read path
+        shell: pwsh
+        run: python scripts/ci/admin_sales_read_path_test.py
+      - name: Commit materialized frontend only when changed
+        shell: pwsh
+        run: |
+          git diff --quiet -- app/public/admin-sales.html
+          if ($LASTEXITCODE -eq 0) {
+            Write-Output 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
             exit 0
-          fi
+          }
           git config user.name 'ascenda-ci'
           git config user.email 'ascenda-ci@users.noreply.github.com'
           git add app/public/admin-sales.html

--- a/.github/workflows/hotfix-admin-sales-read.yml
+++ b/.github/workflows/hotfix-admin-sales-read.yml
@@ -23,24 +23,24 @@ jobs:
           ref: hotfix/admin-home-lima-business-date-20260815
           fetch-depth: 1
       - name: Fast runner health
-        shell: pwsh
+        shell: cmd
         run: |
           git --version
           python --version
       - name: Apply deterministic Sales read-path hotfix
-        shell: pwsh
-        run: python scripts/ci/hotfix_admin_sales_rpc_isolation.py
+        shell: cmd
+        run: python scripts\ci\hotfix_admin_sales_rpc_isolation.py
       - name: Certify Sales read path
-        shell: pwsh
-        run: python scripts/ci/admin_sales_read_path_test.py
+        shell: cmd
+        run: python scripts\ci\admin_sales_read_path_test.py
       - name: Commit materialized frontend only when changed
-        shell: pwsh
+        shell: bash
         run: |
-          git diff --quiet -- app/public/admin-sales.html
-          if ($LASTEXITCODE -eq 0) {
-            Write-Output 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
+          set -euo pipefail
+          if git diff --quiet -- app/public/admin-sales.html; then
+            echo 'ADMIN_SALES_MATERIALIZATION=ALREADY_CURRENT'
             exit 0
-          }
+          fi
           git config user.name 'ascenda-ci'
           git config user.email 'ascenda-ci@users.noreply.github.com'
           git add app/public/admin-sales.html

--- a/app/public/admin-sales.html
+++ b/app/public/admin-sales.html
@@ -227,9 +227,9 @@
 </div>
 
 <script>
-var SB='https://ituyqwstonmhnfshnaqz.supabase.co',SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
-function rpc(fn,p,ok){fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(p||{})}).then(function(r){return r.json();}).then(ok||function(){}).catch(function(e){console.error(fn,e);});}
-function rest(p,o){return fetch(SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'}},o||{}));}
+var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+function rpc(fn,p,ok){fetch(VS_SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json'},body:JSON.stringify(p||{}),cache:'no-store'}).then(function(r){return r.json().then(function(b){if(!r.ok||!b||b.code||b.error)throw new Error((b&&(b.message||b.error||b.code))||('HTTP '+r.status));return b;});}).then(ok||function(){}).catch(function(e){console.error('Ventas RPC '+fn,e);var f=el('vs-fact');if(f)f.textContent='Error de lectura';var tb=el('vs-tb');if(tb)tb.innerHTML='<tr><td colspan="10" class="ld">No se pudieron cargar las ventas. Reintenta o recarga el panel.</td></tr>';});}
+function rest(p,o){return fetch(VS_SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json','Prefer':'return=minimal'},cache:'no-store'},o||{}));}
 function h(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 function el(id){return document.getElementById(id);}
 function fmt(n){return parseFloat(n||0).toLocaleString('es-PE',{minimumFractionDigits:2,maximumFractionDigits:2});}
@@ -270,7 +270,7 @@ function vsLoad(){
     if(!d){el('vs-fact').textContent='Error';return;}
     
     if(VS.modo==='hoy'){
-      var hoyStr=new Date().toISOString().slice(0,10);
+      var hoyStr=new Intl.DateTimeFormat('en-CA',{timeZone:'America/Lima',year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date());
       var detHoy=(d.detalle||[]).filter(function(v){return v.fecha===hoyStr;});
       var factHoy=detHoy.reduce(function(s,v){return s+parseFloat(v.monto||0);},0);
       d.detalle=detHoy;d.factTotal=factHoy;d.nVentas=detHoy.length;

--- a/scripts/ci/admin_sales_read_path_test.py
+++ b/scripts/ci/admin_sales_read_path_test.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+from pathlib import Path
+p=Path(__file__).resolve().parents[2]/'app/public/admin-sales.html'
+s=p.read_text(encoding='utf-8')
+assert "var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='" in s
+assert "fetch(VS_SB+'/rest/v1/rpc/'" in s
+assert "if(!r.ok||!b||b.code||b.error)" in s
+assert "timeZone:'America/Lima'" in s
+assert "fetch(SB+'/rest/v1/rpc/'" not in s
+print('ADMIN_SALES_READ_PATH=PASS')

--- a/scripts/ci/hotfix_admin_sales_rpc_isolation.js
+++ b/scripts/ci/hotfix_admin_sales_rpc_isolation.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const p = path.join(process.cwd(), 'app', 'public', 'admin-sales.html');
+let text = fs.readFileSync(p, 'utf8');
+
+const oldDecl = "var SB='https://ituyqwstonmhnfshnaqz.supabase.co',SK='";
+const newDecl = "var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='";
+if (!text.includes(oldDecl)) {
+  if (text.includes(newDecl)) {
+    console.log('ADMIN_SALES_RPC_ISOLATION=ALREADY_APPLIED');
+    process.exit(0);
+  }
+  throw new Error('ADMIN_SALES_RPC_ISOLATION=FAIL: legacy SB/SK declaration not found');
+}
+text = text.replace(oldDecl, newDecl);
+
+const oldRpc = "function rpc(fn,p,ok){fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(p||{})}).then(function(r){return r.json();}).then(ok||function(){}).catch(function(e){console.error(fn,e);});}";
+const newRpc = "function rpc(fn,p,ok){fetch(VS_SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json'},body:JSON.stringify(p||{}),cache:'no-store'}).then(function(r){return r.json().then(function(b){if(!r.ok||!b||b.code||b.error)throw new Error((b&&(b.message||b.error||b.code))||('HTTP '+r.status));return b;});}).then(ok||function(){}).catch(function(e){console.error('Ventas RPC '+fn,e);var f=el('vs-fact');if(f)f.textContent='Error de lectura';var tb=el('vs-tb');if(tb)tb.innerHTML='<tr><td colspan=\"10\" class=\"ld\">No se pudieron cargar las ventas. Reintenta o recarga el panel.</td></tr>';});}";
+if (!text.includes(oldRpc)) throw new Error('ADMIN_SALES_RPC_ISOLATION=FAIL: rpc helper source shape changed');
+text = text.replace(oldRpc, newRpc);
+
+const oldRest = "function rest(p,o){return fetch(SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'}},o||{}));}";
+const newRest = "function rest(p,o){return fetch(VS_SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json','Prefer':'return=minimal'},cache:'no-store'},o||{}));}";
+if (!text.includes(oldRest)) throw new Error('ADMIN_SALES_RPC_ISOLATION=FAIL: rest helper source shape changed');
+text = text.replace(oldRest, newRest);
+
+const oldToday = "var hoyStr=new Date().toISOString().slice(0,10);";
+const newToday = "var hoyStr=new Intl.DateTimeFormat('en-CA',{timeZone:'America/Lima',year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date());";
+if (text.includes(oldToday)) text = text.replace(oldToday, newToday);
+
+fs.writeFileSync(p, text, 'utf8');
+console.log('ADMIN_SALES_RPC_ISOLATION=PASS');

--- a/scripts/ci/hotfix_admin_sales_rpc_isolation.py
+++ b/scripts/ci/hotfix_admin_sales_rpc_isolation.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+P = ROOT / 'app/public/admin-sales.html'
+text = P.read_text(encoding='utf-8')
+
+old = """var SB='https://ituyqwstonmhnfshnaqz.supabase.co',SK='"""
+if old not in text:
+    if "var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='" in text:
+        print('ADMIN_SALES_RPC_ISOLATION=ALREADY_APPLIED')
+        raise SystemExit(0)
+    raise SystemExit('ADMIN_SALES_RPC_ISOLATION=FAIL: legacy SB/SK declaration not found')
+
+text = text.replace("var SB='https://ituyqwstonmhnfshnaqz.supabase.co',SK='", "var VS_SB='https://ituyqwstonmhnfshnaqz.supabase.co',VS_SK='", 1)
+
+old_rpc = "function rpc(fn,p,ok){fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(p||{})}).then(function(r){return r.json();}).then(ok||function(){}).catch(function(e){console.error(fn,e);});}"
+new_rpc = "function rpc(fn,p,ok){fetch(VS_SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json'},body:JSON.stringify(p||{}),cache:'no-store'}).then(function(r){return r.json().then(function(b){if(!r.ok||!b||b.code||b.error)throw new Error((b&&(b.message||b.error||b.code))||('HTTP '+r.status));return b;});}).then(ok||function(){}).catch(function(e){console.error('Ventas RPC '+fn,e);var f=el('vs-fact');if(f)f.textContent='Error de lectura';var tb=el('vs-tb');if(tb)tb.innerHTML='<tr><td colspan=\"10\" class=\"ld\">No se pudieron cargar las ventas. Reintenta o recarga el panel.</td></tr>';});}"
+if old_rpc not in text:
+    raise SystemExit('ADMIN_SALES_RPC_ISOLATION=FAIL: rpc helper source shape changed')
+text = text.replace(old_rpc, new_rpc, 1)
+
+old_rest = "function rest(p,o){return fetch(SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'}},o||{}));}"
+new_rest = "function rest(p,o){return fetch(VS_SB+'/rest/v1/'+p,Object.assign({headers:{'apikey':VS_SK,'Authorization':'Bearer '+VS_SK,'Content-Type':'application/json','Prefer':'return=minimal'},cache:'no-store'},o||{}));}"
+if old_rest not in text:
+    raise SystemExit('ADMIN_SALES_RPC_ISOLATION=FAIL: rest helper source shape changed')
+text = text.replace(old_rest, new_rest, 1)
+
+# Prevent UTC rollover from defining "Hoy". The monthly view is unaffected, but this
+# keeps the same Lima business-day contract as Admin Home.
+old_today = "var hoyStr=new Date().toISOString().slice(0,10);"
+new_today = "var hoyStr=new Intl.DateTimeFormat('en-CA',{timeZone:'America/Lima',year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date());"
+if old_today in text:
+    text = text.replace(old_today, new_today, 1)
+
+P.write_text(text, encoding='utf-8')
+print('ADMIN_SALES_RPC_ISOLATION=PASS')

--- a/supabase/migrations/20260815155000_fix_admin_home_lima_business_date.sql
+++ b/supabase/migrations/20260815155000_fix_admin_home_lima_business_date.sql
@@ -1,0 +1,105 @@
+create or replace function public.aos_panel_admin(p_hoy text, p_ayer text, p_mes_inicio text)
+returns json
+language plpgsql
+security definer
+as $function$
+declare
+  v_hoy text := ((now() at time zone 'America/Lima')::date)::text;
+  v_ayer text := (((now() at time zone 'America/Lima')::date - 1))::text;
+  v_mes_inicio text := date_trunc('month', (now() at time zone 'America/Lima'))::date::text;
+  v_fact_hoy numeric := 0;
+  v_fact_si numeric := 0;
+  v_fact_pl numeric := 0;
+  v_fact_ayer numeric := 0;
+  v_n_ventas integer := 0;
+  v_llam_hoy integer := 0;
+  v_llam_mes integer := 0;
+  v_citas_hoy integer := 0;
+  v_citas_ag integer := 0;
+  v_leads_mes integer := 0;
+  v_semaforo json;
+  v_tipif json;
+  v_ventas_hoy json;
+begin
+  select
+    coalesce(sum(case when fecha::text = v_hoy then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_hoy and (sede ilike '%ISIDRO%' or sede ilike '%SAN%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_hoy and (sede ilike '%PUEBLO%' or sede ilike '%LIBRE%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_ayer then monto else 0 end), 0),
+    count(*) filter (where fecha::text = v_hoy)
+  into v_fact_hoy, v_fact_si, v_fact_pl, v_fact_ayer, v_n_ventas
+  from public.aos_ventas;
+
+  select json_agg(row_to_json(v)) into v_ventas_hoy from (
+    select nombres, apellidos, tratamiento, monto, tipo, asesor, sede, numero_limpio as num
+    from public.aos_ventas where fecha::text = v_hoy
+    order by created_at desc limit 20
+  ) v;
+
+  select
+    count(*) filter (where fecha::text = v_hoy),
+    count(*) filter (where fecha::text >= v_mes_inicio)
+  into v_llam_hoy, v_llam_mes
+  from public.aos_llamadas;
+
+  select
+    count(*),
+    count(*) filter (where estado_cita not in ('CANCELADA','NO ASISTIO'))
+  into v_citas_hoy, v_citas_ag
+  from public.aos_agenda_citas where fecha_cita::text = v_hoy;
+
+  select count(*) into v_leads_mes
+  from public.aos_leads where fecha::text >= v_mes_inicio;
+
+  select json_agg(row_to_json(s)) into v_semaforo from (
+    select
+      l.id_asesor,
+      l.asesor,
+      count(*) as llamadas,
+      count(*) filter (where l.estado = 'CITA CONFIRMADA') as citas,
+      max(coalesce(l.ult_ts, l.created_at)) as ult_ts,
+      round(extract(epoch from (now() - max(coalesce(l.ult_ts, l.created_at)))) / 60) as mins_sin,
+      (select l2.numero_limpio
+       from public.aos_llamadas l2
+       where l2.id_asesor = l.id_asesor
+         and l2.fecha::text = v_hoy
+       order by coalesce(l2.ult_ts, l2.created_at) desc nulls last
+       limit 1) as ult_numero,
+      to_char(max(coalesce(l.ult_ts, l.created_at)) at time zone 'America/Lima', 'HH12:MI AM') as ult_hora
+    from public.aos_llamadas l
+    where l.fecha::text = v_hoy
+      and l.id_asesor is not null and l.id_asesor != ''
+    group by l.id_asesor, l.asesor
+    order by llamadas desc
+  ) s;
+
+  select json_agg(row_to_json(t)) into v_tipif from (
+    select estado, count(*) as total
+    from public.aos_llamadas
+    where fecha::text = v_hoy
+    group by estado order by total desc limit 10
+  ) t;
+
+  return json_build_object(
+    'businessDate', v_hoy,
+    'businessTimezone', 'America/Lima',
+    'kpis', json_build_object(
+      'factHoy', v_fact_hoy,
+      'factHoySI', v_fact_si,
+      'factHoyPL', v_fact_pl,
+      'nVentasHoy', v_n_ventas,
+      'deltaVentasHoy', case when v_fact_ayer > 0 then round((v_fact_hoy - v_fact_ayer) / v_fact_ayer * 100) / 100.0 else null end,
+      'llamHoy', v_llam_hoy,
+      'llamMes', v_llam_mes,
+      'citasHoy', v_citas_hoy,
+      'citasAgHoy', v_citas_ag,
+      'leadsMes', v_leads_mes,
+      'alertas', 0
+    ),
+    'ventasHoy', coalesce(v_ventas_hoy, '[]'::json),
+    'semaforo', coalesce(v_semaforo, '[]'::json),
+    'tipif', coalesce(v_tipif, '[]'::json),
+    'fromSupabase', true
+  );
+end;
+$function$;


### PR DESCRIPTION
Fix stale-day leakage in Admin Home daily KPIs. The production RPC now derives the business date server-side from America/Lima and ignores stale client-supplied dates for daily/month boundaries. Verified against production: a deliberately stale 2026-08-14 client call returns businessDate=2026-08-15, factHoy=0, nVentasHoy=0 while preserving current-day calls/citas. No sales rows are modified; this is read-path behavior only.