### PR TITLE
F4 FAST P0: restore Ventas/Cartera/Caja on current main

### DIFF
--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -1,0 +1,21 @@
+// ASCENDA OS — F4 production canary P0 browser cleanup.
+(function(){
+'use strict';
+if(window.__AOS_F4_PRODUCTION_CANARY_P0__)return;
+window.__AOS_F4_PRODUCTION_CANARY_P0__=true;
+
+function cleanCajaClosedState(){
+  var box=document.getElementById('no-sesion-msg');
+  if(!box)return;
+  var extras=box.querySelectorAll('.btn-abrir-inline');
+  Array.prototype.forEach.call(extras,function(b){b.remove();});
+}
+
+function run(){cleanCajaClosedState();}
+run();
+
+try{
+  var obs=new MutationObserver(function(){run();});
+  obs.observe(document.documentElement||document.body,{childList:true,subtree:true});
+}catch(e){}
+})();

--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -5,6 +5,7 @@ self.addEventListener('activate',function(e){e.waitUntil(self.clients.claim());}
 
 var PROTECTED={aos_catalogo_categorias:1,aos_catalogo_servicios:1,aos_catalogo_toppings:1,aos_catalogo_productos_detalle:1,aos_planes_trabajo:1,aos_plan_trabajo_items:1};
 var CAJA={aos_caja_abrir:'aos_caja_abrir_v2',aos_caja_cerrar:'aos_caja_cerrar_v2',aos_caja_editar_pago:'aos_caja_editar_pago_v2',aos_caja_eliminar_venta:'aos_caja_eliminar_venta_v2',aos_caja_ingreso_extra:'aos_caja_ingreso_extra_v2',aos_caja_registrar_gasto:'aos_caja_registrar_gasto_v2'};
+var CARTERA={aos_cartera_gateway:'aos_cartera_gateway_v2'};
 var IDENTITY={aos_admin_crear_usuario:'aos_admin_crear_usuario_v3',aos_admin_cambiar_password:'aos_admin_cambiar_password_v3',aos_cambiar_password:'aos_cambiar_password_v3'};
 
 async function getToken(){try{var c=await caches.open('aos-phase2-auth');var r=await c.match('/__aos_app_token');return r?await r.text():'';}catch(e){return '';}}
@@ -17,11 +18,14 @@ async function rpcFrom(req,name,payload){var u=new URL(req.url);var target=u.ori
 async function injectF4(req){
   var r=await fetch(req,{cache:'no-store'});if(!r.ok)return r;
   var type=(r.headers.get('content-type')||'').toLowerCase();if(type.indexOf('text/html')<0)return r;
-  var html=await r.text();
+  var html=await r.text(),tags='';
   if(html.indexOf('/f4-revenue-ops.js')<0){
-    var tags='<script src="/f4-revenue-ops.js?v=20260814-f4"></script><script src="/f4-kronia-revenue-bridge.js?v=20260814-f4"></script>';
-    html=html.indexOf('</body>')>=0?html.replace('</body>',tags+'</body>'):html+tags;
+    tags+='<script src="/f4-revenue-ops.js?v=20260815-f4-canary-p0"></script><script src="/f4-kronia-revenue-bridge.js?v=20260815-f4-canary-p0"></script>';
   }
+  if(html.indexOf('/f4-production-canary-hotfix.js')<0){
+    tags+='<script src="/f4-production-canary-hotfix.js?v=20260815-p0"></script>';
+  }
+  if(tags){html=html.indexOf('</body>')>=0?html.replace('</body>',tags+'</body>'):html+tags;}
   var h=new Headers(r.headers);h.set('Cache-Control','no-store, no-cache, must-revalidate');h.delete('content-length');
   return new Response(html,{status:r.status,statusText:r.statusText,headers:h});
 }
@@ -36,8 +40,11 @@ self.addEventListener('fetch',function(event){
   if(rm&&IDENTITY[rm[1]]){
     event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();if(rm[1]==='aos_admin_cambiar_password'&&!p.p_usuario_id){return json({ok:false,error:'LEGACY_IDENTITY_FLOW_RETIRED'},403);}if(rm[1]==='aos_cambiar_password')p={p_token:p.p_token,p_password_actual:p.p_password_actual,p_password_nuevo:p.p_password_nuevo};var r=await rpcFrom(req,IDENTITY[rm[1]],p);if(isMissing(r))return fetch(req);return r;})());return;
   }
+  if(rm&&CARTERA[rm[1]]){
+    event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();var r=await rpcFrom(req,CARTERA[rm[1]],p);if(isMissing(r))return json({ok:false,error:'F4_CARTERA_GATEWAY_UNAVAILABLE'},503);return r;})());return;
+  }
   if(rm&&CAJA[rm[1]]){
-    event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();delete p.p_usuario;var r=await rpcFrom(req,CAJA[rm[1]],p);if(isMissing(r))return fetch(req);return r;})());return;
+    event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();delete p.p_usuario;var r=await rpcFrom(req,CAJA[rm[1]],p);if(isMissing(r))return json({ok:false,error:'SECURE_CAJA_GATEWAY_UNAVAILABLE'},503);return r;})());return;
   }
   var tm=u.pathname.match(/\/rest\/v1\/([^/]+)$/),table=tm&&tm[1],method=req.method.toUpperCase();
   if(table&&PROTECTED[table]&&(method==='POST'||method==='PATCH'||method==='DELETE')){

--- a/supabase/migrations/20260815162000_f4_revenue_production_canary_p0.sql
+++ b/supabase/migrations/20260815162000_f4_revenue_production_canary_p0.sql
@@ -1,0 +1,83 @@
+-- ASCENDA OS — F4 production canary P0.
+-- Fixes runtime inheritance when hardened wrappers call legacy SECURITY DEFINER
+-- functions that still resolve unqualified public relations.
+-- Also introduces a strong-Auth V3 Cartera read bridge for the production panel.
+
+begin;
+
+do $guard$
+begin
+  if has_schema_privilege('anon','public','CREATE')
+     or has_schema_privilege('authenticated','public','CREATE')
+     or has_schema_privilege('public','public','CREATE') then
+    raise exception 'F4_P0_PUBLIC_SCHEMA_CREATE_MUST_BE_REVOKED';
+  end if;
+end
+$guard$;
+
+alter function public.aos_sales_admin_gateway_v4(text,integer,integer,text,text,text)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_editar_venta_v4(text,bigint,timestamptz,jsonb,text)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_importar_ventas_v4(text,jsonb)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_grabar_venta_caja_v4(text,text,text,text,text,text,text,text,text,text,text,jsonb,text,numeric,text,text,text,text,text,text,text,text,numeric)
+  set search_path = pg_catalog, public, extensions;
+
+alter function public.aos_caja_abrir_v2(text,text,numeric,numeric,numeric,date)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_caja_cerrar_v2(text,text,numeric,numeric,numeric,numeric,text)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_caja_editar_pago_v2(text,text,text,text,numeric,text,text,text,text,text,uuid)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_caja_eliminar_venta_v2(text,text,text)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_caja_ingreso_extra_v2(text,text,text,date,text,numeric,text)
+  set search_path = pg_catalog, public, extensions;
+alter function public.aos_caja_registrar_gasto_v2(text,text,text,date,text,numeric,text,text)
+  set search_path = pg_catalog, public, extensions;
+
+create or replace function public.aos_cartera_gateway_v2(
+  p_token text,
+  p_estado text default '',
+  p_sede text default '',
+  p_limit integer default 50,
+  p_offset integer default 0
+) returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_actor uuid;
+  v_result jsonb;
+begin
+  v_actor:=public.aos_f4_actor(p_token,'admin-cartera');
+  if v_actor is null then
+    return jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+
+  v_result:=public.aos_cartera_gateway(
+    p_token,p_estado,p_sede,p_limit,p_offset
+  );
+  if coalesce((v_result->>'ok')::boolean,false)=false then
+    return v_result;
+  end if;
+
+  update public.aos_app_sessions_v3
+  set last_used_at=now()
+  where user_id=v_actor and revoked=false;
+
+  return v_result || jsonb_build_object(
+    'contract','F4_CARTERA_GATEWAY_V2',
+    'strongAuth',true
+  );
+end
+$function$;
+
+revoke all on function public.aos_cartera_gateway_v2(text,text,text,integer,integer) from public;
+grant execute on function public.aos_cartera_gateway_v2(text,text,text,integer,integer) to anon,authenticated;
+
+notify pgrst, 'reload schema';
+
+commit;


### PR DESCRIPTION
FAST production repair rebased directly from current main. Production DB P0 migration has already been applied successfully and verified read-only: sales data intact, Sales V4/Caja V2 safe search_path active, Cartera V2 exists. This PR only carries the corresponding browser routing/duplicate-button cleanup plus the migration file into repository history. Previous P0 exact-head gates were all green. Goal: minimal safe frontend deploy, no business-data mutation, no cutover yet.