### PR TITLE
Hotfix WA-3: restore cross-tab 2FA session bridge

### DIFF
--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -34,10 +34,20 @@ async function injectF4(req){
   return new Response(html,{status:r.status,statusText:r.statusText,headers:h});
 }
 
+async function injectSameOriginAppToken(req){
+  var h=new Headers(req.headers),t=String(await getToken()).trim();
+  if(t.length>=32)h.set('X-AOS-App-Token',t);
+  return fetch(new Request(req,{headers:h,cache:'no-store'}));
+}
+
 self.addEventListener('fetch',function(event){
   var req=event.request,u;
   try{u=new URL(req.url);}catch(e){return;}
   if(u.origin===self.location.origin&&req.method==='GET'&&(u.pathname==='/app'||u.pathname==='/app.html')){event.respondWith(injectF4(req));return;}
+  // WA-3 APIs are same-origin and may be opened from a different browser tab.
+  // sessionStorage is tab-scoped, so inject the already-governed Phase 2 token
+  // from the same-origin cache. The server still performs 2FA/panel/ownership checks.
+  if(u.origin===self.location.origin&&u.pathname.indexOf('/api/wa3/')===0){event.respondWith(injectSameOriginAppToken(req));return;}
   if(u.hostname.indexOf('supabase.co')<0)return;
 
   var rm=u.pathname.match(/\/rest\/v1\/rpc\/([^/]+)$/);


### PR DESCRIPTION
Supersedes #170 after rebasing onto the latest `main`.

- Injects the existing governed 2FA app token into same-origin `/api/wa3/*` requests through the Phase 2 Service Worker.
- Fixes WA-3 stuck at `Validando sesión…` when opened in another tab.
- Preserves server-side 2FA, panel, ownership and canary checks.
- No data, Meta, routing, AI-send or database changes.