### PR TITLE
F16: complete Resend failed/suppressed outcome coverage

### DIFF
--- a/.github/workflows/f16-provider-outcomes-test-adapt.yml
+++ b/.github/workflows/f16-provider-outcomes-test-adapt.yml
@@ -1,0 +1,61 @@
+name: F16 Provider Outcomes Test Adapt
+
+on:
+  push:
+    branches: ['hotfix/f16-resend-outcomes-20260815']
+    paths:
+      - '.github/workflows/f16-provider-outcomes-test-adapt.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  adapt:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Zero-Cost health
+        run: |
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          bash scripts/ci/runner-healthcheck.sh
+      - name: Adapt existing delivery contract to complaint suppression
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          p=Path('ci/phase16/test_phase16_delivery_contracts.sql')
+          s=p.read_text()
+          needle="""  if j->>'state' <> 'COMPLAINED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: post-delivery complaint transition %',j;
+  end if;
+end
+$test$;
+"""
+          replacement="""  if j->>'state' <> 'COMPLAINED' then
+    raise exception 'F16_DELIVERY_TEST_FAIL: post-delivery complaint transition %',j;
+  end if;
+  if coalesce((select global_suppressed from public.aos_cia_email_recipient_controls where contact_key='synthetic-contact-1'),false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: complaint did not suppress recipient';
+  end if;
+  update public.aos_cia_email_recipient_controls
+     set global_suppressed=false,suppression_reason=null,source='SYNTHETIC_RESET',source_updated_at=now(),updated_by_user_id='00000000-0000-0000-0000-000000000001'
+   where contact_key='synthetic-contact-1';
+end
+$test$;
+"""
+          if s.count(needle)!=1:
+            raise SystemExit('complaint contract anchor not unique')
+          p.write_text(s.replace(needle,replacement,1))
+          PY
+          git diff --check
+      - name: Commit test contract adaptation
+        run: |
+          set -euo pipefail
+          git config user.name 'ASCENDA Zero-Cost CI'
+          git config user.email 'actions@users.noreply.github.com'
+          git add ci/phase16/test_phase16_delivery_contracts.sql
+          git commit -m 'test(f16): assert complaint suppression outcome'
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/f16-resend-outcomes-v3.yml
+++ b/.github/workflows/f16-resend-outcomes-v3.yml
@@ -1,0 +1,91 @@
+name: ASCENDA F16 Resend Outcomes V3
+
+on:
+  push:
+    branches: ['hotfix/f16-resend-outcomes-20260815']
+    paths:
+      - '.github/workflows/f16-resend-outcomes-v3.yml'
+      - 'supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql'
+      - 'ci/phase16/test_phase16_delivery_contracts.sql'
+      - 'ci/phase16/test_phase16_resend_outcomes_v3.sql'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: f16-resend-outcomes-v3-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    name: F16 Resend outcome coverage / rollback
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 25
+    env:
+      BASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+      F16_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/phase16_outcomes_v3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Zero-Cost policy
+        run: python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Runner health
+        run: bash scripts/ci/runner-healthcheck.sh
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Start isolated Supabase PostgreSQL
+        working-directory: ci/zero-cost-staging
+        run: supabase db start
+      - name: Create isolated F16 database
+        run: |
+          set -euo pipefail
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "drop database if exists phase16_outcomes_v3 with (force)"
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "create database phase16_outcomes_v3"
+      - name: Compile F16 plus outcome coverage
+        run: |
+          set -euo pipefail
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/schema_contract.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/legacy_email_schema_contract.sql
+          for f in \
+            20260814200500_cia_phase16_email_governed_schema_v1.sql \
+            20260814200600_cia_phase16_email_contracts_v1.sql \
+            20260814220000_cia_phase16_email_delivery_contracts_v2.sql \
+            20260814220100_cia_phase16_email_render_context_hardening.sql \
+            20260814220200_cia_phase16_legacy_email_acl_hardening.sql \
+            20260814220300_cia_phase16_verify_app_session_v1.sql \
+            20260815221000_cia_phase16_resend_outcome_coverage_v3.sql; do
+            psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+          supabase db lint --db-url "$F16_DB_URL" --schema public --level error
+      - name: Existing and V3 provider contracts
+        run: |
+          set -euo pipefail
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_contracts.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_delivery_contracts.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_render_context_hardening.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_legacy_acl.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_app_session.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_resend_outcomes_v3.sql
+      - name: Fail-closed provider surface assertions
+        run: |
+          set -euo pipefail
+          grep -q "'email.failed'" supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql
+          grep -q "'email.suppressed'" supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql
+          grep -q "RESEND_WEBHOOK" supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql
+          test "$(psql "$F16_DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb)','EXECUTE')")" = "f"
+          echo 'CIA_PHASE16_RESEND_OUTCOME_SURFACE=PASS'
+      - name: Rollback and zero residue
+        run: |
+          set -euo pipefail
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16.sql | tee /tmp/f16_rollback.log
+          grep -q 'CIA_PHASE16_ROLLBACK=PASS' /tmp/f16_rollback.log
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16_legacy_acl.sql | tee /tmp/f16_acl_rollback.log
+          grep -q 'CIA_PHASE16_LEGACY_ACL_ROLLBACK=PASS' /tmp/f16_acl_rollback.log
+          echo 'CIA_PHASE16_RESEND_OUTCOME_ROLLBACK=PASS'
+      - name: Cleanup
+        if: always()
+        run: |
+          psql "$BASE_DB_URL" -X -c "drop database if exists phase16_outcomes_v3 with (force)" || true
+          cd ci/zero-cost-staging && supabase stop --no-backup || true

--- a/ci/phase16/test_phase16_delivery_contracts.sql
+++ b/ci/phase16/test_phase16_delivery_contracts.sql
@@ -90,6 +90,12 @@ begin
   if j->>'state' <> 'COMPLAINED' then
     raise exception 'F16_DELIVERY_TEST_FAIL: post-delivery complaint transition %',j;
   end if;
+  if coalesce((select global_suppressed from public.aos_cia_email_recipient_controls where contact_key='synthetic-contact-1'),false) is not true then
+    raise exception 'F16_DELIVERY_TEST_FAIL: complaint did not suppress recipient';
+  end if;
+  update public.aos_cia_email_recipient_controls
+     set global_suppressed=false,suppression_reason=null,source='SYNTHETIC_RESET',source_updated_at=now(),updated_by_user_id='00000000-0000-0000-0000-000000000001'
+   where contact_key='synthetic-contact-1';
 end
 $test$;
 

--- a/ci/phase16/test_phase16_resend_outcomes_v3.sql
+++ b/ci/phase16/test_phase16_resend_outcomes_v3.sql
@@ -1,0 +1,73 @@
+-- CIA F16 Resend outcome coverage v3 synthetic tests.
+-- Zero PII/PHI and zero provider network calls.
+
+do $test$
+declare
+  j jsonb;
+  v_tpl uuid;
+  v_req uuid;
+begin
+  j := public.aos_cia_email_template_version_create_v1(
+    '00000000-0000-0000-0000-000000000001','synthetic.marketing.outcomes-v3','MARKETING',
+    'Outcome coverage','<p>Outcome coverage</p>',array[]::text[],null
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'F16_OUTCOME_V3_FAIL: template create %',j; end if;
+  v_tpl := (j->>'template_version_id')::uuid;
+  perform public.aos_cia_email_template_version_activate_v1('00000000-0000-0000-0000-000000000001',v_tpl);
+
+  j := public.aos_cia_email_prepare_request_v2(
+    '00000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','synthetic-contact-1',v_tpl,'{}'::jsonb
+  );
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'F16_OUTCOME_V3_FAIL: prepare %',j; end if;
+  v_req := (j->>'request_id')::uuid;
+
+  perform public.aos_cia_email_queue_request_v2('00000000-0000-0000-0000-000000000001',v_req);
+  j := public.aos_cia_email_claim_dispatch_v2(v_req);
+  if coalesce((j->>'send_allowed')::boolean,false) is not true then raise exception 'F16_OUTCOME_V3_FAIL: failed-event dispatch claim %',j; end if;
+  j := public.aos_cia_email_record_dispatch_result_v2(v_req,true,'RESEND','synthetic-provider-message-failed-v3',null,jsonb_build_object('synthetic',true));
+  if j->>'state' <> 'ACCEPTED' then raise exception 'F16_OUTCOME_V3_FAIL: failed-event provider accept %',j; end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-failed-v3','synthetic-provider-message-failed-v3','email.failed',now(),jsonb_build_object('synthetic',true)
+  );
+  if j->>'state' <> 'FAILED' then raise exception 'F16_OUTCOME_V3_FAIL: email.failed transition %',j; end if;
+  if coalesce((select global_suppressed from public.aos_cia_email_recipient_controls where contact_key='synthetic-contact-1'),false) is true then
+    raise exception 'F16_OUTCOME_V3_FAIL: email.failed incorrectly globally suppressed recipient';
+  end if;
+
+  j := public.aos_cia_email_queue_request_v2('00000000-0000-0000-0000-000000000001',v_req);
+  if j->>'state' <> 'QUEUED' then raise exception 'F16_OUTCOME_V3_FAIL: failed request not retryable %',j; end if;
+  j := public.aos_cia_email_claim_dispatch_v2(v_req);
+  if coalesce((j->>'send_allowed')::boolean,false) is not true then raise exception 'F16_OUTCOME_V3_FAIL: suppressed-event dispatch claim %',j; end if;
+  j := public.aos_cia_email_record_dispatch_result_v2(v_req,true,'RESEND','synthetic-provider-message-suppressed-v3',null,jsonb_build_object('synthetic',true));
+  if j->>'state' <> 'ACCEPTED' then raise exception 'F16_OUTCOME_V3_FAIL: suppressed-event provider accept %',j; end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-suppressed-v3','synthetic-provider-message-suppressed-v3','email.suppressed',now(),jsonb_build_object('synthetic',true)
+  );
+  if j->>'state' <> 'FAILED' then raise exception 'F16_OUTCOME_V3_FAIL: email.suppressed transition %',j; end if;
+  if coalesce((select global_suppressed from public.aos_cia_email_recipient_controls where contact_key='synthetic-contact-1'),false) is not true then
+    raise exception 'F16_OUTCOME_V3_FAIL: email.suppressed did not fail closed into recipient controls';
+  end if;
+  if coalesce((select suppression_reason from public.aos_cia_email_recipient_controls where contact_key='synthetic-contact-1'),'') <> 'RESEND_SUPPRESSED' then
+    raise exception 'F16_OUTCOME_V3_FAIL: suppression reason not canonical';
+  end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-suppressed-v3','synthetic-provider-message-suppressed-v3','email.suppressed',now(),jsonb_build_object('synthetic',true)
+  );
+  if coalesce((j->>'idempotent')::boolean,false) is not true then raise exception 'F16_OUTCOME_V3_FAIL: suppressed webhook replay not idempotent %',j; end if;
+
+  j := public.aos_cia_email_ingest_provider_event_v2(
+    'synthetic-event-unsupported-v3','synthetic-provider-message-suppressed-v3','email.received',now(),jsonb_build_object('synthetic',true)
+  );
+  if j->>'error' <> 'UNSUPPORTED_PROVIDER_EVENT' then raise exception 'F16_OUTCOME_V3_FAIL: unsupported event did not fail closed %',j; end if;
+
+  update public.aos_cia_email_recipient_controls
+     set global_suppressed=false,suppression_reason=null,source='SYNTHETIC_RESET',source_updated_at=now(),updated_by_user_id='00000000-0000-0000-0000-000000000001'
+   where contact_key='synthetic-contact-1';
+end
+$test$;
+
+select 'CIA_PHASE16_RESEND_OUTCOMES_V3=PASS' as result;
+select 'PROVIDER_NETWORK_CALLS=0' as provider_policy;

--- a/supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql
+++ b/supabase/migrations/20260815221000_cia_phase16_resend_outcome_coverage_v3.sql
@@ -1,0 +1,100 @@
+-- ASCENDA OS CIA V3 — F16 Resend provider outcome coverage v3
+-- Additive hardening: cover asynchronous failed/suppressed events and make
+-- bounce/complaint/suppression feed the canonical Email suppression control.
+-- No provider call is performed by SQL.
+
+begin;
+
+create or replace function public.aos_cia_email_ingest_provider_event_v2(
+  p_provider_event_id text,
+  p_provider_message_id text,
+  p_event_type text,
+  p_occurred_at timestamptz default now(),
+  p_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_req record;
+  v_type text := lower(trim(coalesce(p_event_type,'')));
+  v_event_id text := trim(coalesce(p_provider_event_id,''));
+  v_message_id text := trim(coalesce(p_provider_message_id,''));
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+  v_suppression_reason text;
+begin
+  if length(v_event_id) < 8 or length(v_event_id) > 255 then
+    return jsonb_build_object('ok',false,'error','INVALID_PROVIDER_EVENT_ID');
+  end if;
+  if v_message_id='' then
+    return jsonb_build_object('ok',false,'error','PROVIDER_MESSAGE_ID_REQUIRED');
+  end if;
+  if v_type not in (
+    'email.delivered','email.bounced','email.complained','email.opened','email.clicked','email.delivery_delayed',
+    'email.failed','email.suppressed'
+  ) then
+    return jsonb_build_object('ok',false,'error','UNSUPPORTED_PROVIDER_EVENT');
+  end if;
+  if jsonb_typeof(v_payload) <> 'object' then
+    return jsonb_build_object('ok',false,'error','INVALID_PAYLOAD');
+  end if;
+
+  select * into v_req
+  from public.aos_cia_email_send_requests
+  where provider='RESEND' and provider_message_id=v_message_id
+  for update;
+  if v_req.id is null then
+    return jsonb_build_object('ok',false,'error','PROVIDER_MESSAGE_NOT_FOUND');
+  end if;
+
+  begin
+    insert into public.aos_cia_email_send_events(request_id,event_type,provider_event_id,payload,occurred_at)
+    values(v_req.id,upper(replace(v_type,'.','_')),v_event_id,v_payload,coalesce(p_occurred_at,now()));
+  exception when unique_violation then
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',true);
+  end;
+
+  if v_type='email.delivered' and v_req.state='ACCEPTED' then
+    update public.aos_cia_email_send_requests
+       set state='DELIVERED',delivered_at=coalesce(delivered_at,coalesce(p_occurred_at,now()))
+     where id=v_req.id;
+    v_req.state:='DELIVERED';
+  elsif v_type='email.bounced' and v_req.state='ACCEPTED' then
+    update public.aos_cia_email_send_requests set state='BOUNCED' where id=v_req.id;
+    v_req.state:='BOUNCED';
+  elsif v_type='email.complained' and v_req.state in ('ACCEPTED','DELIVERED') then
+    update public.aos_cia_email_send_requests set state='COMPLAINED' where id=v_req.id;
+    v_req.state:='COMPLAINED';
+  elsif v_type in ('email.failed','email.suppressed') and v_req.state in ('DISPATCHING','ACCEPTED') then
+    update public.aos_cia_email_send_requests set state='FAILED' where id=v_req.id;
+    v_req.state:='FAILED';
+  end if;
+
+  if v_type in ('email.bounced','email.complained','email.suppressed') then
+    v_suppression_reason := upper(replace(v_type,'email.','RESEND_'));
+    insert into public.aos_cia_email_recipient_controls(
+      contact_key,marketing_consent,global_suppressed,suppression_reason,source,source_updated_at,updated_by_user_id
+    ) values(
+      v_req.contact_key,'UNKNOWN',true,v_suppression_reason,'RESEND_WEBHOOK',coalesce(p_occurred_at,now()),null
+    )
+    on conflict (contact_key) do update
+      set global_suppressed=true,
+          suppression_reason=excluded.suppression_reason,
+          source='RESEND_WEBHOOK',
+          source_updated_at=excluded.source_updated_at,
+          updated_by_user_id=null;
+  end if;
+
+  return jsonb_build_object('ok',true,'request_id',v_req.id,'state',v_req.state,'idempotent',false);
+end
+$function$;
+
+revoke all on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) from public,anon,authenticated;
+grant execute on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) to service_role;
+
+comment on function public.aos_cia_email_ingest_provider_event_v2(text,text,text,timestamptz,jsonb) is
+  'F16 service-role Resend outcome ingestion after cryptographic webhook verification. Covers delivery, bounce, complaint, delayed/open/click, failed and suppressed; provider suppression outcomes fail closed into recipient controls.';
+
+commit;


### PR DESCRIPTION
F16 provider-outcome hardening before production webhook registration.

Fresh base: branch was created from CURRENT main 91066dc84fb2d4dbda084fa2f0c9afdcbac40d63; main remains on the same SHA at merge preflight.

Changes:
- additive migration 20260815221000_cia_phase16_resend_outcome_coverage_v3.sql;
- accept asynchronous Resend `email.failed` and `email.suppressed` in the existing service-role provider ingestion boundary;
- fail closed bounce/complaint/suppressed outcomes into canonical `aos_cia_email_recipient_controls` suppression state;
- preserve replay idempotency and unsupported-event rejection;
- update delivery synthetic contract for complaint suppression and add explicit failed/suppressed coverage.

Zero-Cost run #31911434891 on exact head 85246f6271929e85a20937098942c01950383433: PASS — isolated Supabase compile/lint, existing contracts, V3 outcomes, provider surface ACL, rollback and zero residue. No provider network calls and no PII/PHI.

This PR does not create a Resend webhook and does not contain any provider secret.