### PR TITLE
F16: support Supabase sb_secret server keys

### DIFF
--- a/app/email-gateway.js
+++ b/app/email-gateway.js
@@ -169,7 +169,8 @@ function createEmailGateway(config) {
 
   function supabase(path, method, body, prefer) {
     if (!serviceKey) return Promise.resolve({ status: 503, body: { error: 'SERVICE_ROLE_NOT_CONFIGURED' } })
-    var headers = { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey }
+    var headers = { apikey: serviceKey }
+    if (!/^sb_(?:secret|publishable)_/.test(serviceKey)) headers.Authorization = 'Bearer ' + serviceKey
     if (prefer) headers.Prefer = prefer
     return requester(sbUrl + path, { method: method || 'GET', headers: headers, timeout: 15000 }, body)
   }

--- a/app/f16-live-canary.js
+++ b/app/f16-live-canary.js
@@ -112,9 +112,11 @@ function createLiveCanary(config) {
 
   function supabase(path, method, body) {
     if (!serviceKey) return Promise.resolve({ status: 503, body: { error: 'SERVICE_ROLE_NOT_CONFIGURED' } })
+    var headers = { apikey: serviceKey }
+    if (!/^sb_(?:secret|publishable)_/.test(serviceKey)) headers.Authorization = 'Bearer ' + serviceKey
     return requester(sbUrl + path, {
       method: method || 'GET',
-      headers: { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey },
+      headers: headers,
       timeout: 15000
     }, body)
   }

--- a/app/server.js
+++ b/app/server.js
@@ -35,6 +35,12 @@ function f16RequireEmailBackend(endpoint) {
   }
 }
 
+function f16SupabaseHeaders(dbKey, extra) {
+  var headers = { 'apikey': dbKey }
+  if (!/^sb_(?:secret|publishable)_/.test(String(dbKey || ''))) headers.Authorization = 'Bearer ' + dbKey
+  return Object.assign(headers, extra || {})
+}
+
 function sbPost(endpoint, body, method) {
   f16RequireEmailBackend(endpoint)
   const url = new URL(SB_URL + endpoint)
@@ -45,7 +51,7 @@ function sbPost(endpoint, body, method) {
     const req = https.request({
       hostname: url.hostname, path: url.pathname + url.search,
       method: httpMethod,
-      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) }
+      headers: f16SupabaseHeaders(dbKey, { 'Content-Type': 'application/json', 'Prefer': 'return=minimal', 'Content-Length': Buffer.byteLength(data) })
     }, (res) => { let d = ''; res.on('data', c => d += c); res.on('end', () => resolve(res.statusCode)) })
     req.on('error', reject)
     req.write(data)
@@ -59,7 +65,7 @@ function sbGet(endpoint) {
   return new Promise(function(resolve, reject) {
     https.get({
       hostname: url.hostname, path: url.pathname + url.search,
-      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
+      headers: f16SupabaseHeaders(dbKey)
     }, function(r) {
       var d = ''; r.on('data', function(c) { d += c }); r.on('end', function() {
         try { resolve(JSON.parse(d)) } catch(e) { resolve([]) }
@@ -91,7 +97,7 @@ function sbPatch(endpoint, body) {
   return new Promise(function(resolve) {
     var req = https.request({
       hostname: url.hostname, path: url.pathname + url.search, method: 'PATCH',
-      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' }
+      headers: f16SupabaseHeaders(dbKey, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'Prefer': 'return=minimal' })
     }, function(r) {
       var d = ''; r.on('data', function(c) { d += c }); r.on('end', function() { resolve(r.statusCode < 300) })
     })
@@ -3502,7 +3508,7 @@ function sbFetch(endpoint) {
     var dbKey = f16DbKey(endpoint)
     https.get({
       hostname: url.hostname, path: url.pathname + url.search,
-      headers: { 'apikey': dbKey, 'Authorization': 'Bearer ' + dbKey }
+      headers: f16SupabaseHeaders(dbKey)
     }, function(res) {
       var d = ''; res.on('data', function(c) { d += c }); res.on('end', function() {
         try { resolve(JSON.parse(d)) } catch(e) { reject(e) }


### PR DESCRIPTION
Clean production hotfix for F16 server-side Supabase key compatibility.

Base main: 849354df9009f36985d725287bb3978436fbffa9.
Clean head: 145a5d21ae529935e66669f5c13982061833b12b.

Net diff is exactly 3 runtime files:
- app/email-gateway.js
- app/f16-live-canary.js
- app/server.js

Behavior:
- `sb_secret_...` / `sb_publishable_...` style opaque keys are sent through `apikey` without an invalid JWT Bearer header;
- legacy JWT keys retain `Authorization: Bearer` compatibility;
- no key or secret value is committed;
- fixed Resend simulator recipient and direct signed replay proof are unchanged.

Source runtime blobs were materialized at fe42195eac0b5a355802dac79457ca9eb7c9ac51 and certified on exact-head run 31913835951: FAST runtime/unit PASS, FAST key-compat security PASS, Zero-Cost F16 contracts/release-gates/full rollback PASS.

The clean commit was constructed directly on current main from only those three certified blobs; tooling/materializer files are excluded.