### PR TITLE
release(f16): rollback-safe certified Email runtime with Railway env compatibility

### DIFF
--- a/.github/workflows/cia-phase16-email.yml
+++ b/.github/workflows/cia-phase16-email.yml
@@ -1,0 +1,109 @@
+name: ASCENDA CIA Phase 16 Email Contracts
+
+on:
+  push:
+    branches: ['release/cia-phase16-email-20260815-v5']
+    paths:
+      - 'supabase/migrations/*cia_phase16_email*.sql'
+      - 'ci/phase16/**'
+      - 'app/email-gateway.js'
+      - 'app/server.js'
+      - 'app/public/admin-email.html'
+      - 'app/public/attendance.html'
+      - 'app/public/agenda.js'
+      - 'app/public/calls.js'
+      - 'app/public/citas.html'
+      - 'app/public/caja.html'
+      - 'app/public/calls.html'
+      - '.github/workflows/cia-phase16-email.yml'
+      - 'scripts/ci/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cia-phase16-email-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: F16 synthetic Email contract / rollback
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 25
+    env:
+      BASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+      F16_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/phase16_test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Zero-Cost policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Runner health
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Expose trusted runner Node
+        run: bash scripts/ci/expose-runner-node.sh
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Start isolated Supabase PostgreSQL
+        working-directory: ci/zero-cost-staging
+        run: supabase db start
+      - name: Create dedicated synthetic F16 database
+        run: |
+          set -euo pipefail
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "drop database if exists phase16_test with (force)"
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "create database phase16_test"
+      - name: Build and compile exact F16 contract
+        run: |
+          set -euo pipefail
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/schema_contract.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/legacy_email_schema_contract.sql
+          for f in 20260814200500_cia_phase16_email_governed_schema_v1.sql 20260814200600_cia_phase16_email_contracts_v1.sql 20260814220000_cia_phase16_email_delivery_contracts_v2.sql 20260814220100_cia_phase16_email_render_context_hardening.sql 20260814220200_cia_phase16_legacy_email_acl_hardening.sql 20260814220300_cia_phase16_verify_app_session_v1.sql; do psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"; done
+          supabase db lint --db-url "$F16_DB_URL" --schema public --level error
+      - name: Synthetic positive and negative contracts
+        run: |
+          set -euo pipefail
+          for f in test_phase16_contracts.sql test_phase16_delivery_contracts.sql test_phase16_render_context_hardening.sql test_phase16_legacy_acl.sql test_phase16_app_session.sql; do psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f "ci/phase16/$f"; done
+      - name: Server-authoritative gateway contracts
+        run: |
+          set -euo pipefail
+          node --check app/email-gateway.js
+          node --check app/server.js
+          node --check app/public/agenda.js
+          node --check app/public/calls.js
+          node ci/phase16/test_email_gateway.js
+          grep -q "if (p === '/api/email-gateway')" app/server.js
+          grep -q "EMAIL_GATEWAY.handleWebhook" app/server.js
+          grep -q "EMAIL_GATEWAY.verifyApp" app/server.js
+          grep -q "LEGACY_2FA_RETIRED" app/server.js
+          grep -q "F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED" app/server.js
+          grep -q "GOVERNED_ACTIVATION_REQUIRED" app/email-gateway.js
+          grep -q "aos_cia_verify_app_session_v1" app/email-gateway.js
+          grep -q "emCall('LEGACY_SEND'" app/public/admin-email.html
+          grep -q "process.env.SUPABASE_SERVICE_ROLE_KEY" app/server.js
+          grep -q "process.env.service_role" app/server.js
+          grep -q "process.env.SUPABASE_SERVICE_ROLE_KEY" app/email-gateway.js
+          grep -q "process.env.service_role" app/email-gateway.js
+          grep -q "f16RequireEmailBackend" app/server.js
+          ! grep -q "fetch(SB+" app/public/admin-email.html
+          ! grep -q "'apikey':SK" app/public/admin-email.html
+          ! grep -q "fetch('/api/send-email'" app/public/admin-email.html
+          ! grep -Eq "['\"]re_[A-Za-z0-9_-]{20,}['\"]" app/server.js
+          for f in app/public/attendance.html app/public/agenda.js app/public/calls.js app/public/citas.html app/public/caja.html app/public/calls.html; do grep -q "X-ASCENDA-Session" "$f"; done
+          echo 'CIA_PHASE16_RUNTIME_BOUNDARY=PASS'
+      - name: Rollback and zero-residue proof
+        run: |
+          set -euo pipefail
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16.sql | tee /tmp/f16_rollback.log
+          grep -q 'CIA_PHASE16_ROLLBACK=PASS' /tmp/f16_rollback.log
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16_legacy_acl.sql | tee /tmp/f16_acl_rollback.log
+          grep -q 'CIA_PHASE16_LEGACY_ACL_ROLLBACK=PASS' /tmp/f16_acl_rollback.log
+          test "$(psql "$F16_DB_URL" -X -qAt -c "select count(*) from pg_class c join pg_namespace n on n.oid=c.relnamespace where n.nspname='public' and c.relname like 'aos_cia_email_%'")" = "0"
+          echo 'CIA_PHASE16_ZERO_COST_CONTRACT_GATE=PASS'
+          echo 'DELIVERY_ENABLED=false'
+      - name: Cleanup
+        if: always()
+        run: |
+          psql "$BASE_DB_URL" -X -c "drop database if exists phase16_test with (force)" || true
+          cd ci/zero-cost-staging && supabase stop --no-backup || true

--- a/.github/workflows/cia-phase16-policy.yml
+++ b/.github/workflows/cia-phase16-policy.yml
@@ -1,0 +1,53 @@
+name: ASCENDA CIA Phase 16 Email Policy
+
+on:
+  push:
+    branches: ['release/cia-phase16-email-20260815-v5']
+    paths:
+      - 'app/email-gateway.js'
+      - 'app/server.js'
+      - 'app/public/attendance.html'
+      - 'app/public/agenda.js'
+      - 'app/public/calls.js'
+      - 'app/public/citas.html'
+      - 'app/public/caja.html'
+      - 'app/public/calls.html'
+      - 'ci/phase16/**'
+      - 'scripts/ci/expose-runner-node.sh'
+      - '.github/workflows/cia-phase16-policy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cia-phase16-email-policy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    name: F16 transactional auth / marketing fail-closed
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Zero-Cost policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Runner health
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Expose trusted runner Node
+        run: bash scripts/ci/expose-runner-node.sh
+      - name: Syntax and gateway policy
+        run: |
+          set -euo pipefail
+          node --check app/email-gateway.js
+          node --check app/server.js
+          node ci/phase16/test_email_gateway_policy.js
+      - name: Transactional caller session contract
+        run: |
+          set -euo pipefail
+          for f in app/public/attendance.html app/public/agenda.js app/public/calls.js app/public/citas.html app/public/caja.html app/public/calls.html; do grep -q 'X-ASCENDA-Session' "$f"; done
+          grep -q 'LEGACY_2FA_RETIRED' app/server.js
+          grep -q 'F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED' app/server.js
+          ! grep -Eq "['\"]re_[A-Za-z0-9_-]{20,}['\"]" app/server.js
+          echo 'CIA_PHASE16_TRANSACTIONAL_POLICY_GATE=PASS'

--- a/.github/workflows/cia-phase16-release-materialize.yml
+++ b/.github/workflows/cia-phase16-release-materialize.yml
@@ -1,0 +1,108 @@
+name: ASCENDA CIA Phase 16 Clean Release Materialize
+
+on:
+  push:
+    branches:
+      - 'release/cia-phase16-email-20260815-v5'
+    paths:
+      - '.github/workflows/cia-phase16-release-materialize.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cia-phase16-clean-release-materialize-v5
+  cancel-in-progress: false
+
+jobs:
+  materialize:
+    name: F16 clean release materialization v5 payload
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 12
+    steps:
+      - name: Checkout clean release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
+
+      - name: Enforce Zero-Cost CI V2 policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Self-hosted runner healthcheck
+        run: bash scripts/ci/runner-healthcheck.sh
+
+      - name: Verify clean current-main base
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF_NAME}" = "release/cia-phase16-email-20260815-v5"
+          git fetch --no-tags --depth=5 origin release/cia-phase16-email-20260815-v5
+          git fetch --no-tags origin 42d77fe6fbe65c275927db0b4a776d4493f10ef3
+          git merge-base --is-ancestor 42d77fe6fbe65c275927db0b4a776d4493f10ef3 HEAD
+          echo 'CIA_PHASE16_CLEAN_BASE=PASS'
+
+      - name: Copy certified F16 non-workflow allowlist from engineering SHA
+        env:
+          SOURCE_SHA: e374bff05ae596dbc244ed06f3784f108b6634c5
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$SOURCE_SHA"
+          files=(
+            app/email-gateway.js
+            ci/phase16/legacy_email_schema_contract.sql
+            ci/phase16/rollback_phase16.sql
+            ci/phase16/rollback_phase16_legacy_acl.sql
+            ci/phase16/schema_contract.sql
+            ci/phase16/test_email_gateway.js
+            ci/phase16/test_email_gateway_policy.js
+            ci/phase16/test_phase16_app_session.sql
+            ci/phase16/test_phase16_contracts.sql
+            ci/phase16/test_phase16_delivery_contracts.sql
+            ci/phase16/test_phase16_legacy_acl.sql
+            ci/phase16/test_phase16_render_context_hardening.sql
+            docs/control/commercial-intelligence/PHASE_16_IMPACT_REPORT_20260814.md
+            scripts/ci/expose-runner-node.sh
+            scripts/ci/phase16_apply_runtime_patch.py
+            scripts/ci/phase16_patch_email_backend_acl.py
+            scripts/ci/phase16_patch_runtime.py
+            scripts/ci/phase16_patch_transactional_email.py
+            supabase/migrations/20260814200500_cia_phase16_email_governed_schema_v1.sql
+            supabase/migrations/20260814200600_cia_phase16_email_contracts_v1.sql
+            supabase/migrations/20260814220000_cia_phase16_email_delivery_contracts_v2.sql
+            supabase/migrations/20260814220100_cia_phase16_email_render_context_hardening.sql
+            supabase/migrations/20260814220200_cia_phase16_legacy_email_acl_hardening.sql
+            supabase/migrations/20260814220300_cia_phase16_verify_app_session_v1.sql
+          )
+          for f in "${files[@]}"; do
+            mkdir -p "$(dirname "$f")"
+            git show "$SOURCE_SHA:$f" > "$f"
+          done
+          echo "CIA_PHASE16_RELEASE_PAYLOAD_COUNT=${#files[@]}"
+
+      - name: Adapt F16 payload to CURRENT main runtime
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          p = Path('scripts/ci/phase16_patch_transactional_email.py')
+          s = p.read_text()
+          s = s.replace('    # F11 calls.html is now only a loader wrapper; the live legacy panel is\n    # fetched and executed from calls-v2.html by calls-loader-v3.js.\n    ROOT / "app/public/calls-v2.html",\n', '    # CURRENT main serves the live Call Center directly from calls.html.\n    ROOT / "app/public/calls.html",\n')
+          s = re.sub(r'\n\ndef assert_live_call_center_consumer\(\) -> None:.*?\n\ndef patch_server', '\n\ndef patch_server', s, flags=re.S)
+          s = s.replace('    assert_live_call_center_consumer()\n', '')
+          p.write_text(s)
+          PY
+          python3 -m py_compile scripts/ci/phase16_apply_runtime_patch.py scripts/ci/phase16_patch_runtime.py scripts/ci/phase16_patch_email_backend_acl.py scripts/ci/phase16_patch_transactional_email.py
+          grep -q "app/public/calls.html" scripts/ci/phase16_patch_transactional_email.py
+          ! grep -q "calls-v2.html" scripts/ci/phase16_patch_transactional_email.py
+          git diff --check
+          echo 'CIA_PHASE16_CURRENT_MAIN_PAYLOAD_ADAPTATION=PASS'
+
+      - name: Commit clean F16 non-workflow payload
+        run: |
+          set -euo pipefail
+          git config user.name 'ASCENDA Zero-Cost CI'
+          git config user.email 'actions@users.noreply.github.com'
+          git add app/email-gateway.js ci/phase16 docs/control/commercial-intelligence/PHASE_16_IMPACT_REPORT_20260814.md scripts/ci/expose-runner-node.sh scripts/ci/phase16_apply_runtime_patch.py scripts/ci/phase16_patch_email_backend_acl.py scripts/ci/phase16_patch_runtime.py scripts/ci/phase16_patch_transactional_email.py supabase/migrations/20260814200500_cia_phase16_email_governed_schema_v1.sql supabase/migrations/20260814200600_cia_phase16_email_contracts_v1.sql supabase/migrations/20260814220000_cia_phase16_email_delivery_contracts_v2.sql supabase/migrations/20260814220100_cia_phase16_email_render_context_hardening.sql supabase/migrations/20260814220200_cia_phase16_legacy_email_acl_hardening.sql supabase/migrations/20260814220300_cia_phase16_verify_app_session_v1.sql
+          git commit -m 'release(cia): materialize clean F16 Email payload v5'
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/cia-phase16-runtime-certify.yml
+++ b/.github/workflows/cia-phase16-runtime-certify.yml
@@ -1,0 +1,83 @@
+name: ASCENDA CIA Phase 16 Runtime Certification
+
+on:
+  push:
+    branches: ['release/cia-phase16-email-20260815-v5']
+    paths:
+      - 'app/server.js'
+      - 'app/email-gateway.js'
+      - 'app/public/admin-email.html'
+      - 'app/public/agenda.js'
+      - 'app/public/attendance.html'
+      - 'app/public/caja.html'
+      - 'app/public/calls.html'
+      - 'app/public/calls.js'
+      - 'app/public/citas.html'
+      - 'ci/phase16/**'
+      - '.github/workflows/cia-phase16-runtime-certify.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cia-phase16-runtime-certify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: F16 exact-head runtime certification
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 12
+    steps:
+      - name: Checkout exact triggering SHA
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Enforce Zero-Cost CI V2 policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Self-hosted runner healthcheck
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Expose trusted runner Node
+        run: bash scripts/ci/expose-runner-node.sh
+      - name: Runtime syntax assertions
+        run: |
+          set -euo pipefail
+          node --check app/server.js
+          node --check app/email-gateway.js
+          node --check app/public/agenda.js
+          node --check app/public/calls.js
+      - name: Authoritative Email boundary assertions
+        run: |
+          set -euo pipefail
+          grep -q "if (p === '/api/email-gateway') return EMAIL_GATEWAY.handleAdmin(req, res)" app/server.js
+          grep -q "if (p === '/api/send-email') return EMAIL_GATEWAY.handleAdmin(req, res)" app/server.js
+          grep -q "if (p === '/api/resend-webhook') return EMAIL_GATEWAY.handleWebhook(req, res)" app/server.js
+          grep -q "process.env.SUPABASE_SERVICE_ROLE_KEY" app/server.js
+          grep -q "process.env.service_role" app/server.js
+          grep -q "process.env.SUPABASE_SERVICE_ROLE_KEY" app/email-gateway.js
+          grep -q "process.env.service_role" app/email-gateway.js
+          grep -q "process.env.RESEND_API_KEY || ''" app/email-gateway.js
+          grep -q "process.env.RESEND_WEBHOOK_SECRET || ''" app/email-gateway.js
+          grep -q "aos_cia_verify_app_session_v1" app/email-gateway.js
+          grep -q "GOVERNED_ACTIVATION_REQUIRED" app/email-gateway.js
+          grep -q "function emSessionToken" app/public/admin-email.html
+          grep -q "emCall('LEGACY_SEND'" app/public/admin-email.html
+          ! grep -q "fetch(SB+" app/public/admin-email.html
+          ! grep -q "'apikey':SK" app/public/admin-email.html
+          ! grep -q "fetch('/api/send-email'" app/public/admin-email.html
+          ! grep -Eq "['\"]re_[A-Za-z0-9_-]{20,}['\"]" app/server.js
+          ! grep -Eq "['\"]re_[A-Za-z0-9_-]{20,}['\"]" app/email-gateway.js
+          for f in app/public/attendance.html app/public/agenda.js app/public/calls.js app/public/citas.html app/public/caja.html app/public/calls.html; do grep -q "X-ASCENDA-Session" "$f"; done
+          echo 'CIA_PHASE16_RUNTIME_EXACT_HEAD=PASS'
+      - name: Gateway unit contracts
+        run: |
+          set -euo pipefail
+          node ci/phase16/test_email_gateway.js
+          node ci/phase16/test_email_gateway_policy.js
+      - name: Working tree remains clean
+        run: |
+          set -euo pipefail
+          git diff --exit-code
+          test -z "$(git status --porcelain)"
+          echo 'CIA_PHASE16_RUNTIME_READ_ONLY=PASS'

--- a/.github/workflows/cia-phase16-runtime-patch.yml
+++ b/.github/workflows/cia-phase16-runtime-patch.yml
@@ -1,0 +1,82 @@
+name: ASCENDA CIA Phase 16 Runtime Patch
+
+on:
+  push:
+    branches: ['release/cia-phase16-email-20260815-v5']
+    paths:
+      - 'scripts/ci/phase16_*'
+      - '.github/workflows/cia-phase16-runtime-patch.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cia-phase16-runtime-patch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  patch:
+    name: F16 deterministic runtime migration
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 12
+    steps:
+      - name: Checkout exact triggering SHA
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Enforce Zero-Cost CI V2 policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Self-hosted runner healthcheck
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Expose trusted runner Node
+        run: bash scripts/ci/expose-runner-node.sh
+      - name: Apply deterministic runtime patches
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/phase16_apply_runtime_patch.py
+          python3 scripts/ci/phase16_patch_email_backend_acl.py
+          python3 scripts/ci/phase16_patch_transactional_email.py
+      - name: Runtime syntax and security assertions
+        run: |
+          set -euo pipefail
+          node --check app/server.js
+          node --check app/email-gateway.js
+          node --check app/public/agenda.js
+          node --check app/public/calls.js
+          grep -q "if (p === '/api/email-gateway')" app/server.js
+          grep -q "EMAIL_GATEWAY.handleWebhook" app/server.js
+          grep -q "EMAIL_GATEWAY.verifyApp" app/server.js
+          grep -q "LEGACY_2FA_RETIRED" app/server.js
+          grep -q "F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED" app/server.js
+          grep -q "GOVERNED_ACTIVATION_REQUIRED" app/email-gateway.js
+          grep -q "aos_cia_verify_app_session_v1" app/email-gateway.js
+          grep -q "emCall('LEGACY_SEND'" app/public/admin-email.html
+          grep -q "SUPABASE_SERVICE_ROLE_KEY || ''" app/server.js
+          grep -q "f16RequireEmailBackend" app/server.js
+          ! grep -q "fetch(SB+" app/public/admin-email.html
+          ! grep -q "'apikey':SK" app/public/admin-email.html
+          ! grep -q "fetch('/api/send-email'" app/public/admin-email.html
+          ! grep -Eq "['\"]re_[A-Za-z0-9_-]{20,}['\"]" app/server.js
+          for f in app/public/attendance.html app/public/agenda.js app/public/calls.js app/public/citas.html app/public/caja.html app/public/calls.html; do grep -q "X-ASCENDA-Session" "$f"; done
+          echo 'CIA_PHASE16_RUNTIME_SECURITY_ASSERTIONS=PASS'
+      - name: Verify exact changed runtime scope
+        run: |
+          set -euo pipefail
+          git diff --check
+          changed="$(git diff --name-only | sort)"
+          expected=$'app/public/admin-email.html\napp/public/agenda.js\napp/public/attendance.html\napp/public/caja.html\napp/public/calls.html\napp/public/calls.js\napp/public/citas.html\napp/server.js'
+          if [ "$changed" != "$expected" ]; then
+            echo 'Unexpected runtime patch scope:' >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+          echo 'CIA_PHASE16_RUNTIME_SCOPE=PASS'
+      - name: Commit governed runtime migration
+        run: |
+          set -euo pipefail
+          git config user.name 'ASCENDA Zero-Cost CI'
+          git config user.email 'actions@users.noreply.github.com'
+          git add app/server.js app/public/admin-email.html app/public/attendance.html app/public/agenda.js app/public/calls.js app/public/citas.html app/public/caja.html app/public/calls.html
+          git commit -m 'feat(cia): enforce authoritative Email runtime boundaries'
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/f16-service-role-env-alias.yml
+++ b/.github/workflows/f16-service-role-env-alias.yml
@@ -1,0 +1,62 @@
+name: ASCENDA CIA Phase 16 Environment Alias
+
+on:
+  push:
+    branches: ['release/cia-phase16-email-20260815-v5']
+    paths:
+      - '.github/workflows/f16-service-role-env-alias.yml'
+      - 'scripts/ci/f16_env_alias_patch.py'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cia-phase16-env-alias-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  patch:
+    name: F16 environment alias compatibility
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Zero-Cost policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Runner health
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Expose trusted runner Node
+        run: bash scripts/ci/expose-runner-node.sh
+      - name: Apply environment-only alias compatibility
+        run: python3 scripts/ci/f16_env_alias_patch.py
+      - name: Verify syntax and security boundary
+        run: |
+          set -euo pipefail
+          node --check app/server.js
+          node --check app/email-gateway.js
+          node ci/phase16/test_email_gateway.js
+          node ci/phase16/test_email_gateway_policy.js
+          grep -q 'process.env.SUPABASE_SERVICE_ROLE_KEY' app/server.js
+          grep -q 'process.env.service_role' app/server.js
+          grep -q 'process.env.SUPABASE_SERVICE_ROLE_KEY' app/email-gateway.js
+          grep -q 'process.env.service_role' app/email-gateway.js
+          ! grep -Eq "['\"](eyJ|re_)[A-Za-z0-9._-]{20,}['\"]" app/email-gateway.js
+          git diff --check
+      - name: Verify exact changed scope
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only | sort)"
+          expected=$'app/email-gateway.js\napp/server.js'
+          test "$changed" = "$expected"
+          echo 'CIA_PHASE16_ENV_ALIAS_SCOPE=PASS'
+      - name: Commit environment-only compatibility
+        run: |
+          set -euo pipefail
+          git config user.name 'ASCENDA Zero-Cost CI'
+          git config user.email 'actions@users.noreply.github.com'
+          git add app/server.js app/email-gateway.js
+          git commit -m 'fix(f16): accept Railway service-role env alias'
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/f16-service-role-env-alias.yml
+++ b/.github/workflows/f16-service-role-env-alias.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash scripts/ci/runner-healthcheck.sh
       - name: Expose trusted runner Node
         run: bash scripts/ci/expose-runner-node.sh
-      - name: Apply environment-only alias compatibility
+      - name: Apply or certify environment-only alias compatibility
         run: python3 scripts/ci/f16_env_alias_patch.py
       - name: Verify syntax and security boundary
         run: |
@@ -45,16 +45,24 @@ jobs:
           grep -q 'process.env.service_role' app/email-gateway.js
           ! grep -Eq "['\"](eyJ|re_)[A-Za-z0-9._-]{20,}['\"]" app/email-gateway.js
           git diff --check
-      - name: Verify exact changed scope
+      - name: Verify compatible changed scope
         run: |
           set -euo pipefail
           changed="$(git diff --name-only | sort)"
           expected=$'app/email-gateway.js\napp/server.js'
-          test "$changed" = "$expected"
-          echo 'CIA_PHASE16_ENV_ALIAS_SCOPE=PASS'
-      - name: Commit environment-only compatibility
+          if [ -z "$changed" ]; then
+            echo 'CIA_PHASE16_ENV_ALIAS_ALREADY_MATERIALIZED=PASS'
+          else
+            test "$changed" = "$expected"
+            echo 'CIA_PHASE16_ENV_ALIAS_SCOPE=PASS'
+          fi
+      - name: Commit environment-only compatibility if needed
         run: |
           set -euo pipefail
+          if [ -z "$(git diff --name-only)" ]; then
+            echo 'CIA_PHASE16_ENV_ALIAS_NO_COMMIT_NEEDED=PASS'
+            exit 0
+          fi
           git config user.name 'ASCENDA Zero-Cost CI'
           git config user.email 'actions@users.noreply.github.com'
           git add app/server.js app/email-gateway.js

--- a/app/email-gateway.js
+++ b/app/email-gateway.js
@@ -1,0 +1,415 @@
+'use strict'
+
+const crypto = require('crypto')
+const https = require('https')
+
+const DEFAULT_SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
+const MAX_BODY_BYTES = 1024 * 1024
+const WEBHOOK_MAX_SKEW_SECONDS = 300
+
+function jsonResponse(res, status, body) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff'
+  })
+  res.end(JSON.stringify(body))
+}
+
+function readRawBody(req, maxBytes) {
+  maxBytes = maxBytes || MAX_BODY_BYTES
+  return new Promise(function(resolve, reject) {
+    var chunks = []
+    var total = 0
+    req.on('data', function(chunk) {
+      total += chunk.length
+      if (total > maxBytes) {
+        reject(new Error('BODY_TOO_LARGE'))
+        try { req.destroy() } catch (_) {}
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', function() { resolve(Buffer.concat(chunks)) })
+    req.on('error', reject)
+  })
+}
+
+function requestJson(urlString, options, body) {
+  return new Promise(function(resolve, reject) {
+    var url = new URL(urlString)
+    var payload = body == null ? null : Buffer.from(JSON.stringify(body))
+    var headers = Object.assign({}, options && options.headers ? options.headers : {})
+    if (payload) {
+      headers['Content-Type'] = headers['Content-Type'] || 'application/json'
+      headers['Content-Length'] = payload.length
+    }
+    var req = https.request({
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: (options && options.method) || 'GET',
+      headers: headers,
+      timeout: (options && options.timeout) || 15000
+    }, function(r) {
+      var chunks = []
+      r.on('data', function(c) { chunks.push(c) })
+      r.on('end', function() {
+        var text = Buffer.concat(chunks).toString('utf8')
+        var parsed = null
+        if (text) {
+          try { parsed = JSON.parse(text) } catch (_) { parsed = { raw: text.slice(0, 1000) } }
+        }
+        resolve({ status: r.statusCode || 0, headers: r.headers, body: parsed, text: text })
+      })
+    })
+    req.on('timeout', function() { req.destroy(new Error('UPSTREAM_TIMEOUT')) })
+    req.on('error', reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+function base64Secret(secret) {
+  var s = String(secret || '')
+  if (s.indexOf('whsec_') === 0) s = s.slice(6)
+  try { return Buffer.from(s, 'base64') } catch (_) { return Buffer.from('') }
+}
+
+function timingSafeBase64Equal(a, b) {
+  try {
+    var aa = Buffer.from(String(a || ''), 'base64')
+    var bb = Buffer.from(String(b || ''), 'base64')
+    return aa.length > 0 && aa.length === bb.length && crypto.timingSafeEqual(aa, bb)
+  } catch (_) { return false }
+}
+
+function verifySvixSignature(rawBody, headers, secret, nowSeconds) {
+  var eventId = String(headers['svix-id'] || headers['Svix-Id'] || '')
+  var timestamp = String(headers['svix-timestamp'] || headers['Svix-Timestamp'] || '')
+  var signatureHeader = String(headers['svix-signature'] || headers['Svix-Signature'] || '')
+  if (!eventId || !timestamp || !signatureHeader || !secret) return { ok: false, error: 'WEBHOOK_SIGNATURE_REQUIRED' }
+
+  var ts = Number(timestamp)
+  var now = Number(nowSeconds == null ? Math.floor(Date.now() / 1000) : nowSeconds)
+  if (!Number.isFinite(ts) || Math.abs(now - ts) > WEBHOOK_MAX_SKEW_SECONDS) return { ok: false, error: 'WEBHOOK_TIMESTAMP_INVALID' }
+
+  var key = base64Secret(secret)
+  if (!key.length) return { ok: false, error: 'WEBHOOK_SECRET_INVALID' }
+  var signed = Buffer.concat([Buffer.from(eventId + '.' + timestamp + '.'), Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody || '')])
+  var expected = crypto.createHmac('sha256', key).update(signed).digest('base64')
+  var candidates = signatureHeader.split(/\s+/).map(function(v) {
+    var parts = v.split(',')
+    return parts.length === 2 && parts[0] === 'v1' ? parts[1] : ''
+  }).filter(Boolean)
+  var valid = candidates.some(function(candidate) { return timingSafeBase64Equal(candidate, expected) })
+  return valid ? { ok: true, eventId: eventId, timestamp: ts } : { ok: false, error: 'WEBHOOK_SIGNATURE_INVALID' }
+}
+
+function htmlEscape(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+}
+
+function renderTemplate(template, context, keys, htmlMode) {
+  var out = String(template || '')
+  var ctx = context && typeof context === 'object' && !Array.isArray(context) ? context : {}
+  var required = Array.isArray(keys) ? keys : []
+  for (var i = 0; i < required.length; i++) {
+    var key = String(required[i] || '')
+    if (!key || !Object.prototype.hasOwnProperty.call(ctx, key)) return { ok: false, error: 'RENDER_CONTEXT_MISSING', key: key }
+    var value = htmlMode ? htmlEscape(ctx[key]) : String(ctx[key] == null ? '' : ctx[key]).replace(/[\r\n]+/g, ' ')
+    out = out.split('{{' + key + '}}').join(value)
+  }
+  if (/\{\{[A-Za-z0-9_]+\}\}/.test(out)) return { ok: false, error: 'UNRESOLVED_TEMPLATE_VARIABLE' }
+  return { ok: true, value: out }
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(String(value || '')).digest('hex')
+}
+
+function validEmail(email) {
+  var v = String(email || '').trim()
+  return v.length <= 320 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)
+}
+
+function safeLegacyQuery(query) {
+  query = String(query || '')
+  if (query.length > 2500 || /[\r\n\0]/.test(query)) return null
+  var params = new URLSearchParams(query)
+  var allowedControl = { select: true, order: true, limit: true, offset: true }
+  for (const pair of params.entries()) {
+    var name = pair[0]
+    var value = pair[1]
+    if (!allowedControl[name] && !/^[A-Za-z][A-Za-z0-9_]*$/.test(name)) return null
+    if (value.length > 1500 || /(?:;|--|\/\*)/.test(value)) return null
+  }
+  return params.toString()
+}
+
+function createEmailGateway(config) {
+  config = config || {}
+  var sbUrl = String(config.supabaseUrl || process.env.SUPABASE_URL || DEFAULT_SB_URL).replace(/\/$/, '')
+  var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))
+  var resendKey = String(config.resendApiKey != null ? config.resendApiKey : (process.env.RESEND_API_KEY || ''))
+  var webhookSecret = String(config.webhookSecret != null ? config.webhookSecret : (process.env.RESEND_WEBHOOK_SECRET || ''))
+  var requester = config.requestJson || requestJson
+
+  function configured() {
+    return {
+      service_role_configured: serviceKey.length > 20,
+      resend_key_configured: resendKey.length > 10,
+      webhook_secret_configured: webhookSecret.length > 10
+    }
+  }
+
+  function supabase(path, method, body, prefer) {
+    if (!serviceKey) return Promise.resolve({ status: 503, body: { error: 'SERVICE_ROLE_NOT_CONFIGURED' } })
+    var headers = { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey }
+    if (prefer) headers.Prefer = prefer
+    return requester(sbUrl + path, { method: method || 'GET', headers: headers, timeout: 15000 }, body)
+  }
+
+  function rpc(name, params) {
+    return supabase('/rest/v1/rpc/' + encodeURIComponent(name), 'POST', params || {})
+  }
+
+  async function verifyAdmin(token) {
+    if (!serviceKey) return { ok: false, status: 503, error: 'SERVICE_ROLE_NOT_CONFIGURED' }
+    if (!token || String(token).length < 32) return { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    var result = await rpc('aos_cia_verify_admin_session_v1', { p_token: String(token) })
+    var body = result.body
+    if (result.status >= 300 || !body || body.ok !== true || !body.user_id) return { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    return { ok: true, user_id: body.user_id, usuario: body.usuario || '' }
+  }
+
+  async function verifyApp(token) {
+    if (!serviceKey) return { ok: false, status: 503, error: 'SERVICE_ROLE_NOT_CONFIGURED' }
+    if (!token || String(token).length < 32) return { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    var result = await rpc('aos_cia_verify_app_session_v1', { p_token: String(token) })
+    var body = result.body
+    if (result.status >= 300 || !body || body.ok !== true || !body.user_id) return { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    return {
+      ok: true, user_id: body.user_id, nombre: body.nombre || '', rol: body.rol || '',
+      assurance_level: body.assurance_level || '', expires_at: body.expires_at || null
+    }
+  }
+
+  async function governed(token, action, payload) {
+    var result = await rpc('aos_cia_email_admin_gateway_v2', { p_token: String(token), p_action: String(action || ''), p_payload: payload || {} })
+    if (result.status >= 300) return { ok: false, error: 'GOVERNED_RPC_FAILED', status: result.status }
+    return result.body || { ok: false, error: 'EMPTY_GOVERNED_RESPONSE' }
+  }
+
+  async function sendResend(payload, idempotencyKey) {
+    if (!resendKey) return { ok: false, status: 503, error: 'PROVIDER_NOT_CONFIGURED' }
+    var result = await requester('https://api.resend.com/emails', {
+      method: 'POST',
+      timeout: 15000,
+      headers: {
+        Authorization: 'Bearer ' + resendKey,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': String(idempotencyKey || '').slice(0, 256)
+      }
+    }, payload)
+    var id = result.body && result.body.id ? String(result.body.id) : ''
+    if (result.status >= 200 && result.status < 300 && id) return { ok: true, status: result.status, id: id }
+    return { ok: false, status: result.status || 502, error: 'PROVIDER_REJECTED', provider_code: result.body && (result.body.name || result.body.statusCode) ? String(result.body.name || result.body.statusCode).slice(0, 100) : '' }
+  }
+
+  var legacyReadTables = new Set(['aos_configuracion','aos_email_plantillas','aos_email_flujos','aos_plantillas_mensajes','aos_email_envios'])
+  var legacyRpcNames = new Set(['aos_email_buscar_paciente','aos_email_historial_paciente','aos_email_dashboard'])
+  var legacyPatchFields = {
+    aos_email_flujos: new Set(['activo','updated_at']),
+    aos_email_plantillas: new Set(['nombre','asunto','html_body','updated_at']),
+    aos_plantillas_mensajes: new Set(['nombre','cuerpo','sede','updated_at'])
+  }
+
+  async function legacyRead(table, query) {
+    if (!legacyReadTables.has(table)) return { ok: false, status: 403, error: 'LEGACY_TABLE_NOT_ALLOWED' }
+    var clean = safeLegacyQuery(query)
+    if (clean == null) return { ok: false, status: 400, error: 'INVALID_LEGACY_QUERY' }
+    var result = await supabase('/rest/v1/' + table + (clean ? '?' + clean : ''), 'GET')
+    return result.status < 300 ? { ok: true, data: result.body || [] } : { ok: false, status: result.status, error: 'LEGACY_READ_FAILED' }
+  }
+
+  async function legacyRpc(name, params) {
+    if (!legacyRpcNames.has(name)) return { ok: false, status: 403, error: 'LEGACY_RPC_NOT_ALLOWED' }
+    var result = await rpc(name, params || {})
+    return result.status < 300 ? { ok: true, data: result.body } : { ok: false, status: result.status, error: 'LEGACY_RPC_FAILED' }
+  }
+
+  async function legacyPatch(table, id, changes) {
+    var allowed = legacyPatchFields[table]
+    if (!allowed || !id) return { ok: false, status: 403, error: 'LEGACY_PATCH_NOT_ALLOWED' }
+    var clean = {}
+    Object.keys(changes || {}).forEach(function(k) { if (allowed.has(k)) clean[k] = changes[k] })
+    if (!Object.keys(clean).length || Object.keys(clean).length !== Object.keys(changes || {}).length) return { ok: false, status: 400, error: 'INVALID_PATCH_FIELDS' }
+    var result = await supabase('/rest/v1/' + table + '?id=eq.' + encodeURIComponent(String(id)), 'PATCH', clean, 'return=minimal')
+    return result.status < 300 ? { ok: true } : { ok: false, status: result.status, error: 'LEGACY_PATCH_FAILED' }
+  }
+
+  async function legacySend(actor, payload) {
+    var to = Array.isArray(payload.to) ? payload.to[0] : payload.to
+    var subject = String(payload.subject || '').trim()
+    var html = String(payload.html || '')
+    var clientRequestId = String(payload.client_request_id || '')
+    if (!validEmail(to) || !subject || subject.length > 998 || !html || html.length > 500000 || clientRequestId.length < 8) {
+      return { ok: false, status: 400, error: 'INVALID_SEND_INTENT' }
+    }
+    if (!payload.plantilla_id) return { ok: false, status: 400, error: 'TEMPLATE_REQUIRED' }
+    var templateMeta = await supabase('/rest/v1/aos_email_plantillas?select=id,tipo,activo&id=eq.' + encodeURIComponent(String(payload.plantilla_id)) + '&limit=1', 'GET')
+    var templateRow = templateMeta.status < 300 && Array.isArray(templateMeta.body) ? templateMeta.body[0] : null
+    if (!templateRow || templateRow.activo === false) return { ok: false, status: 400, error: 'TEMPLATE_NOT_ACTIVE' }
+    var transactionalTypes = new Set([
+      'agradecimiento','agradecimiento_visita','bienvenida','catalogo','comprobante','confirmacion_cita',
+      'confirmacion_pago','no_asistencia','recibo_venta','recordatorio','recordatorio_hoy','reprogramacion',
+      'saldo_pendiente','seguimiento'
+    ])
+    var templateType = String(templateRow.tipo || '').toLowerCase().trim()
+    if (!transactionalTypes.has(templateType)) {
+      return { ok: false, status: 403, error: 'GOVERNED_ACTIVATION_REQUIRED', template_type: templateType }
+    }
+    var idempotencyKey = 'f16-legacy-' + sha256([actor.user_id,to,subject,payload.plantilla_id || '',clientRequestId].join('|'))
+    var provider = await sendResend({
+      from: String(process.env.RESEND_FROM_EMAIL || 'Clinica Zi Vital <info@zivital.pe>'),
+      to: [String(to).trim()],
+      subject: subject.replace(/[\r\n]+/g, ' '),
+      html: html
+    }, idempotencyKey)
+
+    var log = {
+      destinatario_email: String(to).trim(),
+      destinatario_nombre: String(payload.nombre || '').slice(0, 200),
+      destinatario_numero: String(payload.numero || '').slice(0, 80),
+      plantilla_id: payload.plantilla_id || null,
+      campania_id: payload.campania_id || null,
+      flujo_id: payload.flujo_id || null,
+      flujo_paso: payload.flujo_paso || null,
+      asunto: subject,
+      variables_usadas: payload.variables && typeof payload.variables === 'object' ? payload.variables : {},
+      estado: provider.ok ? 'enviado' : 'error',
+      resend_id: provider.ok ? provider.id : null,
+      error_msg: provider.ok ? null : provider.error,
+      enviado_at: provider.ok ? new Date().toISOString() : null
+    }
+    await supabase('/rest/v1/aos_email_envios', 'POST', log, 'return=minimal').catch(function() {})
+    return provider.ok ? { ok: true, id: provider.id, idempotency_key: idempotencyKey } : { ok: false, status: provider.status, error: provider.error }
+  }
+
+  async function dispatchRequest(token, requestId) {
+    var queued = await governed(token, 'QUEUE_REQUEST', { request_id: requestId })
+    if (!queued || queued.ok !== true) return queued || { ok: false, error: 'QUEUE_FAILED' }
+
+    var claimResult = await rpc('aos_cia_email_claim_dispatch_v2', { p_request_id: requestId })
+    var claim = claimResult.body
+    if (claimResult.status >= 300 || !claim || claim.ok !== true) return claim || { ok: false, error: 'DISPATCH_CLAIM_FAILED' }
+    if (claim.send_allowed !== true) return claim
+
+    var subject = renderTemplate(claim.subject_template, claim.render_context, claim.variable_keys, false)
+    var html = renderTemplate(claim.html_template, claim.render_context, claim.variable_keys, true)
+    if (!subject.ok || !html.ok) {
+      await rpc('aos_cia_email_record_dispatch_result_v2', {
+        p_request_id: requestId, p_accepted: false, p_provider: 'RESEND', p_provider_message_id: null,
+        p_error_code: subject.error || html.error || 'RENDER_FAILED', p_payload: { stage: 'render' }
+      })
+      return { ok: false, error: subject.error || html.error || 'RENDER_FAILED' }
+    }
+
+    var provider = await sendResend({
+      from: String(process.env.RESEND_FROM_EMAIL || 'Clinica Zi Vital <info@zivital.pe>'),
+      to: [claim.recipient_email],
+      subject: subject.value,
+      html: html.value
+    }, 'f16-' + claim.idempotency_key)
+
+    var recorded = await rpc('aos_cia_email_record_dispatch_result_v2', {
+      p_request_id: requestId,
+      p_accepted: provider.ok,
+      p_provider: 'RESEND',
+      p_provider_message_id: provider.ok ? provider.id : null,
+      p_error_code: provider.ok ? null : provider.error,
+      p_payload: { provider_status: provider.status || null }
+    })
+    if (recorded.status >= 300 || !recorded.body || recorded.body.ok !== true) return { ok: false, error: 'DISPATCH_AUDIT_FAILED' }
+    return provider.ok ? { ok: true, request_id: requestId, state: 'ACCEPTED', provider_message_id: provider.id } : { ok: false, error: provider.error || 'PROVIDER_REJECTED', state: 'FAILED' }
+  }
+
+  async function handleAdmin(req, res) {
+    if (req.method === 'OPTIONS') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
+    if (req.method !== 'POST') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
+    try {
+      var raw = await readRawBody(req)
+      var body
+      try { body = JSON.parse(raw.toString('utf8') || '{}') } catch (_) { return jsonResponse(res, 400, { ok: false, error: 'INVALID_JSON' }) }
+      var token = String(req.headers['x-ascenda-session'] || body.token || '')
+      var actor = await verifyAdmin(token)
+      if (!actor.ok) return jsonResponse(res, actor.status || 401, { ok: false, error: actor.error })
+      var action = String(body.action || '').toUpperCase()
+      var payload = body.payload && typeof body.payload === 'object' ? body.payload : {}
+      var out
+      if (action === 'CONFIG_HEALTH') out = { ok: true, config: configured() }
+      else if (action === 'GOVERNED') out = await governed(token, payload.action, payload.payload || {})
+      else if (action === 'DISPATCH_REQUEST') out = await dispatchRequest(token, payload.request_id)
+      else if (action === 'LEGACY_READ') out = await legacyRead(String(payload.table || ''), String(payload.query || ''))
+      else if (action === 'LEGACY_RPC') out = await legacyRpc(String(payload.name || ''), payload.params || {})
+      else if (action === 'LEGACY_PATCH') out = await legacyPatch(String(payload.table || ''), payload.id, payload.changes || {})
+      else if (action === 'LEGACY_SEND') out = await legacySend(actor, payload)
+      else out = { ok: false, status: 400, error: 'UNSUPPORTED_ACTION' }
+      return jsonResponse(res, out && out.ok ? 200 : (out && out.status ? out.status : 400), out || { ok: false, error: 'EMPTY_RESPONSE' })
+    } catch (e) {
+      var code = e && e.message === 'BODY_TOO_LARGE' ? 413 : 500
+      return jsonResponse(res, code, { ok: false, error: code === 413 ? 'BODY_TOO_LARGE' : 'EMAIL_GATEWAY_ERROR' })
+    }
+  }
+
+  async function handleWebhook(req, res) {
+    if (req.method !== 'POST') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
+    if (!webhookSecret || !serviceKey) return jsonResponse(res, 503, { ok: false, error: 'WEBHOOK_NOT_CONFIGURED' })
+    try {
+      var raw = await readRawBody(req)
+      var verified = verifySvixSignature(raw, req.headers || {}, webhookSecret)
+      if (!verified.ok) return jsonResponse(res, 401, { ok: false, error: verified.error })
+      var event
+      try { event = JSON.parse(raw.toString('utf8')) } catch (_) { return jsonResponse(res, 400, { ok: false, error: 'INVALID_JSON' }) }
+      var data = event && event.data && typeof event.data === 'object' ? event.data : {}
+      var messageId = String(data.email_id || data.id || '')
+      var eventType = String(event.type || '')
+      var occurredAt = event.created_at || new Date().toISOString()
+      var ingest = await rpc('aos_cia_email_ingest_provider_event_v2', {
+        p_provider_event_id: verified.eventId,
+        p_provider_message_id: messageId,
+        p_event_type: eventType,
+        p_occurred_at: occurredAt,
+        p_payload: { provider: 'RESEND', type: eventType }
+      })
+      if (ingest.status >= 300 || !ingest.body || ingest.body.ok !== true) {
+        if (ingest.body && ingest.body.error === 'PROVIDER_MESSAGE_NOT_FOUND') return jsonResponse(res, 202, { ok: true, ignored: 'UNKNOWN_PROVIDER_MESSAGE' })
+        return jsonResponse(res, 400, { ok: false, error: ingest.body && ingest.body.error ? ingest.body.error : 'WEBHOOK_INGEST_FAILED' })
+      }
+      return jsonResponse(res, 200, { ok: true, idempotent: ingest.body.idempotent === true })
+    } catch (_) {
+      return jsonResponse(res, 500, { ok: false, error: 'WEBHOOK_ERROR' })
+    }
+  }
+
+  return {
+    handleAdmin: handleAdmin,
+    handleWebhook: handleWebhook,
+    verifyAdmin: verifyAdmin,
+    verifyApp: verifyApp,
+    dispatchRequest: dispatchRequest,
+    configured: configured
+  }
+}
+
+module.exports = {
+  createEmailGateway: createEmailGateway,
+  verifySvixSignature: verifySvixSignature,
+  renderTemplate: renderTemplate,
+  safeLegacyQuery: safeLegacyQuery,
+  htmlEscape: htmlEscape,
+  sha256: sha256
+}

--- a/app/public/admin-email.html
+++ b/app/public/admin-email.html
@@ -220,14 +220,19 @@
 <div class="inner-toast" id="em-toast"></div>
 
 <script>
-var SB='https://ituyqwstonmhnfshnaqz.supabase.co';
-var SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
 function el(id){var e=document.getElementById(id);return e||{textContent:'',innerHTML:'',style:{},value:'',classList:{add:function(){},remove:function(){},toggle:function(){}},querySelectorAll:function(){return[];},setAttribute:function(){}};}
 function fmt(n){return typeof n==='number'?n.toLocaleString('es-PE'):n;}
 function h(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 function fmt(n){return Number(n||0).toLocaleString('es-PE');}
-function rpc(fn,params,cb){fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(params)}).then(function(r){return r.json();}).then(cb).catch(function(e){console.error(fn,e);});}
-function q(table,query,cb){fetch(SB+'/rest/v1/'+table+'?'+query,{headers:{'apikey':SK,'Authorization':'Bearer '+SK}}).then(function(r){return r.json();}).then(cb);}
+function emSessionToken(){return sessionStorage.getItem('aos_si_token')||sessionStorage.getItem('aos_app_token')||'';}
+function emCall(action,payload){
+  var token=emSessionToken();
+  if(!token)return Promise.reject(new Error('Sesión administrativa requerida'));
+  return fetch('/api/email-gateway',{method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':token},body:JSON.stringify({action:action,payload:payload||{}})}).then(function(r){return r.json().then(function(b){if(!r.ok||!b||b.ok!==true)throw new Error((b&&b.error)||('HTTP '+r.status));return b;});});
+}
+function rpc(fn,params,cb){emCall('LEGACY_RPC',{name:fn,params:params||{}}).then(function(r){cb(r.data);}).catch(function(e){console.error(fn,e);showToast('Error de sesión/email',e.message,true);});}
+function q(table,query,cb){emCall('LEGACY_READ',{table:table,query:query||''}).then(function(r){cb(r.data||[]);}).catch(function(e){console.error(table,e);showToast('Error de sesión/email',e.message,true);cb([]);});}
+function emPatch(table,id,changes,cb){emCall('LEGACY_PATCH',{table:table,id:id,changes:changes||{}}).then(function(r){if(cb)cb(null,r);}).catch(function(e){if(cb)cb(e);else showToast('Error al guardar',e.message,true);});}
 function showToast(t,m,err){var tw=el('em-toast');var d=document.createElement('div');d.className='toast-item';d.style.borderBottom='3px solid '+(err?'#DC2626':'#00C9A7');d.innerHTML='<div style="font-size:20px;">'+(err?'❌':'✅')+'</div><div><div style="font-weight:800;font-size:13px;">'+t+'</div><div style="font-size:10px;color:#6B7BA8;">'+m+'</div></div>';tw.appendChild(d);setTimeout(function(){d.style.animation='toastOut .3s forwards';setTimeout(function(){d.remove();},300);},4000);}
 
 var D={};var TAB='dashboard';
@@ -342,26 +347,23 @@ function loadTplPreview(id,nombre){
     el('send-preview').innerHTML=preview;
   });
 }
+var _sendClientRequestId='';
 function doSendEmail(email,nombre,numero){
   var tplId=el('send-tpl').value;var asunto=el('send-asunto').value;
   if(!asunto){showToast('Error','Escribe un asunto',true);return;}
-  // Get template HTML
+  if(!_sendClientRequestId)_sendClientRequestId=(window.crypto&&crypto.randomUUID)?crypto.randomUUID():('email-'+Date.now()+'-'+Math.random().toString(36).slice(2));
   q('aos_email_plantillas','select=html_body,variables&id=eq.'+tplId,function(rows){
     if(!rows||!rows[0])return;
     var htmlBody=rows[0].html_body.replace(/\{\{nombre\}\}/g,nombre).replace(/\{\{tratamiento\}\}/g,'').replace(/\{\{fecha_cita\}\}/g,'').replace(/\{\{hora_cita\}\}/g,'').replace(/\{\{sede\}\}/g,'').replace(/\{\{monto\}\}/g,'').replace(/\{\{fecha\}\}/g,'');
-    fetch('/api/send-email',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({
+    emCall('LEGACY_SEND',{
       to:email,subject:asunto.replace(/\{\{nombre\}\}/g,nombre),html:htmlBody,
-      nombre:nombre,numero:numero,plantilla_id:tplId,
-      variables:{nombre:nombre}
-    })}).then(function(r){return r.json();}).then(function(res){
-      if(res.id){
-        showToast('Email Enviado','Correo enviado exitosamente a '+email);
-        el('m-send').classList.remove('open');
-        if(numero)verContacto(numero);
-      } else {
-        showToast('Error al enviar',res.message||res.error||'Error desconocido',true);
-      }
-    }).catch(function(e){showToast('Error',e.message,true);});
+      nombre:nombre,numero:numero,plantilla_id:tplId,variables:{nombre:nombre},client_request_id:_sendClientRequestId
+    }).then(function(res){
+      showToast('Email Enviado','Correo enviado exitosamente a '+email);
+      _sendClientRequestId='';
+      el('m-send').classList.remove('open');
+      if(numero)verContacto(numero);
+    }).catch(function(e){showToast('Error al enviar',e.message,true);});
   });
 }
 
@@ -504,7 +506,8 @@ function verFlujo(id){
 }
 
 function toggleFlujo(id,activo){
-  fetch(SB+'/rest/v1/aos_email_flujos?id=eq.'+id,{method:'PATCH',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'},body:JSON.stringify({activo:activo,updated_at:new Date().toISOString()})}).then(function(){
+  emPatch('aos_email_flujos',id,{activo:activo,updated_at:new Date().toISOString()},function(err){
+    if(err){showToast('Error al actualizar flujo',err.message,true);return;}
     showToast('Flujo '+(activo?'Activado':'Desactivado'),'');
     el('m-flujo').classList.remove('open');loadFlujos();loadDashboard();
   });
@@ -600,8 +603,8 @@ function openTplEditor(id){
 function insertWaVar(v){var ta=el('wa-body');if(!ta)return;var s=ta.selectionStart;var txt=ta.value;ta.value=txt.slice(0,s)+'{{'+v+'}}'+txt.slice(s);ta.focus();updateWaPreview();}
 function updateWaPreview(){var body=el('wa-body')?el('wa-body').value:'';el('wa-preview').innerHTML=body.replace(/\{\{(\w+)\}\}/g,'<span style="background:#FFFBEB;padding:1px 4px;border-radius:3px;color:#D97706;font-weight:700;">{{$1}}</span>');}
 function saveWaTpl(id){
-  var data={nombre:el('wa-nombre').value,cuerpo:el('wa-body').value,sede:el('wa-sede').value||null};
-  fetch(SB+'/rest/v1/aos_plantillas_mensajes?id=eq.'+id,{method:'PATCH',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'},body:JSON.stringify(data)}).then(function(r){if(r.ok){showToast('Plantilla guardada',data.nombre);loadPlantillas();}else{showToast('Error','',true);}});
+  var data={nombre:el('wa-nombre').value,cuerpo:el('wa-body').value,sede:el('wa-sede').value||null,updated_at:new Date().toISOString()};
+  emPatch('aos_plantillas_mensajes',id,data,function(err){if(err){showToast('Error',err.message,true);return;}showToast('Plantilla guardada',data.nombre);loadPlantillas();});
 }
 function filtrarTpl(){}
 function renderTplGrid(){}
@@ -626,12 +629,9 @@ function updateTplPreview(){
 }
 function savePlantilla(id){
   var body=_htmlMode?el('tpl-html-raw').value:el('tpl-editor').innerHTML;
-  // Clean the variable spans back to {{var}} format
   body=body.replace(/<span[^>]*>\{\{(\w+)\}\}<\/span>/g,'{{$1}}');
   var data={nombre:el('tpl-nombre').value,asunto:el('tpl-asunto').value,html_body:body,updated_at:new Date().toISOString()};
-  fetch(SB+'/rest/v1/aos_email_plantillas?id=eq.'+id,{method:'PATCH',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json','Prefer':'return=minimal'},body:JSON.stringify(data)}).then(function(r){
-    if(r.ok){showToast('Plantilla guardada',''+data.nombre);loadPlantillas();}else{showToast('Error al guardar');}
-  });
+  emPatch('aos_email_plantillas',id,data,function(err){if(err){showToast('Error al guardar',err.message,true);return;}showToast('Plantilla guardada',''+data.nombre);loadPlantillas();});
 }
 
 function loadEnviados(){

--- a/app/public/agenda.js
+++ b/app/public/agenda.js
@@ -16,7 +16,7 @@ function enviarEmailConfirmacionCita(d) {
     fechaLabel = dias[dp.getDay()] + ' ' + dp.getDate() + ' de ' + meses[dp.getMonth()] + ', ' + dp.getFullYear();
   } catch(e) {}
   fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
     body: JSON.stringify({ to: correo, template: 'confirmacion_cita', nombre: nombre, tratamiento: d.tratamiento || 'Consulta', hora: d.hora_cita || '', sede: d.sede || '', fecha: fechaLabel, dni: d.dni || '', telefono: d.numero_limpio || d.numero || '', email: correo })
   }).then(function(r) { return r.json(); }).then(function(res) {
     if (res && (res.ok || res.id)) { if (window.AOS_showToast) AOS_showToast('📧 Email enviado', correo, ''); }
@@ -550,7 +550,7 @@ function agGuardarEstado(){
           var pac=pacs&&pacs[0];
           if(pac&&pac.Email){
             fetch('https://ascenda-os-production.up.railway.app/api/send-template',{
-              method:'POST',headers:{'Content-Type':'application/json'},
+              method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
               body:JSON.stringify({
                 to:pac.Email,
                 template:'no_asistencia',

--- a/app/public/attendance.html
+++ b/app/public/attendance.html
@@ -1075,7 +1075,7 @@ function guardarProgSesion(sesionId,tratNombre){
       var pacEmail=(AT.det&&AT.det.paciente)?(AT.det.paciente.email||AT.det.paciente.Email||AT.det.paciente.correo||''):'';
       if(pacEmail&&pacEmail.indexOf('@')>-1){
         var pacNom=((c.nombre||'')+' '+(c.apellido||'')).trim();
-        fetch(window.location.origin+'/api/send-template',{method:'POST',headers:{'Content-Type':'application/json'},
+        fetch(window.location.origin+'/api/send-template',{method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
           body:JSON.stringify({to:pacEmail,template:'confirmacion_cita',nombre:pacNom,tratamiento:tratNombre,hora:hora,sede:sede,fecha:fecha,telefono:c.numero_limpio||''})
         }).then(function(r){return r.json()}).then(function(d){
           if(d&&(d.ok||d.id)&&window.AOS_showToast)AOS_showToast('📧 Email cita enviado',pacEmail,'');

--- a/app/public/caja.html
+++ b/app/public/caja.html
@@ -2360,7 +2360,7 @@ function grabarCotizacion() {
       var _pacNombre = ((pac.nombres||pac.Nombres||'')+ ' '+(pac.apellidos||pac.Apellidos||'')).trim();
       var _tratList = itemsConPago.map(function(it){return it.nombre;}).join(', ');
       fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
-        method:'POST', headers:{'Content-Type':'application/json'},
+        method:'POST', headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
         body: JSON.stringify({ to:_pacEmail, template:'confirmacion_pago', nombre:_pacNombre, tratamiento:_tratList, monto:totalPagado, saldo_actual:0, metodo_pago:(itemsConPago[0]&&itemsConPago[0].metodoPago)||'' })
       }).then(function(r){return r.json()}).then(function(res){
         if(res&&(res.ok||res.id)) toast('📧 Comprobante enviado a '+_pacEmail,'ok');
@@ -2618,7 +2618,7 @@ function emCajaEnviarInline() {
     fetch(_SB+'/rest/v1/aos_pacientes?numero_limpio=eq.'+d.pac.numero,{method:'PATCH',headers:{'apikey':_SK,'Authorization':'Bearer '+_SK,'Content-Type':'application/json','Prefer':'return=minimal'},body:JSON.stringify({"Email":email})}).catch(function(){});
   }
   toast('Enviando...','');
-  fetch('https://ascenda-os-production.up.railway.app/api/send-template',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({to:email,template:template,nombre:d.nombre,items:d.items,total:d.total,moneda:'PEN',metodo:'',sede:CAJA.sede||'',fecha:fechaLima(),venta_id:''})}).then(function(r){return r.json()}).then(function(res){
+  fetch('https://ascenda-os-production.up.railway.app/api/send-template',{method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},body:JSON.stringify({to:email,template:template,nombre:d.nombre,items:d.items,total:d.total,moneda:'PEN',metodo:'',sede:CAJA.sede||'',fecha:fechaLima(),venta_id:''})}).then(function(r){return r.json()}).then(function(res){
     var m = document.getElementById('email-modal-inline'); if(m) m.remove();
     if(res&&(res.ok||res.id)) toast('\u2705 Email enviado a '+email,'ok');
     else toast('Error: '+(res.error||''),'warn');
@@ -2650,7 +2650,7 @@ function emCajaEnviar() {
 
   toast('Enviando...', '');
   fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
     body: JSON.stringify({ to: email, template: template, nombre: d.nombre, items: d.items, total: d.total, moneda: 'PEN', metodo: '', sede: CAJA.sede || '', fecha: fechaLima(), venta_id: '' })
   }).then(function(r) { return r.json(); }).then(function(res) {
     cerrarOv('ov-email-caja');

--- a/app/public/calls.html
+++ b/app/public/calls.html
@@ -505,7 +505,7 @@ function enviarEmailConfirmacionCita(datosCita) {
   console.log('[EMAIL-CITA] Enviando confirmación a ' + correo + ' — ' + nombre);
   fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
     body: JSON.stringify({
       to: correo,
       template: 'confirmacion_cita',

--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -22,7 +22,7 @@ function enviarEmailConfirmacionCita(datosCita) {
   console.log('[EMAIL-CITA] Enviando confirmación a ' + correo + ' — ' + nombre);
   fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
     body: JSON.stringify({
       to: correo,
       template: 'confirmacion_cita',

--- a/app/public/citas.html
+++ b/app/public/citas.html
@@ -105,7 +105,7 @@ function enviarEmailConfirmacionCita(datosCita) {
     fechaLabel = dias[dp.getDay()] + ' ' + dp.getDate() + ' de ' + meses[dp.getMonth()] + ', ' + dp.getFullYear();
   } catch(e) {}
   fetch('https://ascenda-os-production.up.railway.app/api/send-template', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
     body: JSON.stringify({ to: correo, template: 'confirmacion_cita', nombre: nombre, tratamiento: datosCita.tratamiento || 'Consulta', hora: datosCita.hora_cita || '', sede: datosCita.sede || '', fecha: fechaLabel, dni: datosCita.dni || '', telefono: datosCita.numero_limpio || '', email: correo })
   }).then(function(r) { return r.json(); }).then(function(d) {
     if (d && (d.ok || d.id)) { if (window.AOS_showToast) AOS_showToast('📧 Email enviado', correo, ''); }

--- a/app/server.js
+++ b/app/server.js
@@ -2,6 +2,8 @@ const http = require('http')
 const https = require('https')
 const fs   = require('fs')
 const path = require('path')
+const { createEmailGateway } = require('./email-gateway')
+const EMAIL_GATEWAY = createEmailGateway()
 const PORT = parseInt(process.env.PORT || '4173', 10)
 // Servir siempre desde public/ (archivos HTML estáticos editados directamente)
 // El build de vite no aplica a estos archivos
@@ -19,16 +21,29 @@ const MIME = {
 const SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
 const SB_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0'
 const VERIFY_TOKEN = 'ascendaos_zivital_2026'
+// F16: Email tables are backend-only. No service-role value is stored in source.
+const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''
+function f16DbKey(endpoint) {
+  var e = String(endpoint || '')
+  return /^\/rest\/v1\/aos_emails?_/.test(e) ? EMAIL_SB_KEY : SB_KEY
+}
+function f16RequireEmailBackend(endpoint) {
+  if (/^\/rest\/v1\/aos_emails?_/.test(String(endpoint || '')) && !EMAIL_SB_KEY) {
+    throw new Error('EMAIL_SERVICE_ROLE_NOT_CONFIGURED')
+  }
+}
 
 function sbPost(endpoint, body, method) {
+  f16RequireEmailBackend(endpoint)
   const url = new URL(SB_URL + endpoint)
   const httpMethod = String(method || 'POST').toUpperCase() === 'PATCH' ? 'PATCH' : 'POST'
+  const dbKey = f16DbKey(endpoint)
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body)
     const req = https.request({
       hostname: url.hostname, path: url.pathname + url.search,
       method: httpMethod,
-      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) }
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) }
     }, (res) => { let d = ''; res.on('data', c => d += c); res.on('end', () => resolve(res.statusCode)) })
     req.on('error', reject)
     req.write(data)
@@ -36,11 +51,13 @@ function sbPost(endpoint, body, method) {
   })
 }
 function sbGet(endpoint) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.resolve([]) }
   const url = new URL(SB_URL + endpoint)
+  const dbKey = f16DbKey(endpoint)
   return new Promise(function(resolve, reject) {
     https.get({
       hostname: url.hostname, path: url.pathname + url.search,
-      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY }
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
     }, function(r) {
       var d = ''; r.on('data', function(c) { d += c }); r.on('end', function() {
         try { resolve(JSON.parse(d)) } catch(e) { resolve([]) }
@@ -65,12 +82,14 @@ function sbRpc(fnName, params) {
   })
 }
 function sbPatch(endpoint, body) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.resolve(false) }
   const url = new URL(SB_URL + endpoint)
+  const dbKey = f16DbKey(endpoint)
   var data = JSON.stringify(body || {})
   return new Promise(function(resolve) {
     var req = https.request({
       hostname: url.hostname, path: url.pathname + url.search, method: 'PATCH',
-      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' }
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' }
     }, function(r) {
       var d = ''; r.on('data', function(c) { d += c }); r.on('end', function() { resolve(r.statusCode < 300) })
     })
@@ -911,6 +930,10 @@ function serve(f, res) {
 // ═══ SERVER ═══
 http.createServer(function(req, res) {
   var p = req.url.split('?')[0]
+  // F16: all admin Email writes and provider webhooks enter through a server-authoritative boundary.
+  if (p === '/api/email-gateway') return EMAIL_GATEWAY.handleAdmin(req, res)
+  if (p === '/api/send-email') return EMAIL_GATEWAY.handleAdmin(req, res)
+  if (p === '/api/resend-webhook') return EMAIL_GATEWAY.handleWebhook(req, res)
   if (p === '/webhook' || p === '/webhook/') {
     if (req.method === 'GET') return webhookVerify(req, res)
     if (req.method === 'POST') return webhookMessage(req, res)
@@ -1475,106 +1498,33 @@ http.createServer(function(req, res) {
     res.end(connData); return
   }
   // ═══ FIN STUDIO API ═══
-  // ===== RESEND EMAIL API =====
-  if (p === '/api/send-email' && req.method === 'POST') {
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
-      try {
-        var d = JSON.parse(body)
-        if (!d.to || !d.subject || !d.html) { res.writeHead(400); res.end(JSON.stringify({error:'Missing to, subject, or html'})); return }
-        var RESEND_KEY = process.env.RESEND_API_KEY || 're_UEV4yw2G_GdVeWHn4fLQnYSAL7uKXzSjt'
-        var emailData = JSON.stringify({
-          from: d.from || 'Clínica Zi Vital <info@zivital.pe>',
-          to: Array.isArray(d.to) ? d.to : [d.to],
-          subject: d.subject,
-          html: d.html,
-          reply_to: d.reply_to || 'jaureguitorrescesar@gmail.com'
-        })
-        var rReq = https.request({
-          hostname: 'api.resend.com', path: '/emails', method: 'POST',
-          headers: { 'Authorization': 'Bearer ' + RESEND_KEY, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(emailData) }
-        }, function(rRes) {
-          var rData = ''; rRes.on('data', function(c) { rData += c }); rRes.on('end', function() {
-            try {
-              var result = JSON.parse(rData)
-              // Log to Supabase
-              var logData = JSON.stringify({
-                destinatario_email: Array.isArray(d.to) ? d.to[0] : d.to,
-                destinatario_nombre: d.nombre || '',
-                destinatario_numero: d.numero || '',
-                plantilla_id: d.plantilla_id || null,
-                campania_id: d.campania_id || null,
-                flujo_id: d.flujo_id || null,
-                flujo_paso: d.flujo_paso || null,
-                asunto: d.subject,
-                variables_usadas: d.variables || {},
-                estado: result.id ? 'enviado' : 'error',
-                resend_id: result.id || null,
-                error_msg: result.message || null,
-                enviado_at: result.id ? new Date().toISOString() : null
-              })
-              var logReq = https.request({
-                hostname: 'ituyqwstonmhnfshnaqz.supabase.co', path: '/rest/v1/aos_email_envios', method: 'POST',
-                headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(logData) }
-              }, function() {})
-              logReq.on('error', function() {})
-              logReq.write(logData); logReq.end()
-
-              res.writeHead(result.id ? 200 : 400, { 'Content-Type': 'application/json' })
-              res.end(JSON.stringify(result))
-            } catch(e) { res.writeHead(500); res.end(JSON.stringify({error:'Parse error: ' + rData})) }
-          })
-        })
-        rReq.on('error', function(e) { res.writeHead(500); res.end(JSON.stringify({error:e.message})) })
-        rReq.write(emailData); rReq.end()
-      } catch(e) { res.writeHead(400); res.end(JSON.stringify({error:'Invalid JSON'})) }
-    }); return
+  // ===== F16 EMAIL ADMIN SEND =====
+  // Handled above by EMAIL_GATEWAY with authoritative admin session verification.
+  // ===== F16 LEGACY 2FA RETIRED =====
+  // Current Auth V3 sends 2FA inside aos_login_v3. This legacy public provider path is closed.
+  if (p === '/api/send-2fa') {
+    res.writeHead(410, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+    res.end(JSON.stringify({ ok:false, error:'LEGACY_2FA_RETIRED' })); return
   }
-  if (p === '/api/send-email' && req.method === 'OPTIONS') {
-    res.writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST', 'Access-Control-Allow-Headers': 'Content-Type' })
-    res.end(); return
-  }
-  // ===== FIN RESEND =====
-  // ===== 2FA CODE EMAIL =====
-  if (p === '/api/send-2fa' && req.method === 'POST') {
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
-      try {
-        var d = JSON.parse(body)
-        if (!d.email || !d.code || !d.nombre) { res.writeHead(400); res.end('{"error":"missing fields"}'); return }
-        var RESEND_KEY = process.env.RESEND_API_KEY || 're_UEV4yw2G_GdVeWHn4fLQnYSAL7uKXzSjt'
-        var emailData = JSON.stringify({
-          from: 'AscendaOS <info@zivital.pe>',
-          to: [d.email],
-          subject: '🔐 Código de verificación — AscendaOS',
-          html: '<div style="font-family:Arial;max-width:400px;margin:0 auto;text-align:center;"><div style="background:linear-gradient(135deg,#071D4A,#0A4FBF);padding:24px;border-radius:12px 12px 0 0;"><div style="color:#00E5A0;font-size:10px;font-weight:700;letter-spacing:2px;">ASCENDA OS</div><div style="color:#fff;font-size:18px;font-weight:800;margin-top:6px;">Código de Verificación</div></div><div style="background:#fff;padding:24px;border:1px solid #eee;border-radius:0 0 12px 12px;"><p>Hola <b>' + d.nombre + '</b>,</p><p style="font-size:13px;color:#6B7BA8;">Tu código de acceso es:</p><div style="background:#F0F4FC;border-radius:12px;padding:20px;margin:16px 0;"><div style="font-family:monospace;font-size:36px;font-weight:800;letter-spacing:8px;color:#0A4FBF;">' + d.code + '</div></div><p style="font-size:11px;color:#9AAAC8;">Este código expira en 5 minutos. Si no solicitaste este código, ignora este mensaje.</p></div></div>'
-        })
-        var rReq = https.request({
-          hostname: 'api.resend.com', path: '/emails', method: 'POST',
-          headers: { 'Authorization': 'Bearer ' + RESEND_KEY, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(emailData) }
-        }, function(rRes) {
-          var rData = ''; rRes.on('data', function(c) { rData += c }); rRes.on('end', function() {
-            res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(rData)
-          })
-        })
-        rReq.on('error', function(e) { res.writeHead(500); res.end('{"error":"' + e.message + '"}') })
-        rReq.write(emailData); rReq.end()
-      } catch(e) { res.writeHead(400); res.end('{"error":"Invalid JSON"}') }
-    }); return
-  }
-  if (p === '/api/send-2fa' && req.method === 'OPTIONS') {
-    res.writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST', 'Access-Control-Allow-Headers': 'Content-Type' })
-    res.end(); return
-  }
-  // ===== FIN 2FA =====
+  // ===== FIN F16 LEGACY 2FA =====
   // ===== TEMPLATE EMAILS (confirmación cita, recibo venta, seguimiento) =====
   if (p === '/api/send-template' && req.method === 'POST') {
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
+    var templateToken = String(req.headers['x-ascenda-session'] || '')
+    EMAIL_GATEWAY.verifyApp(templateToken).then(function(templateAuth) {
+      if (!templateAuth || templateAuth.ok !== true) {
+        res.writeHead(401, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+        res.end(JSON.stringify({ok:false,error:'UNAUTHORIZED'})); return
+      }
+      var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
       try {
         var d = JSON.parse(body)
         if (!d.to || !d.template) { res.writeHead(400); res.end('{"error":"missing to/template"}'); return }
         var html = '', subject = '', tipo = d.template
+        // F16: template endpoint is transactional only. Marketing must use governed activation/consent.
+        if (EMAILS_TRANSACCIONALES.indexOf(String(tipo || '')) === -1) {
+          res.writeHead(403, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+          res.end(JSON.stringify({ok:false,error:'GOVERNED_ACTIVATION_REQUIRED',template:String(tipo||'')})); return
+        }
         // Construir variables para la plantilla
         var vars = { nombre: d.nombre||'Paciente', tratamiento: d.tratamiento||'', fecha: d.fecha||'', hora: d.hora||'', sede: d.sede||'', fecha_cita: d.fecha||d.fecha_cita||'', hora_cita: d.hora||d.hora_cita||'', monto: d.monto ? parseFloat(d.monto).toFixed(2) : '', metodo_pago: d.metodo_pago||d.metodo||'', saldo_actual: d.saldo_actual ? parseFloat(d.saldo_actual).toFixed(2) : '0.00', ultimo_tratamiento: d.ultimo_tratamiento||'', dias: d.dias||'', dias_sin_visita: d.dias_sin_visita||d.dias||'', ultima_fecha: d.ultima_fecha||'', catalogo_items: d.catalogo_items||'', pagados: d.pagados||'', dni: d.dni||'', email: d.email||d.to||'', telefono: d.telefono||'', venta_id: d.venta_id||'' }
 
@@ -1676,133 +1626,20 @@ http.createServer(function(req, res) {
           })
           .catch(function(e) { res.writeHead(500); res.end('{"error":"' + e.message + '"}') })
       } catch(e) { res.writeHead(400); res.end('{"error":"Invalid JSON"}') }
-    }); return
+      })
+    }).catch(function() {
+      res.writeHead(401, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+      res.end(JSON.stringify({ok:false,error:'UNAUTHORIZED'}))
+    })
+    return
   }
   if (p === '/api/send-template' && req.method === 'OPTIONS') {
-    res.writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST', 'Access-Control-Allow-Headers': 'Content-Type' })
-    res.end(); return
+    res.writeHead(405, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+    res.end(JSON.stringify({ok:false,error:'METHOD_NOT_ALLOWED'})); return
   }
   // ===== FIN TEMPLATE EMAILS =====
-  // ===== RESEND WEBHOOK — open/click/bounce tracking =====
-  if (p === '/api/resend-webhook' && req.method === 'POST') {
-    var wBody = ''; req.on('data', function(c) { wBody += c }); req.on('end', function() {
-      try {
-        var evt = JSON.parse(wBody)
-        var evtType = evt.type || ''
-        var evtData = evt.data || {}
-        var emailId = evtData.email_id || ''
-        var emailTo = evtData.to ? (Array.isArray(evtData.to) ? evtData.to[0] : evtData.to) : ''
-        var clickUrl = evtData.click && evtData.click.link ? evtData.click.link : ''
-
-        console.log('[WEBHOOK] ' + evtType + ' — ' + emailTo + (clickUrl ? ' → ' + clickUrl : ''))
-
-        // ═══ 1. GUARDAR EVENTO RAW ═══
-        sbPost('/rest/v1/aos_email_eventos', {
-          resend_id: emailId, tipo_evento: evtType,
-          email_destino: emailTo, metadata: evtData
-        }).catch(function(){})
-
-        // ═══ 2. ACTUALIZAR TRACKING en email enviado ═══
-        if (evtType === 'email.delivered' && emailId) {
-          sbPost('/rest/v1/aos_emails_enviados?resend_id=eq.' + emailId, {
-            ultimo_evento: new Date().toISOString()
-          }, 'PATCH').catch(function(){})
-        }
-
-        if (evtType === 'email.opened' && emailId) {
-          sbPost('/rest/v1/aos_emails_enviados?resend_id=eq.' + emailId, {
-            abierto: true, ultimo_evento: new Date().toISOString()
-          }, 'PATCH').catch(function(){})
-
-          // ═══ 3. SCORE DE ENGAGEMENT: incrementar score del paciente ═══
-          if (emailTo) {
-            sbFetch('/rest/v1/aos_pacientes?or=("Email".eq.' + encodeURIComponent(emailTo) + ')&select=numero_limpio,"SCORE_ESTADO"&limit=1')
-              .then(function(pacs) {
-                if (pacs && pacs[0]) {
-                  var newScore = Math.min((parseInt(pacs[0].SCORE_ESTADO) || 0) + 1, 100)
-                  sbPost('/rest/v1/aos_pacientes?numero_limpio=eq.' + pacs[0].numero_limpio, {
-                    "SCORE_ESTADO": newScore.toString()
-                  }, 'PATCH').catch(function(){})
-                }
-              }).catch(function(){})
-          }
-        }
-
-        if (evtType === 'email.clicked' && emailId) {
-          // Incrementar clicks
-          sbFetch('/rest/v1/aos_emails_enviados?resend_id=eq.' + emailId + '&select=clicks,tipo,destinatario').then(function(rows) {
-            if (rows && rows[0]) {
-              sbPost('/rest/v1/aos_emails_enviados?resend_id=eq.' + emailId, {
-                clicks: (rows[0].clicks || 0) + 1, abierto: true, ultimo_evento: new Date().toISOString()
-              }, 'PATCH').catch(function(){})
-
-              // ═══ 4. ALERTA AL ASESOR: si clickeó link de agendar/WhatsApp ═══
-              var isActionClick = clickUrl && (clickUrl.indexOf('wa.me') > -1 || clickUrl.indexOf('agendar') > -1 || clickUrl.indexOf('whatsapp') > -1)
-              if (isActionClick) {
-                var tipoEmail = rows[0].tipo || 'email'
-                // Buscar nombre del paciente
-                sbFetch('/rest/v1/aos_pacientes?or=("Email".eq.' + encodeURIComponent(emailTo) + ')&select="Nombres","Apellidos",numero_limpio,tratamiento_principal&limit=1')
-                  .then(function(pacs) {
-                    var pacNombre = pacs && pacs[0] ? (pacs[0].Nombres || '') + ' ' + (pacs[0].Apellidos || '') : emailTo
-                    var pacNum = pacs && pacs[0] ? pacs[0].numero_limpio : ''
-                    // Notificación interna al CRM
-                    notifyAdmin(
-                      '🔥 ' + pacNombre.trim() + ' quiere agendar',
-                      'Hizo click en "Agendar" desde email ' + tipoEmail + '. Llamar ahora. Tel: ' + pacNum,
-                      'LEAD_CALIENTE', 'ALTA'
-                    )
-                    // Log de acción
-                    logAction('cartero', 'click_agendar', pacNombre.trim() + ' clickeó agendar desde ' + tipoEmail, {
-                      email: emailTo, tipo_email: tipoEmail, url: clickUrl, numero: pacNum
-                    })
-                    console.log('[WEBHOOK] 🔥 LEAD CALIENTE: ' + pacNombre.trim() + ' clickeó agendar desde ' + tipoEmail)
-                  }).catch(function(){})
-              }
-            }
-          }).catch(function(){})
-        }
-
-        if (evtType === 'email.bounced' || evtType === 'email.complained') {
-          if (emailId) {
-            sbPost('/rest/v1/aos_emails_enviados?resend_id=eq.' + emailId, {
-              rebotado: true, ultimo_evento: new Date().toISOString()
-            }, 'PATCH').catch(function(){})
-          }
-
-          // ═══ 5. AUTO-LIMPIAR EMAILS INVÁLIDOS ═══
-          if (emailTo) {
-            // Marcar email como inválido en el paciente para que Elena no le envíe más
-            sbFetch('/rest/v1/aos_pacientes?or=("Email".eq.' + encodeURIComponent(emailTo) + ')&select=numero_limpio,"Nombres","Email"&limit=1')
-              .then(function(pacs) {
-                if (pacs && pacs[0]) {
-                  var motivo = evtType === 'email.complained' ? 'SPAM' : 'REBOTADO'
-                  sbPost('/rest/v1/aos_pacientes?numero_limpio=eq.' + pacs[0].numero_limpio, {
-                    "Email": pacs[0].Email + ' [' + motivo + ']'
-                  }, 'PATCH').catch(function(){})
-                  console.log('[WEBHOOK] ⚠ Email invalidado: ' + emailTo + ' (' + motivo + ') — ' + (pacs[0].Nombres || ''))
-                  // Alerta para que César sepa
-                  notifyAdmin(
-                    '⚠ Email ' + motivo + ': ' + (pacs[0].Nombres || ''),
-                    'El email ' + emailTo + ' fue marcado como ' + motivo + '. Se desactivó para futuros envíos.',
-                    'EMAIL', 'MEDIA'
-                  )
-                }
-              }).catch(function(){})
-          }
-        }
-
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end('{"ok":true}')
-      } catch(e) {
-        console.error('[WEBHOOK] Error:', e.message)
-        res.writeHead(400); res.end('{"error":"invalid payload"}')
-      }
-    }); return
-  }
-  if (p === '/api/resend-webhook' && req.method === 'OPTIONS') {
-    res.writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST', 'Access-Control-Allow-Headers': 'Content-Type' })
-    res.end(); return
-  }
+  // ===== F16 RESEND WEBHOOK =====
+  // Handled above by EMAIL_GATEWAY with cryptographic signature + replay protection.
 
   // ===== RESEND STATS — datos reales de emails enviados =====
   if (p === '/api/resend-stats' && req.method === 'GET') {
@@ -2229,7 +2066,7 @@ function saveContent(agentId, tipo, titulo, contenido, metadata) {
 // MOTOR DE ACCIONES — agentes actúan, no solo analizan
 // ═══════════════════════════════════════════════════════════════
 
-var RESEND_KEY_AG = process.env.RESEND_API_KEY || 're_UEV4yw2G_GdVeWHn4fLQnYSAL7uKXzSjt'
+var RESEND_KEY_AG = process.env.RESEND_API_KEY || ''
 
 // ═══ BRANDING CACHE (se carga al inicio y refresca cada 30min) ═══
 var BRAND = {
@@ -2320,10 +2157,14 @@ function validarEmail(email) {
 }
 
 // Tipos transaccionales: NO se limitan por cadencia (son respuestas a acciones del paciente)
-var EMAILS_TRANSACCIONALES = ['confirmacion_cita', 'recibo_venta', 'recordatorio_hoy', 'recordatorio_manana', 'bienvenida', 'confirmacion_pago', 'cotizacion']
+var EMAILS_TRANSACCIONALES = ['confirmacion_cita','recibo_venta','recordatorio_hoy','recordatorio_manana','recordatorio','bienvenida','confirmacion_pago','cotizacion','catalogo','comprobante','agradecimiento','agradecimiento_visita','no_asistencia','reprogramacion','saldo_pendiente','seguimiento']
 
 function sendAgentEmail(to, subject, html, tipo, destinatario_id) {
   return new Promise(function(resolve) {
+    // F16: all marketing/reactivation/cross-sell agent sends require governed Audience activation + consent.
+    if (EMAILS_TRANSACCIONALES.indexOf(String(tipo || '')) === -1) {
+      resolve({ skip:true, reason:'F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED', governed_activation_required:true }); return
+    }
     // Anti-duplicado: verificar si ya se envió hoy
     sbFetch('/rest/v1/aos_emails_enviados?tipo=eq.' + encodeURIComponent(tipo) + '&destinatario=eq.' + encodeURIComponent(destinatario_id) + '&fecha_envio=eq.' + limaDateStr())
       .then(function(rows) {
@@ -2858,9 +2699,10 @@ function executeAction(agent, task, queryResult) {
   // Guardar alerta en panel (siempre)
   function saveEmailAlerta(tipo, template, titulo, detalle, destinatario, resendId) {
     var body = JSON.stringify({ tipo: tipo, template: template, titulo: titulo, detalle: detalle || '', destinatario: destinatario || '', resend_id: resendId || '' })
+    if (!EMAIL_SB_KEY) return
     var url = new URL(SB_URL + '/rest/v1/aos_email_alertas')
     var req = https.request({ hostname: url.hostname, path: url.pathname, method: 'POST',
-      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(body) }
+      headers: { 'apikey': EMAIL_SB_KEY, 'Authorization': 'Bearer ' + EMAIL_SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(body) }
     }, function(){})
     req.on('error', function(){})
     req.write(body); req.end()
@@ -3650,11 +3492,13 @@ function loadAIKeys() {
 }
 
 function sbFetch(endpoint) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.reject(e) }
   return new Promise(function(resolve, reject) {
     var url = new URL(SB_URL + endpoint)
+    var dbKey = f16DbKey(endpoint)
     https.get({
       hostname: url.hostname, path: url.pathname + url.search,
-      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY }
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
     }, function(res) {
       var d = ''; res.on('data', function(c) { d += c }); res.on('end', function() {
         try { resolve(JSON.parse(d)) } catch(e) { reject(e) }

--- a/ci/phase16/f16_redeploy_recertify.trigger
+++ b/ci/phase16/f16_redeploy_recertify.trigger
@@ -1,0 +1,1 @@
+F16 exact-head recertification after updating Runtime + Contracts assertions for canonical and Railway service-role environment names. Trigger v6. No runtime behavior change.

--- a/ci/phase16/f16_redeploy_recertify.trigger
+++ b/ci/phase16/f16_redeploy_recertify.trigger
@@ -1,1 +1,1 @@
-F16 exact-head recertification after updating Runtime + Contracts assertions for canonical and Railway service-role environment names. Trigger v6. No runtime behavior change.
+F16 rollback-safe snapshot exact-head recertification with idempotent Railway environment alias gate. Trigger v7. No runtime behavior change.

--- a/ci/phase16/legacy_email_schema_contract.sql
+++ b/ci/phase16/legacy_email_schema_contract.sql
@@ -1,0 +1,35 @@
+-- F16 synthetic legacy Email ACL fixture. Schema-only; no real records or PII/PHI.
+
+do $roles$
+begin
+  if not exists (select 1 from pg_roles where rolname='service_role') then create role service_role nologin bypassrls; end if;
+end
+$roles$;
+
+do $tables$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'aos_email_alertas','aos_email_audiencias','aos_email_cadencia','aos_email_campanias','aos_email_envios',
+    'aos_email_eventos','aos_email_flujo_ejecuciones','aos_email_flujos','aos_email_plantillas',
+    'aos_emails_empresa','aos_emails_enviados'
+  ] loop
+    execute format('create table if not exists public.%I (id uuid primary key default gen_random_uuid(), payload jsonb not null default ''{}''::jsonb)',t);
+    execute format('grant all on table public.%I to anon,authenticated,service_role',t);
+  end loop;
+end
+$tables$;
+
+create or replace function public.aos_email_buscar_paciente(p_buscar text,p_limite integer default 20)
+returns jsonb language sql stable as $$ select '[]'::jsonb $$;
+create or replace function public.aos_email_dashboard()
+returns jsonb language sql stable as $$ select '{}'::jsonb $$;
+create or replace function public.aos_email_historial_paciente(p_numero text)
+returns jsonb language sql stable as $$ select '[]'::jsonb $$;
+
+grant execute on function public.aos_email_buscar_paciente(text,integer) to public,anon,authenticated,service_role;
+grant execute on function public.aos_email_dashboard() to public,anon,authenticated,service_role;
+grant execute on function public.aos_email_historial_paciente(text) to public,anon,authenticated,service_role;
+
+select 'CIA_PHASE16_LEGACY_EMAIL_FIXTURE=PASS' as result;

--- a/ci/phase16/rollback_phase16.sql
+++ b/ci/phase16/rollback_phase16.sql
@@ -1,0 +1,44 @@
+-- CIA F16 Zero-Cost rollback/recovery proof.
+-- Drops only additive F16 objects created by the F16 migrations under test.
+
+drop function if exists public.aos_cia_verify_app_session_v1(text);
+drop function if exists public.aos_cia_email_admin_gateway_v2(text,text,jsonb);
+drop function if exists public.aos_cia_email_release_mark_v1(text,boolean,text);
+drop function if exists public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb);
+drop function if exists public.aos_cia_email_record_dispatch_result_v2(uuid,boolean,text,text,text,jsonb);
+drop function if exists public.aos_cia_email_claim_dispatch_v2(uuid);
+drop function if exists public.aos_cia_email_queue_request_v2(uuid,uuid);
+drop function if exists public.aos_cia_email_prepare_request_v2(uuid,uuid,text,uuid,jsonb);
+
+drop function if exists public.aos_cia_email_admin_gateway_v1(text,text,jsonb);
+drop function if exists public.aos_cia_email_f17_readiness_v1();
+drop function if exists public.aos_cia_email_prepare_request_v1(uuid,uuid,text,uuid);
+drop function if exists public.aos_cia_email_template_version_activate_v1(uuid,uuid);
+drop function if exists public.aos_cia_email_template_version_create_v1(uuid,text,text,text,text,text[],uuid);
+drop function if exists public.aos_cia_email_preview_activation_v1(uuid,text,integer,integer);
+drop function if exists public.aos_cia_email_eligibility_v1(uuid,text,text);
+
+drop trigger if exists trg_aos_cia_email_send_events_append_only_v1 on public.aos_cia_email_send_events;
+drop trigger if exists trg_aos_cia_email_request_guard_v1 on public.aos_cia_email_send_requests;
+drop trigger if exists trg_aos_cia_email_template_guard_v1 on public.aos_cia_email_template_versions;
+drop trigger if exists trg_aos_cia_email_control_events_append_only_v1 on public.aos_cia_email_recipient_control_events;
+drop trigger if exists trg_aos_cia_email_control_audit_v1 on public.aos_cia_email_recipient_controls;
+
+drop function if exists public.aos_cia_email_request_guard_v1();
+drop function if exists public.aos_cia_email_template_guard_v1();
+drop function if exists public.aos_cia_email_append_only_guard_v1();
+drop function if exists public.aos_cia_email_control_audit_v1();
+
+drop table if exists public.aos_cia_email_release_state;
+drop table if exists public.aos_cia_email_send_events;
+drop table if exists public.aos_cia_email_send_requests;
+drop table if exists public.aos_cia_email_template_versions;
+drop table if exists public.aos_cia_email_recipient_control_events;
+drop table if exists public.aos_cia_email_recipient_controls;
+
+select case when count(*)=0 then 'CIA_PHASE16_ROLLBACK=PASS' else 'CIA_PHASE16_ROLLBACK=FAIL' end as rollback_result
+from pg_class c join pg_namespace n on n.oid=c.relnamespace
+where n.nspname='public' and c.relname in (
+  'aos_cia_email_recipient_controls','aos_cia_email_recipient_control_events','aos_cia_email_template_versions',
+  'aos_cia_email_send_requests','aos_cia_email_send_events','aos_cia_email_release_state'
+);

--- a/ci/phase16/rollback_phase16_legacy_acl.sql
+++ b/ci/phase16/rollback_phase16_legacy_acl.sql
@@ -1,0 +1,32 @@
+-- F16 emergency rollback for legacy Email ACL hardening.
+-- Restores the exact pre-F16 browser privilege posture observed in production baseline.
+-- Use only as recovery if the authoritative server boundary cannot sustain Email operations.
+
+do $rollback$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'aos_email_alertas','aos_email_audiencias','aos_email_cadencia','aos_email_campanias','aos_email_envios',
+    'aos_email_eventos','aos_email_flujo_ejecuciones','aos_email_flujos','aos_email_plantillas',
+    'aos_emails_empresa','aos_emails_enviados'
+  ] loop
+    execute format('alter table public.%I disable row level security',t);
+    execute format('grant all on table public.%I to anon,authenticated',t);
+  end loop;
+end
+$rollback$;
+
+grant execute on function public.aos_email_buscar_paciente(text,integer) to public,anon,authenticated,service_role;
+grant execute on function public.aos_email_dashboard() to public,anon,authenticated,service_role;
+grant execute on function public.aos_email_historial_paciente(text) to public,anon,authenticated,service_role;
+
+select case when count(*)=0 then 'CIA_PHASE16_LEGACY_ACL_ROLLBACK=PASS' else 'CIA_PHASE16_LEGACY_ACL_ROLLBACK=FAIL' end as rollback_result
+from pg_class c join pg_namespace n on n.oid=c.relnamespace
+where n.nspname='public'
+  and c.relname in (
+    'aos_email_alertas','aos_email_audiencias','aos_email_cadencia','aos_email_campanias','aos_email_envios',
+    'aos_email_eventos','aos_email_flujo_ejecuciones','aos_email_flujos','aos_email_plantillas',
+    'aos_emails_empresa','aos_emails_enviados'
+  )
+  and c.relrowsecurity;

--- a/ci/phase16/schema_contract.sql
+++ b/ci/phase16/schema_contract.sql
@@ -1,0 +1,136 @@
+-- Synthetic dependency contract for CIA F16 Zero-Cost CI.
+-- No production data, emails, phone numbers, tokens or provider credentials.
+
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+do $roles$
+begin
+  if not exists (select 1 from pg_roles where rolname='anon') then create role anon nologin; end if;
+  if not exists (select 1 from pg_roles where rolname='authenticated') then create role authenticated nologin; end if;
+  if not exists (select 1 from pg_roles where rolname='service_role') then create role service_role nologin bypassrls; end if;
+end
+$roles$;
+
+create table public.aos_usuarios (
+  id uuid primary key,
+  nombre text not null,
+  rol text not null default 'ADMIN',
+  activo boolean not null default true,
+  paneles_acceso text[] not null default '{}'::text[]
+);
+
+create table public.aos_app_sessions_v3 (
+  token_hash text primary key,
+  user_id uuid not null references public.aos_usuarios(id),
+  assurance_level text not null default 'PASSWORD',
+  expires_at timestamptz not null,
+  last_used_at timestamptz,
+  revoked boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create table public.aos_audiencia_activaciones (
+  id uuid primary key,
+  audiencia_id uuid,
+  audiencia_version_id uuid,
+  created_at timestamptz not null default now()
+);
+
+create table public.aos_audiencia_activacion_config (
+  activacion_id uuid primary key references public.aos_audiencia_activaciones(id),
+  snapshot_id uuid,
+  nombre text,
+  purpose text,
+  channel text,
+  mode text,
+  baseline_count integer,
+  baseline_resolved_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by_user_id uuid,
+  created_at timestamptz not null default now()
+);
+
+create table public.aos_audiencia_activacion_estado (
+  activacion_id uuid primary key references public.aos_audiencia_activaciones(id),
+  estado text not null,
+  updated_by_user_id uuid,
+  updated_at timestamptz not null default now(),
+  started_at timestamptz,
+  ended_at timestamptz
+);
+
+create table public.aos_cia_activation_members_fixture (
+  activation_id uuid not null,
+  contact_key text not null,
+  primary key (activation_id, contact_key)
+);
+
+create table public.aos_cia_audience_source_v1_1 (
+  contact_key text primary key,
+  identity_conflict boolean not null default false,
+  canonical_email text,
+  email_valid boolean,
+  email_bounced_count integer not null default 0,
+  facts_observed_at timestamptz,
+  email_last_event_at timestamptz
+);
+
+create or replace function public.aos_cia_activation_member_keys_v1(p_activation_id uuid)
+returns table(contact_key text)
+language sql
+stable
+set search_path=''
+as $function$
+  select f.contact_key
+  from public.aos_cia_activation_members_fixture f
+  where f.activation_id=p_activation_id
+  order by f.contact_key
+$function$;
+
+create or replace function public.aos_cia_verify_admin_session_v1(p_token text)
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $function$
+  select case when p_token='synthetic-admin-token'
+    then jsonb_build_object('ok',true,'user_id','00000000-0000-0000-0000-000000000001')
+    else jsonb_build_object('ok',false,'error','UNAUTHORIZED') end
+$function$;
+
+create or replace function public.aos_cia_kronia_f16_readiness_v1()
+returns jsonb
+language sql
+stable
+set search_path=''
+as $function$
+  select jsonb_build_object(
+    'ok',true,
+    'status','READY_GOVERNED_ORCHESTRATION',
+    'mode','GOVERNED_SHADOW',
+    'ready_for_f16',true,
+    'audit',jsonb_build_object('auto_execute_calls',0,'auto_execute_proposals',0),
+    'registry',jsonb_build_object('active_tools',6,'active_agents',6,'bad_tools',0,'bad_agents',0)
+  )
+$function$;
+
+insert into public.aos_usuarios(id,nombre,rol,activo,paneles_acceso)
+values
+  ('00000000-0000-0000-0000-000000000001','Synthetic Admin','ADMIN',true,array['admin-email']),
+  ('00000000-0000-0000-0000-000000000002','Synthetic Operator','ASESOR',true,array['calls','agenda']);
+
+insert into public.aos_app_sessions_v3(token_hash,user_id,assurance_level,expires_at,revoked)
+values
+  (encode(extensions.digest('synthetic-app-token-valid-000000000000000001','sha256'),'hex'),'00000000-0000-0000-0000-000000000002','PASSWORD',now()+interval '8 hours',false),
+  (encode(extensions.digest('synthetic-app-token-revoked-00000000000001','sha256'),'hex'),'00000000-0000-0000-0000-000000000002','PASSWORD',now()+interval '8 hours',true),
+  (encode(extensions.digest('synthetic-app-token-expired-00000000000001','sha256'),'hex'),'00000000-0000-0000-0000-000000000002','PASSWORD',now()-interval '1 minute',false);
+
+revoke all on table public.aos_usuarios from anon,authenticated;
+revoke all on table public.aos_app_sessions_v3 from anon,authenticated;
+revoke all on table public.aos_audiencia_activaciones from anon,authenticated;
+revoke all on table public.aos_audiencia_activacion_config from anon,authenticated;
+revoke all on table public.aos_audiencia_activacion_estado from anon,authenticated;
+revoke all on table public.aos_cia_activation_members_fixture from anon,authenticated;
+revoke all on table public.aos_cia_audience_source_v1_1 from anon,authenticated;

--- a/ci/phase16/test_email_gateway.js
+++ b/ci/phase16/test_email_gateway.js
@@ -1,0 +1,153 @@
+'use strict'
+
+const assert = require('assert')
+const crypto = require('crypto')
+const EventEmitter = require('events')
+const gatewayLib = require('../../app/email-gateway')
+
+function signature(secret, eventId, timestamp, raw) {
+  var keyText = secret.indexOf('whsec_') === 0 ? secret.slice(6) : secret
+  var key = Buffer.from(keyText, 'base64')
+  return crypto.createHmac('sha256', key)
+    .update(Buffer.concat([Buffer.from(eventId + '.' + timestamp + '.'), raw]))
+    .digest('base64')
+}
+
+function mockRequest(body, headers) {
+  var req = new EventEmitter()
+  req.method = 'POST'
+  req.headers = headers || {}
+  req.destroy = function() {}
+  process.nextTick(function() {
+    if (body) req.emit('data', Buffer.from(body))
+    req.emit('end')
+  })
+  return req
+}
+
+function mockResponse() {
+  var result = { status: 0, headers: {}, body: '' }
+  result.writeHead = function(status, headers) { result.status = status; result.headers = headers || {} }
+  result.end = function(body) { result.body = String(body || ''); if (result.resolve) result.resolve(result) }
+  result.done = new Promise(function(resolve) { result.resolve = resolve })
+  return result
+}
+
+async function run() {
+  var raw = Buffer.from(JSON.stringify({ type: 'email.delivered', data: { email_id: 'synthetic-provider-message' } }))
+  var secret = 'whsec_' + Buffer.from('synthetic-webhook-signing-key-32bytes').toString('base64')
+  var eventId = 'synthetic-event-123456'
+  var now = 1900000000
+  var sig = signature(secret, eventId, String(now), raw)
+
+  var verified = gatewayLib.verifySvixSignature(raw, {
+    'svix-id': eventId,
+    'svix-timestamp': String(now),
+    'svix-signature': 'v1,' + sig
+  }, secret, now)
+  assert.strictEqual(verified.ok, true, 'valid webhook signature must pass')
+
+  var bad = gatewayLib.verifySvixSignature(raw, {
+    'svix-id': eventId,
+    'svix-timestamp': String(now),
+    'svix-signature': 'v1,' + Buffer.from('invalid-signature').toString('base64')
+  }, secret, now)
+  assert.strictEqual(bad.ok, false, 'invalid webhook signature must fail')
+
+  var stale = gatewayLib.verifySvixSignature(raw, {
+    'svix-id': eventId,
+    'svix-timestamp': String(now - 301),
+    'svix-signature': 'v1,' + signature(secret, eventId, String(now - 301), raw)
+  }, secret, now)
+  assert.strictEqual(stale.ok, false, 'stale webhook timestamp must fail')
+  assert.strictEqual(stale.error, 'WEBHOOK_TIMESTAMP_INVALID')
+
+  var rendered = gatewayLib.renderTemplate('<p>{{name}}</p>', { name: '<script>x</script>' }, ['name'], true)
+  assert.strictEqual(rendered.ok, true)
+  assert.strictEqual(rendered.value, '<p>&lt;script&gt;x&lt;/script&gt;</p>', 'HTML context must be escaped')
+  assert.strictEqual(gatewayLib.renderTemplate('{{missing}}', {}, ['missing'], false).ok, false, 'missing context must fail closed')
+  assert.ok(gatewayLib.safeLegacyQuery('select=id,nombre&order=nombre') !== null, 'safe legacy query should pass')
+  assert.strictEqual(gatewayLib.safeLegacyQuery('select=*&x=eq.a;drop'), null, 'SQL-like delimiters must be rejected')
+
+  var providerCalls = 0
+  var claimCalls = 0
+  var recorded = []
+  async function fakeRequester(url, options, body) {
+    if (url.indexOf('/rpc/aos_cia_email_admin_gateway_v2') >= 0) {
+      return { status: 200, body: { ok: true, state: 'QUEUED', request_id: '00000000-0000-0000-0000-000000000009' } }
+    }
+    if (url.indexOf('/rpc/aos_cia_email_claim_dispatch_v2') >= 0) {
+      claimCalls++
+      if (claimCalls === 1) {
+        return { status: 200, body: {
+          ok: true, request_id: '00000000-0000-0000-0000-000000000009', send_allowed: true, state: 'DISPATCHING',
+          recipient_email: 'recipient@example.test', subject_template: 'Hello {{name}}', html_template: '<p>Hello {{name}}</p>',
+          variable_keys: ['name'], render_context: { name: 'Synthetic' }, idempotency_key: 'synthetic-idempotency-key'
+        } }
+      }
+      return { status: 200, body: { ok: true, request_id: '00000000-0000-0000-0000-000000000009', send_allowed: false, state: 'ACCEPTED', idempotent: true } }
+    }
+    if (url.indexOf('/rpc/aos_cia_email_record_dispatch_result_v2') >= 0) {
+      recorded.push(body)
+      return { status: 200, body: { ok: true, state: body.p_accepted ? 'ACCEPTED' : 'FAILED' } }
+    }
+    if (url.indexOf('api.resend.com/emails') >= 0) {
+      providerCalls++
+      assert.strictEqual(options.headers['Idempotency-Key'], 'f16-synthetic-idempotency-key')
+      return { status: 200, body: { id: 'synthetic-provider-id' } }
+    }
+    throw new Error('unexpected mock URL: ' + url)
+  }
+
+  var gateway = gatewayLib.createEmailGateway({
+    supabaseUrl: 'https://synthetic.supabase.test',
+    serviceRoleKey: 'synthetic-service-role-key-long-enough-for-test-only',
+    resendApiKey: 'synthetic-resend-key-long-enough-for-test-only',
+    webhookSecret: secret,
+    requestJson: fakeRequester
+  })
+  var first = await gateway.dispatchRequest('synthetic-admin-token-that-is-long-enough-123456', '00000000-0000-0000-0000-000000000009')
+  assert.strictEqual(first.ok, true)
+  assert.strictEqual(providerCalls, 1, 'first dispatch must call provider exactly once')
+  assert.strictEqual(recorded.length, 1, 'provider result must be audited')
+
+  var second = await gateway.dispatchRequest('synthetic-admin-token-that-is-long-enough-123456', '00000000-0000-0000-0000-000000000009')
+  assert.strictEqual(second.send_allowed, false)
+  assert.strictEqual(providerCalls, 1, 'duplicate dispatch must not call provider twice')
+
+  var noProvider = gatewayLib.createEmailGateway({
+    supabaseUrl: 'https://synthetic.supabase.test',
+    serviceRoleKey: 'synthetic-service-role-key-long-enough-for-test-only',
+    resendApiKey: '',
+    webhookSecret: secret,
+    requestJson: async function(url, options, body) {
+      if (url.indexOf('/rpc/aos_cia_email_admin_gateway_v2') >= 0) return { status: 200, body: { ok: true, state: 'QUEUED' } }
+      if (url.indexOf('/rpc/aos_cia_email_claim_dispatch_v2') >= 0) return { status: 200, body: {
+        ok: true, send_allowed: true, state: 'DISPATCHING', recipient_email: 'recipient@example.test',
+        subject_template: 'Subject', html_template: '<p>Body</p>', variable_keys: [], render_context: {}, idempotency_key: 'missing-provider-test'
+      } }
+      if (url.indexOf('/rpc/aos_cia_email_record_dispatch_result_v2') >= 0) return { status: 200, body: { ok: true, state: 'FAILED' } }
+      throw new Error('network provider call should not occur when provider key missing')
+    }
+  })
+  var failedClosed = await noProvider.dispatchRequest('synthetic-admin-token-that-is-long-enough-123456', '00000000-0000-0000-0000-000000000010')
+  assert.strictEqual(failedClosed.ok, false)
+  assert.strictEqual(failedClosed.state, 'FAILED', 'missing provider config must fail closed and audit FAILED')
+
+  var unauthorizedGateway = gatewayLib.createEmailGateway({ serviceRoleKey: 'synthetic-service-role-key-long-enough-for-test-only', requestJson: async function() { throw new Error('must not call upstream') } })
+  var req = mockRequest(JSON.stringify({ action: 'CONFIG_HEALTH', payload: {} }), {})
+  var res = mockResponse()
+  unauthorizedGateway.handleAdmin(req, res)
+  var completed = await res.done
+  assert.strictEqual(completed.status, 401, 'missing admin session must be rejected before upstream access')
+
+  console.log('CIA_PHASE16_EMAIL_GATEWAY_UNIT=PASS')
+  console.log('WEBHOOK_SIGNATURE_REPLAY_BOUNDARY=PASS')
+  console.log('IDEMPOTENT_PROVIDER_DISPATCH=PASS')
+  console.log('MISSING_PROVIDER_FAIL_CLOSED=PASS')
+}
+
+run().catch(function(err) {
+  console.error('CIA_PHASE16_EMAIL_GATEWAY_UNIT=FAIL', err && err.message ? err.message : err)
+  process.exit(1)
+})

--- a/ci/phase16/test_email_gateway_policy.js
+++ b/ci/phase16/test_email_gateway_policy.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const EventEmitter = require('events')
+const gatewayLib = require('../../app/email-gateway')
+
+// F16 exact-SHA certification trigger: no functional test semantics changed.
+function mockRequest(body, headers) {
+  var req = new EventEmitter()
+  req.method = 'POST'
+  req.headers = headers || {}
+  req.destroy = function() {}
+  process.nextTick(function() {
+    req.emit('data', Buffer.from(body || ''))
+    req.emit('end')
+  })
+  return req
+}
+
+function mockResponse() {
+  var out = { status: 0, headers: {}, body: '' }
+  out.writeHead = function(status, headers) { out.status = status; out.headers = headers || {} }
+  out.end = function(body) { out.body = String(body || ''); if (out.resolve) out.resolve(out) }
+  out.done = new Promise(function(resolve) { out.resolve = resolve })
+  return out
+}
+
+async function run() {
+  var providerCalls = 0
+  var currentTemplateType = 'reactivacion'
+  async function requester(url, options, body) {
+    if (url.indexOf('/rpc/aos_cia_verify_admin_session_v1') >= 0) {
+      return { status: 200, body: { ok: true, user_id: '00000000-0000-0000-0000-000000000001', usuario: 'synthetic-admin' } }
+    }
+    if (url.indexOf('/rpc/aos_cia_verify_app_session_v1') >= 0) {
+      if (body && body.p_token === 'synthetic-app-token-valid-000000000000000001') {
+        return { status: 200, body: { ok: true, user_id: '00000000-0000-0000-0000-000000000002', rol: 'ASESOR', assurance_level: 'PASSWORD' } }
+      }
+      return { status: 200, body: { ok: false, error: 'UNAUTHORIZED' } }
+    }
+    if (url.indexOf('/rest/v1/aos_email_plantillas?') >= 0) {
+      return { status: 200, body: [{ id: '20000000-0000-0000-0000-000000000001', tipo: currentTemplateType, activo: true }] }
+    }
+    if (url.indexOf('api.resend.com/emails') >= 0) {
+      providerCalls++
+      return { status: 200, body: { id: 'synthetic-provider-id' } }
+    }
+    if (url.indexOf('/rest/v1/aos_email_envios') >= 0) return { status: 201, body: null }
+    throw new Error('unexpected request ' + url)
+  }
+
+  var gateway = gatewayLib.createEmailGateway({
+    supabaseUrl: 'https://synthetic.supabase.test',
+    serviceRoleKey: 'synthetic-service-role-key-long-enough-for-test-only',
+    resendApiKey: 'synthetic-resend-key-long-enough-for-test-only',
+    webhookSecret: 'whsec_' + Buffer.from('synthetic-webhook-key-32bytes-long').toString('base64'),
+    requestJson: requester
+  })
+
+  var appOk = await gateway.verifyApp('synthetic-app-token-valid-000000000000000001')
+  assert.strictEqual(appOk.ok, true, 'current Auth V3 app session should verify')
+  var appBad = await gateway.verifyApp('synthetic-app-token-invalid-00000000000000001')
+  assert.strictEqual(appBad.ok, false, 'invalid Auth V3 app session must fail')
+
+  var marketingReq = mockRequest(JSON.stringify({
+    action: 'LEGACY_SEND',
+    payload: {
+      to: 'recipient@example.test', subject: 'Synthetic marketing', html: '<p>test</p>',
+      plantilla_id: '20000000-0000-0000-0000-000000000001', client_request_id: 'synthetic-request-001'
+    }
+  }), { 'x-ascenda-session': 'synthetic-admin-token-that-is-long-enough-123456' })
+  var marketingRes = mockResponse()
+  gateway.handleAdmin(marketingReq, marketingRes)
+  var blocked = await marketingRes.done
+  var blockedBody = JSON.parse(blocked.body)
+  assert.strictEqual(blocked.status, 403, 'legacy marketing must be blocked')
+  assert.strictEqual(blockedBody.error, 'GOVERNED_ACTIVATION_REQUIRED')
+  assert.strictEqual(providerCalls, 0, 'blocked marketing must not call provider')
+
+  currentTemplateType = 'confirmacion_cita'
+  var txnReq = mockRequest(JSON.stringify({
+    action: 'LEGACY_SEND',
+    payload: {
+      to: 'recipient@example.test', subject: 'Synthetic confirmation', html: '<p>test</p>',
+      plantilla_id: '20000000-0000-0000-0000-000000000001', client_request_id: 'synthetic-request-002'
+    }
+  }), { 'x-ascenda-session': 'synthetic-admin-token-that-is-long-enough-123456' })
+  var txnRes = mockResponse()
+  gateway.handleAdmin(txnReq, txnRes)
+  var sent = await txnRes.done
+  assert.strictEqual(sent.status, 200, 'transactional manual email should remain operational')
+  assert.strictEqual(providerCalls, 1, 'transactional email should call provider exactly once')
+
+  var server = fs.readFileSync(path.join(__dirname, '../../app/server.js'), 'utf8')
+  assert.ok(server.includes("EMAIL_GATEWAY.verifyApp(templateToken)"), 'send-template must verify current app session')
+  assert.ok(server.includes('LEGACY_2FA_RETIRED'), 'legacy public 2FA provider route must be retired')
+  assert.ok(server.includes('F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED'), 'agent marketing bypass must be closed')
+  var sendTemplateStart = server.indexOf("if (p === '/api/send-template' && req.method === 'POST')")
+  assert.ok(sendTemplateStart >= 0)
+  var sendTemplateWindow = server.slice(sendTemplateStart, sendTemplateStart + 700)
+  assert.strictEqual(sendTemplateWindow.includes("Access-Control-Allow-Origin', '*'"), false, 'transactional email endpoint must not use wildcard CORS')
+
+  console.log('CIA_PHASE16_GATEWAY_POLICY=PASS')
+  console.log('AUTH_V3_TRANSACTIONAL_EMAIL=PASS')
+  console.log('UNGOVERNED_MARKETING_PROVIDER_CALLS=0')
+  console.log('LEGACY_2FA_PUBLIC_PROVIDER_PATH=RETIRED')
+}
+
+run().catch(function(err) {
+  console.error('CIA_PHASE16_GATEWAY_POLICY=FAIL', err && err.message ? err.message : err)
+  process.exit(1)
+})

--- a/ci/phase16/test_phase16_app_session.sql
+++ b/ci/phase16/test_phase16_app_session.sql
@@ -1,0 +1,38 @@
+-- F16 synthetic Auth V3 session verification tests.
+
+do $test$
+declare j jsonb;
+begin
+  j := public.aos_cia_verify_app_session_v1('synthetic-app-token-valid-000000000000000001');
+  if coalesce((j->>'ok')::boolean,false) is not true
+     or j->>'user_id' <> '00000000-0000-0000-0000-000000000002'
+     or j->>'rol' <> 'ASESOR' then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: valid current session rejected %',j;
+  end if;
+
+  j := public.aos_cia_verify_app_session_v1('synthetic-app-token-revoked-00000000000001');
+  if coalesce((j->>'ok')::boolean,true) is true then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: revoked session accepted %',j;
+  end if;
+
+  j := public.aos_cia_verify_app_session_v1('synthetic-app-token-expired-00000000000001');
+  if coalesce((j->>'ok')::boolean,true) is true then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: expired session accepted %',j;
+  end if;
+
+  j := public.aos_cia_verify_app_session_v1('wrong-token-that-is-long-enough-to-pass-length-only');
+  if coalesce((j->>'ok')::boolean,true) is true then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: invalid token accepted %',j;
+  end if;
+
+  if has_function_privilege('anon','public.aos_cia_verify_app_session_v1(text)','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_cia_verify_app_session_v1(text)','EXECUTE') then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: app-session verifier leaked to browser role';
+  end if;
+  if not has_function_privilege('service_role','public.aos_cia_verify_app_session_v1(text)','EXECUTE') then
+    raise exception 'F16_APP_SESSION_TEST_FAIL: service role cannot verify app sessions';
+  end if;
+end
+$test$;
+
+select 'CIA_PHASE16_APP_SESSION_VERIFIER=PASS' as result;

--- a/ci/phase16/test_phase16_contracts.sql
+++ b/ci/phase16/test_phase16_contracts.sql
@@ -1,0 +1,213 @@
+-- CIA F16 synthetic contract tests. Zero PII/PHI and zero provider calls.
+
+insert into public.aos_usuarios(id,nombre) values
+('00000000-0000-0000-0000-000000000001','Synthetic Admin')
+on conflict (id) do update set nombre=excluded.nombre;
+
+insert into public.aos_audiencia_activaciones(id,audiencia_id,audiencia_version_id) values
+('10000000-0000-0000-0000-000000000001','20000000-0000-0000-0000-000000000001','30000000-0000-0000-0000-000000000001'),
+('10000000-0000-0000-0000-000000000002','20000000-0000-0000-0000-000000000002','30000000-0000-0000-0000-000000000002'),
+('10000000-0000-0000-0000-000000000003','20000000-0000-0000-0000-000000000003','30000000-0000-0000-0000-000000000003');
+
+insert into public.aos_audiencia_activacion_config(activacion_id,nombre,purpose,channel,mode,baseline_count,created_by_user_id) values
+('10000000-0000-0000-0000-000000000001','Synthetic Email Active','MARKETING','EMAIL','BATCH',4,'00000000-0000-0000-0000-000000000001'),
+('10000000-0000-0000-0000-000000000002','Synthetic Email Draft','MARKETING','EMAIL','BATCH',1,'00000000-0000-0000-0000-000000000001'),
+('10000000-0000-0000-0000-000000000003','Synthetic SMS Active','MARKETING','SMS','BATCH',1,'00000000-0000-0000-0000-000000000001');
+
+insert into public.aos_audiencia_activacion_estado(activacion_id,estado,updated_by_user_id,started_at) values
+('10000000-0000-0000-0000-000000000001','ACTIVE','00000000-0000-0000-0000-000000000001',now()),
+('10000000-0000-0000-0000-000000000002','DRAFT','00000000-0000-0000-0000-000000000001',null),
+('10000000-0000-0000-0000-000000000003','ACTIVE','00000000-0000-0000-0000-000000000001',now());
+
+insert into public.aos_cia_activation_members_fixture(activation_id,contact_key) values
+('10000000-0000-0000-0000-000000000001','synthetic-contact-1'),
+('10000000-0000-0000-0000-000000000001','synthetic-contact-2'),
+('10000000-0000-0000-0000-000000000001','synthetic-contact-3'),
+('10000000-0000-0000-0000-000000000001','synthetic-contact-4'),
+('10000000-0000-0000-0000-000000000002','synthetic-contact-1'),
+('10000000-0000-0000-0000-000000000003','synthetic-contact-1');
+
+insert into public.aos_cia_audience_source_v1_1(contact_key,identity_conflict,canonical_email,email_valid,email_bounced_count,facts_observed_at,email_last_event_at) values
+('synthetic-contact-1',false,'alpha@example.test',true,0,now(),null),
+('synthetic-contact-2',false,'bounce@example.test',true,1,now(),now()),
+('synthetic-contact-3',true,'conflict@example.test',true,0,now(),null),
+('synthetic-contact-4',false,null,false,0,now(),null);
+
+do $test$
+declare
+  j jsonb;
+begin
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','synthetic-contact-1','MARKETING');
+  if j->>'eligibility_status' <> 'UNKNOWN' or j->>'reason_code' <> 'MARKETING_CONSENT_UNKNOWN' or (j->>'send_allowed')::boolean then
+    raise exception 'F16_TEST_FAIL: missing marketing consent must fail closed: %',j;
+  end if;
+
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000003','synthetic-contact-1','MARKETING');
+  if j->>'eligibility_status' <> 'BLOCKED' or j->>'reason_code' <> 'CHANNEL_NOT_EMAIL' then
+    raise exception 'F16_TEST_FAIL: non-email activation must block: %',j;
+  end if;
+
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','not-a-member','MARKETING');
+  if j->>'reason_code' <> 'NOT_ACTIVATION_MEMBER' then
+    raise exception 'F16_TEST_FAIL: non-member must block: %',j;
+  end if;
+
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','synthetic-contact-2','MARKETING');
+  if j->>'eligibility_status' <> 'UNKNOWN' or j->>'reason_code' <> 'BOUNCE_REVIEW_REQUIRED' then
+    raise exception 'F16_TEST_FAIL: bounce history must fail closed: %',j;
+  end if;
+
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','synthetic-contact-3','MARKETING');
+  if j->>'eligibility_status' <> 'BLOCKED' or j->>'reason_code' <> 'IDENTITY_CONFLICT' then
+    raise exception 'F16_TEST_FAIL: identity conflict must block: %',j;
+  end if;
+
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','synthetic-contact-4','MARKETING');
+  if j->>'eligibility_status' <> 'BLOCKED' or j->>'reason_code' <> 'EMAIL_MISSING' then
+    raise exception 'F16_TEST_FAIL: missing email must block: %',j;
+  end if;
+end
+$test$;
+
+insert into public.aos_cia_email_recipient_controls(contact_key,marketing_consent,global_suppressed,source,source_updated_at,updated_by_user_id)
+values('synthetic-contact-1','ALLOWED',false,'SYNTHETIC_FIXTURE',now(),'00000000-0000-0000-0000-000000000001');
+
+do $test$
+declare j jsonb;
+begin
+  j := public.aos_cia_email_eligibility_v1('10000000-0000-0000-0000-000000000001','synthetic-contact-1','MARKETING');
+  if j->>'eligibility_status' <> 'ELIGIBLE' or j->>'consent_status' <> 'ALLOWED' or (j->>'send_allowed')::boolean then
+    raise exception 'F16_TEST_FAIL: allowed marketing preview wrong: %',j;
+  end if;
+  if (select count(*) from public.aos_cia_email_recipient_control_events where contact_key='synthetic-contact-1' and event_type='CREATED') <> 1 then
+    raise exception 'F16_TEST_FAIL: control audit event missing';
+  end if;
+end
+$test$;
+
+do $test$
+declare
+  j jsonb;
+  v_tpl uuid;
+  v_req uuid;
+  v_req2 uuid;
+begin
+  j := public.aos_cia_email_template_version_create_v1(
+    '00000000-0000-0000-0000-000000000001','synthetic.marketing.welcome','MARKETING',
+    'Synthetic subject {{name}}','<p>Synthetic {{name}}</p>',array['name'],null
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true or j->>'state' <> 'SHADOW' then
+    raise exception 'F16_TEST_FAIL: template create failed: %',j;
+  end if;
+  v_tpl := (j->>'template_version_id')::uuid;
+
+  j := public.aos_cia_email_template_version_activate_v1('00000000-0000-0000-0000-000000000001',v_tpl);
+  if j->>'state' <> 'ACTIVE' then raise exception 'F16_TEST_FAIL: template activate failed: %',j; end if;
+
+  j := public.aos_cia_email_prepare_request_v1(
+    '00000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000002','synthetic-contact-1',v_tpl
+  );
+  if coalesce((j->>'ok')::boolean,false) or j->>'error' <> 'ACTIVATION_NOT_ACTIVE' then
+    raise exception 'F16_TEST_FAIL: draft activation prepared request: %',j;
+  end if;
+
+  j := public.aos_cia_email_prepare_request_v1(
+    '00000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','synthetic-contact-1',v_tpl
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true or j->>'state' <> 'PREPARED' or (j->>'send_performed')::boolean then
+    raise exception 'F16_TEST_FAIL: prepare request failed: %',j;
+  end if;
+  v_req := (j->>'request_id')::uuid;
+
+  j := public.aos_cia_email_prepare_request_v1(
+    '00000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','synthetic-contact-1',v_tpl
+  );
+  v_req2 := (j->>'request_id')::uuid;
+  if v_req2 <> v_req or coalesce((j->>'idempotent')::boolean,false) is not true then
+    raise exception 'F16_TEST_FAIL: idempotency failed: %',j;
+  end if;
+
+  if (select count(*) from public.aos_cia_email_send_requests) <> 1 then
+    raise exception 'F16_TEST_FAIL: duplicate request persisted';
+  end if;
+  if (select count(*) from public.aos_cia_email_send_events where request_id=v_req and event_type='PREPARED') <> 1 then
+    raise exception 'F16_TEST_FAIL: prepared audit event count wrong';
+  end if;
+end
+$test$;
+
+do $test$
+declare j jsonb;
+begin
+  j := public.aos_cia_email_admin_gateway_v1('wrong-token','READINESS','{}'::jsonb);
+  if j->>'error' <> 'UNAUTHORIZED' then raise exception 'F16_TEST_FAIL: invalid admin token not blocked: %',j; end if;
+
+  j := public.aos_cia_email_admin_gateway_v1('synthetic-admin-token','PREVIEW',jsonb_build_object(
+    'activation_id','10000000-0000-0000-0000-000000000001','purpose','MARKETING','limit',10,'offset',0
+  ));
+  if coalesce((j->>'ok')::boolean,false) is not true or (j->>'send_allowed')::boolean then
+    raise exception 'F16_TEST_FAIL: gateway preview must be non-sending: %',j;
+  end if;
+
+  j := public.aos_cia_email_admin_gateway_v1('synthetic-admin-token','READINESS','{}'::jsonb);
+  if coalesce((j->>'ok')::boolean,false) is not true or coalesce((j->>'ready_for_f17')::boolean,true) is true or coalesce((j->>'delivery_enabled')::boolean,true) is true then
+    raise exception 'F16_TEST_FAIL: interim readiness semantics wrong: %',j;
+  end if;
+end
+$test$;
+
+do $test$
+begin
+  if has_table_privilege('anon','public.aos_cia_email_send_requests','SELECT')
+     or has_table_privilege('anon','public.aos_cia_email_send_requests','INSERT')
+     or has_table_privilege('authenticated','public.aos_cia_email_send_requests','SELECT')
+     or has_table_privilege('authenticated','public.aos_cia_email_send_requests','INSERT') then
+    raise exception 'F16_TEST_FAIL: direct request table privilege leaked';
+  end if;
+  if has_table_privilege('anon','public.aos_cia_email_recipient_controls','SELECT')
+     or has_table_privilege('authenticated','public.aos_cia_email_recipient_controls','SELECT') then
+    raise exception 'F16_TEST_FAIL: direct control table privilege leaked';
+  end if;
+  if not has_function_privilege('anon','public.aos_cia_email_admin_gateway_v1(text,text,jsonb)','EXECUTE') then
+    raise exception 'F16_TEST_FAIL: governed browser gateway not executable';
+  end if;
+  if has_function_privilege('anon','public.aos_cia_email_prepare_request_v1(uuid,uuid,text,uuid)','EXECUTE') then
+    raise exception 'F16_TEST_FAIL: internal prepare function exposed';
+  end if;
+end
+$test$;
+
+do $test$
+declare v_id uuid;
+begin
+  select id into v_id from public.aos_cia_email_send_requests limit 1;
+  begin
+    update public.aos_cia_email_send_requests set state='DELIVERED' where id=v_id;
+    raise exception 'F16_TEST_FAIL: illegal transition unexpectedly accepted';
+  exception when others then
+    if sqlerrm like 'F16_TEST_FAIL:%' then raise; end if;
+    if sqlerrm not like 'EMAIL_SEND_REQUEST_INVALID_TRANSITION:%' then raise; end if;
+  end;
+
+  begin
+    update public.aos_cia_email_send_requests set contact_key='mutated-contact' where id=v_id;
+    raise exception 'F16_TEST_FAIL: immutable request identity unexpectedly changed';
+  exception when others then
+    if sqlerrm like 'F16_TEST_FAIL:%' then raise; end if;
+    if sqlerrm <> 'EMAIL_SEND_REQUEST_IDENTITY_IMMUTABLE' then raise; end if;
+  end;
+
+  begin
+    update public.aos_cia_email_send_events set event_type='MUTATED' where request_id=v_id;
+    raise exception 'F16_TEST_FAIL: append-only event unexpectedly changed';
+  exception when others then
+    if sqlerrm like 'F16_TEST_FAIL:%' then raise; end if;
+    if sqlerrm <> 'EMAIL_AUDIT_APPEND_ONLY' then raise; end if;
+  end;
+end
+$test$;
+
+select 'CIA_PHASE16_CONTRACTS=PASS' as result;
+select 'SYNTHETIC_ONLY=PASS' as fixture_policy;
+select 'PROVIDER_CALLS=0' as provider_policy;
+select 'DELIVERY_ENABLED=false' as delivery_policy;

--- a/ci/phase16/test_phase16_delivery_contracts.sql
+++ b/ci/phase16/test_phase16_delivery_contracts.sql
@@ -1,0 +1,171 @@
+-- CIA F16 delivery/provider synthetic tests. Zero PII/PHI and zero provider network calls.
+
+do $test$
+declare
+  j jsonb;
+  v_tpl uuid;
+  v_req uuid;
+  v_req2 uuid;
+begin
+  j := public.aos_cia_email_template_version_create_v1(
+    '00000000-0000-0000-0000-000000000001','synthetic.marketing.delivery','MARKETING',
+    'Hello {{name}}','<p>Hello {{name}}</p>',array['name'],null
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'F16_DELIVERY_TEST_FAIL: template create %',j; end if;
+  v_tpl := (j->>'template_version_id')::uuid;
+  j := public.aos_cia_email_template_version_activate_v1('00000000-0000-0000-0000-000000000001',v_tpl);
+  if j->>'state' <> 'ACTIVE' then raise exception 'F16_DELIVERY_TEST_FAIL: template activate %',j; end if;
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'synthetic-contact-1',v_tpl,jsonb_build_object('name','Synthetic Recipient')
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true or j->>'state' <> 'PREPARED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: prepare v2 %',j;
+  end if;
+  v_req := (j->>'request_id')::uuid;
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'synthetic-contact-1',v_tpl,jsonb_build_object('name','Synthetic Recipient')
+  );
+  v_req2 := (j->>'request_id')::uuid;
+  if v_req2 <> v_req or coalesce((j->>'idempotent')::boolean,false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: prepare idempotency %',j;
+  end if;
+
+  j := public.aos_cia_email_queue_request_v2('00000000-0000-0000-0000-000000000001',v_req);
+  if coalesce((j->>'ok')::boolean,false) is not true or j->>'state' <> 'QUEUED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: queue %',j;
+  end if;
+
+  j := public.aos_cia_email_queue_request_v2('00000000-0000-0000-0000-000000000001',v_req);
+  if coalesce((j->>'ok')::boolean,false) is not true or coalesce((j->>'idempotent')::boolean,false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: queue idempotency %',j;
+  end if;
+
+  j := public.aos_cia_email_claim_dispatch_v2(v_req);
+  if coalesce((j->>'ok')::boolean,false) is not true or coalesce((j->>'send_allowed')::boolean,false) is not true
+     or j->>'state' <> 'DISPATCHING' or j->>'recipient_email' <> 'alpha@example.test' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: dispatch claim %',j;
+  end if;
+  if j->'render_context'->>'name' <> 'Synthetic Recipient' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: immutable render context missing %',j;
+  end if;
+
+  j := public.aos_cia_email_claim_dispatch_v2(v_req);
+  if coalesce((j->>'send_allowed')::boolean,true) is true or coalesce((j->>'in_progress')::boolean,false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: duplicate concurrent claim %',j;
+  end if;
+
+  j := public.aos_cia_email_record_dispatch_result_v2(
+    v_req,true,'RESEND','synthetic-provider-message-001',null,jsonb_build_object('synthetic',true)
+  );
+  if j->>'state' <> 'ACCEPTED' then raise exception 'F16_DELIVERY_TEST_FAIL: provider accept %',j; end if;
+
+  j := public.aos_cia_email_record_dispatch_result_v2(
+    v_req,true,'RESEND','synthetic-provider-message-001',null,jsonb_build_object('synthetic',true)
+  );
+  if coalesce((j->>'idempotent')::boolean,false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: provider accept idempotency %',j;
+  end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-delivered-001','synthetic-provider-message-001','email.delivered',now(),jsonb_build_object('synthetic',true)
+  );
+  if j->>'state' <> 'DELIVERED' then raise exception 'F16_DELIVERY_TEST_FAIL: delivered event %',j; end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-delivered-001','synthetic-provider-message-001','email.delivered',now(),jsonb_build_object('synthetic',true)
+  );
+  if coalesce((j->>'idempotent')::boolean,false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: webhook replay dedup %',j;
+  end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-complaint-001','synthetic-provider-message-001','email.complained',now(),jsonb_build_object('synthetic',true)
+  );
+  if j->>'state' <> 'COMPLAINED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: post-delivery complaint transition %',j;
+  end if;
+end
+$test$;
+
+do $test$
+declare
+  j jsonb;
+  v_tpl uuid;
+  v_req uuid;
+begin
+  j := public.aos_cia_email_template_version_create_v1(
+    '00000000-0000-0000-0000-000000000001','synthetic.marketing.suppression-recheck','MARKETING',
+    'Suppression test','<p>Suppression test</p>',array[]::text[],null
+  );
+  v_tpl := (j->>'template_version_id')::uuid;
+  perform public.aos_cia_email_template_version_activate_v1('00000000-0000-0000-0000-000000000001',v_tpl);
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','synthetic-contact-1',v_tpl,'{}'::jsonb
+  );
+  v_req := (j->>'request_id')::uuid;
+  if v_req is null then raise exception 'F16_DELIVERY_TEST_FAIL: suppression request prepare %',j; end if;
+
+  update public.aos_cia_email_recipient_controls
+     set global_suppressed=true,suppression_reason='SYNTHETIC_TEST',updated_by_user_id='00000000-0000-0000-0000-000000000001'
+   where contact_key='synthetic-contact-1';
+
+  j := public.aos_cia_email_queue_request_v2('00000000-0000-0000-0000-000000000001',v_req);
+  if coalesce((j->>'ok')::boolean,true) is true or j->>'state' <> 'CANCELLED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: suppression was not rechecked at queue %',j;
+  end if;
+
+  update public.aos_cia_email_recipient_controls
+     set global_suppressed=false,suppression_reason=null,updated_by_user_id='00000000-0000-0000-0000-000000000001'
+   where contact_key='synthetic-contact-1';
+end
+$test$;
+
+do $test$
+declare j jsonb;
+begin
+  j := public.aos_cia_email_admin_gateway_v2('wrong-token','READINESS','{}'::jsonb);
+  if j->>'error' <> 'UNAUTHORIZED' then raise exception 'F16_DELIVERY_TEST_FAIL: gateway v2 invalid token %',j; end if;
+
+  j := public.aos_cia_email_admin_gateway_v2('synthetic-admin-token','READINESS','{}'::jsonb);
+  if coalesce((j->>'ok')::boolean,false) is not true or coalesce((j->>'ready_for_f17')::boolean,true) is true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: readiness must remain false before production gates %',j;
+  end if;
+  if coalesce((j->'release_gates'->>'canary_passed')::boolean,true) is true
+     or coalesce((j->'release_gates'->>'rollback_verified')::boolean,true) is true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: production evidence gates defaulted open %',j;
+  end if;
+end
+$test$;
+
+do $test$
+begin
+  if not has_function_privilege('anon','public.aos_cia_email_admin_gateway_v2(text,text,jsonb)','EXECUTE') then
+    raise exception 'F16_DELIVERY_TEST_FAIL: browser gateway v2 missing';
+  end if;
+  if has_function_privilege('anon','public.aos_cia_email_claim_dispatch_v2(uuid)','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_cia_email_claim_dispatch_v2(uuid)','EXECUTE') then
+    raise exception 'F16_DELIVERY_TEST_FAIL: internal dispatch claim leaked';
+  end if;
+  if has_function_privilege('anon','public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb)','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb)','EXECUTE') then
+    raise exception 'F16_DELIVERY_TEST_FAIL: provider event ingestion leaked';
+  end if;
+  if has_function_privilege('anon','public.aos_cia_email_release_mark_v1(text,boolean,text)','EXECUTE') then
+    raise exception 'F16_DELIVERY_TEST_FAIL: release evidence mutator leaked';
+  end if;
+  if has_table_privilege('anon','public.aos_cia_email_release_state','SELECT')
+     or has_table_privilege('authenticated','public.aos_cia_email_release_state','SELECT') then
+    raise exception 'F16_DELIVERY_TEST_FAIL: release state table leaked';
+  end if;
+end
+$test$;
+
+select 'CIA_PHASE16_DELIVERY_CONTRACTS=PASS' as result;
+select 'PROVIDER_NETWORK_CALLS=0' as provider_policy;
+select 'F17_READINESS_DEFAULT=false' as readiness_policy;

--- a/ci/phase16/test_phase16_legacy_acl.sql
+++ b/ci/phase16/test_phase16_legacy_acl.sql
@@ -1,0 +1,49 @@
+-- F16 synthetic legacy Email ACL closure tests.
+
+do $test$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'aos_email_alertas','aos_email_audiencias','aos_email_cadencia','aos_email_campanias','aos_email_envios',
+    'aos_email_eventos','aos_email_flujo_ejecuciones','aos_email_flujos','aos_email_plantillas',
+    'aos_emails_empresa','aos_emails_enviados'
+  ] loop
+    if not (select c.relrowsecurity from pg_class c join pg_namespace n on n.oid=c.relnamespace where n.nspname='public' and c.relname=t) then
+      raise exception 'F16_LEGACY_ACL_TEST_FAIL: RLS disabled on %',t;
+    end if;
+    if has_table_privilege('anon',format('public.%I',t),'SELECT')
+       or has_table_privilege('anon',format('public.%I',t),'INSERT')
+       or has_table_privilege('anon',format('public.%I',t),'UPDATE')
+       or has_table_privilege('anon',format('public.%I',t),'DELETE')
+       or has_table_privilege('authenticated',format('public.%I',t),'SELECT')
+       or has_table_privilege('authenticated',format('public.%I',t),'INSERT')
+       or has_table_privilege('authenticated',format('public.%I',t),'UPDATE')
+       or has_table_privilege('authenticated',format('public.%I',t),'DELETE') then
+      raise exception 'F16_LEGACY_ACL_TEST_FAIL: browser privilege remains on %',t;
+    end if;
+    if not has_table_privilege('service_role',format('public.%I',t),'SELECT')
+       or not has_table_privilege('service_role',format('public.%I',t),'INSERT')
+       or not has_table_privilege('service_role',format('public.%I',t),'UPDATE') then
+      raise exception 'F16_LEGACY_ACL_TEST_FAIL: service role compatibility missing on %',t;
+    end if;
+  end loop;
+
+  if has_function_privilege('anon','public.aos_email_buscar_paciente(text,integer)','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_email_buscar_paciente(text,integer)','EXECUTE')
+     or has_function_privilege('anon','public.aos_email_dashboard()','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_email_dashboard()','EXECUTE')
+     or has_function_privilege('anon','public.aos_email_historial_paciente(text)','EXECUTE')
+     or has_function_privilege('authenticated','public.aos_email_historial_paciente(text)','EXECUTE') then
+    raise exception 'F16_LEGACY_ACL_TEST_FAIL: legacy RPC browser execute remains';
+  end if;
+
+  if not has_function_privilege('service_role','public.aos_email_buscar_paciente(text,integer)','EXECUTE')
+     or not has_function_privilege('service_role','public.aos_email_dashboard()','EXECUTE')
+     or not has_function_privilege('service_role','public.aos_email_historial_paciente(text)','EXECUTE') then
+    raise exception 'F16_LEGACY_ACL_TEST_FAIL: service role RPC compatibility missing';
+  end if;
+end
+$test$;
+
+select 'CIA_PHASE16_LEGACY_EMAIL_ACL=PASS' as result;

--- a/ci/phase16/test_phase16_render_context_hardening.sql
+++ b/ci/phase16/test_phase16_render_context_hardening.sql
@@ -1,0 +1,49 @@
+-- F16 synthetic render-context hardening regression tests.
+
+do $test$
+declare
+  j jsonb;
+  v_tpl uuid;
+  v_req uuid;
+begin
+  j := public.aos_cia_email_template_version_create_v1(
+    '00000000-0000-0000-0000-000000000001','synthetic.render.required','MARKETING',
+    'Hello {{name}}','<p>Hello {{name}} — {{code}}</p>',array['name','code'],null
+  );
+  v_tpl := (j->>'template_version_id')::uuid;
+  perform public.aos_cia_email_template_version_activate_v1('00000000-0000-0000-0000-000000000001',v_tpl);
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'synthetic-contact-1',v_tpl,jsonb_build_object('name','Synthetic')
+  );
+  if j->>'error' <> 'RENDER_CONTEXT_MISSING' or coalesce((j->>'send_performed')::boolean,true) is true then
+    raise exception 'F16_RENDER_CONTEXT_TEST_FAIL: missing variable did not fail closed %',j;
+  end if;
+  if exists(select 1 from public.aos_cia_email_send_requests where template_version_id=v_tpl) then
+    raise exception 'F16_RENDER_CONTEXT_TEST_FAIL: malformed immutable request was persisted';
+  end if;
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'synthetic-contact-1',v_tpl,jsonb_build_object('name','Synthetic','code','A1')
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true then
+    raise exception 'F16_RENDER_CONTEXT_TEST_FAIL: complete context rejected %',j;
+  end if;
+  v_req := (j->>'request_id')::uuid;
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'synthetic-contact-1',v_tpl,jsonb_build_object('name','Synthetic','code','DIFFERENT')
+  );
+  if j->>'error' <> 'IDEMPOTENCY_CONTEXT_MISMATCH' or (j->>'request_id')::uuid <> v_req then
+    raise exception 'F16_RENDER_CONTEXT_TEST_FAIL: context mismatch did not fail closed %',j;
+  end if;
+end
+$test$;
+
+select 'CIA_PHASE16_RENDER_CONTEXT_HARDENING=PASS' as result;

--- a/docs/control/commercial-intelligence/PHASE_16_IMPACT_REPORT_20260814.md
+++ b/docs/control/commercial-intelligence/PHASE_16_IMPACT_REPORT_20260814.md
@@ -1,0 +1,392 @@
+# ASCENDA OS — CIA V3 FASE 16 IMPACT REPORT
+
+**Fase:** F16 — Email Integration  
+**Estado:** `IN_PROGRESS / BASELINE + CRITICAL SECURITY PREFLIGHT`  
+**Fecha:** 2026-08-14 (America/Lima)  
+**Branch:** `feature/cia-phase16-email-integration-20260814`  
+**Baseline GitHub staging:** `f0a087bd957dc19a81b5f8a0144b0bbc6a901549`  
+**Supabase producción:** `ituyqwstonmhnfshnaqz`  
+**Riesgo:** **CRITICAL** — delivery externo + secretos/provider + autorización + PII + ACL/RLS + webhook + legacy automation.  
+**CI obligatorio:** ASCENDA Zero-Cost CI V2 (`self-hosted`, `Linux`, `X64`, `ascenda-zero-cost-v2`).
+
+---
+
+## 1. Objetivo
+
+Integrar Email como primer **channel adapter gobernado** sobre Audience/Activation central, sin crear un Audience Engine paralelo, sin enviar desde F15 preview y sin romper el email legacy durante la transición.
+
+Contrato objetivo:
+
+`Audience/Activation → Email Eligibility/Preview → immutable Send Request → Queue/Dispatch → Provider Adapter → Delivery Outcome → Attribution/Audit`
+
+Separaciones obligatorias:
+
+- Audience ≠ Email eligibility.
+- Email eligibility ≠ consent.
+- Preview ≠ send permission.
+- Send request ≠ provider delivery.
+- Provider accepted ≠ delivered.
+- Recommendation/Agent interpretation ≠ authority.
+- Transactional/Auth email ≠ marketing email.
+
+---
+
+## 2. Bootstrap / recovery verificado
+
+Antes de escribir se verificó:
+
+- `AGENTS.md` CURRENT desde `infra/zero-cost-ci-v2`;
+- `SECURITY.md` CURRENT desde `infra/zero-cost-ci-v2`;
+- `docs/control/ASCENDA_CONTROL_MASTER.md`;
+- `docs/control/ASCENDA_ZERO_COST_VALIDATION_STANDARD.md` CURRENT/V2;
+- `docs/control/ASCENDA_ZERO_COST_CI_V2_HANDOFF.md` CURRENT;
+- CIA `CIA_AGENT_BOOTSTRAP_CURRENT.md`, `CIA_MASTER_ALIGNMENT_CURRENT.md`, `ROADMAP_STATUS.md` desde `staging`;
+- `staging` live = `f0a087bd957dc19a81b5f8a0144b0bbc6a901549`;
+- F15→F16 Supabase live = `READY_GOVERNED_ORCHESTRATION`, `ready_for_f16=true`;
+- PR infra #97 continúa OPEN sobre SHA `5b38155cf116b3de512b78f0059ba73b0dd17f93`, con jobs Zero-Cost queued/pending y sin fallback facturable.
+
+**Regla:** no mover el HEAD de PR #97 desde este workstream. F16 puede desarrollar en branch aislada, pero su gate final de GitHub deberá ejecutarse con Zero-Cost CI V2 y SHA exacto antes de release.
+
+---
+
+## 3. Runtime productivo Email identificado
+
+### Frontend
+
+`app/public/admin-email.html`
+
+Estado observado:
+
+- panel operativo de Email Marketing;
+- dashboard, bandeja, flujos, plantillas y campaña;
+- consulta Supabase desde browser mediante clave pública/anon;
+- usa RPC legacy `aos_email_buscar_paciente`, `aos_email_historial_paciente`, `aos_email_dashboard`;
+- lectura directa de tablas Email desde browser;
+- envío manual mediante `/api/send-email`.
+
+### Backend
+
+`app/server.js`
+
+Superficies Email encontradas:
+
+- `/api/send-email`;
+- `/api/send-template`;
+- `/api/send-2fa`;
+- `/api/resend-webhook`;
+- endpoints/stats Resend;
+- motor CARTERO / agentes para recordatorio, recibo, seguimiento, reactivación, cumpleaños, saldos, no-asistencia, reposición, predicciones y flujos multi-paso;
+- retry de fallidos;
+- provider Resend;
+- persistencia en tablas `aos_email_*` / `aos_emails_*`.
+
+### Incidente legacy ya corregido y preservado
+
+`EMAIL_FLOW_NULL_LEAK_20260812.md` documenta el bug histórico donde PATCH se ejecutaba como POST y se perdía el query string. El runtime actual filtra `flujo_id=not.is.null`; Supabase live confirma:
+
+- active null flow = 0;
+- active valid flow = 337;
+- historial cancelado/null conservado = 13,617.
+
+F16 no debe reintroducir ese bug ni borrar evidencia histórica.
+
+---
+
+## 4. Baseline Supabase Email — read-only
+
+Objetos legacy identificados: **11 tablas**.
+
+| Objeto | Filas live | RLS |
+|---|---:|---|
+| `aos_email_alertas` | 2,356 | OFF |
+| `aos_email_audiencias` | 0 | OFF |
+| `aos_email_cadencia` | 1,809 | OFF |
+| `aos_email_campanias` | 0 | OFF |
+| `aos_email_envios` | 19 | OFF |
+| `aos_email_eventos` | 1,023 | OFF |
+| `aos_email_flujo_ejecuciones` | 13,954 | OFF |
+| `aos_email_flujos` | 5 | OFF |
+| `aos_email_plantillas` | 29 | OFF |
+| `aos_emails_empresa` | 1 | OFF |
+| `aos_emails_enviados` | 1,953 | OFF |
+
+Estados observados:
+
+- `aos_email_envios`: 17 `enviado`, 2 `error`;
+- `aos_email_flujo_ejecuciones`: 337 `activo`, 13,617 `cancelado`.
+
+No se extrajo ni persistió PII/PHI en documentación o CI.
+
+CIA ya posee contratos previos relevantes:
+
+- `aos_cia_email_adapter_v2`;
+- `aos_cia_email_facts_v1`;
+- `aos_cia_email_runtime_cache_v2` (RLS ON, ~11.5k rows);
+- Audience/Profile adapters con `email_valid` y bounce facts.
+
+F16 debe consumir estos contratos en vez de duplicarlos.
+
+---
+
+## 5. Hallazgos CRITICAL / HIGH de preflight
+
+### F16-C01 — ACL legacy Email excesivamente abierta — CRITICAL
+
+Las 11 tablas Email legacy tienen RLS OFF y `anon` + `authenticated` conservan privilegios amplios de tabla, incluyendo SELECT/INSERT/UPDATE/DELETE y privilegios adicionales.
+
+Impacto:
+
+- browser/cliente no confiable puede alcanzar superficie Email directamente según grants actuales;
+- contiene destinatarios, historial de envíos, templates, flujos y eventos;
+- cerrar grants sin migration progresiva rompería el panel y workers legacy que todavía consumen ese contrato.
+
+**Tratamiento:** migration progresiva, gateway/RPC server-authoritative, consumer matrix y canary antes de REVOKE final. No hacer big-bang.
+
+### F16-C02 — Endpoints de envío no demuestran autorización server-side — CRITICAL
+
+Los endpoints de envío Email observados aceptan POST y configuran CORS permisivo. En el bloque observado no existe un gate de sesión/rol previo equivalente al CIA ADMIN gateway.
+
+**Tratamiento:** separar endpoint público/browser de provider dispatch; exigir identidad/sesión server-authoritative y scope ADMIN/servicio interno. Negative auth obligatorio en Zero-Cost Staging.
+
+### F16-C03 — Provider credential con fallback hardcodeado en runtime — CRITICAL
+
+`app/server.js` contiene fallback literal para credencial del provider cuando falta la variable de entorno. El valor NO se reproduce en este documento.
+
+Consecuencias:
+
+- remover el literal del HEAD no basta si el secreto fue válido/expuesto en historial;
+- requiere rotación controlada del secreto del provider;
+- afecta también rutas transaccionales/Auth que comparten provider, por lo que no se cambia de forma aislada ni se rompe 2FA.
+
+**Tratamiento:** secret rotation + environment-only + smoke Auth/2FA + Email. La rotación/cutover productivo requiere autorización explícita.
+
+### F16-C04 — Webhook provider sin evidencia de verificación criptográfica — CRITICAL
+
+El handler `/api/resend-webhook` procesa payload del provider; en el baseline no se encontró integración de firma tipo Svix/webhook secret.
+
+**Tratamiento:** firma obligatoria + replay window/idempotency + rejection de payload forged en Zero-Cost tests antes de confiar eventos de delivered/open/click/bounce.
+
+### F16-H01 — Browser consulta datos Email/PII directamente — HIGH
+
+`admin-email.html` usa acceso Supabase desde browser para RPC y lectura directa. El panel debe migrar progresivamente a un gateway ADMIN gobernado.
+
+### F16-H02 — Consent/suppression marketing no tiene fuente autoritativa explícita — HIGH
+
+Se observan facts de `email_valid` y bounce, pero no se detectó una fuente canónica de opt-in marketing/unsubscribe/suppression en el dominio Email. `consentimiento_general` clínico no debe reinterpretarse automáticamente como consentimiento comercial.
+
+**Regla fail-closed:** ausencia de consentimiento comercial autoritativo = `UNKNOWN`, nunca TRUE.
+
+### F16-H03 — Delivery está acoplado a múltiples caminos legacy — HIGH
+
+Manual send, templates, CARTERO, flows y retries pueden enviar. F16 debe evitar múltiples productores de envío sin idempotency global.
+
+---
+
+## 6. Scope F16
+
+### Dentro de F16
+
+1. contrato canónico Email sobre Audience/Activation;
+2. propósito de mensaje `TRANSACTIONAL | AUTH | MARKETING | OPERATIONAL` separado;
+3. eligibility/preview/freshness;
+4. template/campaign versioning;
+5. send request inmutable + idempotency key;
+6. queue/dispatch separada de provider outcome;
+7. provider adapter Resend desacoplado del Audience Engine;
+8. webhook verification + event idempotency;
+9. bounce/suppression/unsubscribe semantics;
+10. ADMIN gateway server-authoritative;
+11. migration progresiva de ACL legacy;
+12. audit end-to-end;
+13. legacy fallback/canary;
+14. output reusable F17.
+
+### Fuera de scope / coordinado
+
+- no rediseñar toda Auth/2FA dentro de F16;
+- no cerrar KronIA V2 K0–K8;
+- no migrar todos los providers futuros;
+- no usar clinical history/photos/diagnoses/notes como features comerciales;
+- no crear una nueva Audience DB paralela;
+- no borrar historial Email legacy;
+- no rotar secretos productivos sin gate/autorización.
+
+---
+
+## 7. Arquitectura objetivo incremental
+
+### Plane A — Read/Preview
+
+`Audience/Activation + CIA Email facts → aos_cia_email_eligibility_v1 → Preview`
+
+Output mínimo:
+
+- contact identity estable;
+- email normalizado;
+- email_valid;
+- bounced/suppressed status;
+- consent status `ALLOWED | BLOCKED | UNKNOWN` por propósito;
+- reason codes;
+- freshness;
+- audience/activation provenance;
+- `send_allowed=false` en preview.
+
+### Plane B — Send Request
+
+Nueva persistencia privada F16 con:
+
+- request_id UUID;
+- activation/audience provenance;
+- purpose;
+- recipient identity;
+- template_id + immutable template_version/digest;
+- idempotency_key UNIQUE;
+- state machine;
+- requested_by + authorization provenance;
+- scheduled_at;
+- created_at.
+
+No guardar secretos.
+
+### Plane C — Dispatch / Provider
+
+Solo backend autorizado puede pasar `QUEUED → DISPATCHING` y llamar provider.
+
+- retry controlado;
+- no duplicar send si provider accepted/idempotency ya existe;
+- provider response separada del estado final de delivery;
+- rate/error boundaries.
+
+### Plane D — Outcomes
+
+Webhook verificado produce eventos append-only e idempotentes:
+
+`ACCEPTED | DELIVERED | BOUNCED | COMPLAINED | OPENED | CLICKED | FAILED` según señal real disponible.
+
+No tratar OPEN/CLICK como autoridad comercial; son observaciones.
+
+---
+
+## 8. Consumer matrix inicial
+
+| Consumidor | Estado | Acción F16 |
+|---|---|---|
+| `admin-email.html` | legacy productivo | adapter/gateway gradual |
+| `/api/send-email` | productivo | auth + request boundary |
+| `/api/send-template` | productivo | auth/purpose + request boundary |
+| `/api/send-2fa` | productivo/Auth | preservar; coordinar security/secret rotation |
+| `/api/resend-webhook` | productivo | firma + idempotency |
+| CARTERO agentes | productivo | adapter progresivo + idempotency |
+| multi-step flows | productivo | mantener 337 activos; adapter gradual |
+| retries | productivo | dedup/idempotency central |
+| CIA F15 preview | governed shadow | continúa non-sending |
+| F17 | futuro | consume contract reusable |
+
+---
+
+## 9. Plan Zero-Cost CI V2
+
+Fixtures **100% sintéticos**:
+
+- contactos ficticios;
+- emails `example.test` / dominios reservados;
+- provider stub local; nunca provider real;
+- fake webhook signatures/fixtures de test;
+- sin service-role/prod secrets;
+- sin pacientes, teléfonos, DNI, emails reales o PHI.
+
+Gates mínimos:
+
+1. migration replay exacta;
+2. DB lint;
+3. positive/negative ACL/RLS;
+4. invalid/forged session blocked;
+5. send request idempotency;
+6. retry does not duplicate;
+7. UNKNOWN consent fails closed for MARKETING;
+8. AUTH/transactional policy separada;
+9. webhook valid signature accepted;
+10. forged/replayed webhook rejected;
+11. provider stub timeout/error/retry;
+12. legacy fallback contract;
+13. rollback/recovery;
+14. zero residue;
+15. no secret scan findings in changed scope;
+16. exact SHA certified on `ASCENDA-ZERO-COST-V2`.
+
+No `ubuntu-latest`, `windows-latest` ni `macos-*` como fallback.
+
+---
+
+## 10. Production read-only preflight obligatorio
+
+Antes del primer cutover:
+
+- revalidar RLS/grants live;
+- checksums de funciones/endpoints/migrations;
+- counts y states sin leer PII;
+- confirmar 337 flujos activos o nuevo valor live;
+- identificar runtime commit efectivamente desplegado;
+- comprobar provider config por presencia, nunca imprimir secreto;
+- verificar 2FA/Auth health sin mutación;
+- verificar F15→F16 readiness;
+- asegurar que el legacy path sigue disponible para rollback/canary.
+
+---
+
+## 11. Canary / cutover propuesto
+
+Orden de menor blast radius:
+
+1. shadow preview únicamente;
+2. ADMIN gateway read-only;
+3. un envío sintético/controlado del adapter fuera de pacientes reales si el provider permite sandbox/test;
+4. canary ADMIN de una operación Email explícitamente autorizada;
+5. mover un único path legacy al new dispatch adapter;
+6. observar outcomes/retry/idempotency;
+7. expandir por path, no big-bang;
+8. solo después revocar acceso directo legacy correspondiente.
+
+Cualquier envío productivo real o rotación de secreto requiere autorización explícita del propietario después del preflight.
+
+---
+
+## 12. Rollback / recovery
+
+- features/gate de F16 deben poder quedar OFF sin afectar legacy;
+- migrations iniciales serán additive/backward-compatible;
+- no DROP/TRUNCATE/DELETE de Email legacy;
+- no REVOKE final antes de gateway/canary;
+- adapter nuevo puede deshabilitarse y devolver tráfico al legacy durante transición;
+- webhook nuevo puede quedar shadow-log-only antes de authoritative processing;
+- secret rotation tendrá plan de rollback de configuración sin reintroducir secreto hardcodeado.
+
+---
+
+## 13. Gates de cierre F16
+
+F16 NO se declarará `100_COMPLETE` mientras alguno permanezca abierto:
+
+- [x] Recovery CURRENT + live state.
+- [x] F15→F16 readiness PASS.
+- [x] Baseline Email runtime + DB inventory.
+- [x] Impact Report CRITICAL.
+- [x] Branch aislada.
+- [ ] Contratos/migrations F16 implementados.
+- [ ] Consumer compatibility tests.
+- [ ] Zero-Cost Staging PASS en SHA final.
+- [ ] Security negatives PASS.
+- [ ] Secret/provider hardening coordinado.
+- [ ] Production read-only preflight final PASS.
+- [ ] Autorización explícita de cutover productivo.
+- [ ] Canary PASS.
+- [ ] Post-deploy smoke/reconciliation PASS.
+- [ ] Rollback/recovery verificado.
+- [ ] Output F17 readiness PASS.
+- [ ] GitHub / `aos_memory` / Notion reconciliados.
+
+---
+
+## 14. Próxima acción segura
+
+Implementar primero en esta branch el **read/preview + private send-request contracts** y los tests sintéticos/negative-auth correspondientes, sin activar delivery real ni cambiar ACL productiva. Mantener PR #97 congelado y permitir que su único runner procese la cola secuencialmente.

--- a/scripts/ci/expose-runner-node.sh
+++ b/scripts/ci/expose-runner-node.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Zero-Cost CI V2: expose the GitHub runner-bundled Node runtime to shell steps.
+# GitHub JavaScript actions can run even when `node` is not exported on PATH.
+# This script reuses trusted local runner binaries only: no package install,
+# no network download, no secret access, and no hosted-runner fallback.
+# F16 env-alias exact-head recertification marker; no runtime behavior change.
+
+if command -v node >/dev/null 2>&1; then
+  echo "ASCENDA_RUNNER_NODE=ALREADY_AVAILABLE"
+  node --version
+  exit 0
+fi
+
+: "${GITHUB_PATH:?GITHUB_PATH is required on GitHub Actions}"
+
+roots=("/home/ascenda-runner/actions-runner/actions-runner")
+if [[ -n "${RUNNER_TEMP:-}" ]]; then
+  roots+=("$(dirname "$(dirname "$RUNNER_TEMP")")")
+fi
+if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+  roots+=("$(dirname "$(dirname "$(dirname "$GITHUB_WORKSPACE")")")")
+fi
+
+node_bin=""
+for root in "${roots[@]}"; do
+  for candidate in \
+    "$root"/externals/node24/bin/node \
+    "$root"/externals/node20/bin/node \
+    "$root"/externals/node*/bin/node \
+    "$root"/bin/node; do
+    if [[ -e "$candidate" && -x "$candidate" ]]; then
+      node_bin="$candidate"
+      break 2
+    fi
+  done
+done
+
+if [[ -z "$node_bin" && -n "${RUNNER_TOOL_CACHE:-}" ]]; then
+  for candidate in "$RUNNER_TOOL_CACHE"/node/*/*/bin/node; do
+    if [[ -e "$candidate" && -x "$candidate" ]]; then
+      node_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$node_bin" ]]; then
+  echo "ASCENDA_RUNNER_NODE=FAIL bundled Node executable not found in trusted runner roots" >&2
+  exit 1
+fi
+
+node_dir="$(dirname "$node_bin")"
+printf '%s\n' "$node_dir" >> "$GITHUB_PATH"
+"$node_bin" --version
+echo "ASCENDA_RUNNER_NODE=PROVISIONED_LOCAL"

--- a/scripts/ci/f16_env_alias_patch.py
+++ b/scripts/ci/f16_env_alias_patch.py
@@ -2,25 +2,31 @@
 from pathlib import Path
 
 
-def replace_exact(path, old, new, label):
+def ensure_alias(path, old, new, label):
     p = Path(path)
     text = p.read_text(encoding='utf-8')
-    count = text.count(old)
-    if count != 1:
-        raise SystemExit(f'{label}: expected exactly 1 occurrence, found {count}')
-    p.write_text(text.replace(old, new, 1), encoding='utf-8')
+    old_count = text.count(old)
+    new_count = text.count(new)
+    if old_count == 1 and new_count == 0:
+        p.write_text(text.replace(old, new, 1), encoding='utf-8')
+        print(f'{label}=APPLIED')
+        return
+    if old_count == 0 and new_count == 1:
+        print(f'{label}=ALREADY_MATERIALIZED')
+        return
+    raise SystemExit(f'{label}: invalid state old={old_count} new={new_count}')
 
 
-replace_exact(
+ensure_alias(
     'app/server.js',
     "const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''",
     "const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''",
-    'server env alias',
+    'CIA_PHASE16_SERVER_ENV_ALIAS',
 )
-replace_exact(
+ensure_alias(
     'app/email-gateway.js',
     "var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || ''))",
     "var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))",
-    'gateway env alias',
+    'CIA_PHASE16_GATEWAY_ENV_ALIAS',
 )
 print('CIA_PHASE16_ENV_ALIAS_PATCH=PASS')

--- a/scripts/ci/f16_env_alias_patch.py
+++ b/scripts/ci/f16_env_alias_patch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+def replace_exact(path, old, new, label):
+    p = Path(path)
+    text = p.read_text(encoding='utf-8')
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'{label}: expected exactly 1 occurrence, found {count}')
+    p.write_text(text.replace(old, new, 1), encoding='utf-8')
+
+
+replace_exact(
+    'app/server.js',
+    "const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''",
+    "const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''",
+    'server env alias',
+)
+replace_exact(
+    'app/email-gateway.js',
+    "var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || ''))",
+    "var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))",
+    'gateway env alias',
+)
+print('CIA_PHASE16_ENV_ALIAS_PATCH=PASS')

--- a/scripts/ci/phase16_apply_runtime_patch.py
+++ b/scripts/ci/phase16_apply_runtime_patch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Execute the original runtime patch after replacing one over-broad local assertion.
+
+The historical assertion searched 1800 characters after the new governed /api/send-email
+route and could see unrelated wildcard-CORS endpoints, producing a false positive even
+after the permissive send-email block had been removed. This wrapper narrows the assertion
+for execution without weakening the actual workflow boundary tests.
+
+The Zero-Cost self-hosted runner executes JavaScript actions with its bundled Node runtime,
+but that binary is not necessarily exported on the shell PATH. F16 JavaScript syntax and
+unit gates require `node`, so this wrapper exposes the already-bundled runner binary to
+subsequent workflow steps through GITHUB_PATH. It never falls back to a paid runner and
+never downloads a toolchain from an ungoverned source.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PATCH = ROOT / "scripts/ci/phase16_patch_runtime.py"
+
+OLD = '''    if "Access-Control-Allow-Origin', '*'" in text and "/api/send-email" in text:
+        # Other historical endpoints can still use CORS, but the removed /api/send-email block may not.
+        legacy_section = text[text.find("/api/send-email") : text.find("/api/send-email") + 1800]
+        if "Access-Control-Allow-Origin', '*'" in legacy_section:
+            raise RuntimeError("server send-email CORS wildcard still reachable")
+'''
+NEW = '''    if "// ===== RESEND EMAIL API =====" in text:
+        raise RuntimeError("legacy permissive send-email implementation remains")
+    if text.count("if (p === '/api/send-email') return EMAIL_GATEWAY.handleAdmin(req, res)") != 1:
+        raise RuntimeError("governed send-email route is not unique")
+'''
+
+
+def expose_runner_node() -> None:
+    """Expose the runner-bundled Node binary to subsequent GitHub Actions steps."""
+    if shutil.which("node"):
+        print("CIA_PHASE16_NODE_PATH=ALREADY_AVAILABLE")
+        return
+
+    github_path = os.environ.get("GITHUB_PATH")
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if not github_path or not runner_temp:
+        raise RuntimeError("node missing and GitHub runner path metadata unavailable")
+
+    temp_path = pathlib.Path(runner_temp).resolve()
+    search_roots = [temp_path, *temp_path.parents]
+    candidates: list[pathlib.Path] = []
+    for root in search_roots:
+        externals = root / "externals"
+        if externals.is_dir():
+            candidates.extend(externals.glob("node*/bin/node"))
+
+    candidates = sorted({p.resolve() for p in candidates if p.is_file()}, reverse=True)
+    if not candidates:
+        raise RuntimeError("node missing and no bundled runner Node binary was found")
+
+    node_bin_dir = candidates[0].parent
+    with open(github_path, "a", encoding="utf-8") as fh:
+        fh.write(f"{node_bin_dir}\n")
+
+    print(f"CIA_PHASE16_NODE_PATH=PROVISIONED bundled={candidates[0].name}")
+
+
+def main() -> int:
+    expose_runner_node()
+
+    original = PATCH.read_text(encoding="utf-8")
+    if OLD not in original:
+        raise RuntimeError("runtime assertion source changed; manual review required")
+    executable = original.replace(OLD, NEW, 1)
+    PATCH.write_text(executable, encoding="utf-8")
+    try:
+        subprocess.run([sys.executable, str(PATCH)], cwd=ROOT, check=True)
+    finally:
+        PATCH.write_text(original, encoding="utf-8")
+    print("CIA_PHASE16_RUNTIME_ASSERTION_FIX=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/phase16_patch_email_backend_acl.py
+++ b/scripts/ci/phase16_patch_email_backend_acl.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""F16 compatibility patch: legacy Email server data access must be server/service-role only.
+
+The patch is intentionally narrow. Non-Email Supabase calls continue using the historical
+server key so unrelated domains do not change semantics. Email table access fails closed
+when SUPABASE_SERVICE_ROLE_KEY is absent, which is verified before production canary.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVER = ROOT / "app/server.js"
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise RuntimeError(f"{label}: expected 1 occurrence, found {n}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    text = SERVER.read_text(encoding="utf-8")
+    before = text
+
+    marker = "const VERIFY_TOKEN = 'ascendaos_zivital_2026'\n"
+    insert = """const VERIFY_TOKEN = 'ascendaos_zivital_2026'
+// F16: Email tables are backend-only. No service-role value is stored in source.
+const EMAIL_SB_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+function f16DbKey(endpoint) {
+  var e = String(endpoint || '')
+  return /^\/rest\/v1\/aos_emails?_/.test(e) ? EMAIL_SB_KEY : SB_KEY
+}
+function f16RequireEmailBackend(endpoint) {
+  if (/^\/rest\/v1\/aos_emails?_/.test(String(endpoint || '')) && !EMAIL_SB_KEY) {
+    throw new Error('EMAIL_SERVICE_ROLE_NOT_CONFIGURED')
+  }
+}
+"""
+    if "function f16DbKey(endpoint)" not in text:
+        text = replace_once(text, marker, insert, "insert Email backend key selector")
+
+    old = """function sbPost(endpoint, body, method) {
+  const url = new URL(SB_URL + endpoint)
+  const httpMethod = String(method || 'POST').toUpperCase() === 'PATCH' ? 'PATCH' : 'POST'
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body)
+    const req = https.request({
+      hostname: url.hostname, path: url.pathname + url.search,
+      method: httpMethod,
+      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) }
+"""
+    new = """function sbPost(endpoint, body, method) {
+  f16RequireEmailBackend(endpoint)
+  const url = new URL(SB_URL + endpoint)
+  const httpMethod = String(method || 'POST').toUpperCase() === 'PATCH' ? 'PATCH' : 'POST'
+  const dbKey = f16DbKey(endpoint)
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body)
+    const req = https.request({
+      hostname: url.hostname, path: url.pathname + url.search,
+      method: httpMethod,
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) }
+"""
+    text = replace_once(text, old, new, "sbPost Email key selection")
+
+    old = """function sbGet(endpoint) {
+  const url = new URL(SB_URL + endpoint)
+  return new Promise(function(resolve, reject) {
+    https.get({
+      hostname: url.hostname, path: url.pathname + url.search,
+      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY }
+"""
+    new = """function sbGet(endpoint) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.resolve([]) }
+  const url = new URL(SB_URL + endpoint)
+  const dbKey = f16DbKey(endpoint)
+  return new Promise(function(resolve, reject) {
+    https.get({
+      hostname: url.hostname, path: url.pathname + url.search,
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
+"""
+    text = replace_once(text, old, new, "sbGet Email key selection")
+
+    old = """function sbPatch(endpoint, body) {
+  const url = new URL(SB_URL + endpoint)
+  var data = JSON.stringify(body || {})
+  return new Promise(function(resolve) {
+    var req = https.request({
+      hostname: url.hostname, path: url.pathname + url.search, method: 'PATCH',
+      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' }
+"""
+    new = """function sbPatch(endpoint, body) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.resolve(false) }
+  const url = new URL(SB_URL + endpoint)
+  const dbKey = f16DbKey(endpoint)
+  var data = JSON.stringify(body || {})
+  return new Promise(function(resolve) {
+    var req = https.request({
+      hostname: url.hostname, path: url.pathname + url.search, method: 'PATCH',
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' }
+"""
+    text = replace_once(text, old, new, "sbPatch Email key selection")
+
+    old = """function sbFetch(endpoint) {
+  return new Promise(function(resolve, reject) {
+    var url = new URL(SB_URL + endpoint)
+    https.get({
+      hostname: url.hostname, path: url.pathname + url.search,
+      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY }
+"""
+    new = """function sbFetch(endpoint) {
+  try { f16RequireEmailBackend(endpoint) } catch (e) { return Promise.reject(e) }
+  return new Promise(function(resolve, reject) {
+    var url = new URL(SB_URL + endpoint)
+    var dbKey = f16DbKey(endpoint)
+    https.get({
+      hostname: url.hostname, path: url.pathname + url.search,
+      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
+"""
+    text = replace_once(text, old, new, "sbFetch Email key selection")
+
+    old = """    var url = new URL(SB_URL + '/rest/v1/aos_email_alertas')
+    var req = https.request({ hostname: url.hostname, path: url.pathname, method: 'POST',
+      headers: { 'apikey': SB_KEY, 'Authorization': 'Bearer ' + SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(body) }
+"""
+    new = """    if (!EMAIL_SB_KEY) return
+    var url = new URL(SB_URL + '/rest/v1/aos_email_alertas')
+    var req = https.request({ hostname: url.hostname, path: url.pathname, method: 'POST',
+      headers: { 'apikey': EMAIL_SB_KEY, 'Authorization': 'Bearer ' + EMAIL_SB_KEY, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(body) }
+"""
+    text = replace_once(text, old, new, "saveEmailAlerta service-role boundary")
+
+    if text == before:
+        raise RuntimeError("no changes applied")
+    if "SUPABASE_SERVICE_ROLE_KEY || ''" not in text:
+        raise RuntimeError("service-role environment boundary missing")
+    if "f16RequireEmailBackend(endpoint)" not in text:
+        raise RuntimeError("Email fail-closed boundary missing")
+
+    SERVER.write_text(text, encoding="utf-8")
+    print("CIA_PHASE16_EMAIL_BACKEND_ACL_PATCH=PASS")
+    print("EMAIL_SERVICE_ROLE_SOURCE_SECRET=0")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"CIA_PHASE16_EMAIL_BACKEND_ACL_PATCH=FAIL:{type(exc).__name__}:{exc}", file=sys.stderr)
+        raise

--- a/scripts/ci/phase16_patch_runtime.py
+++ b/scripts/ci/phase16_patch_runtime.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Apply the F16 Email runtime migration deterministically.
+
+This script intentionally fails closed if the expected legacy source shape changes.
+It never embeds or prints secret values.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVER = ROOT / "app/server.js"
+ADMIN = ROOT / "app/public/admin-email.html"
+
+
+def must_replace(text: str, old: str, new: str, label: str, count: int = 1) -> str:
+    found = text.count(old)
+    if found != count:
+        raise RuntimeError(f"{label}: expected {count} exact occurrence(s), found {found}")
+    return text.replace(old, new, count)
+
+
+def must_sub(text: str, pattern: str, repl: str, label: str, count: int = 1, flags: int = 0) -> str:
+    # Treat migration replacement bodies as literal source text. Passing them directly
+    # to re.subn makes Python parse backslashes in JavaScript regexes (for example
+    # \\w) as replacement-template escapes; Python 3.14 correctly rejects those.
+    # A callable replacement returns the body verbatim and keeps the patch deterministic.
+    out, n = re.subn(pattern, lambda _match: repl, text, count=count, flags=flags)
+    if n != count:
+        raise RuntimeError(f"{label}: expected {count} regex replacement(s), found {n}")
+    return out
+
+
+def assert_literal_regex_replacement() -> None:
+    """Regression guard for JS regex source embedded in deterministic replacements."""
+    probe = r"body.replace(/<span>(\\w+)<\\/span>/g,'$1')"
+    actual = must_sub("ANCHOR", r"ANCHOR", probe, "literal replacement regression")
+    if actual != probe:
+        raise RuntimeError("literal replacement regression: backslash-bearing JS source mutated")
+
+
+def patch_server(text: str) -> str:
+    if "createEmailGateway" not in text:
+        text = must_replace(
+            text,
+            "const path = require('path')\n",
+            "const path = require('path')\nconst { createEmailGateway } = require('./email-gateway')\nconst EMAIL_GATEWAY = createEmailGateway()\n",
+            "server gateway import",
+        )
+
+    route_anchor = "http.createServer(function(req, res) {\n  var p = req.url.split('?')[0]\n"
+    route_block = (
+        "http.createServer(function(req, res) {\n"
+        "  var p = req.url.split('?')[0]\n"
+        "  // F16: all admin Email writes and provider webhooks enter through a server-authoritative boundary.\n"
+        "  if (p === '/api/email-gateway') return EMAIL_GATEWAY.handleAdmin(req, res)\n"
+        "  if (p === '/api/send-email') return EMAIL_GATEWAY.handleAdmin(req, res)\n"
+        "  if (p === '/api/resend-webhook') return EMAIL_GATEWAY.handleWebhook(req, res)\n"
+    )
+    if "if (p === '/api/email-gateway')" not in text:
+        text = must_replace(text, route_anchor, route_block, "server Email gateway routing")
+
+    # Remove the now-unreachable permissive admin send implementation so it cannot regress by route reordering.
+    if "// ===== RESEND EMAIL API =====" in text:
+        text = must_sub(
+            text,
+            r"  // ===== RESEND EMAIL API =====\n.*?  // ===== FIN RESEND =====\n",
+            "  // ===== F16 EMAIL ADMIN SEND =====\n  // Handled above by EMAIL_GATEWAY with authoritative admin session verification.\n",
+            "remove permissive send-email block",
+            flags=re.S,
+        )
+
+    # Remove the legacy unsigned webhook implementation. Signed raw-body verification is handled above.
+    if "// ===== RESEND WEBHOOK — open/click/bounce tracking =====" in text:
+        text = must_sub(
+            text,
+            r"  // ===== RESEND WEBHOOK — open/click/bounce tracking =====\n.*?(?=  // ===== RESEND STATS)",
+            "  // ===== F16 RESEND WEBHOOK =====\n  // Handled above by EMAIL_GATEWAY with cryptographic signature + replay protection.\n\n",
+            "remove unsigned webhook block",
+            flags=re.S,
+        )
+
+    # Source-level provider credentials are prohibited. Replace every env||literal Resend fallback generically.
+    text, fallback_count = re.subn(
+        r"process\.env\.RESEND_API_KEY\s*\|\|\s*(['\"])re_[^'\"]+\1",
+        "process.env.RESEND_API_KEY || ''",
+        text,
+    )
+    if fallback_count < 1 and "process.env.RESEND_API_KEY || ''" not in text:
+        raise RuntimeError("server Resend fallback: no governed env-only expression found")
+
+    if re.search(r"(['\"])re_[A-Za-z0-9_-]{20,}\1", text):
+        raise RuntimeError("server secret scan: source-level provider credential remains")
+    if "Access-Control-Allow-Origin', '*'" in text and "/api/send-email" in text:
+        # Other historical endpoints can still use CORS, but the removed /api/send-email block may not.
+        legacy_section = text[text.find("/api/send-email") : text.find("/api/send-email") + 1800]
+        if "Access-Control-Allow-Origin', '*'" in legacy_section:
+            raise RuntimeError("server send-email CORS wildcard still reachable")
+    return text
+
+
+def patch_admin(text: str) -> str:
+    text = must_sub(
+        text,
+        r"var SB='https://[^']+';\nvar SK='[^']+';\n",
+        "",
+        "remove browser Supabase constants",
+    )
+
+    old_helpers = (
+        "function rpc(fn,params,cb){fetch(SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':SK,'Authorization':'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(params)}).then(function(r){return r.json();}).then(cb).catch(function(e){console.error(fn,e);});}\n"
+        "function q(table,query,cb){fetch(SB+'/rest/v1/'+table+'?'+query,{headers:{'apikey':SK,'Authorization':'Bearer '+SK}}).then(function(r){return r.json();}).then(cb);}\n"
+    )
+    new_helpers = r"""function emSessionToken(){return sessionStorage.getItem('aos_si_token')||sessionStorage.getItem('aos_app_token')||'';}
+function emCall(action,payload){
+  var token=emSessionToken();
+  if(!token)return Promise.reject(new Error('Sesión administrativa requerida'));
+  return fetch('/api/email-gateway',{method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':token},body:JSON.stringify({action:action,payload:payload||{}})}).then(function(r){return r.json().then(function(b){if(!r.ok||!b||b.ok!==true)throw new Error((b&&b.error)||('HTTP '+r.status));return b;});});
+}
+function rpc(fn,params,cb){emCall('LEGACY_RPC',{name:fn,params:params||{}}).then(function(r){cb(r.data);}).catch(function(e){console.error(fn,e);showToast('Error de sesión/email',e.message,true);});}
+function q(table,query,cb){emCall('LEGACY_READ',{table:table,query:query||''}).then(function(r){cb(r.data||[]);}).catch(function(e){console.error(table,e);showToast('Error de sesión/email',e.message,true);cb([]);});}
+function emPatch(table,id,changes,cb){emCall('LEGACY_PATCH',{table:table,id:id,changes:changes||{}}).then(function(r){if(cb)cb(null,r);}).catch(function(e){if(cb)cb(e);else showToast('Error al guardar',e.message,true);});}
+"""
+    text = must_replace(text, old_helpers, new_helpers, "replace browser Supabase helpers")
+
+    text = must_sub(
+        text,
+        r"function toggleFlujo\(id,activo\)\{\n.*?\n\}\n\nvar _tplMode",
+        "function toggleFlujo(id,activo){\n  emPatch('aos_email_flujos',id,{activo:activo,updated_at:new Date().toISOString()},function(err){\n    if(err){showToast('Error al actualizar flujo',err.message,true);return;}\n    showToast('Flujo '+(activo?'Activado':'Desactivado'),'');\n    el('m-flujo').classList.remove('open');loadFlujos();loadDashboard();\n  });\n}\n\nvar _tplMode",
+        "migrate flow PATCH",
+        flags=re.S,
+    )
+
+    text = must_sub(
+        text,
+        r"function saveWaTpl\(id\)\{\n.*?\n\}\nfunction filtrarTpl",
+        "function saveWaTpl(id){\n  var data={nombre:el('wa-nombre').value,cuerpo:el('wa-body').value,sede:el('wa-sede').value||null,updated_at:new Date().toISOString()};\n  emPatch('aos_plantillas_mensajes',id,data,function(err){if(err){showToast('Error',err.message,true);return;}showToast('Plantilla guardada',data.nombre);loadPlantillas();});\n}\nfunction filtrarTpl",
+        "migrate WhatsApp template PATCH",
+        flags=re.S,
+    )
+
+    text = must_sub(
+        text,
+        r"function savePlantilla\(id\)\{\n.*?\n\}\n\nfunction loadEnviados",
+        "function savePlantilla(id){\n  var body=_htmlMode?el('tpl-html-raw').value:el('tpl-editor').innerHTML;\n  body=body.replace(/<span[^>]*>\\{\\{(\\w+)\\}\\}<\\/span>/g,'{{$1}}');\n  var data={nombre:el('tpl-nombre').value,asunto:el('tpl-asunto').value,html_body:body,updated_at:new Date().toISOString()};\n  emPatch('aos_email_plantillas',id,data,function(err){if(err){showToast('Error al guardar',err.message,true);return;}showToast('Plantilla guardada',''+data.nombre);loadPlantillas();});\n}\n\nfunction loadEnviados",
+        "migrate Email template PATCH",
+        flags=re.S,
+    )
+
+    text = must_sub(
+        text,
+        r"function doSendEmail\(email,nombre,numero\)\{\n.*?\n\}\n\nfunction loadDashboard",
+        r"""var _sendClientRequestId='';
+function doSendEmail(email,nombre,numero){
+  var tplId=el('send-tpl').value;var asunto=el('send-asunto').value;
+  if(!asunto){showToast('Error','Escribe un asunto',true);return;}
+  if(!_sendClientRequestId)_sendClientRequestId=(window.crypto&&crypto.randomUUID)?crypto.randomUUID():('email-'+Date.now()+'-'+Math.random().toString(36).slice(2));
+  q('aos_email_plantillas','select=html_body,variables&id=eq.'+tplId,function(rows){
+    if(!rows||!rows[0])return;
+    var htmlBody=rows[0].html_body.replace(/\{\{nombre\}\}/g,nombre).replace(/\{\{tratamiento\}\}/g,'').replace(/\{\{fecha_cita\}\}/g,'').replace(/\{\{hora_cita\}\}/g,'').replace(/\{\{sede\}\}/g,'').replace(/\{\{monto\}\}/g,'').replace(/\{\{fecha\}\}/g,'');
+    emCall('LEGACY_SEND',{
+      to:email,subject:asunto.replace(/\{\{nombre\}\}/g,nombre),html:htmlBody,
+      nombre:nombre,numero:numero,plantilla_id:tplId,variables:{nombre:nombre},client_request_id:_sendClientRequestId
+    }).then(function(res){
+      showToast('Email Enviado','Correo enviado exitosamente a '+email);
+      _sendClientRequestId='';
+      el('m-send').classList.remove('open');
+      if(numero)verContacto(numero);
+    }).catch(function(e){showToast('Error al enviar',e.message,true);});
+  });
+}
+
+function loadDashboard""",
+        "migrate manual Email send",
+        flags=re.S,
+    )
+
+    if "fetch(SB+" in text or "'apikey':SK" in text or "Bearer '+SK" in text:
+        raise RuntimeError("admin-email direct Supabase access remains")
+    if "fetch('/api/send-email'" in text:
+        raise RuntimeError("admin-email direct legacy send remains")
+    return text
+
+
+def main() -> int:
+    assert_literal_regex_replacement()
+    before_server = SERVER.read_text(encoding="utf-8")
+    before_admin = ADMIN.read_text(encoding="utf-8")
+    after_server = patch_server(before_server)
+    after_admin = patch_admin(before_admin)
+
+    SERVER.write_text(after_server, encoding="utf-8")
+    ADMIN.write_text(after_admin, encoding="utf-8")
+
+    changed = []
+    if before_server != after_server:
+        changed.append("app/server.js")
+    if before_admin != after_admin:
+        changed.append("app/public/admin-email.html")
+    if changed != ["app/server.js", "app/public/admin-email.html"]:
+        raise RuntimeError(f"unexpected changed-file set: {changed}")
+
+    print("CIA_PHASE16_RUNTIME_PATCH=PASS")
+    print("CHANGED_FILES=" + ",".join(changed))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"CIA_PHASE16_RUNTIME_PATCH=FAIL:{type(exc).__name__}:{exc}", file=sys.stderr)
+        raise

--- a/scripts/ci/phase16_patch_transactional_email.py
+++ b/scripts/ci/phase16_patch_transactional_email.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""F16 deterministic patch for transactional Email auth and legacy marketing closure."""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVER = ROOT / "app/server.js"
+CONSUMERS = [
+    ROOT / "app/public/attendance.html",
+    ROOT / "app/public/agenda.js",
+    ROOT / "app/public/calls.js",
+    ROOT / "app/public/citas.html",
+    ROOT / "app/public/caja.html",
+    # CURRENT main serves the live Call Center directly from calls.html.
+    ROOT / "app/public/calls.html",
+]
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise RuntimeError(f"{label}: expected 1 occurrence, found {n}")
+    return text.replace(old, new, 1)
+
+
+def sub_once(text: str, pattern: str, repl: str, label: str, flags: int = 0) -> str:
+    out, n = re.subn(pattern, repl, text, count=1, flags=flags)
+    if n != 1:
+        raise RuntimeError(f"{label}: expected 1 replacement, found {n}")
+    return out
+
+
+def patch_server(text: str) -> str:
+    # Retire legacy unauthenticated 2FA sender. Auth V3 delivers 2FA inside aos_login_v3.
+    if "LEGACY_2FA_RETIRED" not in text:
+        text = sub_once(
+            text,
+            r"  // ===== 2FA CODE EMAIL =====\n.*?  // ===== FIN 2FA =====\n",
+            """  // ===== F16 LEGACY 2FA RETIRED =====
+  // Current Auth V3 sends 2FA inside aos_login_v3. This legacy public provider path is closed.
+  if (p === '/api/send-2fa') {
+    res.writeHead(410, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+    res.end(JSON.stringify({ ok:false, error:'LEGACY_2FA_RETIRED' })); return
+  }
+  // ===== FIN F16 LEGACY 2FA =====
+""",
+            "retire legacy send-2fa",
+            flags=re.S,
+        )
+
+    # Expand the explicit transactional allowlist; marketing classes must use governed activation.
+    old_list = "var EMAILS_TRANSACCIONALES = ['confirmacion_cita', 'recibo_venta', 'recordatorio_hoy', 'recordatorio_manana', 'bienvenida', 'confirmacion_pago', 'cotizacion']"
+    new_list = "var EMAILS_TRANSACCIONALES = ['confirmacion_cita','recibo_venta','recordatorio_hoy','recordatorio_manana','recordatorio','bienvenida','confirmacion_pago','cotizacion','catalogo','comprobante','agradecimiento','agradecimiento_visita','no_asistencia','reprogramacion','saldo_pendiente','seguimiento']"
+    if old_list in text:
+        text = replace_once(text, old_list, new_list, "expand transactional allowlist")
+    elif new_list not in text:
+        raise RuntimeError("transactional allowlist shape changed")
+
+    send_anchor = """function sendAgentEmail(to, subject, html, tipo, destinatario_id) {
+  return new Promise(function(resolve) {
+    // Anti-duplicado: verificar si ya se envió hoy
+"""
+    send_hardened = """function sendAgentEmail(to, subject, html, tipo, destinatario_id) {
+  return new Promise(function(resolve) {
+    // F16: all marketing/reactivation/cross-sell agent sends require governed Audience activation + consent.
+    if (EMAILS_TRANSACCIONALES.indexOf(String(tipo || '')) === -1) {
+      resolve({ skip:true, reason:'F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED', governed_activation_required:true }); return
+    }
+    // Anti-duplicado: verificar si ya se envió hoy
+"""
+    if "F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED" not in text:
+        text = replace_once(text, send_anchor, send_hardened, "block ungoverned agent marketing")
+
+    # Require current Auth V3 app session before existing transactional send-template implementation.
+    start = """  if (p === '/api/send-template' && req.method === 'POST') {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
+"""
+    hardened_start = """  if (p === '/api/send-template' && req.method === 'POST') {
+    var templateToken = String(req.headers['x-ascenda-session'] || '')
+    EMAIL_GATEWAY.verifyApp(templateToken).then(function(templateAuth) {
+      if (!templateAuth || templateAuth.ok !== true) {
+        res.writeHead(401, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+        res.end(JSON.stringify({ok:false,error:'UNAUTHORIZED'})); return
+      }
+      var body = ''; req.on('data', function(c) { body += c }); req.on('end', function() {
+"""
+    if "var templateToken = String(req.headers['x-ascenda-session'] || '')" not in text:
+        text = replace_once(text, start, hardened_start, "secure send-template start")
+
+    type_anchor = "        var html = '', subject = '', tipo = d.template\n"
+    type_policy = """        var html = '', subject = '', tipo = d.template
+        // F16: template endpoint is transactional only. Marketing must use governed activation/consent.
+        if (EMAILS_TRANSACCIONALES.indexOf(String(tipo || '')) === -1) {
+          res.writeHead(403, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+          res.end(JSON.stringify({ok:false,error:'GOVERNED_ACTIVATION_REQUIRED',template:String(tipo||'')})); return
+        }
+"""
+    if "template endpoint is transactional only" not in text:
+        text = replace_once(text, type_anchor, type_policy, "send-template marketing policy")
+
+    end = """      } catch(e) { res.writeHead(400); res.end('{\"error\":\"Invalid JSON\"}') }
+    }); return
+  }
+  if (p === '/api/send-template' && req.method === 'OPTIONS') {
+    res.writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST', 'Access-Control-Allow-Headers': 'Content-Type' })
+    res.end(); return
+  }
+  // ===== FIN TEMPLATE EMAILS =====
+"""
+    hardened_end = """      } catch(e) { res.writeHead(400); res.end('{\"error\":\"Invalid JSON\"}') }
+      })
+    }).catch(function() {
+      res.writeHead(401, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+      res.end(JSON.stringify({ok:false,error:'UNAUTHORIZED'}))
+    })
+    return
+  }
+  if (p === '/api/send-template' && req.method === 'OPTIONS') {
+    res.writeHead(405, { 'Content-Type':'application/json', 'Cache-Control':'no-store' })
+    res.end(JSON.stringify({ok:false,error:'METHOD_NOT_ALLOWED'})); return
+  }
+  // ===== FIN TEMPLATE EMAILS =====
+"""
+    if "send-template' && req.method === 'OPTIONS') {\n    res.writeHead(405" not in text:
+        text = replace_once(text, end, hardened_end, "secure send-template end")
+
+    if re.search(r"if \(p === '/api/send-template'.{0,250}Access-Control-Allow-Origin.{0,80}\*", text, flags=re.S):
+        raise RuntimeError("send-template wildcard CORS remains")
+    if "LEGACY_2FA_RETIRED" not in text or "F16_MARKETING_GOVERNED_ACTIVATION_REQUIRED" not in text:
+        raise RuntimeError("transactional/2FA Email controls missing")
+    return text
+
+
+def patch_consumer(path: pathlib.Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    before = text
+    pos = 0
+    changes = 0
+    while True:
+        idx = text.find('/api/send-template', pos)
+        if idx < 0:
+            break
+        window_end = min(len(text), idx + 700)
+        window = text[idx:window_end]
+        if "X-ASCENDA-Session" in window:
+            pos = idx + 18
+            continue
+        candidates = [
+            "headers:{'Content-Type':'application/json'}",
+            'headers:{"Content-Type":"application/json"}',
+            "headers: { 'Content-Type': 'application/json' }",
+            'headers: { "Content-Type": "application/json" }',
+        ]
+        found = None
+        for c in candidates:
+            rel = window.find(c)
+            if rel >= 0:
+                found = (rel, c)
+                break
+        if not found:
+            raise RuntimeError(f"{path.name}: send-template caller lacks expected JSON headers near offset {idx}")
+        rel, old = found
+        absolute = idx + rel
+        quote = "'" if "'Content-Type'" in old else '"'
+        new = "headers:{%sContent-Type%s:%sapplication/json%s,%sX-ASCENDA-Session%s:(sessionStorage.getItem('aos_app_token')||'')}" % (quote,quote,quote,quote,quote,quote)
+        text = text[:absolute] + new + text[absolute + len(old):]
+        changes += 1
+        pos = absolute + len(new)
+    if changes < 1:
+        raise RuntimeError(f"{path.name}: no send-template caller patched")
+    path.write_text(text, encoding="utf-8")
+    return text != before
+
+
+def main() -> int:
+    server = SERVER.read_text(encoding="utf-8")
+    patched = patch_server(server)
+    SERVER.write_text(patched, encoding="utf-8")
+
+    changed = ["app/server.js"]
+    for path in CONSUMERS:
+        if patch_consumer(path):
+            changed.append(str(path.relative_to(ROOT)))
+
+    expected = sorted(["app/server.js"] + [str(p.relative_to(ROOT)) for p in CONSUMERS])
+    if sorted(changed) != expected:
+        raise RuntimeError(f"unexpected transactional Email patch scope: {changed}")
+    print("CIA_PHASE16_TRANSACTIONAL_EMAIL_PATCH=PASS")
+    print("TRANSACTIONAL_CALLERS_AUTH_HEADER=6")
+    print("LEGACY_2FA_PUBLIC_SEND=RETIRED")
+    print("UNGOVERNED_MARKETING_AGENT_SEND=BLOCKED")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"CIA_PHASE16_TRANSACTIONAL_EMAIL_PATCH=FAIL:{type(exc).__name__}:{exc}", file=sys.stderr)
+        raise

--- a/supabase/migrations/20260814200500_cia_phase16_email_governed_schema_v1.sql
+++ b/supabase/migrations/20260814200500_cia_phase16_email_governed_schema_v1.sql
@@ -1,0 +1,246 @@
+-- ASCENDA OS CIA V3 — F16 Email governed schema v1
+-- Additive only. No legacy Email ACL changes and no provider delivery activation.
+
+create table if not exists public.aos_cia_email_recipient_controls (
+  contact_key text primary key,
+  marketing_consent text not null default 'UNKNOWN'
+    check (marketing_consent in ('ALLOWED','BLOCKED','UNKNOWN')),
+  global_suppressed boolean not null default false,
+  suppression_reason text,
+  source text not null default 'UNKNOWN',
+  source_updated_at timestamptz,
+  updated_by_user_id uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.aos_cia_email_recipient_control_events (
+  id bigint generated always as identity primary key,
+  contact_key text not null,
+  event_type text not null check (event_type in ('CREATED','UPDATED')),
+  old_value jsonb,
+  new_value jsonb not null,
+  actor_user_id uuid,
+  occurred_at timestamptz not null default now()
+);
+
+create table if not exists public.aos_cia_email_template_versions (
+  id uuid primary key default extensions.gen_random_uuid(),
+  template_key text not null,
+  version integer not null check (version > 0),
+  purpose text not null check (purpose in ('AUTH','TRANSACTIONAL','MARKETING','OPERATIONAL')),
+  subject_template text not null,
+  html_template text not null,
+  variable_keys text[] not null default '{}'::text[],
+  content_digest text not null,
+  state text not null default 'SHADOW' check (state in ('SHADOW','ACTIVE','RETIRED')),
+  legacy_template_id uuid,
+  created_by_user_id uuid not null,
+  created_at timestamptz not null default now(),
+  activated_at timestamptz,
+  retired_at timestamptz,
+  unique (template_key, version)
+);
+
+create table if not exists public.aos_cia_email_send_requests (
+  id uuid primary key default extensions.gen_random_uuid(),
+  correlation_id uuid not null default extensions.gen_random_uuid(),
+  activation_id uuid not null references public.aos_audiencia_activaciones(id) on delete restrict,
+  contact_key text not null,
+  recipient_email text not null,
+  purpose text not null check (purpose in ('AUTH','TRANSACTIONAL','MARKETING','OPERATIONAL')),
+  template_version_id uuid not null references public.aos_cia_email_template_versions(id) on delete restrict,
+  template_digest text not null,
+  idempotency_key text not null unique,
+  eligibility_status text not null check (eligibility_status in ('ELIGIBLE','BLOCKED','UNKNOWN')),
+  consent_status text not null check (consent_status in ('ALLOWED','BLOCKED','UNKNOWN','NOT_REQUIRED')),
+  state text not null default 'PREPARED'
+    check (state in ('PREPARED','QUEUED','DISPATCHING','ACCEPTED','DELIVERED','BOUNCED','COMPLAINED','FAILED','CANCELLED')),
+  provider text,
+  provider_message_id text,
+  dispatch_attempts integer not null default 0 check (dispatch_attempts >= 0),
+  scheduled_at timestamptz,
+  requested_by_user_id uuid not null,
+  authorization_provenance jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  accepted_at timestamptz,
+  delivered_at timestamptz,
+  terminal_at timestamptz
+);
+
+create unique index if not exists aos_cia_email_send_requests_provider_message_uidx
+  on public.aos_cia_email_send_requests(provider, provider_message_id)
+  where provider is not null and provider_message_id is not null;
+
+create index if not exists aos_cia_email_send_requests_state_schedule_idx
+  on public.aos_cia_email_send_requests(state, scheduled_at, created_at);
+
+create index if not exists aos_cia_email_send_requests_activation_idx
+  on public.aos_cia_email_send_requests(activation_id, created_at desc);
+
+create table if not exists public.aos_cia_email_send_events (
+  id bigint generated always as identity primary key,
+  request_id uuid not null references public.aos_cia_email_send_requests(id) on delete restrict,
+  event_type text not null,
+  provider_event_id text,
+  payload jsonb not null default '{}'::jsonb,
+  occurred_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists aos_cia_email_send_events_provider_event_uidx
+  on public.aos_cia_email_send_events(provider_event_id)
+  where provider_event_id is not null;
+
+create index if not exists aos_cia_email_send_events_request_idx
+  on public.aos_cia_email_send_events(request_id, occurred_at, id);
+
+alter table public.aos_cia_email_recipient_controls enable row level security;
+alter table public.aos_cia_email_recipient_control_events enable row level security;
+alter table public.aos_cia_email_template_versions enable row level security;
+alter table public.aos_cia_email_send_requests enable row level security;
+alter table public.aos_cia_email_send_events enable row level security;
+
+revoke all on table public.aos_cia_email_recipient_controls from public, anon, authenticated;
+revoke all on table public.aos_cia_email_recipient_control_events from public, anon, authenticated;
+revoke all on table public.aos_cia_email_template_versions from public, anon, authenticated;
+revoke all on table public.aos_cia_email_send_requests from public, anon, authenticated;
+revoke all on table public.aos_cia_email_send_events from public, anon, authenticated;
+
+create or replace function public.aos_cia_email_control_audit_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  if tg_op = 'INSERT' then
+    insert into public.aos_cia_email_recipient_control_events(contact_key,event_type,old_value,new_value,actor_user_id)
+    values(new.contact_key,'CREATED',null,to_jsonb(new),new.updated_by_user_id);
+    return new;
+  end if;
+  new.updated_at := now();
+  insert into public.aos_cia_email_recipient_control_events(contact_key,event_type,old_value,new_value,actor_user_id)
+  values(new.contact_key,'UPDATED',to_jsonb(old),to_jsonb(new),new.updated_by_user_id);
+  return new;
+end
+$function$;
+
+create or replace function public.aos_cia_email_append_only_guard_v1()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+begin
+  raise exception 'EMAIL_AUDIT_APPEND_ONLY';
+end
+$function$;
+
+create or replace function public.aos_cia_email_template_guard_v1()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+begin
+  if old.id is distinct from new.id
+     or old.template_key is distinct from new.template_key
+     or old.version is distinct from new.version
+     or old.purpose is distinct from new.purpose
+     or old.subject_template is distinct from new.subject_template
+     or old.html_template is distinct from new.html_template
+     or old.variable_keys is distinct from new.variable_keys
+     or old.content_digest is distinct from new.content_digest
+     or old.legacy_template_id is distinct from new.legacy_template_id
+     or old.created_by_user_id is distinct from new.created_by_user_id
+     or old.created_at is distinct from new.created_at then
+    raise exception 'EMAIL_TEMPLATE_VERSION_IMMUTABLE';
+  end if;
+  if old.state = 'RETIRED' and new.state <> old.state then
+    raise exception 'EMAIL_TEMPLATE_RETIRED_TERMINAL';
+  end if;
+  if old.state = 'SHADOW' and new.state not in ('SHADOW','ACTIVE','RETIRED') then
+    raise exception 'EMAIL_TEMPLATE_INVALID_TRANSITION';
+  end if;
+  if old.state = 'ACTIVE' and new.state not in ('ACTIVE','RETIRED') then
+    raise exception 'EMAIL_TEMPLATE_INVALID_TRANSITION';
+  end if;
+  return new;
+end
+$function$;
+
+create or replace function public.aos_cia_email_request_guard_v1()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+begin
+  if old.id is distinct from new.id
+     or old.correlation_id is distinct from new.correlation_id
+     or old.activation_id is distinct from new.activation_id
+     or old.contact_key is distinct from new.contact_key
+     or old.recipient_email is distinct from new.recipient_email
+     or old.purpose is distinct from new.purpose
+     or old.template_version_id is distinct from new.template_version_id
+     or old.template_digest is distinct from new.template_digest
+     or old.idempotency_key is distinct from new.idempotency_key
+     or old.eligibility_status is distinct from new.eligibility_status
+     or old.consent_status is distinct from new.consent_status
+     or old.requested_by_user_id is distinct from new.requested_by_user_id
+     or old.authorization_provenance is distinct from new.authorization_provenance
+     or old.created_at is distinct from new.created_at then
+    raise exception 'EMAIL_SEND_REQUEST_IDENTITY_IMMUTABLE';
+  end if;
+
+  if old.state is distinct from new.state then
+    if not (
+      (old.state = 'PREPARED' and new.state in ('QUEUED','CANCELLED')) or
+      (old.state = 'QUEUED' and new.state in ('DISPATCHING','CANCELLED')) or
+      (old.state = 'DISPATCHING' and new.state in ('ACCEPTED','FAILED','QUEUED','CANCELLED')) or
+      (old.state = 'FAILED' and new.state in ('QUEUED','CANCELLED')) or
+      (old.state = 'ACCEPTED' and new.state in ('DELIVERED','BOUNCED','COMPLAINED','FAILED'))
+    ) then
+      raise exception 'EMAIL_SEND_REQUEST_INVALID_TRANSITION:%->%', old.state, new.state;
+    end if;
+  end if;
+
+  new.updated_at := now();
+  if new.state in ('DELIVERED','BOUNCED','COMPLAINED','CANCELLED') and new.terminal_at is null then
+    new.terminal_at := now();
+  end if;
+  return new;
+end
+$function$;
+
+drop trigger if exists trg_aos_cia_email_control_audit_v1 on public.aos_cia_email_recipient_controls;
+create trigger trg_aos_cia_email_control_audit_v1
+before insert or update on public.aos_cia_email_recipient_controls
+for each row execute function public.aos_cia_email_control_audit_v1();
+
+drop trigger if exists trg_aos_cia_email_control_events_append_only_v1 on public.aos_cia_email_recipient_control_events;
+create trigger trg_aos_cia_email_control_events_append_only_v1
+before update or delete on public.aos_cia_email_recipient_control_events
+for each row execute function public.aos_cia_email_append_only_guard_v1();
+
+drop trigger if exists trg_aos_cia_email_template_guard_v1 on public.aos_cia_email_template_versions;
+create trigger trg_aos_cia_email_template_guard_v1
+before update on public.aos_cia_email_template_versions
+for each row execute function public.aos_cia_email_template_guard_v1();
+
+drop trigger if exists trg_aos_cia_email_request_guard_v1 on public.aos_cia_email_send_requests;
+create trigger trg_aos_cia_email_request_guard_v1
+before update on public.aos_cia_email_send_requests
+for each row execute function public.aos_cia_email_request_guard_v1();
+
+drop trigger if exists trg_aos_cia_email_send_events_append_only_v1 on public.aos_cia_email_send_events;
+create trigger trg_aos_cia_email_send_events_append_only_v1
+before update or delete on public.aos_cia_email_send_events
+for each row execute function public.aos_cia_email_append_only_guard_v1();
+
+revoke all on function public.aos_cia_email_control_audit_v1() from public, anon, authenticated;
+revoke all on function public.aos_cia_email_append_only_guard_v1() from public, anon, authenticated;
+revoke all on function public.aos_cia_email_template_guard_v1() from public, anon, authenticated;
+revoke all on function public.aos_cia_email_request_guard_v1() from public, anon, authenticated;
+
+comment on table public.aos_cia_email_send_requests is 'F16 governed Email request ledger. PREPARED is non-delivery intent; provider dispatch is a separate later gate.';
+comment on table public.aos_cia_email_recipient_controls is 'F16 commercial Email control plane. Missing marketing consent remains UNKNOWN/fail-closed.';

--- a/supabase/migrations/20260814200600_cia_phase16_email_contracts_v1.sql
+++ b/supabase/migrations/20260814200600_cia_phase16_email_contracts_v1.sql
@@ -1,0 +1,451 @@
+-- ASCENDA OS CIA V3 — F16 Email preview/request contracts v1
+-- No provider dispatch. No legacy ACL changes. No Email send is performed by this migration.
+
+create or replace function public.aos_cia_email_eligibility_v1(
+  p_activation_id uuid,
+  p_contact_key text,
+  p_purpose text default 'MARKETING'
+)
+returns jsonb
+language plpgsql
+stable
+set search_path = ''
+as $function$
+declare
+  v_purpose text := upper(trim(coalesce(p_purpose,'')));
+  v_contact text := trim(coalesce(p_contact_key,''));
+  v_channel text;
+  v_activation_state text;
+  v_source record;
+  v_control record;
+  v_consent text := 'UNKNOWN';
+  v_status text := 'UNKNOWN';
+  v_reason text := 'UNKNOWN';
+  v_freshness text := 'UNKNOWN';
+  v_member boolean := false;
+begin
+  if p_activation_id is null then
+    return jsonb_build_object('ok',false,'eligibility_status','BLOCKED','reason_code','ACTIVATION_REQUIRED','send_allowed',false);
+  end if;
+  if v_contact = '' then
+    return jsonb_build_object('ok',false,'eligibility_status','BLOCKED','reason_code','CONTACT_REQUIRED','send_allowed',false);
+  end if;
+  if v_purpose not in ('AUTH','TRANSACTIONAL','MARKETING','OPERATIONAL') then
+    return jsonb_build_object('ok',false,'eligibility_status','BLOCKED','reason_code','INVALID_PURPOSE','send_allowed',false);
+  end if;
+
+  select upper(trim(c.channel)), st.estado
+    into v_channel, v_activation_state
+  from public.aos_audiencia_activacion_config c
+  join public.aos_audiencia_activacion_estado st on st.activacion_id=c.activacion_id
+  where c.activacion_id=p_activation_id;
+
+  if v_channel is null then
+    return jsonb_build_object('ok',false,'eligibility_status','BLOCKED','reason_code','ACTIVATION_NOT_FOUND','send_allowed',false);
+  end if;
+  if v_channel <> 'EMAIL' then
+    return jsonb_build_object('ok',true,'eligibility_status','BLOCKED','reason_code','CHANNEL_NOT_EMAIL','activation_state',v_activation_state,'send_allowed',false);
+  end if;
+
+  select exists(
+    select 1 from public.aos_cia_activation_member_keys_v1(p_activation_id) m
+    where m.contact_key=v_contact
+  ) into v_member;
+  if not v_member then
+    return jsonb_build_object('ok',true,'eligibility_status','BLOCKED','reason_code','NOT_ACTIVATION_MEMBER','activation_state',v_activation_state,'send_allowed',false);
+  end if;
+
+  select s.contact_key,s.identity_conflict,s.canonical_email,s.email_valid,
+         s.email_bounced_count,s.facts_observed_at,s.email_last_event_at
+    into v_source
+  from public.aos_cia_audience_source_v1_1 s
+  where s.contact_key=v_contact;
+
+  if v_source.contact_key is null then
+    return jsonb_build_object('ok',true,'eligibility_status','BLOCKED','reason_code','CONTACT_SOURCE_NOT_FOUND','activation_state',v_activation_state,'send_allowed',false);
+  end if;
+
+  if v_source.facts_observed_at is null then
+    v_freshness := 'UNKNOWN';
+  elsif v_source.facts_observed_at >= now() - interval '2 days' then
+    v_freshness := 'FRESH';
+  elsif v_source.facts_observed_at >= now() - interval '7 days' then
+    v_freshness := 'AGING';
+  else
+    v_freshness := 'STALE';
+  end if;
+
+  select c.marketing_consent,c.global_suppressed,c.suppression_reason,c.source,c.source_updated_at
+    into v_control
+  from public.aos_cia_email_recipient_controls c
+  where c.contact_key=v_contact;
+
+  if v_purpose='MARKETING' then
+    v_consent := coalesce(v_control.marketing_consent,'UNKNOWN');
+  else
+    v_consent := 'NOT_REQUIRED';
+  end if;
+
+  if coalesce(v_source.identity_conflict,false) then
+    v_status := 'BLOCKED'; v_reason := 'IDENTITY_CONFLICT';
+  elsif nullif(trim(coalesce(v_source.canonical_email,'')),'') is null then
+    v_status := 'BLOCKED'; v_reason := 'EMAIL_MISSING';
+  elsif coalesce(v_source.email_valid,false) is not true then
+    v_status := 'BLOCKED'; v_reason := 'EMAIL_INVALID';
+  elsif coalesce(v_control.global_suppressed,false) then
+    v_status := 'BLOCKED'; v_reason := 'GLOBAL_SUPPRESSION';
+  elsif v_purpose='MARKETING' and v_consent='BLOCKED' then
+    v_status := 'BLOCKED'; v_reason := 'MARKETING_CONSENT_BLOCKED';
+  elsif coalesce(v_source.email_bounced_count,0) > 0 then
+    v_status := 'UNKNOWN'; v_reason := 'BOUNCE_REVIEW_REQUIRED';
+  elsif v_purpose='MARKETING' and v_consent <> 'ALLOWED' then
+    v_status := 'UNKNOWN'; v_reason := 'MARKETING_CONSENT_UNKNOWN';
+  elsif v_freshness='UNKNOWN' then
+    v_status := 'UNKNOWN'; v_reason := 'FRESHNESS_UNKNOWN';
+  else
+    v_status := 'ELIGIBLE'; v_reason := 'ELIGIBLE_PREVIEW';
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,
+    'activation_id',p_activation_id,
+    'activation_state',v_activation_state,
+    'channel',v_channel,
+    'contact_key',v_contact,
+    'email',v_source.canonical_email,
+    'email_valid',coalesce(v_source.email_valid,false),
+    'bounced_count',coalesce(v_source.email_bounced_count,0),
+    'consent_status',v_consent,
+    'global_suppressed',coalesce(v_control.global_suppressed,false),
+    'control_source',coalesce(v_control.source,'UNKNOWN'),
+    'eligibility_status',v_status,
+    'reason_code',v_reason,
+    'freshness_status',v_freshness,
+    'facts_observed_at',v_source.facts_observed_at,
+    'send_allowed',false,
+    'preview_only',true
+  );
+end
+$function$;
+
+create or replace function public.aos_cia_email_preview_activation_v1(
+  p_activation_id uuid,
+  p_purpose text default 'MARKETING',
+  p_limit integer default 50,
+  p_offset integer default 0
+)
+returns jsonb
+language plpgsql
+stable
+set search_path = ''
+as $function$
+declare
+  v_limit integer := greatest(1,least(coalesce(p_limit,50),100));
+  v_offset integer := greatest(0,coalesce(p_offset,0));
+  v_total integer;
+  v_items jsonb;
+begin
+  select count(*)::integer into v_total
+  from public.aos_cia_activation_member_keys_v1(p_activation_id);
+
+  select coalesce(jsonb_agg(x.item order by x.contact_key),'[]'::jsonb)
+    into v_items
+  from (
+    select m.contact_key,
+           public.aos_cia_email_eligibility_v1(p_activation_id,m.contact_key,p_purpose) as item
+    from public.aos_cia_activation_member_keys_v1(p_activation_id) m
+    order by m.contact_key
+    limit v_limit offset v_offset
+  ) x;
+
+  return jsonb_build_object(
+    'ok',true,
+    'activation_id',p_activation_id,
+    'purpose',upper(trim(coalesce(p_purpose,'MARKETING'))),
+    'total_members',v_total,
+    'limit',v_limit,
+    'offset',v_offset,
+    'items',v_items,
+    'send_allowed',false,
+    'preview_only',true
+  );
+exception when others then
+  if sqlerrm like '%ACTIVATION_NOT_FOUND%' then
+    return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_FOUND','send_allowed',false);
+  end if;
+  raise;
+end
+$function$;
+
+create or replace function public.aos_cia_email_template_version_create_v1(
+  p_actor_user_id uuid,
+  p_template_key text,
+  p_purpose text,
+  p_subject_template text,
+  p_html_template text,
+  p_variable_keys text[] default '{}'::text[],
+  p_legacy_template_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_key text := lower(trim(coalesce(p_template_key,'')));
+  v_purpose text := upper(trim(coalesce(p_purpose,'')));
+  v_version integer;
+  v_digest text;
+  v_id uuid;
+begin
+  if p_actor_user_id is null then return jsonb_build_object('ok',false,'error','ACTOR_REQUIRED'); end if;
+  if v_key !~ '^[a-z0-9][a-z0-9._-]{1,79}$' then return jsonb_build_object('ok',false,'error','INVALID_TEMPLATE_KEY'); end if;
+  if v_purpose not in ('AUTH','TRANSACTIONAL','MARKETING','OPERATIONAL') then return jsonb_build_object('ok',false,'error','INVALID_PURPOSE'); end if;
+  if nullif(trim(coalesce(p_subject_template,'')),'') is null then return jsonb_build_object('ok',false,'error','SUBJECT_REQUIRED'); end if;
+  if nullif(trim(coalesce(p_html_template,'')),'') is null then return jsonb_build_object('ok',false,'error','HTML_REQUIRED'); end if;
+  if length(p_subject_template) > 500 or length(p_html_template) > 500000 then return jsonb_build_object('ok',false,'error','TEMPLATE_TOO_LARGE'); end if;
+
+  perform pg_advisory_xact_lock(hashtext('F16_EMAIL_TEMPLATE:'||v_key));
+  select coalesce(max(version),0)+1 into v_version
+  from public.aos_cia_email_template_versions where template_key=v_key;
+
+  v_digest := md5(v_key||'|'||v_purpose||'|'||p_subject_template||'|'||p_html_template||'|'||array_to_string(coalesce(p_variable_keys,'{}'::text[]),','));
+
+  insert into public.aos_cia_email_template_versions(
+    template_key,version,purpose,subject_template,html_template,variable_keys,content_digest,state,legacy_template_id,created_by_user_id
+  ) values(
+    v_key,v_version,v_purpose,p_subject_template,p_html_template,coalesce(p_variable_keys,'{}'::text[]),v_digest,'SHADOW',p_legacy_template_id,p_actor_user_id
+  ) returning id into v_id;
+
+  return jsonb_build_object('ok',true,'template_version_id',v_id,'template_key',v_key,'version',v_version,'digest',v_digest,'state','SHADOW');
+end
+$function$;
+
+create or replace function public.aos_cia_email_template_version_activate_v1(
+  p_actor_user_id uuid,
+  p_template_version_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_tpl record;
+begin
+  if p_actor_user_id is null then return jsonb_build_object('ok',false,'error','ACTOR_REQUIRED'); end if;
+  select * into v_tpl from public.aos_cia_email_template_versions where id=p_template_version_id for update;
+  if v_tpl.id is null then return jsonb_build_object('ok',false,'error','TEMPLATE_VERSION_NOT_FOUND'); end if;
+  if v_tpl.state='RETIRED' then return jsonb_build_object('ok',false,'error','TEMPLATE_VERSION_RETIRED'); end if;
+
+  update public.aos_cia_email_template_versions
+     set state='RETIRED', retired_at=now()
+   where template_key=v_tpl.template_key and id<>v_tpl.id and state='ACTIVE';
+
+  update public.aos_cia_email_template_versions
+     set state='ACTIVE', activated_at=coalesce(activated_at,now()), retired_at=null
+   where id=v_tpl.id;
+
+  return jsonb_build_object('ok',true,'template_version_id',v_tpl.id,'template_key',v_tpl.template_key,'version',v_tpl.version,'state','ACTIVE','actor_user_id',p_actor_user_id);
+end
+$function$;
+
+create or replace function public.aos_cia_email_prepare_request_v1(
+  p_actor_user_id uuid,
+  p_activation_id uuid,
+  p_contact_key text,
+  p_template_version_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_tpl record;
+  v_elig jsonb;
+  v_activation_state text;
+  v_key text;
+  v_existing uuid;
+  v_id uuid;
+begin
+  if p_actor_user_id is null then return jsonb_build_object('ok',false,'error','ACTOR_REQUIRED'); end if;
+
+  select t.* into v_tpl
+  from public.aos_cia_email_template_versions t
+  where t.id=p_template_version_id;
+  if v_tpl.id is null then return jsonb_build_object('ok',false,'error','TEMPLATE_VERSION_NOT_FOUND'); end if;
+  if v_tpl.state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','TEMPLATE_NOT_ACTIVE'); end if;
+
+  select st.estado into v_activation_state
+  from public.aos_audiencia_activacion_estado st
+  where st.activacion_id=p_activation_id;
+  if v_activation_state is null then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_FOUND'); end if;
+  if v_activation_state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_ACTIVE','state',v_activation_state); end if;
+
+  v_elig := public.aos_cia_email_eligibility_v1(p_activation_id,p_contact_key,v_tpl.purpose);
+  if coalesce(v_elig->>'eligibility_status','UNKNOWN') <> 'ELIGIBLE' then
+    return jsonb_build_object('ok',false,'error','EMAIL_NOT_ELIGIBLE','eligibility',v_elig,'send_performed',false);
+  end if;
+  if coalesce(v_elig->>'consent_status','UNKNOWN') not in ('ALLOWED','NOT_REQUIRED') then
+    return jsonb_build_object('ok',false,'error','CONSENT_NOT_ALLOWED','eligibility',v_elig,'send_performed',false);
+  end if;
+
+  v_key := md5(p_activation_id::text||'|'||trim(p_contact_key)||'|'||p_template_version_id::text||'|'||v_tpl.purpose);
+  perform pg_advisory_xact_lock(hashtext('F16_EMAIL_REQUEST:'||v_key));
+  select id into v_existing from public.aos_cia_email_send_requests where idempotency_key=v_key;
+  if v_existing is not null then
+    return jsonb_build_object('ok',true,'request_id',v_existing,'idempotent',true,'state','PREPARED','send_performed',false);
+  end if;
+
+  insert into public.aos_cia_email_send_requests(
+    activation_id,contact_key,recipient_email,purpose,template_version_id,template_digest,idempotency_key,
+    eligibility_status,consent_status,state,requested_by_user_id,authorization_provenance
+  ) values(
+    p_activation_id,trim(p_contact_key),v_elig->>'email',v_tpl.purpose,v_tpl.id,v_tpl.content_digest,v_key,
+    v_elig->>'eligibility_status',v_elig->>'consent_status','PREPARED',p_actor_user_id,
+    jsonb_build_object('actor_user_id',p_actor_user_id,'via','CIA_EMAIL_ADMIN_GATEWAY_V1','prepared_only',true)
+  ) returning id into v_id;
+
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_id,'PREPARED',jsonb_build_object('eligibility_reason',v_elig->>'reason_code','send_performed',false));
+
+  return jsonb_build_object('ok',true,'request_id',v_id,'idempotent',false,'state','PREPARED','send_performed',false,'eligibility',v_elig);
+end
+$function$;
+
+create or replace function public.aos_cia_email_f17_readiness_v1()
+returns jsonb
+language plpgsql
+stable
+set search_path = ''
+as $function$
+declare
+  v_f15 jsonb;
+  v_tables integer;
+  v_rls integer;
+  v_anon_direct boolean;
+  v_auth_direct boolean;
+  v_templates integer;
+  v_requests integer;
+  v_illegal integer;
+begin
+  v_f15 := public.aos_cia_kronia_f16_readiness_v1();
+  select count(*)::integer into v_tables
+  from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname in (
+    'aos_cia_email_recipient_controls','aos_cia_email_recipient_control_events','aos_cia_email_template_versions','aos_cia_email_send_requests','aos_cia_email_send_events'
+  ) and c.relkind='r';
+
+  select count(*)::integer into v_rls
+  from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname in (
+    'aos_cia_email_recipient_controls','aos_cia_email_recipient_control_events','aos_cia_email_template_versions','aos_cia_email_send_requests','aos_cia_email_send_events'
+  ) and c.relrowsecurity;
+
+  v_anon_direct := has_table_privilege('anon','public.aos_cia_email_send_requests','SELECT')
+                   or has_table_privilege('anon','public.aos_cia_email_send_requests','INSERT')
+                   or has_table_privilege('anon','public.aos_cia_email_recipient_controls','SELECT');
+  v_auth_direct := has_table_privilege('authenticated','public.aos_cia_email_send_requests','SELECT')
+                   or has_table_privilege('authenticated','public.aos_cia_email_send_requests','INSERT')
+                   or has_table_privilege('authenticated','public.aos_cia_email_recipient_controls','SELECT');
+
+  select count(*)::integer into v_templates from public.aos_cia_email_template_versions where state='ACTIVE';
+  select count(*)::integer into v_requests from public.aos_cia_email_send_requests;
+  select count(*)::integer into v_illegal from public.aos_cia_email_send_requests where state <> 'PREPARED';
+
+  return jsonb_build_object(
+    'ok',coalesce((v_f15->>'ready_for_f16')::boolean,false) and v_tables=5 and v_rls=5 and not v_anon_direct and not v_auth_direct and v_illegal=0,
+    'status','IN_PROGRESS_PREVIEW_ONLY',
+    'mode','GOVERNED_EMAIL_SHADOW',
+    'ready_for_f17',false,
+    'delivery_enabled',false,
+    'send_request_state_enabled','PREPARED_ONLY',
+    'f15_readiness',v_f15,
+    'schema',jsonb_build_object('private_tables',v_tables,'rls_tables',v_rls,'anon_direct_access',v_anon_direct,'authenticated_direct_access',v_auth_direct),
+    'templates_active',v_templates,
+    'requests_total',v_requests,
+    'non_prepared_requests',v_illegal,
+    'next_gate','ZERO_COST_CONTRACTS_THEN_PROVIDER_AUTH_WEBHOOK_CANARY'
+  );
+end
+$function$;
+
+create or replace function public.aos_cia_email_admin_gateway_v1(
+  p_token text,
+  p_action text,
+  p_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_auth jsonb;
+  v_admin uuid;
+  v_action text := upper(trim(coalesce(p_action,'')));
+  v_activation uuid;
+  v_template uuid;
+  v_purpose text;
+  v_contact text;
+  v_limit integer;
+  v_offset integer;
+  v_vars text[];
+  v_items jsonb;
+begin
+  v_auth := public.aos_cia_verify_admin_session_v1(p_token);
+  if coalesce((v_auth->>'ok')::boolean,false) is not true then
+    return jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+  v_admin := (v_auth->>'user_id')::uuid;
+
+  if v_action='READINESS' then
+    return public.aos_cia_email_f17_readiness_v1();
+  elsif v_action='PREVIEW' then
+    begin v_activation := (p_payload->>'activation_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTIVATION_ID'); end;
+    v_purpose := coalesce(nullif(upper(trim(p_payload->>'purpose')),''),'MARKETING');
+    v_limit := greatest(1,least(coalesce((p_payload->>'limit')::integer,50),100));
+    v_offset := greatest(0,coalesce((p_payload->>'offset')::integer,0));
+    return public.aos_cia_email_preview_activation_v1(v_activation,v_purpose,v_limit,v_offset);
+  elsif v_action='TEMPLATE_CREATE_VERSION' then
+    select coalesce(array_agg(value),'{}'::text[]) into v_vars
+    from jsonb_array_elements_text(coalesce(p_payload->'variable_keys','[]'::jsonb)) value;
+    return public.aos_cia_email_template_version_create_v1(
+      v_admin,p_payload->>'template_key',p_payload->>'purpose',p_payload->>'subject_template',p_payload->>'html_template',v_vars,
+      case when nullif(p_payload->>'legacy_template_id','') is null then null else (p_payload->>'legacy_template_id')::uuid end
+    );
+  elsif v_action='TEMPLATE_ACTIVATE' then
+    begin v_template := (p_payload->>'template_version_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_TEMPLATE_VERSION_ID'); end;
+    return public.aos_cia_email_template_version_activate_v1(v_admin,v_template);
+  elsif v_action='PREPARE_REQUEST' then
+    begin v_activation := (p_payload->>'activation_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTIVATION_ID'); end;
+    begin v_template := (p_payload->>'template_version_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_TEMPLATE_VERSION_ID'); end;
+    v_contact := trim(coalesce(p_payload->>'contact_key',''));
+    if v_contact='' then return jsonb_build_object('ok',false,'error','CONTACT_REQUIRED'); end if;
+    return public.aos_cia_email_prepare_request_v1(v_admin,v_activation,v_contact,v_template);
+  elsif v_action='REQUESTS' then
+    v_limit := greatest(1,least(coalesce((p_payload->>'limit')::integer,50),100));
+    select coalesce(jsonb_agg(to_jsonb(x) order by x.created_at desc),'[]'::jsonb) into v_items
+    from (
+      select id,correlation_id,activation_id,contact_key,purpose,template_version_id,state,dispatch_attempts,created_at,updated_at
+      from public.aos_cia_email_send_requests order by created_at desc limit v_limit
+    ) x;
+    return jsonb_build_object('ok',true,'items',v_items,'delivery_enabled',false);
+  end if;
+  return jsonb_build_object('ok',false,'error','UNKNOWN_ACTION');
+exception when invalid_text_representation or numeric_value_out_of_range then
+  return jsonb_build_object('ok',false,'error','INVALID_PAYLOAD');
+end
+$function$;
+
+revoke all on function public.aos_cia_email_eligibility_v1(uuid,text,text) from public, anon, authenticated;
+revoke all on function public.aos_cia_email_preview_activation_v1(uuid,text,integer,integer) from public, anon, authenticated;
+revoke all on function public.aos_cia_email_template_version_create_v1(uuid,text,text,text,text,text[],uuid) from public, anon, authenticated;
+revoke all on function public.aos_cia_email_template_version_activate_v1(uuid,uuid) from public, anon, authenticated;
+revoke all on function public.aos_cia_email_prepare_request_v1(uuid,uuid,text,uuid) from public, anon, authenticated;
+revoke all on function public.aos_cia_email_f17_readiness_v1() from public, anon, authenticated;
+revoke all on function public.aos_cia_email_admin_gateway_v1(text,text,jsonb) from public;
+grant execute on function public.aos_cia_email_admin_gateway_v1(text,text,jsonb) to anon, authenticated;
+
+comment on function public.aos_cia_email_admin_gateway_v1(text,text,jsonb) is 'F16 ADMIN gateway. PREVIEW/PREPARE only; no provider dispatch exists in this contract.';

--- a/supabase/migrations/20260814220000_cia_phase16_email_delivery_contracts_v2.sql
+++ b/supabase/migrations/20260814220000_cia_phase16_email_delivery_contracts_v2.sql
@@ -1,0 +1,555 @@
+-- ASCENDA OS CIA V3 — F16 Email delivery/provider contracts v2
+-- Additive and fail-closed. No provider call is performed by SQL.
+-- Internal dispatch/provider functions are service_role-only; browser access remains through the admin gateway.
+
+begin;
+
+alter table public.aos_cia_email_send_requests
+  add column if not exists render_context jsonb not null default '{}'::jsonb;
+
+alter table public.aos_cia_email_send_requests
+  drop constraint if exists aos_cia_email_send_requests_render_context_object;
+alter table public.aos_cia_email_send_requests
+  add constraint aos_cia_email_send_requests_render_context_object
+  check (jsonb_typeof(render_context)='object');
+
+create table if not exists public.aos_cia_email_release_state (
+  singleton boolean primary key default true check (singleton),
+  gateway_active boolean not null default false,
+  provider_configured boolean not null default false,
+  webhook_verified boolean not null default false,
+  admin_ui_gateway_only boolean not null default false,
+  legacy_acl_hardened boolean not null default false,
+  canary_passed boolean not null default false,
+  rollback_verified boolean not null default false,
+  evidence jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.aos_cia_email_release_state(singleton)
+values(true)
+on conflict (singleton) do nothing;
+
+alter table public.aos_cia_email_release_state enable row level security;
+revoke all on table public.aos_cia_email_release_state from public,anon,authenticated;
+grant select,insert,update on table public.aos_cia_email_release_state to service_role;
+
+create or replace function public.aos_cia_email_request_guard_v1()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+begin
+  if old.id is distinct from new.id
+     or old.correlation_id is distinct from new.correlation_id
+     or old.activation_id is distinct from new.activation_id
+     or old.contact_key is distinct from new.contact_key
+     or old.recipient_email is distinct from new.recipient_email
+     or old.purpose is distinct from new.purpose
+     or old.template_version_id is distinct from new.template_version_id
+     or old.template_digest is distinct from new.template_digest
+     or old.idempotency_key is distinct from new.idempotency_key
+     or old.eligibility_status is distinct from new.eligibility_status
+     or old.consent_status is distinct from new.consent_status
+     or old.render_context is distinct from new.render_context
+     or old.requested_by_user_id is distinct from new.requested_by_user_id
+     or old.authorization_provenance is distinct from new.authorization_provenance
+     or old.created_at is distinct from new.created_at then
+    raise exception 'EMAIL_SEND_REQUEST_IDENTITY_IMMUTABLE';
+  end if;
+
+  if old.state is distinct from new.state then
+    if not (
+      (old.state = 'PREPARED' and new.state in ('QUEUED','CANCELLED')) or
+      (old.state = 'QUEUED' and new.state in ('DISPATCHING','CANCELLED')) or
+      (old.state = 'DISPATCHING' and new.state in ('ACCEPTED','FAILED','QUEUED','CANCELLED')) or
+      (old.state = 'FAILED' and new.state in ('QUEUED','CANCELLED')) or
+      (old.state = 'ACCEPTED' and new.state in ('DELIVERED','BOUNCED','COMPLAINED','FAILED')) or
+      (old.state = 'DELIVERED' and new.state = 'COMPLAINED')
+    ) then
+      raise exception 'EMAIL_SEND_REQUEST_INVALID_TRANSITION:%->%', old.state, new.state;
+    end if;
+  end if;
+
+  new.updated_at := now();
+  if new.state in ('DELIVERED','BOUNCED','COMPLAINED','CANCELLED') and new.terminal_at is null then
+    new.terminal_at := now();
+  end if;
+  return new;
+end
+$function$;
+
+create or replace function public.aos_cia_email_prepare_request_v2(
+  p_actor_user_id uuid,
+  p_activation_id uuid,
+  p_contact_key text,
+  p_template_version_id uuid,
+  p_render_context jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_tpl record;
+  v_elig jsonb;
+  v_activation_state text;
+  v_key text;
+  v_existing record;
+  v_id uuid;
+  v_context jsonb := coalesce(p_render_context,'{}'::jsonb);
+begin
+  if p_actor_user_id is null then return jsonb_build_object('ok',false,'error','ACTOR_REQUIRED'); end if;
+  if jsonb_typeof(v_context) <> 'object' then return jsonb_build_object('ok',false,'error','INVALID_RENDER_CONTEXT'); end if;
+  if pg_column_size(v_context) > 65536 then return jsonb_build_object('ok',false,'error','RENDER_CONTEXT_TOO_LARGE'); end if;
+
+  select t.* into v_tpl
+  from public.aos_cia_email_template_versions t
+  where t.id=p_template_version_id;
+  if v_tpl.id is null then return jsonb_build_object('ok',false,'error','TEMPLATE_VERSION_NOT_FOUND'); end if;
+  if v_tpl.state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','TEMPLATE_NOT_ACTIVE'); end if;
+
+  select st.estado into v_activation_state
+  from public.aos_audiencia_activacion_estado st
+  where st.activacion_id=p_activation_id;
+  if v_activation_state is null then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_FOUND'); end if;
+  if v_activation_state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_ACTIVE','state',v_activation_state); end if;
+
+  v_elig := public.aos_cia_email_eligibility_v1(p_activation_id,p_contact_key,v_tpl.purpose);
+  if coalesce(v_elig->>'eligibility_status','UNKNOWN') <> 'ELIGIBLE' then
+    return jsonb_build_object('ok',false,'error','EMAIL_NOT_ELIGIBLE','eligibility',v_elig,'send_performed',false);
+  end if;
+  if coalesce(v_elig->>'consent_status','UNKNOWN') not in ('ALLOWED','NOT_REQUIRED') then
+    return jsonb_build_object('ok',false,'error','CONSENT_NOT_ALLOWED','eligibility',v_elig,'send_performed',false);
+  end if;
+
+  v_key := md5(p_activation_id::text||'|'||trim(p_contact_key)||'|'||p_template_version_id::text||'|'||v_tpl.purpose);
+  perform pg_advisory_xact_lock(hashtext('F16_EMAIL_REQUEST:'||v_key));
+  select id,state,render_context into v_existing
+  from public.aos_cia_email_send_requests where idempotency_key=v_key;
+  if v_existing.id is not null then
+    return jsonb_build_object(
+      'ok',true,'request_id',v_existing.id,'idempotent',true,'state',v_existing.state,
+      'context_reused',v_existing.render_context=v_context,'send_performed',false
+    );
+  end if;
+
+  insert into public.aos_cia_email_send_requests(
+    activation_id,contact_key,recipient_email,purpose,template_version_id,template_digest,idempotency_key,
+    eligibility_status,consent_status,render_context,state,requested_by_user_id,authorization_provenance
+  ) values(
+    p_activation_id,trim(p_contact_key),v_elig->>'email',v_tpl.purpose,v_tpl.id,v_tpl.content_digest,v_key,
+    v_elig->>'eligibility_status',v_elig->>'consent_status',v_context,'PREPARED',p_actor_user_id,
+    jsonb_build_object('actor_user_id',p_actor_user_id,'via','CIA_EMAIL_ADMIN_GATEWAY_V2','prepared_only',true)
+  ) returning id into v_id;
+
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_id,'PREPARED',jsonb_build_object('eligibility_reason',v_elig->>'reason_code','send_performed',false));
+
+  return jsonb_build_object('ok',true,'request_id',v_id,'idempotent',false,'state','PREPARED','send_performed',false,'eligibility',v_elig);
+end
+$function$;
+
+create or replace function public.aos_cia_email_queue_request_v2(
+  p_actor_user_id uuid,
+  p_request_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_req record;
+  v_elig jsonb;
+begin
+  if p_actor_user_id is null or p_request_id is null then
+    return jsonb_build_object('ok',false,'error','ACTOR_AND_REQUEST_REQUIRED');
+  end if;
+
+  select * into v_req from public.aos_cia_email_send_requests where id=p_request_id for update;
+  if v_req.id is null then return jsonb_build_object('ok',false,'error','REQUEST_NOT_FOUND'); end if;
+  if v_req.state in ('QUEUED','DISPATCHING','ACCEPTED','DELIVERED','BOUNCED','COMPLAINED') then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',true);
+  end if;
+  if v_req.state not in ('PREPARED','FAILED') then
+    return jsonb_build_object('ok',false,'error','REQUEST_NOT_QUEUEABLE','state',v_req.state);
+  end if;
+
+  v_elig := public.aos_cia_email_eligibility_v1(v_req.activation_id,v_req.contact_key,v_req.purpose);
+  if coalesce(v_elig->>'eligibility_status','UNKNOWN') <> 'ELIGIBLE'
+     or coalesce(v_elig->>'consent_status','UNKNOWN') not in ('ALLOWED','NOT_REQUIRED') then
+    update public.aos_cia_email_send_requests set state='CANCELLED' where id=v_req.id;
+    insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+    values(v_req.id,'QUEUE_BLOCKED',jsonb_build_object('eligibility',v_elig,'actor_user_id',p_actor_user_id));
+    return jsonb_build_object('ok',false,'error','EMAIL_NOT_ELIGIBLE_AT_QUEUE','request_id',v_req.id,'state','CANCELLED','eligibility',v_elig);
+  end if;
+
+  update public.aos_cia_email_send_requests set state='QUEUED',scheduled_at=coalesce(scheduled_at,now()) where id=v_req.id;
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_req.id,'QUEUED',jsonb_build_object('actor_user_id',p_actor_user_id,'eligibility_reason',v_elig->>'reason_code'));
+  return jsonb_build_object('ok',true,'request_id',v_req.id,'state','QUEUED','idempotent',false);
+end
+$function$;
+
+create or replace function public.aos_cia_email_claim_dispatch_v2(p_request_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_req record;
+  v_tpl record;
+  v_elig jsonb;
+begin
+  if p_request_id is null then return jsonb_build_object('ok',false,'error','REQUEST_REQUIRED','send_allowed',false); end if;
+
+  select * into v_req from public.aos_cia_email_send_requests where id=p_request_id for update;
+  if v_req.id is null then return jsonb_build_object('ok',false,'error','REQUEST_NOT_FOUND','send_allowed',false); end if;
+  if v_req.state in ('ACCEPTED','DELIVERED','BOUNCED','COMPLAINED') then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',true,'send_allowed',false,'provider_message_id',v_req.provider_message_id);
+  end if;
+  if v_req.state='DISPATCHING' then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state','DISPATCHING','in_progress',true,'send_allowed',false);
+  end if;
+  if v_req.state <> 'QUEUED' then
+    return jsonb_build_object('ok',false,'error','REQUEST_NOT_QUEUED','state',v_req.state,'send_allowed',false);
+  end if;
+
+  v_elig := public.aos_cia_email_eligibility_v1(v_req.activation_id,v_req.contact_key,v_req.purpose);
+  if coalesce(v_elig->>'eligibility_status','UNKNOWN') <> 'ELIGIBLE'
+     or coalesce(v_elig->>'consent_status','UNKNOWN') not in ('ALLOWED','NOT_REQUIRED') then
+    update public.aos_cia_email_send_requests set state='CANCELLED' where id=v_req.id;
+    insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+    values(v_req.id,'DISPATCH_BLOCKED',jsonb_build_object('eligibility',v_elig));
+    return jsonb_build_object('ok',false,'error','EMAIL_NOT_ELIGIBLE_AT_DISPATCH','request_id',v_req.id,'state','CANCELLED','send_allowed',false,'eligibility',v_elig);
+  end if;
+
+  select * into v_tpl from public.aos_cia_email_template_versions where id=v_req.template_version_id;
+  if v_tpl.id is null or v_tpl.state <> 'ACTIVE' or v_tpl.content_digest <> v_req.template_digest then
+    update public.aos_cia_email_send_requests set state='CANCELLED' where id=v_req.id;
+    insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+    values(v_req.id,'DISPATCH_BLOCKED',jsonb_build_object('reason','TEMPLATE_DRIFT_OR_INACTIVE'));
+    return jsonb_build_object('ok',false,'error','TEMPLATE_DRIFT_OR_INACTIVE','request_id',v_req.id,'state','CANCELLED','send_allowed',false);
+  end if;
+
+  update public.aos_cia_email_send_requests
+     set state='DISPATCHING',provider='RESEND',dispatch_attempts=dispatch_attempts+1
+   where id=v_req.id;
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_req.id,'DISPATCHING',jsonb_build_object('provider','RESEND','attempt',v_req.dispatch_attempts+1));
+
+  return jsonb_build_object(
+    'ok',true,'request_id',v_req.id,'correlation_id',v_req.correlation_id,
+    'recipient_email',v_req.recipient_email,'purpose',v_req.purpose,
+    'subject_template',v_tpl.subject_template,'html_template',v_tpl.html_template,
+    'variable_keys',to_jsonb(v_tpl.variable_keys),'render_context',v_req.render_context,
+    'idempotency_key',v_req.idempotency_key,'state','DISPATCHING','send_allowed',true
+  );
+end
+$function$;
+
+create or replace function public.aos_cia_email_record_dispatch_result_v2(
+  p_request_id uuid,
+  p_accepted boolean,
+  p_provider text,
+  p_provider_message_id text default null,
+  p_error_code text default null,
+  p_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_req record;
+  v_provider text := upper(trim(coalesce(p_provider,'')));
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+begin
+  if p_request_id is null or v_provider='' then return jsonb_build_object('ok',false,'error','REQUEST_AND_PROVIDER_REQUIRED'); end if;
+  if jsonb_typeof(v_payload) <> 'object' then return jsonb_build_object('ok',false,'error','INVALID_PAYLOAD'); end if;
+
+  select * into v_req from public.aos_cia_email_send_requests where id=p_request_id for update;
+  if v_req.id is null then return jsonb_build_object('ok',false,'error','REQUEST_NOT_FOUND'); end if;
+
+  if coalesce(p_accepted,false) and v_req.state in ('ACCEPTED','DELIVERED','BOUNCED','COMPLAINED') then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',true);
+  end if;
+  if v_req.state <> 'DISPATCHING' then
+    return jsonb_build_object('ok',false,'error','REQUEST_NOT_DISPATCHING','state',v_req.state);
+  end if;
+
+  if coalesce(p_accepted,false) then
+    if nullif(trim(coalesce(p_provider_message_id,'')),'') is null then
+      return jsonb_build_object('ok',false,'error','PROVIDER_MESSAGE_ID_REQUIRED');
+    end if;
+    update public.aos_cia_email_send_requests
+       set state='ACCEPTED',provider=v_provider,provider_message_id=trim(p_provider_message_id),accepted_at=coalesce(accepted_at,now())
+     where id=v_req.id;
+    insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+    values(v_req.id,'PROVIDER_ACCEPTED',v_payload||jsonb_build_object('provider',v_provider,'provider_message_id',trim(p_provider_message_id)));
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state','ACCEPTED','provider_message_id',trim(p_provider_message_id));
+  end if;
+
+  update public.aos_cia_email_send_requests set state='FAILED',provider=v_provider where id=v_req.id;
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_req.id,'PROVIDER_FAILED',v_payload||jsonb_build_object('provider',v_provider,'error_code',left(coalesce(p_error_code,'PROVIDER_ERROR'),120)));
+  return jsonb_build_object('ok',true,'request_id',v_req.id,'state','FAILED');
+end
+$function$;
+
+create or replace function public.aos_cia_email_ingest_provider_event_v2(
+  p_provider_event_id text,
+  p_provider_message_id text,
+  p_event_type text,
+  p_occurred_at timestamptz default now(),
+  p_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_req record;
+  v_type text := lower(trim(coalesce(p_event_type,'')));
+  v_event_id text := trim(coalesce(p_provider_event_id,''));
+  v_message_id text := trim(coalesce(p_provider_message_id,''));
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+begin
+  if length(v_event_id) < 8 or length(v_event_id) > 255 then return jsonb_build_object('ok',false,'error','INVALID_PROVIDER_EVENT_ID'); end if;
+  if v_message_id='' then return jsonb_build_object('ok',false,'error','PROVIDER_MESSAGE_ID_REQUIRED'); end if;
+  if v_type not in ('email.delivered','email.bounced','email.complained','email.opened','email.clicked','email.delivery_delayed') then
+    return jsonb_build_object('ok',false,'error','UNSUPPORTED_PROVIDER_EVENT');
+  end if;
+  if jsonb_typeof(v_payload) <> 'object' then return jsonb_build_object('ok',false,'error','INVALID_PAYLOAD'); end if;
+
+  select * into v_req
+  from public.aos_cia_email_send_requests
+  where provider='RESEND' and provider_message_id=v_message_id
+  for update;
+  if v_req.id is null then return jsonb_build_object('ok',false,'error','PROVIDER_MESSAGE_NOT_FOUND'); end if;
+
+  begin
+    insert into public.aos_cia_email_send_events(request_id,event_type,provider_event_id,payload,occurred_at)
+    values(v_req.id,upper(replace(v_type,'.','_')),v_event_id,v_payload,coalesce(p_occurred_at,now()));
+  exception when unique_violation then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',true);
+  end;
+
+  if v_type='email.delivered' and v_req.state='ACCEPTED' then
+    update public.aos_cia_email_send_requests set state='DELIVERED',delivered_at=coalesce(delivered_at,coalesce(p_occurred_at,now())) where id=v_req.id;
+    v_req.state:='DELIVERED';
+  elsif v_type='email.bounced' and v_req.state='ACCEPTED' then
+    update public.aos_cia_email_send_requests set state='BOUNCED' where id=v_req.id;
+    v_req.state:='BOUNCED';
+  elsif v_type='email.complained' and v_req.state in ('ACCEPTED','DELIVERED') then
+    update public.aos_cia_email_send_requests set state='COMPLAINED' where id=v_req.id;
+    v_req.state:='COMPLAINED';
+  end if;
+
+  return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',false);
+end
+$function$;
+
+create or replace function public.aos_cia_email_release_mark_v1(
+  p_gate text,
+  p_value boolean,
+  p_evidence text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_gate text := upper(trim(coalesce(p_gate,'')));
+  v_value boolean := coalesce(p_value,false);
+begin
+  if v_gate not in ('GATEWAY_ACTIVE','PROVIDER_CONFIGURED','WEBHOOK_VERIFIED','ADMIN_UI_GATEWAY_ONLY','LEGACY_ACL_HARDENED','CANARY_PASSED','ROLLBACK_VERIFIED') then
+    return jsonb_build_object('ok',false,'error','INVALID_RELEASE_GATE');
+  end if;
+
+  update public.aos_cia_email_release_state
+  set gateway_active=case when v_gate='GATEWAY_ACTIVE' then v_value else gateway_active end,
+      provider_configured=case when v_gate='PROVIDER_CONFIGURED' then v_value else provider_configured end,
+      webhook_verified=case when v_gate='WEBHOOK_VERIFIED' then v_value else webhook_verified end,
+      admin_ui_gateway_only=case when v_gate='ADMIN_UI_GATEWAY_ONLY' then v_value else admin_ui_gateway_only end,
+      legacy_acl_hardened=case when v_gate='LEGACY_ACL_HARDENED' then v_value else legacy_acl_hardened end,
+      canary_passed=case when v_gate='CANARY_PASSED' then v_value else canary_passed end,
+      rollback_verified=case when v_gate='ROLLBACK_VERIFIED' then v_value else rollback_verified end,
+      evidence=evidence||jsonb_build_object(v_gate,jsonb_build_object('value',v_value,'evidence',left(coalesce(p_evidence,''),500),'at',now())),
+      updated_at=now()
+  where singleton=true;
+
+  return jsonb_build_object('ok',true,'gate',v_gate,'value',v_value);
+end
+$function$;
+
+create or replace function public.aos_cia_email_admin_gateway_v2(
+  p_token text,
+  p_action text,
+  p_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_auth jsonb;
+  v_admin uuid;
+  v_action text := upper(trim(coalesce(p_action,'')));
+  v_activation uuid;
+  v_template uuid;
+  v_request uuid;
+  v_contact text;
+begin
+  v_auth := public.aos_cia_verify_admin_session_v1(p_token);
+  if coalesce((v_auth->>'ok')::boolean,false) is not true then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  begin v_admin := (v_auth->>'user_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end;
+
+  if v_action='PREVIEW_ACTIVATION' then
+    begin v_activation := (p_payload->>'activation_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTIVATION_ID'); end;
+    return public.aos_cia_email_preview_activation_v1(v_activation,coalesce(p_payload->>'purpose','MARKETING'),coalesce((p_payload->>'limit')::integer,50),coalesce((p_payload->>'offset')::integer,0));
+  elsif v_action='TEMPLATE_CREATE' then
+    return public.aos_cia_email_template_version_create_v1(
+      v_admin,p_payload->>'template_key',p_payload->>'purpose',p_payload->>'subject_template',p_payload->>'html_template',
+      coalesce(array(select jsonb_array_elements_text(coalesce(p_payload->'variable_keys','[]'::jsonb))),'{}'::text[]),
+      case when nullif(p_payload->>'legacy_template_id','') is null then null else (p_payload->>'legacy_template_id')::uuid end
+    );
+  elsif v_action='TEMPLATE_ACTIVATE' then
+    begin v_template := (p_payload->>'template_version_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_TEMPLATE_VERSION_ID'); end;
+    return public.aos_cia_email_template_version_activate_v1(v_admin,v_template);
+  elsif v_action='PREPARE_REQUEST' then
+    begin v_activation := (p_payload->>'activation_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTIVATION_ID'); end;
+    begin v_template := (p_payload->>'template_version_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_TEMPLATE_VERSION_ID'); end;
+    v_contact := trim(coalesce(p_payload->>'contact_key',''));
+    if v_contact='' then return jsonb_build_object('ok',false,'error','CONTACT_REQUIRED'); end if;
+    return public.aos_cia_email_prepare_request_v2(v_admin,v_activation,v_contact,v_template,coalesce(p_payload->'render_context','{}'::jsonb));
+  elsif v_action='QUEUE_REQUEST' then
+    begin v_request := (p_payload->>'request_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_REQUEST_ID'); end;
+    return public.aos_cia_email_queue_request_v2(v_admin,v_request);
+  elsif v_action='LIST_REQUESTS' then
+    return jsonb_build_object(
+      'ok',true,
+      'items',coalesce((select jsonb_agg(x order by x.created_at desc) from (
+        select id,correlation_id,activation_id,contact_key,purpose,template_version_id,state,provider,provider_message_id,dispatch_attempts,created_at,updated_at
+        from public.aos_cia_email_send_requests
+        order by created_at desc
+        limit greatest(1,least(coalesce((p_payload->>'limit')::integer,50),100))
+      ) x),'[]'::jsonb)
+    );
+  elsif v_action='READINESS' then
+    return public.aos_cia_email_f17_readiness_v1();
+  end if;
+  return jsonb_build_object('ok',false,'error','UNSUPPORTED_ACTION');
+exception when invalid_text_representation then
+  return jsonb_build_object('ok',false,'error','INVALID_PAYLOAD');
+end
+$function$;
+
+create or replace function public.aos_cia_email_f17_readiness_v1()
+returns jsonb
+language plpgsql
+stable
+set search_path = ''
+as $function$
+declare
+  v_f15 jsonb;
+  v_tables integer;
+  v_rls integer;
+  v_anon_direct boolean;
+  v_auth_direct boolean;
+  v_illegal integer;
+  v_release record;
+  v_ready boolean;
+begin
+  v_f15 := public.aos_cia_kronia_f16_readiness_v1();
+
+  select count(*)::integer into v_tables
+  from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname in (
+    'aos_cia_email_recipient_controls','aos_cia_email_recipient_control_events','aos_cia_email_template_versions',
+    'aos_cia_email_send_requests','aos_cia_email_send_events','aos_cia_email_release_state'
+  ) and c.relkind='r';
+
+  select count(*)::integer into v_rls
+  from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname in (
+    'aos_cia_email_recipient_controls','aos_cia_email_recipient_control_events','aos_cia_email_template_versions',
+    'aos_cia_email_send_requests','aos_cia_email_send_events','aos_cia_email_release_state'
+  ) and c.relrowsecurity;
+
+  select exists(
+    select 1 from information_schema.table_privileges
+    where table_schema='public' and table_name like 'aos_cia_email_%' and grantee='anon'
+      and privilege_type in ('SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER')
+  ) into v_anon_direct;
+  select exists(
+    select 1 from information_schema.table_privileges
+    where table_schema='public' and table_name like 'aos_cia_email_%' and grantee='authenticated'
+      and privilege_type in ('SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER')
+  ) into v_auth_direct;
+
+  select count(*)::integer into v_illegal
+  from public.aos_cia_email_send_requests
+  where eligibility_status <> 'ELIGIBLE' and state in ('QUEUED','DISPATCHING','ACCEPTED','DELIVERED');
+
+  select * into v_release from public.aos_cia_email_release_state where singleton=true;
+  v_ready := coalesce((v_f15->>'ready_for_f16')::boolean,false)
+             and v_tables=6 and v_rls=6 and not v_anon_direct and not v_auth_direct and v_illegal=0
+             and coalesce(v_release.gateway_active,false)
+             and coalesce(v_release.provider_configured,false)
+             and coalesce(v_release.webhook_verified,false)
+             and coalesce(v_release.admin_ui_gateway_only,false)
+             and coalesce(v_release.legacy_acl_hardened,false)
+             and coalesce(v_release.canary_passed,false)
+             and coalesce(v_release.rollback_verified,false);
+
+  return jsonb_build_object(
+    'ok',true,
+    'status',case when v_ready then 'READY_F17_EMAIL_CERTIFIED' else 'IN_PROGRESS_DELIVERY_GOVERNANCE' end,
+    'ready_for_f17',v_ready,
+    'delivery_enabled',coalesce(v_release.gateway_active,false) and coalesce(v_release.provider_configured,false),
+    'f15_ready',coalesce((v_f15->>'ready_for_f16')::boolean,false),
+    'governed_tables',v_tables,'rls_tables',v_rls,
+    'browser_direct_table_access',jsonb_build_object('anon',v_anon_direct,'authenticated',v_auth_direct),
+    'illegal_send_states',v_illegal,
+    'release_gates',jsonb_build_object(
+      'gateway_active',coalesce(v_release.gateway_active,false),
+      'provider_configured',coalesce(v_release.provider_configured,false),
+      'webhook_verified',coalesce(v_release.webhook_verified,false),
+      'admin_ui_gateway_only',coalesce(v_release.admin_ui_gateway_only,false),
+      'legacy_acl_hardened',coalesce(v_release.legacy_acl_hardened,false),
+      'canary_passed',coalesce(v_release.canary_passed,false),
+      'rollback_verified',coalesce(v_release.rollback_verified,false)
+    )
+  );
+end
+$function$;
+
+revoke all on function public.aos_cia_email_prepare_request_v2(uuid,uuid,text,uuid,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_queue_request_v2(uuid,uuid) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_claim_dispatch_v2(uuid) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_record_dispatch_result_v2(uuid,boolean,text,text,text,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_release_mark_v1(text,boolean,text) from public,anon,authenticated;
+revoke all on function public.aos_cia_email_admin_gateway_v2(text,text,jsonb) from public;
+revoke all on function public.aos_cia_email_f17_readiness_v1() from public,anon,authenticated;
+
+grant execute on function public.aos_cia_email_claim_dispatch_v2(uuid) to service_role;
+grant execute on function public.aos_cia_email_record_dispatch_result_v2(uuid,boolean,text,text,text,jsonb) to service_role;
+grant execute on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) to service_role;
+grant execute on function public.aos_cia_email_release_mark_v1(text,boolean,text) to service_role;
+grant execute on function public.aos_cia_email_admin_gateway_v2(text,text,jsonb) to anon,authenticated,service_role;
+grant execute on function public.aos_cia_email_f17_readiness_v1() to service_role;
+
+comment on function public.aos_cia_email_claim_dispatch_v2(uuid) is 'F16 service-role dispatch claim. Revalidates eligibility before provider delivery and returns one idempotent provider intent.';
+comment on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) is 'F16 service-role provider outcome ingestion after server cryptographic webhook verification.';
+comment on table public.aos_cia_email_release_state is 'F16 production release evidence gates. Defaults false; F17 readiness cannot pass before real canary/rollback/ACL evidence.';
+
+commit;

--- a/supabase/migrations/20260814220100_cia_phase16_email_render_context_hardening.sql
+++ b/supabase/migrations/20260814220100_cia_phase16_email_render_context_hardening.sql
@@ -1,0 +1,95 @@
+-- ASCENDA OS CIA V3 — F16 render-context hardening
+-- Prevent an immutable/idempotent PREPARED request from being created when an ACTIVE
+-- template is missing one or more declared variables.
+
+begin;
+
+create or replace function public.aos_cia_email_prepare_request_v2(
+  p_actor_user_id uuid,
+  p_activation_id uuid,
+  p_contact_key text,
+  p_template_version_id uuid,
+  p_render_context jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_tpl record;
+  v_elig jsonb;
+  v_activation_state text;
+  v_key text;
+  v_existing record;
+  v_id uuid;
+  v_context jsonb := coalesce(p_render_context,'{}'::jsonb);
+  v_missing_keys text[];
+begin
+  if p_actor_user_id is null then return jsonb_build_object('ok',false,'error','ACTOR_REQUIRED'); end if;
+  if jsonb_typeof(v_context) <> 'object' then return jsonb_build_object('ok',false,'error','INVALID_RENDER_CONTEXT'); end if;
+  if pg_column_size(v_context) > 65536 then return jsonb_build_object('ok',false,'error','RENDER_CONTEXT_TOO_LARGE'); end if;
+
+  select t.* into v_tpl
+  from public.aos_cia_email_template_versions t
+  where t.id=p_template_version_id;
+  if v_tpl.id is null then return jsonb_build_object('ok',false,'error','TEMPLATE_VERSION_NOT_FOUND'); end if;
+  if v_tpl.state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','TEMPLATE_NOT_ACTIVE'); end if;
+
+  select coalesce(array_agg(k order by k),'{}'::text[]) into v_missing_keys
+  from unnest(coalesce(v_tpl.variable_keys,'{}'::text[])) k
+  where not (v_context ? k) or jsonb_typeof(v_context->k) in ('null','object','array');
+  if coalesce(array_length(v_missing_keys,1),0) > 0 then
+    return jsonb_build_object('ok',false,'error','RENDER_CONTEXT_MISSING','missing_keys',to_jsonb(v_missing_keys),'send_performed',false);
+  end if;
+
+  select st.estado into v_activation_state
+  from public.aos_audiencia_activacion_estado st
+  where st.activacion_id=p_activation_id;
+  if v_activation_state is null then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_FOUND'); end if;
+  if v_activation_state <> 'ACTIVE' then return jsonb_build_object('ok',false,'error','ACTIVATION_NOT_ACTIVE','state',v_activation_state); end if;
+
+  v_elig := public.aos_cia_email_eligibility_v1(p_activation_id,p_contact_key,v_tpl.purpose);
+  if coalesce(v_elig->>'eligibility_status','UNKNOWN') <> 'ELIGIBLE' then
+    return jsonb_build_object('ok',false,'error','EMAIL_NOT_ELIGIBLE','eligibility',v_elig,'send_performed',false);
+  end if;
+  if coalesce(v_elig->>'consent_status','UNKNOWN') not in ('ALLOWED','NOT_REQUIRED') then
+    return jsonb_build_object('ok',false,'error','CONSENT_NOT_ALLOWED','eligibility',v_elig,'send_performed',false);
+  end if;
+
+  v_key := md5(p_activation_id::text||'|'||trim(p_contact_key)||'|'||p_template_version_id::text||'|'||v_tpl.purpose);
+  perform pg_advisory_xact_lock(hashtext('F16_EMAIL_REQUEST:'||v_key));
+  select id,state,render_context into v_existing
+  from public.aos_cia_email_send_requests where idempotency_key=v_key;
+  if v_existing.id is not null then
+    if v_existing.render_context is distinct from v_context then
+      return jsonb_build_object('ok',false,'error','IDEMPOTENCY_CONTEXT_MISMATCH','request_id',v_existing.id,'state',v_existing.state,'send_performed',false);
+    end if;
+    return jsonb_build_object(
+      'ok',true,'request_id',v_existing.id,'idempotent',true,'state',v_existing.state,
+      'context_reused',true,'send_performed',false
+    );
+  end if;
+
+  insert into public.aos_cia_email_send_requests(
+    activation_id,contact_key,recipient_email,purpose,template_version_id,template_digest,idempotency_key,
+    eligibility_status,consent_status,render_context,state,requested_by_user_id,authorization_provenance
+  ) values(
+    p_activation_id,trim(p_contact_key),v_elig->>'email',v_tpl.purpose,v_tpl.id,v_tpl.content_digest,v_key,
+    v_elig->>'eligibility_status',v_elig->>'consent_status',v_context,'PREPARED',p_actor_user_id,
+    jsonb_build_object('actor_user_id',p_actor_user_id,'via','CIA_EMAIL_ADMIN_GATEWAY_V2','prepared_only',true)
+  ) returning id into v_id;
+
+  insert into public.aos_cia_email_send_events(request_id,event_type,payload)
+  values(v_id,'PREPARED',jsonb_build_object('eligibility_reason',v_elig->>'reason_code','send_performed',false));
+
+  return jsonb_build_object('ok',true,'request_id',v_id,'idempotent',false,'state','PREPARED','send_performed',false,'eligibility',v_elig);
+end
+$function$;
+
+revoke all on function public.aos_cia_email_prepare_request_v2(uuid,uuid,text,uuid,jsonb) from public,anon,authenticated;
+grant execute on function public.aos_cia_email_prepare_request_v2(uuid,uuid,text,uuid,jsonb) to service_role;
+
+comment on function public.aos_cia_email_prepare_request_v2(uuid,uuid,text,uuid,jsonb) is 'F16 governed Email request preparation: complete immutable render context required; deterministic idempotency fails closed on context mismatch.';
+
+commit;

--- a/supabase/migrations/20260814220200_cia_phase16_legacy_email_acl_hardening.sql
+++ b/supabase/migrations/20260814220200_cia_phase16_legacy_email_acl_hardening.sql
@@ -1,0 +1,35 @@
+-- ASCENDA OS CIA V3 — F16 legacy Email ACL hardening
+-- CRITICAL / additive authorization closure. Apply only after server/browser consumers
+-- use the authoritative backend boundary and SUPABASE_SERVICE_ROLE_KEY is configured.
+
+begin;
+
+do $acl$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'aos_email_alertas','aos_email_audiencias','aos_email_cadencia','aos_email_campanias','aos_email_envios',
+    'aos_email_eventos','aos_email_flujo_ejecuciones','aos_email_flujos','aos_email_plantillas',
+    'aos_emails_empresa','aos_emails_enviados'
+  ] loop
+    execute format('alter table public.%I enable row level security',t);
+    execute format('revoke all on table public.%I from public,anon,authenticated',t);
+    execute format('grant all on table public.%I to service_role',t);
+  end loop;
+end
+$acl$;
+
+revoke all on function public.aos_email_buscar_paciente(text,integer) from public,anon,authenticated;
+revoke all on function public.aos_email_dashboard() from public,anon,authenticated;
+revoke all on function public.aos_email_historial_paciente(text) from public,anon,authenticated;
+
+grant execute on function public.aos_email_buscar_paciente(text,integer) to service_role;
+grant execute on function public.aos_email_dashboard() to service_role;
+grant execute on function public.aos_email_historial_paciente(text) to service_role;
+
+comment on function public.aos_email_buscar_paciente(text,integer) is 'F16 legacy compatibility RPC: service-role only; browser access goes through server-authoritative Email gateway.';
+comment on function public.aos_email_dashboard() is 'F16 legacy compatibility RPC: service-role only; browser access goes through server-authoritative Email gateway.';
+comment on function public.aos_email_historial_paciente(text) is 'F16 legacy compatibility RPC: service-role only; browser access goes through server-authoritative Email gateway.';
+
+commit;

--- a/supabase/migrations/20260814220300_cia_phase16_verify_app_session_v1.sql
+++ b/supabase/migrations/20260814220300_cia_phase16_verify_app_session_v1.sql
@@ -1,0 +1,64 @@
+-- ASCENDA OS CIA V3 — F16 server-only Auth V3 session verification.
+-- Used by server-authoritative transactional Email endpoints. Browser roles receive no EXECUTE.
+
+begin;
+
+create or replace function public.aos_cia_verify_app_session_v1(p_token text)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $function$
+declare
+  v_hash text;
+  v_session record;
+  v_user record;
+begin
+  if coalesce(pg_catalog.length(pg_catalog.btrim(p_token)),0) < 32
+     or coalesce(pg_catalog.length(pg_catalog.btrim(p_token)),0) > 512 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+
+  v_hash := pg_catalog.encode(extensions.digest(pg_catalog.btrim(p_token),'sha256'),'hex');
+
+  select s.user_id,s.assurance_level,s.expires_at,s.revoked
+    into v_session
+  from public.aos_app_sessions_v3 s
+  where s.token_hash=v_hash
+    and s.revoked=false
+    and s.expires_at>pg_catalog.now()
+  limit 1;
+
+  if v_session.user_id is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+
+  select u.id,u.nombre,u.rol,u.activo,u.paneles_acceso
+    into v_user
+  from public.aos_usuarios u
+  where u.id=v_session.user_id and u.activo=true
+  limit 1;
+
+  if v_user.id is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'ok',true,
+    'user_id',v_user.id,
+    'nombre',v_user.nombre,
+    'rol',v_user.rol,
+    'assurance_level',v_session.assurance_level,
+    'expires_at',v_session.expires_at,
+    'paneles_acceso',pg_catalog.to_jsonb(coalesce(v_user.paneles_acceso,'{}'::text[]))
+  );
+end
+$function$;
+
+revoke all on function public.aos_cia_verify_app_session_v1(text) from public,anon,authenticated;
+grant execute on function public.aos_cia_verify_app_session_v1(text) to service_role;
+
+comment on function public.aos_cia_verify_app_session_v1(text) is 'F16 server-only verifier for current Auth V3 opaque app tokens. Hashes token and validates active, unrevoked, unexpired session/user; never exposes token hashes.';
+
+commit;


### PR DESCRIPTION
Owner-authorized F16 production cutover after Railway environment gate remediation.

This release branch was rebuilt directly on CURRENT rollback-safe main `1b71a1236db22fb22cddb6693fd6e26c83847783`; that main has zero file differences versus the substantive pre-F16 main used for certification. This avoids Git revert-history ambiguity from prior cutover/rollback attempts.

Exact release HEAD: `6c49263b6407ec4621b2e31b00dee4474e58ae34`.
Exact-head Zero-Cost gates on this SAME SHA:
- Runtime Certification #31910327115 — PASS
- Email Contracts / synthetic DB / rollback #31910327077 — PASS
- Email Policy #31910327075 — PASS
- Railway environment alias compatibility #31910327089 — PASS (idempotent, environment-only)

Runtime secret lookup remains environment-only: canonical `SUPABASE_SERVICE_ROLE_KEY` first, with Railway compatibility alias `service_role` second. No secret value is stored in code.

Post-deploy mandatory production probes before any DB migration:
- GET /health => 200
- GET /api/resend-webhook => 405 (route present, POST-only)
- POST /api/email-gateway with synthetic invalid session => MUST be 401 UNAUTHORIZED, never 503 SERVICE_ROLE_NOT_CONFIGURED.

This merge does NOT execute the six Supabase F16 migrations and does NOT create a Resend webhook. Issue #104 stays open until migrations, signed/replay-safe webhook, canary, legacy ACL hardening, rollback/recovery and F17 authoritative readiness are all certified.