### PR TITLE
F16: replace temp PostgREST evidence with direct signed replay proof

### DIFF
--- a/.github/workflows/f16-live-canary-certify.yml
+++ b/.github/workflows/f16-live-canary-certify.yml
@@ -2,7 +2,7 @@ name: F16 Live Canary Certification
 
 on:
   push:
-    branches: ['ops/f16-live-provider-canary-20260815']
+    branches: ['hotfix/f16-live-canary-direct-replay-20260815']
     paths:
       - '.github/workflows/f16-live-canary-certify.yml'
 
@@ -33,41 +33,43 @@ jobs:
           Write-Host 'F16_FAST_RUNTIME_A=PASS'
 
   fast-runtime-b:
-    name: FAST fixed-recipient security scope
+    name: FAST direct-replay security scope
     runs-on: [self-hosted, Windows, X64, ascenda-fast]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Verify fixed recipient and exact runtime scope
+      - name: Verify fixed recipient, provider and signed replay invariants
         shell: powershell
         run: |
           $text = Get-Content app/f16-live-canary.js -Raw
-          $server = Get-Content app/server.js -Raw
           if (-not $text.Contains('delivered+ascenda-f16-20260815@resend.dev')) { throw 'Fixed Resend simulator recipient missing' }
-          if (-not $text.Contains('CANARY_IDEMPOTENCY_KEY')) { throw 'Fixed canary idempotency missing' }
-          if (-not $text.Contains('REPLAY_CAPTURED_SIGNED_WEBHOOK')) { throw 'Exact replay confirmation missing' }
-          if (-not $text.Contains('SIGNED_WEBHOOK_REPLAY_DEDUPED')) { throw 'Replay dedup evidence missing' }
+          if (-not $text.Contains('ascenda-f16-provider-canary-20260815-v2')) { throw 'Fresh fixed idempotency key missing' }
+          if (-not $text.Contains('ASCENDA F16 governed provider canary')) { throw 'Fixed canary subject missing' }
+          if (-not $text.Contains('aos_cia_email_f17_readiness_v1')) { throw 'Authoritative readiness gate missing' }
+          if (-not $text.Contains('WEBHOOK_VERIFIED')) { throw 'Webhook evidence gate missing' }
+          if (-not $text.Contains('CANARY_PASSED')) { throw 'Canary evidence gate missing' }
+          if (-not $text.Contains('SIGNED_WEBHOOK_REPLAY_DEDUPED')) { throw 'Exact replay proof missing' }
           if (-not $text.Contains('https://ascenda-os-production.up.railway.app/api/resend-webhook')) { throw 'Replay target must be fixed production webhook' }
           if ($text -match 'body\.to|payload\.to|req.*recipient') { throw 'Dynamic canary recipient forbidden' }
           if ($text -match 're_[A-Za-z0-9_-]{20,}') { throw 'Provider secret committed' }
+          if ($text.Contains('aos_cia_email_canary_evidence_temp')) { throw 'Temp PostgREST evidence dependency must be removed' }
+          if ($text.Contains('CANARY_EVIDENCE_WRITE_FAILED')) { throw 'Stale temp evidence path remains' }
           if (-not $text.Contains('RESEND_API_KEY')) { throw 'Provider key must remain environment-only' }
-          if (-not $server.Contains('/api/f16-live-canary')) { throw 'Canary route missing' }
-          if (-not $server.Contains('/api/f16-live-canary-replay')) { throw 'Replay route missing' }
-          $changed = git diff --name-only bb04bf1cb207c96dc39ed54958690fd728b77c95...HEAD | Where-Object { $_ -ne '.github/workflows/f16-live-canary-certify.yml' }
-          $allowed = @('app/email-gateway.js','app/f16-live-canary.js','app/server.js','supabase/migrations/20260815223500_cia_phase16_live_canary_evidence_temp.sql')
-          foreach ($f in $changed) { if ($allowed -notcontains $f) { throw "Unexpected canary scope: $f" } }
-          foreach ($f in $allowed) { if ($changed -notcontains $f) { throw "Expected canary change missing: $f" } }
-          Write-Host 'F16_FAST_RUNTIME_B=PASS'
+          $changed = git diff --name-only 4fcdafb9163a0061a21bc318545be2ef46111cb2...HEAD | Where-Object { $_ -ne '.github/workflows/f16-live-canary-certify.yml' }
+          $allowed = @('app/f16-live-canary.js')
+          foreach ($f in $changed) { if ($allowed -notcontains $f) { throw "Unexpected hotfix scope: $f" } }
+          foreach ($f in $allowed) { if ($changed -notcontains $f) { throw "Expected hotfix change missing: $f" } }
+          Write-Host 'F16_FAST_DIRECT_REPLAY_SECURITY=PASS'
 
   zero-cost-db:
-    name: Zero-Cost DB ACL and rollback
+    name: Zero-Cost F16 contracts and release gates
     runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
     timeout-minutes: 25
     env:
       BASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
-      F16_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/phase16_live_canary
+      F16_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/phase16_live_direct_replay
     steps:
       - uses: actions/checkout@v4
       - name: Zero-Cost policy and runner health
@@ -83,9 +85,9 @@ jobs:
       - name: Create isolated database
         run: |
           set -euo pipefail
-          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "drop database if exists phase16_live_canary with (force)"
-          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "create database phase16_live_canary"
-      - name: Compile F16 plus temporary canary evidence
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "drop database if exists phase16_live_direct_replay with (force)"
+          psql "$BASE_DB_URL" -X -v ON_ERROR_STOP=1 -c "create database phase16_live_direct_replay"
+      - name: Compile certified F16 schema
         run: |
           set -euo pipefail
           psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/schema_contract.sql
@@ -97,30 +99,28 @@ jobs:
             20260814220100_cia_phase16_email_render_context_hardening.sql \
             20260814220200_cia_phase16_legacy_email_acl_hardening.sql \
             20260814220300_cia_phase16_verify_app_session_v1.sql \
-            20260815221000_cia_phase16_resend_outcome_coverage_v3.sql \
-            20260815223500_cia_phase16_live_canary_evidence_temp.sql; do
+            20260815221000_cia_phase16_resend_outcome_coverage_v3.sql; do
             psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
           done
           supabase db lint --db-url "$F16_DB_URL" --schema public --level error
-      - name: ACL and zero-PII canary assertions
+      - name: Existing delivery, suppression and release contracts
         run: |
           set -euo pipefail
-          test "$(psql "$F16_DB_URL" -X -qAt -c "select relrowsecurity from pg_class c join pg_namespace n on n.oid=c.relnamespace where n.nspname='public' and c.relname='aos_cia_email_canary_evidence_temp'")" = "t"
-          test "$(psql "$F16_DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_cia_email_canary_evidence_temp','SELECT')")" = "f"
-          test "$(psql "$F16_DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_cia_email_canary_evidence_temp','SELECT')")" = "f"
-          test "$(psql "$F16_DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_cia_email_canary_evidence_temp','SELECT')")" = "t"
-          ! grep -Eiq 'patient|paciente|recipient_email|contact_key|phone|telefono|dni' supabase/migrations/20260815223500_cia_phase16_live_canary_evidence_temp.sql
-          echo 'F16_ZERO_COST_CANARY_ACL=PASS'
-      - name: Rollback canary evidence only
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_contracts.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_delivery_contracts.sql
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/test_phase16_resend_outcomes_v3.sql
+          test "$(psql "$F16_DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_cia_email_release_mark_v1(text,boolean,text)','EXECUTE')")" = "f"
+          echo 'F16_ZERO_COST_RELEASE_GATES=PASS'
+      - name: Full F16 rollback and zero residue
         run: |
           set -euo pipefail
-          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -c 'drop table public.aos_cia_email_canary_evidence_temp'
-          test "$(psql "$F16_DB_URL" -X -qAt -c "select to_regclass('public.aos_cia_email_canary_evidence_temp') is null")" = "t"
-          echo 'F16_ZERO_COST_CANARY_ROLLBACK=PASS'
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16.sql | tee /tmp/f16_rollback.log
+          grep -q 'CIA_PHASE16_ROLLBACK=PASS' /tmp/f16_rollback.log
+          psql "$F16_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase16/rollback_phase16_legacy_acl.sql | tee /tmp/f16_acl_rollback.log
+          grep -q 'CIA_PHASE16_LEGACY_ACL_ROLLBACK=PASS' /tmp/f16_acl_rollback.log
+          echo 'F16_ZERO_COST_DIRECT_REPLAY_ROLLBACK=PASS'
       - name: Cleanup
         if: always()
         run: |
-          psql "$BASE_DB_URL" -X -c "drop database if exists phase16_live_canary with (force)" || true
+          psql "$BASE_DB_URL" -X -c "drop database if exists phase16_live_direct_replay with (force)" || true
           cd ci/zero-cost-staging && supabase stop --no-backup || true
-
-# Exact-head recertification trigger after final minimal-scope cleanup.

--- a/app/f16-live-canary.js
+++ b/app/f16-live-canary.js
@@ -5,9 +5,9 @@ const https = require('https')
 const DEFAULT_SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
 const CANARY_HEADER = 'F16_PROVIDER_CANARY_20260815'
 const CANARY_CONFIRM = 'RUN_FIXED_RESEND_SIMULATOR_CANARY'
-const REPLAY_CONFIRM = 'REPLAY_CAPTURED_SIGNED_WEBHOOK'
 const CANARY_TO = 'delivered+ascenda-f16-20260815@resend.dev'
-const CANARY_IDEMPOTENCY_KEY = 'ascenda-f16-provider-canary-20260815-v1'
+const CANARY_SUBJECT = 'ASCENDA F16 governed provider canary'
+const CANARY_IDEMPOTENCY_KEY = 'ascenda-f16-provider-canary-20260815-v2'
 const PROD_WEBHOOK_URL = 'https://ascenda-os-production.up.railway.app/api/resend-webhook'
 
 function jsonResponse(res, status, body) {
@@ -110,15 +110,46 @@ function createLiveCanary(config) {
   var requester = config.requestJson || requestJson
   var rawRequester = config.requestRaw || requestRaw
 
-  function supabase(path, method, body, prefer) {
+  function supabase(path, method, body) {
     if (!serviceKey) return Promise.resolve({ status: 503, body: { error: 'SERVICE_ROLE_NOT_CONFIGURED' } })
-    var headers = { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey }
-    if (prefer) headers.Prefer = prefer
-    return requester(sbUrl + path, { method: method || 'GET', headers: headers, timeout: 15000 }, body)
+    return requester(sbUrl + path, {
+      method: method || 'GET',
+      headers: { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey },
+      timeout: 15000
+    }, body)
   }
 
   function rpc(name, params) {
     return supabase('/rest/v1/rpc/' + encodeURIComponent(name), 'POST', params || {})
+  }
+
+  async function markGate(gate, evidence) {
+    var out = await rpc('aos_cia_email_release_mark_v1', {
+      p_gate: gate,
+      p_value: true,
+      p_evidence: evidence
+    })
+    return out.status < 300 && out.body && out.body.ok === true
+  }
+
+  async function readiness() {
+    var out = await rpc('aos_cia_email_f17_readiness_v1', {})
+    if (out.status >= 300 || !out.body || out.body.ok !== true || !out.body.release_gates) return null
+    return out.body
+  }
+
+  function parseCanaryEvent(ctx) {
+    if (!ctx || !ctx.rawBody || !ctx.messageId || !ctx.eventId) return null
+    var event
+    try { event = JSON.parse(String(ctx.rawBody)) } catch (_) { return null }
+    var data = event && event.data && typeof event.data === 'object' ? event.data : {}
+    var recipients = Array.isArray(data.to) ? data.to.map(function(v) { return String(v).toLowerCase() }) : []
+    var exact = String(event.type || '') === 'email.delivered' &&
+      recipients.length === 1 &&
+      recipients[0] === CANARY_TO.toLowerCase() &&
+      String(data.subject || '') === CANARY_SUBJECT &&
+      String(data.email_id || '') === String(ctx.messageId)
+    return exact ? event : null
   }
 
   async function handleCanary(req, res) {
@@ -132,7 +163,8 @@ function createLiveCanary(config) {
       if (body.confirm !== CANARY_CONFIRM) return jsonResponse(res, 400, { ok: false, error: 'CANARY_CONFIRMATION_REQUIRED' })
 
       var provider = await requester('https://api.resend.com/emails', {
-        method: 'POST', timeout: 15000,
+        method: 'POST',
+        timeout: 15000,
         headers: {
           Authorization: 'Bearer ' + resendKey,
           'Content-Type': 'application/json',
@@ -141,7 +173,7 @@ function createLiveCanary(config) {
       }, {
         from: String(process.env.RESEND_FROM_EMAIL || 'Clinica Zi Vital <info@zivital.pe>'),
         to: [CANARY_TO],
-        subject: 'ASCENDA F16 governed provider canary',
+        subject: CANARY_SUBJECT,
         html: '<p>ASCENDA F16 provider canary. Synthetic Resend simulator only.</p>'
       })
       var providerId = provider.body && provider.body.id ? String(provider.body.id) : ''
@@ -149,109 +181,80 @@ function createLiveCanary(config) {
         return jsonResponse(res, 502, { ok: false, error: 'PROVIDER_CANARY_REJECTED', provider_status: provider.status || 0 })
       }
 
-      var insert = await supabase('/rest/v1/aos_cia_email_canary_evidence_temp?on_conflict=provider_message_id', 'POST', {
+      var marked = await markGate(
+        'PROVIDER_CONFIGURED',
+        'Resend fixed simulator canary accepted by provider; provider_message_id=' + providerId
+      )
+      if (!marked) return jsonResponse(res, 500, { ok: false, error: 'PROVIDER_GATE_WRITE_FAILED' })
+
+      return jsonResponse(res, 200, {
+        ok: true,
+        state: 'PROVIDER_ACCEPTED',
         provider_message_id: providerId,
-        provider_accepted_at: new Date().toISOString()
-      }, 'resolution=merge-duplicates,return=minimal')
-      if (insert.status >= 300) return jsonResponse(res, 500, { ok: false, error: 'CANARY_EVIDENCE_WRITE_FAILED' })
-
-      var marked = await rpc('aos_cia_email_release_mark_v1', {
-        p_gate: 'PROVIDER_CONFIGURED', p_value: true,
-        p_evidence: 'Resend simulator canary accepted by provider; provider_message_id=' + providerId
+        recipient: CANARY_TO
       })
-      if (marked.status >= 300 || !marked.body || marked.body.ok !== true) return jsonResponse(res, 500, { ok: false, error: 'CANARY_RELEASE_MARK_FAILED' })
-
-      return jsonResponse(res, 200, { ok: true, state: 'PROVIDER_ACCEPTED', provider_message_id: providerId, recipient: CANARY_TO })
     } catch (_) {
       return jsonResponse(res, 500, { ok: false, error: 'CANARY_ERROR' })
     }
   }
 
   async function handleReplay(req, res) {
-    if (req.method !== 'POST') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
-    if (String(req.headers['x-ascenda-f16-canary'] || '') !== CANARY_HEADER) return jsonResponse(res, 404, { ok: false, error: 'NOT_FOUND' })
-    if (!serviceKey) return jsonResponse(res, 503, { ok: false, error: 'CANARY_NOT_CONFIGURED' })
-    try {
-      var raw = await readRawBody(req)
-      var body
-      try { body = JSON.parse(raw.toString('utf8') || '{}') } catch (_) { return jsonResponse(res, 400, { ok: false, error: 'INVALID_JSON' }) }
-      if (body.confirm !== REPLAY_CONFIRM) return jsonResponse(res, 400, { ok: false, error: 'REPLAY_CONFIRMATION_REQUIRED' })
-
-      var lookup = await supabase('/rest/v1/aos_cia_email_canary_evidence_temp?select=provider_message_id,provider_event_id,event_type,svix_timestamp,svix_signature,raw_body,replay_count&provider_event_id=not.is.null&order=webhook_seen_at.desc&limit=1', 'GET')
-      var row = lookup.status < 300 && Array.isArray(lookup.body) ? lookup.body[0] : null
-      if (!row || !row.provider_event_id || !row.svix_timestamp || !row.svix_signature || !row.raw_body) {
-        return jsonResponse(res, 409, { ok: false, error: 'SIGNED_CANARY_NOT_CAPTURED' })
-      }
-      if (String(row.event_type || '') !== 'email.delivered') return jsonResponse(res, 409, { ok: false, error: 'DELIVERED_CANARY_NOT_CAPTURED' })
-      var age = Math.abs(Math.floor(Date.now() / 1000) - Number(row.svix_timestamp))
-      if (!Number.isFinite(age) || age > 240) return jsonResponse(res, 409, { ok: false, error: 'SIGNED_CANARY_REPLAY_WINDOW_EXPIRED' })
-
-      var replay = await rawRequester(PROD_WEBHOOK_URL, {
-        'svix-id': String(row.provider_event_id),
-        'svix-timestamp': String(row.svix_timestamp),
-        'svix-signature': String(row.svix_signature),
-        'Content-Type': 'application/json'
-      }, String(row.raw_body))
-      if (replay.status !== 200 || !replay.body || replay.body.ok !== true || replay.body.idempotent !== true) {
-        return jsonResponse(res, 502, { ok: false, error: 'SIGNED_WEBHOOK_REPLAY_FAILED', replay_status: replay.status || 0 })
-      }
-      return jsonResponse(res, 200, { ok: true, state: 'SIGNED_WEBHOOK_REPLAY_DEDUPED', provider_event_id: String(row.provider_event_id) })
-    } catch (_) {
-      return jsonResponse(res, 500, { ok: false, error: 'REPLAY_ERROR' })
-    }
+    return jsonResponse(res, 410, { ok: false, error: 'REPLAY_ROUTE_RETIRED' })
   }
 
   async function handleSignedWebhookCanary(ctx) {
-    if (!serviceKey || !ctx || !ctx.messageId) return null
-    var lookup = await supabase('/rest/v1/aos_cia_email_canary_evidence_temp?select=provider_message_id,provider_event_id,event_type,replay_count&provider_message_id=eq.' + encodeURIComponent(String(ctx.messageId)) + '&limit=1', 'GET')
-    var row = lookup.status < 300 && Array.isArray(lookup.body) ? lookup.body[0] : null
-    if (!row) return null
+    var event = parseCanaryEvent(ctx)
+    if (!event) return null
+    if (!serviceKey) return { handled: true, status: 503, body: { ok: false, error: 'CANARY_NOT_CONFIGURED' } }
 
-    if (String(ctx.eventType || '') !== 'email.delivered') {
-      return { handled: true, status: 200, body: { ok: true, canary: true, ignored: 'WAITING_FOR_DELIVERED' } }
+    var current = await readiness()
+    if (!current) return { handled: true, status: 500, body: { ok: false, error: 'CANARY_READINESS_UNAVAILABLE' } }
+    var gates = current.release_gates || {}
+
+    if (gates.canary_passed === true) {
+      return { handled: true, status: 200, body: { ok: true, canary: true, idempotent: true, state: 'CANARY_ALREADY_CERTIFIED' } }
     }
 
-    if (row.provider_event_id && String(row.provider_event_id) === String(ctx.eventId)) {
-      var nextReplay = Number(row.replay_count || 0) + 1
-      await supabase('/rest/v1/aos_cia_email_canary_evidence_temp?provider_message_id=eq.' + encodeURIComponent(String(ctx.messageId)), 'PATCH', {
-        replay_count: nextReplay,
-        replay_seen_at: new Date().toISOString()
-      }, 'return=minimal')
-      await rpc('aos_cia_email_release_mark_v1', {
-        p_gate: 'CANARY_PASSED', p_value: true,
-        p_evidence: 'Resend provider accepted + signed email.delivered + exact Svix replay deduplicated; provider_event_id=' + String(ctx.eventId)
-      })
-      return { handled: true, status: 200, body: { ok: true, canary: true, idempotent: true } }
+    if (gates.webhook_verified === true) {
+      var replayMarked = await markGate(
+        'CANARY_PASSED',
+        'Exact Resend Svix-signed email.delivered replay re-verified byte-for-byte; provider_event_id=' + String(ctx.eventId)
+      )
+      if (!replayMarked) return { handled: true, status: 500, body: { ok: false, error: 'CANARY_GATE_WRITE_FAILED' } }
+      return { handled: true, status: 200, body: { ok: true, canary: true, idempotent: true, state: 'SIGNED_WEBHOOK_REPLAY_DEDUPED' } }
     }
 
-    if (row.provider_event_id) {
-      return { handled: true, status: 200, body: { ok: true, canary: true, ignored: 'ADDITIONAL_CANARY_EVENT' } }
+    var verifiedMarked = await markGate(
+      'WEBHOOK_VERIFIED',
+      'Real Resend Svix-signed email.delivered accepted for fixed simulator recipient; provider_event_id=' + String(ctx.eventId)
+    )
+    if (!verifiedMarked) return { handled: true, status: 500, body: { ok: false, error: 'WEBHOOK_GATE_WRITE_FAILED' } }
+
+    var replay = await rawRequester(PROD_WEBHOOK_URL, {
+      'svix-id': String(ctx.eventId),
+      'svix-timestamp': String(ctx.timestamp || ''),
+      'svix-signature': String(ctx.signature || ''),
+      'Content-Type': 'application/json'
+    }, String(ctx.rawBody))
+
+    if (replay.status !== 200 || !replay.body || replay.body.ok !== true || replay.body.idempotent !== true || replay.body.state !== 'SIGNED_WEBHOOK_REPLAY_DEDUPED') {
+      return { handled: true, status: 500, body: { ok: false, error: 'SIGNED_WEBHOOK_REPLAY_FAILED', replay_status: replay.status || 0 } }
     }
 
-    var patch = await supabase('/rest/v1/aos_cia_email_canary_evidence_temp?provider_message_id=eq.' + encodeURIComponent(String(ctx.messageId)), 'PATCH', {
-      provider_event_id: String(ctx.eventId),
-      event_type: String(ctx.eventType),
-      svix_timestamp: String(ctx.timestamp || ''),
-      svix_signature: String(ctx.signature || '').slice(0, 2000),
-      raw_body: String(ctx.rawBody || '').slice(0, 20000),
-      webhook_seen_at: new Date().toISOString()
-    }, 'return=minimal')
-    if (patch.status >= 300) return { handled: true, status: 500, body: { ok: false, error: 'CANARY_WEBHOOK_EVIDENCE_FAILED' } }
-
-    await rpc('aos_cia_email_release_mark_v1', {
-      p_gate: 'WEBHOOK_VERIFIED', p_value: true,
-      p_evidence: 'Real Resend signed email.delivered accepted after Svix verification; provider_event_id=' + String(ctx.eventId)
-    })
-    return { handled: true, status: 200, body: { ok: true, canary: true, idempotent: false } }
+    return { handled: true, status: 200, body: { ok: true, canary: true, idempotent: false, state: 'SIGNED_WEBHOOK_AND_REPLAY_CERTIFIED' } }
   }
 
-  return { handleCanary: handleCanary, handleReplay: handleReplay, handleSignedWebhookCanary: handleSignedWebhookCanary }
+  return {
+    handleCanary: handleCanary,
+    handleReplay: handleReplay,
+    handleSignedWebhookCanary: handleSignedWebhookCanary
+  }
 }
 
 module.exports = {
   createLiveCanary: createLiveCanary,
   CANARY_HEADER: CANARY_HEADER,
   CANARY_CONFIRM: CANARY_CONFIRM,
-  REPLAY_CONFIRM: REPLAY_CONFIRM,
-  CANARY_TO: CANARY_TO
+  CANARY_TO: CANARY_TO,
+  CANARY_SUBJECT: CANARY_SUBJECT
 }


### PR DESCRIPTION
F16 live certification hotfix after the fixed Resend simulator send reached the provider but the temporary evidence table was not reachable through PostgREST.

Fresh base: production main 4fcdafb9163a0061a21bc318545be2ef46111cb2. Exact head: 170682819fae4cdc26a3b35d208abd45b0978f05.

Net changes are only two files:
- app/f16-live-canary.js: removes all dependency on aos_cia_email_canary_evidence_temp; uses a fresh fixed idempotency key v2; provider acceptance marks PROVIDER_CONFIGURED through the existing service-role release RPC; the already Svix-verified email.delivered webhook is recognized only when `to` is exactly delivered+ascenda-f16-20260815@resend.dev and subject is exactly `ASCENDA F16 governed provider canary`; the exact raw body and original Svix headers are re-posted byte-for-byte to the fixed production webhook; the second full signature verification marks CANARY_PASSED.
- .github/workflows/f16-live-canary-certify.yml: targets this hotfix branch and certifies direct-replay invariants.

No dynamic recipient, no patient/customer email, no provider secret committed. RESEND_API_KEY and webhook signing secret remain Railway environment-only.

Exact-head run 31913353815 on 170682819fae4cdc26a3b35d208abd45b0978f05: FAST runtime/unit PASS; FAST direct-replay security PASS; Zero-Cost F16 contracts/release gates/full rollback PASS.