### PR TITLE
F5: private idempotent historical source ingest

### DIFF
--- a/.github/workflows/phase5-private-ingest.yml
+++ b/.github/workflows/phase5-private-ingest.yml
@@ -1,0 +1,93 @@
+name: ASCENDA Phase 5 Private Historical Ingest
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*f5_historical_patient_identity*'
+      - 'ci/phase5-historical-identity/**'
+      - '.github/workflows/phase5-private-ingest.yml'
+  push:
+    branches: ['data/**']
+    paths:
+      - 'supabase/migrations/*f5_historical_patient_identity*'
+      - 'ci/phase5-historical-identity/**'
+      - '.github/workflows/phase5-private-ingest.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fast:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Private ingest static contract
+        shell: powershell
+        run: |
+          node --check ci/phase5-historical-identity/private_ingest_contract.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node ci/phase5-historical-identity/private_ingest_contract.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  db:
+    needs: fast
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59622/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce Zero-Cost policy
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Configure isolated ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-phase5-private-ingest"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59621/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59622/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59620/' supabase/config.toml
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-phase5-private-ingest' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do pg_isready -h 127.0.0.1 -p 59622 -U postgres >/dev/null 2>&1 && exit 0; sleep 1; done
+          exit 1
+      - name: Build synthetic prerequisite schema
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase5-historical-identity/schema_contract.sql
+      - name: Apply F5 foundation and private ingest
+        run: |
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815220000_f5_historical_patient_identity_foundation_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815233000_f5_historical_patient_identity_private_ingest_v1.sql
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+      - name: pgTAP private ingest
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "create extension if not exists pgtap with schema extensions"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/phase5-historical-identity/tests/002_private_ingest.sql | tee /tmp/f5-ingest.txt
+          grep -q '1..12' /tmp/f5-ingest.txt
+          if grep -q 'not ok' /tmp/f5-ingest.txt; then exit 1; fi
+      - name: Verify private boundary
+        run: |
+          set -euo pipefail
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_f5_ingest_source_rows_v1(text,jsonb)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('authenticated','public.aos_f5_ingest_source_rows_v1(text,jsonb)','EXECUTE')")" = "f"
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/ci/phase5-historical-identity/private_ingest_contract.js
+++ b/ci/phase5-historical-identity/private_ingest_contract.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const p='supabase/migrations/20260815233000_f5_historical_patient_identity_private_ingest_v1.sql';
+const s=fs.readFileSync(p,'utf8');
+const low=s.toLowerCase();
+function ok(c,m){if(!c) throw new Error(m)}
+ok(s.includes('aos_f5_ingest_source_rows_v1'),'private ingest function missing');
+ok(/security definer/i.test(s),'ingest must be security definer');
+ok(/set search_path = public, pg_temp/i.test(s),'safe search_path missing');
+ok(s.includes('SOURCE_ROW_HASH_CONFLICT'),'hash conflict must fail closed');
+ok(s.includes('on conflict(batch_id,source_row_num) do nothing'),'row idempotency missing');
+ok(s.includes("v_requested > 500"),'bounded chunk size missing');
+ok(/revoke all on function public\.aos_f5_ingest_source_rows_v1\(text,jsonb\) from public, anon, authenticated/i.test(s),'browser execute must be revoked');
+ok(/grant execute on function public\.aos_f5_ingest_source_rows_v1\(text,jsonb\) to service_role/i.test(s),'service-side execution missing');
+for(const forbidden of ['insert into public.aos_pacientes','update public.aos_pacientes','delete from public.aos_pacientes','truncate public.aos_pacientes']) ok(!low.includes(forbidden),`canonical patient mutation forbidden: ${forbidden}`);
+ok(s.includes('raw_payload'),'raw evidence must remain part of ingest');
+ok(s.includes('F5_PRIVATE_INGEST_V1'),'security audit marker missing');
+console.log('F5 private ingest contract: PASS');

--- a/ci/phase5-historical-identity/tests/002_private_ingest.sql
+++ b/ci/phase5-historical-identity/tests/002_private_ingest.sql
@@ -1,0 +1,29 @@
+\set ON_ERROR_STOP on
+begin;
+select plan(12);
+
+insert into public.aos_f5_source_batches_v1(source_sha256,source_filename,source_sede,source_year,source_rows,source_columns,schema_hash,status)
+values(repeat('a',64),'SAN ISIDRO 2024.xlsx','SAN ISIDRO',2024,2,27,'schema','PROFILED');
+
+select is(has_function_privilege('anon','public.aos_f5_ingest_source_rows_v1(text,jsonb)','EXECUTE'),false,'1 anon cannot execute private ingest');
+select is(has_function_privilege('authenticated','public.aos_f5_ingest_source_rows_v1(text,jsonb)','EXECUTE'),false,'2 authenticated cannot execute private ingest');
+select is(has_function_privilege('service_role','public.aos_f5_ingest_source_rows_v1(text,jsonb)','EXECUTE'),true,'3 service role can execute private ingest');
+
+create temporary table r(j jsonb);
+insert into r values(jsonb_build_array(
+ jsonb_build_object('source_row_num',2,'source_patient_id','SRC-1','phone_raw','+51 999111222','phone_key','999111222','phone_type','PERU_9','names_raw','ANA','surnames_raw','PEREZ','name_key','ANA PEREZ','row_content_hash',repeat('1',64),'identity_seed_hash',repeat('b',64),'raw_payload',jsonb_build_object('Nombres','ANA')),
+ jsonb_build_object('source_row_num',3,'source_patient_id','SRC-2','phone_raw','999222333','phone_key','999222333','phone_type','PERU_9','names_raw','LUIS','surnames_raw','ROJAS','name_key','LUIS ROJAS','row_content_hash',repeat('2',64),'identity_seed_hash',repeat('c',64),'raw_payload',jsonb_build_object('Nombres','LUIS'))
+));
+
+select is((public.aos_f5_ingest_source_rows_v1(repeat('a',64),(select j from r))->>'inserted')::integer,2,'4 first ingest inserts two');
+select is((select count(*)::integer from public.aos_f5_patient_source_rows_v1),2,'5 two source rows persisted in transaction');
+select is((select raw_payload->>'Nombres' from public.aos_f5_patient_source_rows_v1 where source_row_num=2),'ANA','6 raw payload preserved');
+select is((public.aos_f5_ingest_source_rows_v1(repeat('a',64),(select j from r))->>'inserted')::integer,0,'7 rerun is idempotent');
+select is((select count(*)::integer from public.aos_f5_patient_source_rows_v1),2,'8 rerun does not duplicate');
+select is((select (metadata->>'staging_complete')::boolean from public.aos_f5_source_batches_v1 where source_sha256=repeat('a',64)),true,'9 batch marked complete when row count matches manifest');
+select throws_ok($$select public.aos_f5_ingest_source_rows_v1(repeat('a',64),jsonb_build_array(jsonb_build_object('source_row_num',2,'source_patient_id','SRC-1','row_content_hash',repeat('9',64),'raw_payload','{}'::jsonb)))$$,'P0001','SOURCE_ROW_HASH_CONFLICT','10 changed content for same source row is rejected');
+select throws_ok($$select public.aos_f5_ingest_source_rows_v1(repeat('d',64),'[]'::jsonb)$$,'P0001','CHUNK_SIZE_OUT_OF_RANGE','11 empty chunks rejected');
+select ok(exists(select 1 from public.aos_f5_audit_v1 where action='SOURCE_ROWS_CHUNK_INGESTED'),'12 ingest is audited');
+
+select * from finish();
+rollback;

--- a/supabase/migrations/20260815233000_f5_historical_patient_identity_private_ingest_v1.sql
+++ b/supabase/migrations/20260815233000_f5_historical_patient_identity_private_ingest_v1.sql
@@ -1,0 +1,107 @@
+-- ASCENDA OS — F5 Historical Patient Identity private ingest v1
+-- CRITICAL PII boundary: service-side/private staging only. No canonical patient mutation.
+
+create or replace function public.aos_f5_ingest_source_rows_v1(
+  p_source_sha256 text,
+  p_rows jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_batch public.aos_f5_source_batches_v1%rowtype;
+  v_requested integer;
+  v_before integer;
+  v_after integer;
+  v_conflicts integer;
+begin
+  if p_source_sha256 is null or btrim(p_source_sha256) !~ '^[0-9a-f]{64}$' then
+    raise exception 'INVALID_SOURCE_SHA256';
+  end if;
+  if p_rows is null or jsonb_typeof(p_rows) <> 'array' then
+    raise exception 'ROWS_MUST_BE_ARRAY';
+  end if;
+  v_requested := jsonb_array_length(p_rows);
+  if v_requested < 1 or v_requested > 500 then
+    raise exception 'CHUNK_SIZE_OUT_OF_RANGE';
+  end if;
+
+  select * into v_batch
+  from public.aos_f5_source_batches_v1
+  where source_sha256 = lower(btrim(p_source_sha256));
+  if not found then raise exception 'SOURCE_BATCH_NOT_FOUND'; end if;
+
+  if exists (
+    select 1
+    from jsonb_to_recordset(p_rows) as r(source_row_num integer, source_patient_id text, row_content_hash text, raw_payload jsonb)
+    where r.source_row_num is null
+       or r.source_row_num < 2
+       or r.source_row_num > v_batch.source_rows + 1
+       or nullif(btrim(r.source_patient_id),'') is null
+       or r.row_content_hash !~ '^[0-9a-f]{64}$'
+       or r.raw_payload is null
+  ) then raise exception 'INVALID_SOURCE_ROW'; end if;
+
+  select count(*) into v_conflicts
+  from jsonb_to_recordset(p_rows) as r(source_row_num integer,row_content_hash text)
+  join public.aos_f5_patient_source_rows_v1 e
+    on e.batch_id=v_batch.id and e.source_row_num=r.source_row_num
+  where e.row_content_hash <> r.row_content_hash;
+  if v_conflicts > 0 then raise exception 'SOURCE_ROW_HASH_CONFLICT'; end if;
+
+  select count(*) into v_before from public.aos_f5_patient_source_rows_v1 where batch_id=v_batch.id;
+
+  insert into public.aos_f5_patient_source_rows_v1(
+    batch_id,source_row_num,source_patient_id,source_created_date,
+    phone_raw,phone_key,phone_type,names_raw,surnames_raw,name_key,
+    email_raw,email_key,document_raw,document_key,document_type,sex_raw,
+    birth_date_raw,birth_date,birth_quality,address_raw,address_street,district,province,department,address_parse_status,
+    occupation,guardian,acquisition_channel,acquisition_reference,clinical_note,allergies,business_line,hc_raw,inactive_raw,tags_raw,
+    last_appointment,next_appointment,task_raw,last_budget_raw,budget_num_a,budget_num_b,row_content_hash,identity_seed_hash,raw_payload
+  )
+  select
+    v_batch.id,r.source_row_num,r.source_patient_id,r.source_created_date,
+    r.phone_raw,r.phone_key,r.phone_type,r.names_raw,r.surnames_raw,r.name_key,
+    r.email_raw,r.email_key,r.document_raw,r.document_key,r.document_type,r.sex_raw,
+    r.birth_date_raw,r.birth_date,r.birth_quality,r.address_raw,r.address_street,r.district,r.province,r.department,r.address_parse_status,
+    r.occupation,r.guardian,r.acquisition_channel,r.acquisition_reference,r.clinical_note,r.allergies,r.business_line,r.hc_raw,r.inactive_raw,r.tags_raw,
+    r.last_appointment,r.next_appointment,r.task_raw,r.last_budget_raw,r.budget_num_a,r.budget_num_b,r.row_content_hash,r.identity_seed_hash,r.raw_payload
+  from jsonb_to_recordset(p_rows) as r(
+    source_row_num integer,source_patient_id text,source_created_date date,
+    phone_raw text,phone_key text,phone_type text,names_raw text,surnames_raw text,name_key text,
+    email_raw text,email_key text,document_raw text,document_key text,document_type text,sex_raw text,
+    birth_date_raw text,birth_date date,birth_quality text,address_raw text,address_street text,district text,province text,department text,address_parse_status text,
+    occupation text,guardian text,acquisition_channel text,acquisition_reference text,clinical_note text,allergies text,business_line text,hc_raw text,inactive_raw text,tags_raw text,
+    last_appointment date,next_appointment date,task_raw text,last_budget_raw text,budget_num_a numeric,budget_num_b numeric,row_content_hash text,identity_seed_hash text,raw_payload jsonb
+  )
+  on conflict(batch_id,source_row_num) do nothing;
+
+  select count(*) into v_after from public.aos_f5_patient_source_rows_v1 where batch_id=v_batch.id;
+
+  update public.aos_f5_source_batches_v1
+  set metadata = metadata || jsonb_build_object(
+        'staged_rows',v_after,
+        'staging_complete',(v_after=source_rows),
+        'last_staged_at',now()
+      ),
+      updated_at=now()
+  where id=v_batch.id;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+  values('SOURCE_ROWS_CHUNK_INGESTED','SOURCE_BATCH',v_batch.id::text,
+    jsonb_build_object('requested',v_requested,'inserted',v_after-v_before,'batch_rows_after',v_after,'expected_rows',v_batch.source_rows));
+
+  return jsonb_build_object('ok',true,'batch_id',v_batch.id,'requested',v_requested,'inserted',v_after-v_before,
+    'existing',v_requested-(v_after-v_before),'batch_rows',v_after,'expected_rows',v_batch.source_rows,'complete',v_after=v_batch.source_rows);
+end;
+$$;
+
+revoke all on function public.aos_f5_ingest_source_rows_v1(text,jsonb) from public, anon, authenticated;
+grant execute on function public.aos_f5_ingest_source_rows_v1(text,jsonb) to service_role;
+
+comment on function public.aos_f5_ingest_source_rows_v1(text,jsonb) is
+'Private F5 idempotent ingestion of normalized historical source evidence. Never mutates aos_pacientes.';
+
+insert into public.aos_security_log(usuario,accion,detalles)
+values('SYSTEM','F5_PRIVATE_INGEST_V1',jsonb_build_object('browser_access',false,'canonical_patient_mutation',false,'max_chunk',500,'at',now()));


### PR DESCRIPTION
## Purpose
Add the private service-side ingestion boundary needed to stage all 15,498 rows from the owner's six SHA-256-manifested historical XLSX sources without touching canonical patients.

## Safety
- max 500 source rows per chunk;
- validates exact source SHA + row number + source patient ID + content hash;
- same batch/row with changed content fails closed (`SOURCE_ROW_HASH_CONFLICT`);
- reruns are idempotent;
- raw payload and normalized evidence are preserved;
- browser roles have no EXECUTE; service_role only;
- no INSERT/UPDATE/DELETE against `aos_pacientes`;
- aggregated audit only, no PII committed to GitHub.

## Certification
Dedicated FAST static contract + Zero-Cost isolated Supabase migration/lint/pgTAP/private-ACL test.

## After merge
Apply exact additive migration to production, ingest all six batches from their exact uploaded SHA-256 files, verify 15,498/15,498 staged, then rebuild source identity clusters/members deterministically before any canonical patient link/enrichment.