### PR TITLE
docs(sentinel): establish control master and 13-phase roadmap

### DIFF
--- a/.github/workflows/sentinel-phase1-governance.yml
+++ b/.github/workflows/sentinel-phase1-governance.yml
@@ -1,0 +1,20 @@
+name: Sentinel F1 Governance Certificate
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/control/SENTINEL_*.md'
+      - 'ci/sentinel/**'
+      - '.github/workflows/sentinel-phase1-governance.yml'
+permissions:
+  contents: read
+jobs:
+  governance:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - shell: powershell
+        run: node ci/sentinel/phase1_governance_contract.js

--- a/.github/workflows/sentinel-phase1-governance.yml
+++ b/.github/workflows/sentinel-phase1-governance.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/sentinel-phase1-governance.yml'
 permissions:
   contents: read
+concurrency:
+  group: sentinel-f1-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   governance:
     runs-on: [self-hosted, Windows, X64, ascenda-fast]
@@ -16,5 +19,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - shell: powershell
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: F1 governance contract
+        shell: powershell
         run: node ci/sentinel/phase1_governance_contract.js

--- a/ci/sentinel/phase1_governance_contract.js
+++ b/ci/sentinel/phase1_governance_contract.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const req = (p) => {
+  const abs = path.join(ROOT, p);
+  if (!fs.existsSync(abs)) throw new Error(`MISSING_REQUIRED_FILE:${p}`);
+  return fs.readFileSync(abs, 'utf8');
+};
+const assert = (ok, msg) => { if (!ok) throw new Error(msg); };
+const mustContain = (text, tokens, label) => tokens.forEach(t => assert(text.includes(t), `${label}:MISSING:${t}`));
+const mustNotContain = (text, tokens, label) => tokens.forEach(t => assert(!text.includes(t), `${label}:FORBIDDEN:${t}`));
+
+const masterPath = 'docs/control/SENTINEL_CONTROL_MASTER.md';
+const roadmapPath = 'docs/control/SENTINEL_ROADMAP_V1.md';
+const policyPath = 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md';
+const reportPath = 'docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md';
+const workflowPath = '.github/workflows/sentinel-phase1-governance.yml';
+
+const master = req(masterPath);
+const roadmap = req(roadmapPath);
+const policy = req(policyPath);
+const report = req(reportPath);
+const workflow = req(workflowPath);
+
+mustContain(master, [
+  'Sentinel — Control Maestro',
+  'Zero PHI/PII telemetry',
+  'Vendor-neutral by design',
+  'Cost-bounded observability',
+  'UNKNOWN',
+  'Sentinel Hub'
+], 'MASTER');
+
+for (let i = 1; i <= 13; i++) {
+  assert(new RegExp(`FASE ${i}\\b`).test(roadmap), `ROADMAP:MISSING_PHASE_${i}`);
+}
+assert(!/FASE 14\b/.test(roadmap), 'ROADMAP:UNEXPECTED_PHASE_14');
+mustContain(roadmap, [
+  'FASE 1 — Governance, Privacy & Cost Guardrails',
+  'FASE 13 — Sentinel Hub, System Map & Certification',
+  'Zero-Cost gate',
+  'Notion'
+], 'ROADMAP');
+
+mustContain(policy, [
+  'allowlist-first',
+  'Session Replay: **OFF**',
+  'pay-as-you-go: OFF',
+  'Costo incremental cloud autorizado para F1: US$0/mes',
+  'SENTINEL_ENABLED',
+  'SENTINEL_SENTRY_ENABLED',
+  'SENTINEL_OTEL_EXPORT_ENABLED',
+  'SENTINEL_REMEDIATION_ENABLED',
+  'development',
+  'zero-cost',
+  'production',
+  'Sentry temporalmente caído',
+  'F1 solo puede certificarse `100_COMPLETE`'
+], 'POLICY');
+
+mustContain(policy, [
+  'DNI/documentos',
+  'teléfonos',
+  'contenido de WhatsApp',
+  '`Authorization`',
+  'service-role',
+  'raw webhook bodies',
+  'prompts/respuestas de IA'
+], 'PRIVACY_DENYLIST');
+
+mustContain(policy, [
+  '`system=ascenda-os`',
+  '`environment`',
+  '`service.name`',
+  '`module`',
+  '`component`',
+  '`capability`',
+  '`dependency`',
+  '`request_id`',
+  '`trace_id`',
+  '`commit_sha`'
+], 'TELEMETRY_ALLOWLIST');
+
+mustNotContain(policy, [
+  'pay-as-you-go: ON',
+  'Session Replay: **ON**',
+  'sendDefaultPii=true',
+  'auto-deploy to production',
+  'auto deploy to production'
+], 'POLICY');
+
+mustContain(report, [
+  'SENTINEL F1',
+  'F1-G01',
+  'F1-G18',
+  'VALIDATING'
+], 'VALIDATION_REPORT');
+
+mustContain(workflow, [
+  'self-hosted',
+  'Windows',
+  'X64',
+  'ascenda-fast',
+  'node ci/sentinel/phase1_governance_contract.js',
+  'cancel-in-progress: true'
+], 'WORKFLOW');
+mustNotContain(workflow, [
+  'ubuntu-latest',
+  'windows-latest',
+  'macos-latest',
+  'macos-'
+], 'WORKFLOW');
+
+// Guard against obvious real secret material in Sentinel control surfaces.
+const scanFiles = [masterPath, roadmapPath, policyPath, reportPath, workflowPath, 'ci/sentinel/phase1_governance_contract.js'];
+const suspicious = [
+  /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
+  /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/
+];
+for (const p of scanFiles) {
+  const text = req(p);
+  for (const re of suspicious) assert(!re.test(text), `SECRET_GUARD:${p}:${re}`);
+}
+
+// F1 is governance-only. On PRs/feature branches, forbid runtime/DB mutations in this workstream.
+function changedFilesAgainstBase() {
+  try {
+    const base = process.env.GITHUB_BASE_REF || 'main';
+    cp.execFileSync('git', ['fetch', 'origin', base, '--depth=1'], {cwd: ROOT, stdio:'ignore'});
+    const mb = cp.execFileSync('git', ['merge-base', 'HEAD', `origin/${base}`], {cwd: ROOT, encoding:'utf8'}).trim();
+    return cp.execFileSync('git', ['diff', '--name-only', `${mb}...HEAD`], {cwd: ROOT, encoding:'utf8'})
+      .split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
+  } catch (_) {
+    return [];
+  }
+}
+const changed = changedFilesAgainstBase();
+const forbiddenPrefixes = ['app/', 'supabase/migrations/', 'supabase/functions/', 'migrations/'];
+for (const p of changed) {
+  assert(!forbiddenPrefixes.some(prefix => p.startsWith(prefix)), `F1_SCOPE_RUNTIME_OR_DB_CHANGE:${p}`);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  certificate: 'SENTINEL_F1_GOVERNANCE_CONTRACT_PASS',
+  phases: 13,
+  incremental_cloud_budget_usd_month: 0,
+  zero_phi_pii: true,
+  payg: false,
+  runtime_db_changes_detected: false,
+  changed_files_checked: changed.length
+}, null, 2));

--- a/docs/control/SENTINEL_CONTROL_MASTER.md
+++ b/docs/control/SENTINEL_CONTROL_MASTER.md
@@ -1,0 +1,247 @@
+# Sentinel — Control Maestro
+
+**Estado:** CURRENT / CANONICAL / DESIGN BASELINE  
+**Fecha:** 2026-08-16 (America/Lima)  
+**Repositorio:** `CESARJAUREGUITORRES/ascenda-os`  
+**Workstream:** `SENTINEL`  
+**Rama fundacional:** `docs/sentinel-control-v1`  
+**Ámbito:** observabilidad, detección, correlación, triage, incidentes y respuesta segura para ASCENDA OS.
+
+---
+
+## 1. Misión
+
+Sentinel es la capa transversal de observabilidad y respuesta a incidentes de ASCENDA OS. Su función es detectar, localizar, explicar y correlacionar fallas técnicas y operativas antes o durante su impacto, sin convertirse en fuente de verdad de negocio ni introducir dependencia obligatoria de un proveedor externo.
+
+Sentinel observa; los dominios funcionales continúan gobernando sus propios datos y contratos.
+
+## 2. Principios no negociables
+
+1. **GitHub + runtime + schema live siguen siendo la verdad técnica.** Notion es continuidad visual y gestión.
+2. **Zero PHI/PII telemetry.** Ninguna historia clínica, nombre de paciente, DNI, teléfono, contenido WhatsApp/email, token, cookie, secreto o payload sensible se envía como telemetría.
+3. **Vendor-neutral by design.** Sentinel no depende estructuralmente de Sentry. OpenTelemetry y contratos propios de Sentinel definen la capa portable.
+4. **Cost-bounded observability.** Ningún sensor puede generar gasto cloud adicional sin gate económico y autorización expresa según `ASCENDA_ZERO_COST_VALIDATION_STANDARD.md`.
+5. **Fail-closed para automatización.** La detección puede ser automática; la mutación de producción nunca lo será por defecto.
+6. **No false-green.** Si Sentinel no puede observar una capacidad debe devolver `UNKNOWN`, no `HEALTHY`.
+7. **No duplicar fuentes de verdad.** Sentinel guarda evidencia operacional y metadatos de incidentes, no copias de datos clínicos/comerciales.
+8. **Toda remediación sigue branch → CI → staging/fixture → PR → canary → autorización → producción cuando corresponda.**
+
+## 3. Decisión de arquitectura: híbrida
+
+### 3.1 Por qué no Sentry-only
+
+Sentry es excelente para excepciones, stack traces, issues agrupados, tracing, releases y debugging, pero no detecta por sí solo todos los fallos funcionales. Un endpoint puede responder HTTP 200 y, aun así, devolver cero leads, una cola vacía o una regla de negocio rota.
+
+Además, el plan Developer es suficiente para una primera capa humana de debugging, pero Sentinel no debe diseñar su panel o incident engine dependiendo de una API/feature que pueda requerir un plan superior.
+
+### 3.2 Por qué no open-source-only desde el día 1
+
+Es técnicamente viable reemplazar Sentry por una combinación self-hosted, pero añade infraestructura, mantenimiento, backups, upgrades y otra superficie de fallo antes de que exista necesidad real. El objetivo inicial es obtener alta señal con costo marginal mínimo.
+
+### 3.3 Estrategia adoptada
+
+- **Sentry Cloud Developer:** sensor especializado de errores/traces de alto valor; no es la base de datos de Sentinel.
+- **OpenTelemetry:** contrato portable de telemetría y futura capa de routing/filter/redaction/sampling.
+- **Uptime Kuma:** disponibilidad externa y health checks cuando exista hosting 24/7 con costo marginal aceptable/autorizado.
+- **Sentinel Core:** topología, reglas de negocio, estados, incidentes `SEN-*`, severidad, evidencias y correlación.
+- **Supabase:** almacenamiento mínimo de estado/incidentes de Sentinel cuando se aprueben sus objetos versionados.
+- **GitHub:** código, releases, commits, PR, CI y evidencia reproducible.
+- **Railway:** runtime/deploy actual; se correlaciona, no se reemplaza.
+- **Telegram:** canal owner para incidentes relevantes; nunca se usa como fuente canónica.
+- **GlitchTip:** ruta de portabilidad/self-hosting compatible con SDK Sentry si en el futuro costo, control o residencia de datos lo justifican.
+
+## 4. Modelo de observación
+
+Sentinel combina cuatro tipos de señal:
+
+1. **Technical Errors** — excepciones, crashes, stack traces, rejects y fallos runtime.
+2. **Availability** — HTTP/TCP/health checks y disponibilidad externa.
+3. **Business Health** — invariantes funcionales, freshness, cardinalidades esperadas, colas, sincronizaciones y contratos operativos.
+4. **Dependencies** — Supabase, Railway, Meta/WhatsApp, Resend/email, IA/providers y otras integraciones.
+
+Ninguna señal individual puede declarar salud global por sí sola.
+
+## 5. Estados canónicos
+
+- `HEALTHY` — evidencia suficiente de operación normal.
+- `DEGRADED` — opera parcialmente o fuera de baseline.
+- `INCIDENT` — impacto funcional confirmado o altamente probable.
+- `CRITICAL` — capacidad crítica caída, seguridad o integridad materialmente afectada.
+- `UNKNOWN` — falta telemetría suficiente o existe inconsistencia entre sensores.
+
+## 6. Taxonomía mínima obligatoria
+
+Toda señal/incident debe poder correlacionarse, cuando aplique, con:
+
+- `system=ascenda-os`
+- `environment`
+- `module`
+- `component`
+- `capability`
+- `dependency`
+- `severity`
+- `release`
+- `commit_sha`
+- `deployment_id` cuando esté disponible
+- `request_id`
+- `trace_id`
+- `incident_id`
+- `sede` solo si puede representarse sin PII/PHI y aporta diagnóstico
+
+No se usarán identificadores de pacientes/personas como tags de observabilidad.
+
+## 7. Incident ID
+
+Formato canónico inicial:
+
+`SEN-YYYY-NNNN`
+
+Un incidente puede relacionar múltiples eventos y sensores, pero debe representar una causa/impacto coherente. El mismo incidente debe poder enlazar evidencia de Sentinel, Sentry, GitHub, Railway, CI y postmortem sin copiar secretos.
+
+## 8. Mapa inicial de dominios
+
+```text
+ASCENDA OS
+├── AUTH
+│   ├── login
+│   ├── session
+│   ├── roles
+│   └── 2FA
+├── SALES
+│   ├── ventas
+│   ├── metas
+│   ├── cartera
+│   └── revenue
+├── CALL CENTER
+│   ├── leads
+│   ├── llamadas
+│   ├── agenda
+│   └── routing
+├── WHATSAPP
+│   ├── inbound
+│   ├── inbox
+│   ├── boxes
+│   ├── routing
+│   ├── human-outbound
+│   ├── ai
+│   └── receipts
+├── EMAIL
+│   ├── provider
+│   ├── campaigns
+│   └── delivery
+├── KRONIA
+│   ├── router
+│   ├── models
+│   ├── tools
+│   └── actions
+├── CLINICAL
+├── INVENTORY
+└── INFRASTRUCTURE
+    ├── supabase
+    ├── railway
+    ├── github
+    └── ci-runners
+```
+
+El registry definitivo debe derivarse del repositorio/runtime real, no de esta lista preliminar.
+
+## 9. Arquitectura objetivo
+
+```text
+ASCENDA runtime / browser / dependencies
+               │
+      ┌────────┼───────────┐
+      │        │           │
+  Sentry    OTel       Health/Business probes
+      │        │           │
+      └────────┴─────┬─────┘
+                     ▼
+                Sentinel Core
+          topology + state + incidents
+                     │
+        ┌────────────┼─────────────┐
+        ▼            ▼             ▼
+   Sentinel Hub   Telegram     Diagnostic Runner
+        │                          │
+        └────────────┬─────────────┘
+                     ▼
+              GitHub branch / PR
+                     ▼
+                 Zero-Cost CI
+                     ▼
+                  canary
+                     ▼
+                 production
+```
+
+## 10. Panel final
+
+Sentinel Hub será un panel **owner/admin técnico**, no un panel SaaS de cliente. Debe mostrar topología y degradación por zona, no solo mensajes genéricos.
+
+Ejemplo esperado:
+
+```text
+WHATSAPP
+└── Outbound Messaging [INCIDENT]
+    ├── ASCENDA API [HEALTHY]
+    ├── 2FA/auth [HEALTHY]
+    ├── routing [HEALTHY]
+    ├── provider send [INCIDENT]
+    └── delivery receipts [DEGRADED]
+```
+
+El panel final debe permitir abrir el incidente, ver evidencia sanitizada, release/commit correlacionado, impacto, estado y siguiente acción.
+
+## 11. Seguridad y privacidad
+
+- `sendDefaultPii=false` o equivalente.
+- scrub/redaction antes de exportar cuando sea técnicamente posible.
+- no request bodies sensibles.
+- no Session Replay sobre flujos clínicos/privados durante la baseline.
+- no contenidos WhatsApp/email.
+- no headers de auth/cookies/tokens.
+- no service role en logs.
+- no PHI/PII en fixtures.
+- toda nueva tabla/RPC de Sentinel pasa migration versionada, RLS/ACL y Zero-Cost validation según riesgo.
+
+## 12. Política económica
+
+- objetivo inicial Sentry: plan Developer / costo base US$0 mientras el volumen y capacidades lo permitan;
+- no activar pay-as-you-go automáticamente;
+- sampling y filtering obligatorios antes de ampliar tracing/logging;
+- no duplicar la misma telemetría en múltiples backends sin una razón demostrable;
+- Uptime Kuma solo se despliega 24/7 cuando exista hosting con costo marginal aceptado; no se crea infraestructura pagada por inercia;
+- cualquier upgrade Sentry o servicio adicional requiere Impact Report económico y autorización expresa.
+
+## 13. Fuentes canónicas
+
+Precedencia Sentinel:
+
+1. GitHub/docs canónicos y SHA exacto.
+2. Runtime/deploy/schema live verificado.
+3. Evidencia de sensores y CI.
+4. Estado/incidentes Sentinel.
+5. Notion para continuidad visual.
+
+Notion nunca puede cerrar una fase que GitHub/runtime no prueben.
+
+## 14. Definition of Done global
+
+Sentinel puede declararse `100_COMPLETE` para una baseline solo cuando:
+
+- las 13 fases del roadmap están cerradas con evidencia;
+- el panel Sentinel está activo y protegido para owner/admin autorizado;
+- los dominios críticos tienen estado y profundidad diagnóstica suficiente;
+- se detectan tanto fallos técnicos como fallos funcionales silenciosos seleccionados;
+- los incidentes tienen IDs `SEN-*` y correlación release/commit;
+- alertas Telegram aplican deduplicación/severidad;
+- Diagnostic Runner funciona sin mutar producción;
+- MCP/AI triage respeta privacidad y mínimo privilegio;
+- remediation mantiene aprobación humana y gates de ASCENDA;
+- un backend puede ser reemplazado sin reescribir el modelo de Sentinel;
+- costos y cuotas están medidos, limitados y documentados;
+- Notion refleja el estado técnico real.
+
+## 15. Roadmap
+
+El roadmap operativo detallado está en `docs/control/SENTINEL_ROADMAP_V1.md`.

--- a/docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md
+++ b/docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md
@@ -1,0 +1,257 @@
+# Sentinel — F1 Governance, Privacy & Cost Policy
+
+**Estado:** CURRENT / CANONICAL / F1  
+**Fecha:** 2026-08-16 (America/Lima)  
+**Workstream:** `SENTINEL`  
+**Control Maestro:** `docs/control/SENTINEL_CONTROL_MASTER.md`  
+**Roadmap:** `docs/control/SENTINEL_ROADMAP_V1.md`
+
+---
+
+## 1. Propósito
+
+Esta política define la frontera obligatoria antes de que Sentinel exporte telemetría real desde ASCENDA OS. F1 no instrumenta producción: establece qué puede observarse, qué está prohibido exportar, cuánto puede costar, cómo se desactiva y qué evidencia es necesaria para habilitar fases posteriores.
+
+## 2. Decisión de arquitectura
+
+Sentinel adopta una arquitectura **híbrida y vendor-neutral**:
+
+- Sentry: sensor especializado de errores/stack traces y debugging de alta señal.
+- OpenTelemetry: contrato portable de traces/metrics/logs y futura capa de filtering, redaction, transformation y sampling.
+- Uptime Kuma: disponibilidad externa cuando exista hosting 24/7 aprobado.
+- Sentinel Core: topología, business-health, estado e incidentes `SEN-*`.
+- GitHub/Railway/Supabase: fuentes técnicas y de runtime ya existentes; Sentinel las correlaciona, no las reemplaza.
+
+Ningún backend externo es requisito para que Sentinel Core pueda existir. La indisponibilidad de Sentry debe degradar observabilidad, nunca la operación clínica/comercial de ASCENDA.
+
+## 3. Anti-scope F1
+
+F1 **NO** autoriza:
+
+- instalar `@sentry/*` en producción;
+- definir `SENTRY_DSN` en Railway;
+- activar tracing productivo;
+- activar Session Replay;
+- exportar logs productivos;
+- desplegar OpenTelemetry Collector productivo;
+- desplegar Uptime Kuma en infraestructura pagada;
+- crear tablas/RPC Sentinel en Supabase;
+- crear Telegram bot productivo;
+- activar Diagnostic Runner, AI triage o remediation;
+- crear el panel Sentinel Hub;
+- introducir pay-as-you-go o upgrades pagados.
+
+Esas capacidades pertenecen a fases posteriores y requieren sus propios gates.
+
+## 4. Regla Zero-PHI/PII Telemetry
+
+La telemetría externa se considera un boundary no confiable para datos clínicos/personales. El modelo es **allowlist-first**: si un atributo no está expresamente permitido, no se exporta.
+
+### 4.1 Datos prohibidos
+
+Nunca deben salir como evento, tag, breadcrumb, log, span attribute, attachment, replay, query string o payload:
+
+- nombre/apellidos de pacientes, leads, clientes, trabajadores o terceros;
+- DNI/documentos, teléfonos, emails, direcciones, fecha de nacimiento;
+- IDs de paciente/lead/persona, incluso hash estable, salvo revisión futura específica;
+- historias clínicas, diagnósticos, notas, evoluciones, prescripciones, alergias, fotos y documentos;
+- contenido de WhatsApp, SMS, email o chat;
+- prompts/respuestas de IA que contengan contenido de usuario/paciente;
+- cuerpos de requests/responses con datos de negocio o personales;
+- cookies, `Authorization`, JWT, app tokens, OTP, session tokens;
+- API keys, service-role, webhook secrets, passwords, private keys;
+- raw webhook bodies;
+- archivos subidos;
+- datos financieros a nivel transacción/persona: monto de pago individual, tarjeta, comprobante, saldo individual;
+- IP del usuario como atributo persistente cuando pueda evitarse;
+- URL/query con identificadores o contenido aportado por usuario.
+
+### 4.2 Atributos permitidos por defecto
+
+Se permiten únicamente metadatos técnicos no personales necesarios para diagnóstico:
+
+- `system=ascenda-os`;
+- `environment`;
+- `service.name`;
+- `service.version` / `release`;
+- `module`;
+- `component`;
+- `capability`;
+- `dependency`;
+- `severity`;
+- `event_type` técnico;
+- ruta normalizada/template sin parámetros personales ni query string;
+- método HTTP;
+- status HTTP/status class;
+- duración/latencia;
+- `request_id` aleatorio no derivado de identidad;
+- `trace_id` aleatorio;
+- `commit_sha`;
+- `deployment_id` no secreto;
+- nombre de sede solo cuando sea estrictamente operativo y no permita identificar a una persona;
+- conteos agregados/no identificables cuando exista una regla explícita de minimización.
+
+### 4.3 Identidad
+
+No se utilizará `user.id`, email, teléfono, DNI ni hash estable de persona como tag de observabilidad en la baseline. Si una fase futura necesita correlación por actor, deberá demostrar necesidad, minimización, pseudonimización no reversible y aprobación de seguridad antes de habilitarla.
+
+## 5. Sanitización obligatoria
+
+Toda integración futura que exporte telemetría debe aplicar dos capas como mínimo:
+
+1. sanitización local antes de transmitir (`beforeSend`, processors OTel o equivalente);
+2. data scrubbing en el backend externo cuando exista.
+
+La segunda capa nunca sustituye a la primera.
+
+Toda suite de instrumentación debe incluir tests negativos con fixtures sintéticos que contengan campos señuelo sensibles y demostrar que no aparecen en la salida exportable.
+
+## 6. Session Replay y captura de contenido
+
+Baseline Sentinel:
+
+- Session Replay: **OFF**;
+- attachments: **OFF**;
+- request/response body capture: **OFF**;
+- console/raw application logs a backend externo: **OFF**;
+- AI prompt/output capture: **OFF**;
+- DOM/form capture de áreas clínicas/comerciales: **OFF**.
+
+Cualquier cambio requiere una fase/Impact Report específico y no puede activarse por configuración accidental.
+
+## 7. Ambientes canónicos
+
+- `development`: local; solo fixtures sintéticos.
+- `zero-cost`: CI/staging efímero; fixtures sintéticos, sin secretos productivos ni PHI/PII real.
+- `staging`: solo cuando exista una necesidad concreta; no asume datos productivos y debe mantener minimización.
+- `production`: telemetría mínima, sanitizada y solo después del gate de la fase que la habilite.
+
+Nunca mezclar eventos de ambientes bajo el mismo valor de `environment`.
+
+## 8. Kill switches
+
+Las fases posteriores deben implementar control independiente por capacidad. Nombres canónicos iniciales:
+
+- `SENTINEL_ENABLED`
+- `SENTINEL_SENTRY_ENABLED`
+- `SENTINEL_OTEL_EXPORT_ENABLED`
+- `SENTINEL_BUSINESS_PROBES_ENABLED`
+- `SENTINEL_TELEGRAM_ENABLED`
+- `SENTINEL_DIAGNOSTIC_RUNNER_ENABLED`
+- `SENTINEL_AI_TRIAGE_ENABLED`
+- `SENTINEL_REMEDIATION_ENABLED`
+
+Regla: desactivar telemetría externa no debe tumbar ASCENDA. Sentinel debe fallar de forma aislada y reportar `UNKNOWN` cuando no pueda observar una capacidad.
+
+Para automatización/remediation, cualquier duda o pérdida de control debe ser **fail-closed**.
+
+## 9. Presupuesto y límites económicos
+
+### 9.1 Presupuesto inicial autorizado
+
+**Costo incremental cloud autorizado para F1: US$0/mes.**
+
+No se autoriza automáticamente:
+
+- pay-as-you-go;
+- upgrade de Sentry;
+- GitHub-hosted runners;
+- Supabase/Railway staging adicional pagado;
+- hosting 24/7 adicional para Kuma;
+- almacenamiento/retención adicional facturable.
+
+Cualquier gasto nuevo requiere Impact Report con necesidad, alternativa cero-costo descartada, costo mensual/variable, límite máximo, rollback/borrado y autorización expresa del propietario.
+
+### 9.2 Sentry baseline observada 2026-08-16
+
+El plan Developer se toma como baseline inicial de evaluación, no como contrato perpetuo. Antes de ampliar consumo o contratar se deben revalidar precios/cuotas vigentes.
+
+Budget operativo Sentinel para la primera activación Sentry:
+
+- errors: objetivo interno <= 2,500/mes durante baseline;
+- warning interno al 50% de la cuota gratuita vigente;
+- protective review al 80%;
+- logs externos: 0 en baseline;
+- Session Replay: 0 en baseline;
+- application metrics Sentry: 0 en baseline;
+- tracing/spans: OFF inicialmente; cualquier sampling >0 se autoriza en F4 después de medir error volume;
+- pay-as-you-go: OFF.
+
+Alcanzar una cuota nunca autoriza gasto automático. La respuesta segura es reducir/suspender señal no crítica y revisar sampling/filtering.
+
+## 10. Asignación de responsabilidades por herramienta
+
+| Necesidad | Herramienta primaria | Regla |
+|---|---|---|
+| Exceptions/stack traces | Sentry | alta señal, payload mínimo |
+| Contrato portable de telemetría | OpenTelemetry | vendor-neutral |
+| Filtering/redaction/sampling | OTel + SDK local | antes de exportar |
+| Uptime externo | Uptime Kuma | solo con observador 24/7 independiente aprobado |
+| Fallo funcional silencioso | Sentinel Business Health | no depender de excepciones |
+| Incident ID / estado | Sentinel Core | `SEN-*` canónico |
+| Código/release/CI | GitHub | fuente técnica |
+| Runtime/deploy | Railway | fuente de deployment |
+| Estado mínimo Sentinel futuro | Supabase | objetos versionados, mínimo privilegio |
+| Alertas owner | Telegram | canal, no fuente de verdad |
+
+## 11. Retención y minimización
+
+- conservar únicamente la evidencia mínima que permita diagnóstico;
+- preferir IDs/referencias a duplicar payloads;
+- no adjuntar dumps, XLSX, imágenes o mensajes a incidentes;
+- no retener telemetría externamente “por si acaso”;
+- cada backend futuro debe documentar retención y borrado;
+- los postmortems no deben copiar PHI/PII/secrets.
+
+## 12. Respuesta ante fuga de telemetría
+
+Si se sospecha que una señal exportó información prohibida:
+
+1. desactivar inmediatamente el exporter/sensor mediante kill switch;
+2. mantener ASCENDA operativa;
+3. registrar finding de seguridad sin repetir el dato filtrado;
+4. identificar backend, intervalo y tipo de dato;
+5. borrar/solicitar borrado cuando sea posible;
+6. rotar credenciales si algún secreto pudo exponerse;
+7. corregir redaction/filtering y agregar test negativo;
+8. reactivar solo después de security review y evidencia.
+
+## 13. Vendor lock-in guard
+
+Sentinel Hub, Incident Engine y Business Health no pueden requerir la API de Sentry para operar. Sentry puede aportar links/evidencia enriquecida, pero la salud global y el historial `SEN-*` deben sobrevivir a:
+
+- Sentry temporalmente caído;
+- agotamiento de cuota;
+- cambio de plan;
+- migración futura a GlitchTip/u otro backend;
+- desactivación deliberada del exporter.
+
+## 14. Reglas para secretos de configuración
+
+- DSN/tokens/config externa se gestionan por variables de entorno/secret manager;
+- no se hardcodean en GitHub, Notion, prompts o screenshots compartidos;
+- documentación usa solo nombres de variables;
+- no imprimir prefijos/longitudes que ayuden a reconstruir secretos;
+- los tests usan valores sintéticos no válidos.
+
+## 15. Definition of Done F1
+
+F1 solo puede certificarse `100_COMPLETE` cuando:
+
+1. current `main` y baseline runtime están verificados;
+2. Control Maestro y roadmap de 13 fases están versionados;
+3. esta política está versionada;
+4. Zero-PHI/PII allowlist/denylist está definida;
+5. ambientes y kill switches están definidos;
+6. presupuesto US$0 y no-auto-billing están definidos;
+7. arquitectura vendor-neutral está explícita;
+8. anti-scope demuestra que F1 no instrumenta producción;
+9. existe contrato automático de gobernanza;
+10. contrato corre en self-hosted CI sin fallback facturable;
+11. PR F1 contiene solo docs/control/CI, sin runtime, DB o secretos;
+12. exact-head CI es PASS;
+13. PR canónico se integra a `main`;
+14. Validation Report final queda `100_COMPLETE`;
+15. Notion F1 se marca `Cerrada/100%` y F2 queda como única `Siguiente`.
+
+Hasta entonces, F1 permanece `EN CURSO`.

--- a/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
@@ -1,0 +1,79 @@
+# SENTINEL F1 — Governance, Privacy & Cost Guardrails — Validation Report
+
+**Fecha:** 2026-08-16 (America/Lima)  
+**Estado:** `VALIDATING`  
+**Baseline main:** `d362442cc111cb712cc627a7e8118e3b190c15b5`  
+**Branch:** `docs/sentinel-control-v1`  
+**PR:** `#179`  
+**Riesgo:** HIGH por política de privacidad/telemetría; implementación F1 es docs/control/CI only.
+
+---
+
+## 1. Objetivo de certificación
+
+Cerrar F1 únicamente cuando Sentinel tenga gobierno verificable antes de cualquier export productivo: privacidad allowlist-first, presupuesto US$0, arquitectura vendor-neutral, kill switches definidos, anti-scope explícito y contrato automático self-hosted.
+
+F1 no instala sensores ni modifica runtime/DB.
+
+## 2. Recovery / evidencia inicial
+
+- `main` verificado en `d362442cc111cb712cc627a7e8118e3b190c15b5`.
+- runtime productivo actual documentado: `server-phase-s.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → server-phase2.js → server.js`.
+- búsqueda sobre current main no encontró `SENTRY_DSN`, `@sentry`, inicialización Sentry, OpenTelemetry ni Uptime Kuma en el runtime.
+- PR histórico #80 y PR #92 documentaron conexión externa Sentry/GitHub/ChatGPT, pero no instrumentación runtime; se consideran antecedente, no certificación Sentinel.
+- `SECURITY.md`, `AGENTS.md` y Zero-Cost CI V2 siguen siendo controles superiores aplicables.
+
+## 3. Baseline económico/técnico externo
+
+Baseline consultada el 2026-08-16 y sujeta a reverificación antes de cualquier upgrade/consumo ampliado:
+
+- Sentry Developer: plan gratuito apto para baseline humana de Error Monitoring/MCP, con cuotas limitadas; Sentinel no depende de su API para el core.
+- OpenTelemetry Collector: arquitectura de processors permite filtering/redaction/transformation/sampling antes de exportar.
+- Uptime Kuma: alternativa self-hosted de availability con notificaciones Telegram; su utilidad requiere observador 24/7 independiente y no autoriza hosting pagado automático.
+
+Fuentes de referencia:
+- `https://sentry.io/pricing/`
+- `https://opentelemetry.io/docs/collector/architecture/`
+- `https://github.com/louislam/uptime-kuma`
+
+## 4. Gates F1
+
+| Gate | Evidencia requerida | Estado |
+|---|---|---|
+| F1-G01 | current `main` verificado | PASS |
+| F1-G02 | branch/PR Sentinel aislado | PASS |
+| F1-G03 | `SENTINEL_CONTROL_MASTER.md` canónico | PASS |
+| F1-G04 | roadmap exactamente 13 fases + F13 Hub/System Map | PASS |
+| F1-G05 | Zero-PHI/PII policy allowlist-first | PASS |
+| F1-G06 | denylist + allowlist de atributos | PASS |
+| F1-G07 | ambientes development/zero-cost/staging/production | PASS |
+| F1-G08 | kill switches definidos | PASS |
+| F1-G09 | presupuesto incremental F1 US$0 + no auto pay-as-you-go | PASS |
+| F1-G10 | arquitectura híbrida/vendor-neutral | PASS |
+| F1-G11 | anti-scope: F1 no instrumenta runtime/DB | PASS |
+| F1-G12 | respuesta ante fuga + secret handling | PASS |
+| F1-G13 | Sentry/OpenTelemetry/Kuma responsibilities separadas | PASS |
+| F1-G14 | contrato automático machine-checkable | PASS |
+| F1-G15 | workflow self-hosted FAST, sin hosted fallback | PENDING until workflow committed |
+| F1-G16 | exact-head F1 CI PASS | PENDING |
+| F1-G17 | diff final demuestra 0 `app/`, 0 migrations/DB, 0 secrets | PENDING |
+| F1-G18 | PR integrado a main + Validation Report final + Notion F1=100/Cerrada, F2 única Siguiente | PENDING |
+
+## 5. Invariantes de cierre
+
+No declarar `100_COMPLETE` mientras cualquier G15–G18 permanezca pendiente.
+
+No se requiere canary productivo porque F1 no introduce runtime, exporter, schema, secret ni provider call. El gate equivalente es exact-head static certification + scope proof + merge documental/control.
+
+## 6. Siguiente loop
+
+1. versionar workflow F1 self-hosted;
+2. ejecutar contrato sobre exact HEAD;
+3. verificar changed files contra `main`;
+4. corregir cualquier fallo sin debilitar la política;
+5. obtener CI PASS;
+6. fusionar PR #179 si el scope sigue docs/control/CI only;
+7. crear checkpoint de cierre exacto si el merge SHA cambia evidencia;
+8. actualizar este reporte a `100_COMPLETE` mediante cierre documental;
+9. actualizar Notion como último paso;
+10. dejar F2 como única fase `Siguiente`.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -1,0 +1,358 @@
+# Sentinel — Roadmap V1
+
+**Estado:** CURRENT / CANONICAL  
+**Fecha:** 2026-08-16 (America/Lima)  
+**Control Maestro:** `docs/control/SENTINEL_CONTROL_MASTER.md`
+
+---
+
+## Regla de ejecución
+
+Cada fase usa el loop ASCENDA:
+
+`recovery → evidencia → branch → implementación → tests → Zero-Cost gate → preflight/canary si aplica → checkpoint → Notion`
+
+Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase se marca cerrada por intención; solo por evidencia.
+
+---
+
+# FASE 1 — Governance, Privacy & Cost Guardrails
+
+**Objetivo:** establecer límites técnicos, económicos y de privacidad antes de emitir telemetría real.
+
+### Trabajos
+- congelar nombre oficial `Sentinel`;
+- aprobar arquitectura híbrida;
+- definir anti-scope;
+- definir Zero-PHI/PII telemetry policy;
+- definir sensitive-field denylist y allowlist de atributos;
+- definir ambientes (`development`, `zero-cost`, `production`);
+- definir cuotas/budget por señal;
+- establecer política `no pay-as-you-go automático`;
+- definir cuándo Sentry, OTel, Kuma o GlitchTip pueden utilizarse;
+- definir rollback/desactivación total de observabilidad;
+- crear Control Maestro GitHub + Notion + bases de fases/hallazgos.
+
+### Gate de salida
+- arquitectura y políticas canónicas versionadas;
+- costo inicial objetivo documentado;
+- no existe telemetría productiva antes de completar privacy gate;
+- Notion y GitHub reflejan la misma fase activa.
+
+---
+
+# FASE 2 — System Registry & Topology Taxonomy
+
+**Objetivo:** construir el mapa verificable de ASCENDA que Sentinel observará.
+
+### Trabajos
+- inventariar paneles productivos `app/public/`;
+- mapear servidores/runtime Node actuales;
+- mapear módulos y capacidades;
+- mapear RPC/tablas relevantes por dominio;
+- mapear dependencias externas;
+- asignar `module/component/capability/dependency`;
+- definir criticidad por capacidad;
+- diferenciar capability observable vs `UNKNOWN`;
+- generar registry canónico machine-readable;
+- contratos para evitar nombres libres/inconsistentes.
+
+### Gate de salida
+- topología inicial crítica validada contra GitHub/runtime;
+- registry versionado;
+- ningún nodo crítico se marca HEALTHY sin señal asignada.
+
+---
+
+# FASE 3 — Telemetry Contract & OpenTelemetry Foundation
+
+**Objetivo:** establecer contrato portable antes de profundizar en cualquier proveedor.
+
+### Trabajos
+- definir resource attributes canónicos;
+- `service.name`, `service.version`, `deployment.environment` y equivalentes Sentinel;
+- definir `request_id`, `trace_id` y propagation;
+- instrumentación Node mínima compatible con arquitectura CommonJS actual;
+- política de sampling;
+- diseño del Collector sin obligación de desplegarlo todavía;
+- processors previstos: filter/redaction/transform/batch/sampling;
+- pruebas para impedir PHI/PII/secrets;
+- exporter interface desacoplada.
+
+### Gate de salida
+- contrato OTel/Correlation estable;
+- fixture local demuestra redaction y tags permitidos;
+- runtime no depende de un backend concreto.
+
+---
+
+# FASE 4 — Sentry Error Monitoring Core
+
+**Objetivo:** incorporar detección de errores de alto valor con volumen controlado.
+
+### Trabajos
+- crear proyecto Sentry Node;
+- configurar privacy/data scrubbing;
+- integrar `@sentry/node` en boundary seguro;
+- `sendDefaultPii=false`;
+- environment/release correctos;
+- errores uncaught/unhandled controlados;
+- tags solo de taxonomía Sentinel;
+- tracing inicialmente OFF o con sampling mínimo aprobado;
+- test sintético no sensible;
+- kill switch por variable de entorno;
+- validar cuota/volumen inicial.
+
+### Gate de salida
+- un error sintético aparece con release/environment correctos;
+- cero datos sensibles detectados;
+- desactivar Sentry no rompe ASCENDA;
+- Sentry permanece sensor, no dependencia de Sentinel Core.
+
+---
+
+# FASE 5 — Availability Layer / Uptime Kuma
+
+**Objetivo:** detectar caídas externas que no requieren una excepción interna.
+
+### Trabajos
+- identificar endpoints/probes seguros;
+- `/health` outer runtime;
+- probes selectivos por dependencias;
+- diseñar deployment Uptime Kuma;
+- verificar costo marginal 24/7 antes de desplegar;
+- configurar retries y anti-flapping;
+- definir status `UP/DOWN/UNKNOWN` traducible a Sentinel;
+- evitar endpoints que expongan métricas sensibles;
+- baseline de disponibilidad.
+
+### Gate de salida
+- disponibilidad externa puede detectarse independientemente del runtime observado;
+- hosting aprobado y documentado o fase queda técnicamente lista sin gasto no autorizado;
+- outage sintético produce señal deduplicada.
+
+---
+
+# FASE 6 — Business Health & Silent Failure Invariants
+
+**Objetivo:** detectar fallos donde HTTP/JS parecen sanos pero el negocio está roto.
+
+### Trabajos
+- identificar invariantes por dominio;
+- freshness de datos;
+- cardinalidades mínimas/máximas razonables;
+- sincronizaciones estancadas;
+- colas/backlogs;
+- respuestas vacías anómalas;
+- reconciliaciones críticas;
+- estados imposibles;
+- probes read-only y mínimo privilegio;
+- baselines por sede cuando sea seguro;
+- suppressions/maintenance windows.
+
+### Gate de salida
+- al menos Call Center, Ventas, WhatsApp y Email tienen una regla de silent failure validada;
+- una anomalía funcional sintética cambia el nodo correspondiente a DEGRADED/INCIDENT sin depender de Sentry.
+
+---
+
+# FASE 7 — Release, Deploy & Correlation Layer
+
+**Objetivo:** poder responder “qué versión estaba corriendo cuando falló”.
+
+### Trabajos
+- release = SHA/versión verificable;
+- correlación GitHub commit/PR;
+- Railway deployment metadata disponible sin secretos;
+- `request_id` extremo a extremo donde aplique;
+- `trace_id` y breadcrumbs sanitizados;
+- timeline deploy→incident;
+- detección de regression window;
+- política de suspect change como inferencia, no certeza.
+
+### Gate de salida
+- incidente sintético identifica SHA exacto y ambiente;
+- rollback target puede determinarse sin adivinanzas.
+
+---
+
+# FASE 8 — Sentinel Incident Engine (`SEN-*`)
+
+**Objetivo:** unificar señales en incidentes interpretables y persistentes.
+
+### Trabajos
+- schema versionado de incidentes;
+- generador `SEN-YYYY-NNNN`;
+- deduplicación/fingerprints;
+- severidades P0/P1/P2/P3;
+- estados OPEN/ACK/INVESTIGATING/MITIGATED/RESOLVED;
+- vínculo a módulos/capacidades;
+- evidence references, no payload sensible;
+- timeline del incidente;
+- reopen rules;
+- postmortem fields;
+- retención y archival.
+
+### Gate de salida
+- señales múltiples pueden converger en un mismo incidente;
+- incident ID es estable y consultable;
+- replay no duplica incidentes indebidamente.
+
+---
+
+# FASE 9 — Alert Routing, Telegram & Noise Control
+
+**Objetivo:** avisar lo correcto, a la persona correcta, sin fatiga de alertas.
+
+### Trabajos
+- Telegram bot/canal owner;
+- P0/P1 inmediato;
+- P2 agrupado;
+- P3 solo panel/log;
+- cooldown/dedup;
+- flapping suppression;
+- recovery notification;
+- maintenance window;
+- plantilla sanitizada;
+- links/IDs a Sentinel/GitHub/Sentry cuando sean accesibles;
+- pruebas de rate/noise.
+
+### Gate de salida
+- incidentes críticos notifican;
+- repetición masiva no genera spam;
+- Telegram nunca incluye PHI/PII/secrets.
+
+---
+
+# FASE 10 — Diagnostic Runner
+
+**Objetivo:** automatizar investigación reproducible sin mutar producción.
+
+### Trabajos
+- trigger controlado desde `SEN-*`;
+- `repository_dispatch`/workflow equivalente solo cuando sea seguro;
+- runner self-hosted dedicado/ruteado según estándar;
+- checkout SHA afectado;
+- contracts/tests del dominio;
+- reproducción con fixtures sintéticos;
+- diff/recent commits;
+- health evidence;
+- root-cause hypothesis report;
+- timeout/cancel/concurrency;
+- cero secretos innecesarios;
+- runner no escribe producción.
+
+### Gate de salida
+- un incidente sintético dispara diagnóstico y genera evidencia reproducible;
+- no existe ruta de mutación productiva desde el job diagnóstico.
+
+---
+
+# FASE 11 — MCP / AI-Assisted Triage
+
+**Objetivo:** permitir que ChatGPT/Codex/agentes investiguen Sentinel con contexto suficiente y mínimo privilegio.
+
+### Trabajos
+- definir herramientas read-only;
+- acceso a incident metadata;
+- acceso controlado a Sentry/MCP cuando el plan/capacidad lo permita;
+- acceso GitHub por SHA/PR;
+- sanitización previa a LLM;
+- prompts/system contract para no inventar causalidad;
+- evidence citations;
+- confidence labels;
+- human-readable diagnosis;
+- audit trail de consultas.
+
+### Gate de salida
+- agente puede investigar `SEN-*` sin copiar manualmente stack traces sensibles;
+- toda conclusión material cita evidencia técnica;
+- no se otorgan herramientas de escritura innecesarias.
+
+---
+
+# FASE 12 — Safe Remediation Loop
+
+**Objetivo:** pasar de diagnóstico a propuesta de fix sin permitir auto-deploy inseguro.
+
+### Trabajos
+- diagnosis → candidate patch;
+- branch aislada;
+- tests específicos;
+- Zero-Cost CI;
+- security gate según riesgo;
+- PR automático opcional;
+- Impact Report;
+- rollback;
+- canary;
+- aprobación humana obligatoria para producción;
+- medir false fixes/reverts;
+- kill switch completo.
+
+### Gate de salida
+- incidente sintético puede llegar hasta PR validado;
+- ninguna ruta puede fusionar/desplegar HIGH/CRITICAL sin gates y autorización;
+- rollback probado.
+
+---
+
+# FASE 13 — Sentinel Hub, System Map & Cross-System Certification
+
+**Objetivo:** entregar el panel interno final dentro de ASCENDA y certificar Sentinel transversalmente.
+
+### Trabajos
+- panel `Sentinel` visible solo a owner/admin autorizado;
+- System Topology Map;
+- drill-down dominio → componente → capability;
+- estados HEALTHY/DEGRADED/INCIDENT/CRITICAL/UNKNOWN;
+- incident list y `SEN-*`;
+- evidencia sanitizada;
+- release/commit/deploy;
+- último health check;
+- impacto y severidad;
+- acciones seguras: ver, reconocer, diagnosticar, abrir GitHub;
+- nunca exponer secretos/PII/PHI;
+- responsive/mobile owner view;
+- history/postmortem;
+- smoke por módulos críticos;
+- resilience test: Sentry down, Kuma down, Collector down, Sentinel Core down;
+- portability test hacia backend alternativo/fixture;
+- cost audit final;
+- seguridad/roles/2FA;
+- documentación y Notion final;
+- SaaS boundary: cliente no ve stack traces ni infraestructura interna.
+
+### Gate de salida
+- panel productivo y protegido;
+- puede localizar una falla a nivel de zona/capability, no solo “módulo caído”;
+- todos los dominios críticos tienen señal o estado UNKNOWN explícito;
+- incident flow detect→notify→diagnose→PR está certificado;
+- costo y cuotas dentro del presupuesto aprobado;
+- GitHub/runtime/Notion alineados;
+- Sentinel puede declararse `100_COMPLETE` para la baseline.
+
+---
+
+## Índice ejecutivo de fases
+
+| # | Fase | Resultado principal |
+|---|---|---|
+| 1 | Governance, Privacy & Cost | límites seguros y económicos |
+| 2 | Registry & Topology | mapa verificable de ASCENDA |
+| 3 | OTel Foundation | contrato portable |
+| 4 | Sentry Core | errores y debugging |
+| 5 | Availability | caídas externas |
+| 6 | Business Health | fallos silenciosos |
+| 7 | Correlation | error→release→deploy |
+| 8 | Incident Engine | IDs `SEN-*` |
+| 9 | Alert Routing | Telegram sin ruido |
+| 10 | Diagnostic Runner | investigación automatizada |
+| 11 | MCP/AI Triage | análisis asistido |
+| 12 | Safe Remediation | fix→PR con gates |
+| 13 | Sentinel Hub | mapa interno + certificación 100% |
+
+## Estado inicial
+
+- Fase 1: `SIGUIENTE`.
+- Fases 2–13: `PENDIENTE`.
+- Ningún sensor productivo queda autorizado únicamente por este documento; cada fase debe ejecutar sus gates.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -31,13 +31,16 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 - establecer política `no pay-as-you-go automático`;
 - definir cuándo Sentry, OTel, Kuma o GlitchTip pueden utilizarse;
 - definir rollback/desactivación total de observabilidad;
-- crear Control Maestro GitHub + Notion + bases de fases/hallazgos.
+- crear Control Maestro GitHub + Notion + bases de fases/hallazgos;
+- añadir contrato machine-checkable y workflow self-hosted de certificación.
 
 ### Gate de salida
 - arquitectura y políticas canónicas versionadas;
 - costo inicial objetivo documentado;
 - no existe telemetría productiva antes de completar privacy gate;
-- Notion y GitHub reflejan la misma fase activa.
+- exact-head F1 CI PASS;
+- scope final sin cambios runtime/DB;
+- Notion y GitHub reflejan la misma fase activa/cerrada.
 
 ---
 
@@ -296,7 +299,7 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 
 ---
 
-# FASE 13 — Sentinel Hub, System Map & Cross-System Certification
+# FASE 13 — Sentinel Hub, System Map & Certification
 
 **Objetivo:** entregar el panel interno final dentro de ASCENDA y certificar Sentinel transversalmente.
 
@@ -351,8 +354,8 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 | 12 | Safe Remediation | fix→PR con gates |
 | 13 | Sentinel Hub | mapa interno + certificación 100% |
 
-## Estado inicial
+## Estado actual
 
-- Fase 1: `SIGUIENTE`.
+- Fase 1: `EN CURSO`.
 - Fases 2–13: `PENDIENTE`.
 - Ningún sensor productivo queda autorizado únicamente por este documento; cada fase debe ejecutar sus gates.


### PR DESCRIPTION
## Objetivo
Formalizar `Sentinel` como workstream transversal de observabilidad y respuesta a incidentes de ASCENDA OS y ejecutar la certificación F1 — Governance, Privacy & Cost Guardrails.

## Incluye
- `SENTINEL_CONTROL_MASTER.md` — arquitectura híbrida, estados, taxonomía, incident IDs y Definition of Done global.
- `SENTINEL_ROADMAP_V1.md` — exactamente 13 fases, con F13 Sentinel Hub + System Map.
- `SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md` — Zero-PHI/PII allowlist-first, anti-scope, ambientes, kill switches, presupuesto US$0, no auto pay-as-you-go y vendor-lock-in guard.
- `SENTINEL_F1_VALIDATION_REPORT_20260816.md` — gates F1-G01..F1-G18.
- `ci/sentinel/phase1_governance_contract.js` — contrato machine-checkable de políticas, scope y secret guard.
- `.github/workflows/sentinel-phase1-governance.yml` — certificado en runner self-hosted FAST, read-only y sin hosted fallback.

## Decisiones clave
- Sentry es sensor especializado, no fuente de verdad de Sentinel.
- OpenTelemetry define portabilidad y futura capa de routing/filter/redaction/sampling.
- Uptime Kuma queda como availability layer cuando exista hosting 24/7 aprobado.
- Sentinel Core cubrirá fallos funcionales silenciosos e incidentes `SEN-*`.
- Sentinel Hub no dependerá de la API de Sentry para operar.
- Zero PHI/PII telemetry; Session Replay/log export/tracing productivo permanecen OFF en F1.
- Costo incremental cloud autorizado F1 = US$0/mes; pay-as-you-go OFF.

## Scope F1
Governance/docs/CI only. F1 no autoriza `@sentry`, DSN Railway, exporters OTel, Supabase Sentinel objects, Telegram, Uptime Kuma deployment ni cambios productivos.

## Gate
No declarar F1 `100_COMPLETE` ni fusionar hasta que:
1. `Sentinel F1 Governance Certificate` PASS sobre exact HEAD;
2. Ascenda CI relevante PASS;
3. diff final confirme 0 `app/`, 0 migrations/DB y 0 secrets;
4. PR siga mergeable.

Después del merge se realizará cierre documental exacto y Notion será actualizado como último paso: F1 `Cerrada/100%`, F2 única `Siguiente`.

## Notion
Existe `Sentinel — Control Maestro`, `Fases Sentinel` (13 fases) y `Hallazgos & Mejoras Sentinel` bajo ASCENDA OS.