### PR TITLE
docs(sentinel): record F1 technical certification checkpoint

### DIFF
--- a/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
@@ -1,46 +1,66 @@
 # SENTINEL F1 — Governance, Privacy & Cost Guardrails — Validation Report
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Estado:** `VALIDATING`  
-**Baseline main:** `d362442cc111cb712cc627a7e8118e3b190c15b5`  
-**Branch:** `docs/sentinel-control-v1`  
-**PR:** `#179`  
-**Riesgo:** HIGH por política de privacidad/telemetría; implementación F1 es docs/control/CI only.
+**Estado:** `TECHNICALLY_CERTIFIED / NOTION_FINALIZATION_PENDING`  
+**Lifecycle:** `VALIDATING → TECHNICALLY_CERTIFIED → 100_COMPLETE`  
+**Baseline inicial:** `main@d362442cc111cb712cc627a7e8118e3b190c15b5`  
+**Fundación integrada:** PR `#179` → `main@052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`  
+**Riesgo:** HIGH por política de privacidad/telemetría; implementación F1 es governance/docs/CI only.
 
 ---
 
-## 1. Objetivo de certificación
+## 1. Resultado técnico
 
-Cerrar F1 únicamente cuando Sentinel tenga gobierno verificable antes de cualquier export productivo: privacidad allowlist-first, presupuesto US$0, arquitectura vendor-neutral, kill switches definidos, anti-scope explícito y contrato automático self-hosted.
+F1 ya dispone de gobierno verificable antes de cualquier export productivo: privacidad allowlist-first, presupuesto incremental US$0, arquitectura vendor-neutral, kill switches definidos, anti-scope explícito y contrato automático self-hosted.
 
-F1 no instala sensores ni modifica runtime/DB.
+F1 no instaló sensores ni modificó runtime/DB.
 
-## 2. Recovery / evidencia inicial
+## 2. Recovery / evidencia
 
-- `main` verificado en `d362442cc111cb712cc627a7e8118e3b190c15b5`.
-- runtime productivo actual documentado: `server-phase-s.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → server-phase2.js → server.js`.
-- búsqueda sobre current main no encontró `SENTRY_DSN`, `@sentry`, inicialización Sentry, OpenTelemetry ni Uptime Kuma en el runtime.
-- PR histórico #80 y PR #92 documentaron conexión externa Sentry/GitHub/ChatGPT, pero no instrumentación runtime; se consideran antecedente, no certificación Sentinel.
-- `SECURITY.md`, `AGENTS.md` y Zero-Cost CI V2 siguen siendo controles superiores aplicables.
+- baseline original verificada en `d362442cc111cb712cc627a7e8118e3b190c15b5`;
+- runtime productivo documentado: `server-phase-s.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → server-phase2.js → server.js`;
+- búsqueda sobre la baseline no encontró `SENTRY_DSN`, `@sentry`, inicialización Sentry, OpenTelemetry ni Uptime Kuma en runtime;
+- PR histórico #80/#92 se conserva solo como antecedente de conexión externa, no como instrumentación Sentinel;
+- `SECURITY.md`, `AGENTS.md` y Zero-Cost CI V2 continúan como controles superiores;
+- PR #179 fue fusionado por squash a `052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`.
 
 ## 3. Baseline económico/técnico externo
 
 Baseline consultada el 2026-08-16 y sujeta a reverificación antes de cualquier upgrade/consumo ampliado:
 
-- Sentry Developer: plan gratuito apto para baseline humana de Error Monitoring/MCP, con cuotas limitadas; Sentinel no depende de su API para el core.
-- OpenTelemetry Collector: arquitectura de processors permite filtering/redaction/transformation/sampling antes de exportar.
-- Uptime Kuma: alternativa self-hosted de availability con notificaciones Telegram; su utilidad requiere observador 24/7 independiente y no autoriza hosting pagado automático.
+- Sentry Developer se evalúa como sensor gratuito de baseline, pero Sentinel Core no depende de su API;
+- OpenTelemetry define la ruta portable de filtering/redaction/transformation/sampling;
+- Uptime Kuma queda reservado para availability cuando exista observador 24/7 independiente y costo aprobado.
 
-Fuentes de referencia:
+Referencias:
 - `https://sentry.io/pricing/`
 - `https://opentelemetry.io/docs/collector/architecture/`
 - `https://github.com/louislam/uptime-kuma`
 
-## 4. Gates F1
+## 4. Evidencia CI exact-head
+
+Candidate certificado antes del merge: `97f7b50cf56eb1c9d4b8d30f674b115fda6f4f57`.
+
+- Sentinel F1 Governance Certificate — run `31932437806` — **PASS**.
+- Ascenda CI — run `31932437815` — **PASS**.
+- Primer intento F1 — run `31932369611` — **FAIL CLOSED** por mismatch de nomenclatura F13; no se debilitó el gate. Se alineó la fuente canónica y el segundo loop pasó.
+
+Scope final PR #179:
+
+1. `.github/workflows/sentinel-phase1-governance.yml`
+2. `ci/sentinel/phase1_governance_contract.js`
+3. `docs/control/SENTINEL_CONTROL_MASTER.md`
+4. `docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md`
+5. `docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md`
+6. `docs/control/SENTINEL_ROADMAP_V1.md`
+
+Resultado: **0 `app/`, 0 migrations/DB, 0 Supabase runtime, 0 secrets intencionales**.
+
+## 5. Gates F1
 
 | Gate | Evidencia requerida | Estado |
 |---|---|---|
-| F1-G01 | current `main` verificado | PASS |
+| F1-G01 | current `main`/baseline verificado | PASS |
 | F1-G02 | branch/PR Sentinel aislado | PASS |
 | F1-G03 | `SENTINEL_CONTROL_MASTER.md` canónico | PASS |
 | F1-G04 | roadmap exactamente 13 fases + F13 Hub/System Map | PASS |
@@ -54,26 +74,22 @@ Fuentes de referencia:
 | F1-G12 | respuesta ante fuga + secret handling | PASS |
 | F1-G13 | Sentry/OpenTelemetry/Kuma responsibilities separadas | PASS |
 | F1-G14 | contrato automático machine-checkable | PASS |
-| F1-G15 | workflow self-hosted FAST, sin hosted fallback | PENDING until workflow committed |
-| F1-G16 | exact-head F1 CI PASS | PENDING |
-| F1-G17 | diff final demuestra 0 `app/`, 0 migrations/DB, 0 secrets | PENDING |
-| F1-G18 | PR integrado a main + Validation Report final + Notion F1=100/Cerrada, F2 única Siguiente | PENDING |
+| F1-G15 | workflow self-hosted FAST, sin hosted fallback | PASS |
+| F1-G16 | exact-head F1 CI PASS | PASS |
+| F1-G17 | diff final demuestra 0 `app/`, 0 migrations/DB, 0 secrets | PASS |
+| F1-G18 | checkpoint de cierre + Notion F1=100/Cerrada, F2 única Siguiente | PENDING |
 
-## 5. Invariantes de cierre
+## 6. Regla de cierre
 
-No declarar `100_COMPLETE` mientras cualquier G15–G18 permanezca pendiente.
+La capacidad técnica F1 está certificada, pero **no se declara `100_COMPLETE` todavía**. Falta el gate de continuidad G18: checkpoint documental final y sincronización de Notion como último paso.
 
-No se requiere canary productivo porque F1 no introduce runtime, exporter, schema, secret ni provider call. El gate equivalente es exact-head static certification + scope proof + merge documental/control.
+No se requiere canary productivo porque F1 no introduce runtime, exporter, schema, secret ni provider call.
 
-## 6. Siguiente loop
+## 7. Siguiente acción exacta
 
-1. versionar workflow F1 self-hosted;
-2. ejecutar contrato sobre exact HEAD;
-3. verificar changed files contra `main`;
-4. corregir cualquier fallo sin debilitar la política;
-5. obtener CI PASS;
-6. fusionar PR #179 si el scope sigue docs/control/CI only;
-7. crear checkpoint de cierre exacto si el merge SHA cambia evidencia;
-8. actualizar este reporte a `100_COMPLETE` mediante cierre documental;
-9. actualizar Notion como último paso;
-10. dejar F2 como única fase `Siguiente`.
+1. fusionar este checkpoint técnico docs-only después de Sentinel F1 CI;
+2. sincronizar Notion con la evidencia integrada;
+3. generar certificado final `100_COMPLETE` sobre una rama fresca;
+4. ejecutar Sentinel F1 CI final;
+5. fusionar certificado final;
+6. actualizar Notion con el commit/PR final y dejar F2 como única `Siguiente`.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -356,6 +356,7 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 
 ## Estado actual
 
-- Fase 1: `EN CURSO`.
-- Fases 2–13: `PENDIENTE`.
+- Fase 1: `CLOSING` — capacidad técnica certificada; continuidad/Notion pendiente.
+- Fase 2: `PENDIENTE` hasta cierre final F1.
+- Fases 3–13: `PENDIENTE`.
 - Ningún sensor productivo queda autorizado únicamente por este documento; cada fase debe ejecutar sus gates.


### PR DESCRIPTION
## Objetivo
Registrar el checkpoint técnico posterior al merge de PR #179 sin declarar todavía F1 `100_COMPLETE`.

## Evidencia
- Fundación Sentinel/F1 integrada a main en `052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`.
- Candidate exact-head `97f7b50cf56eb1c9d4b8d30f674b115fda6f4f57`.
- Sentinel F1 Governance Certificate run `31932437806`: PASS.
- Ascenda CI run `31932437815`: PASS.
- Scope PR #179: 6 archivos governance/docs/CI, 0 app, 0 migrations/DB.
- Primer loop falló cerrado por nomenclatura F13 y fue corregido sin relajar el gate.

## Cambios
- Validation Report pasa a `TECHNICALLY_CERTIFIED / NOTION_FINALIZATION_PENDING`.
- Roadmap pasa F1 a `CLOSING`; F2 sigue pendiente hasta cierre final.

## Scope
Docs-only. No runtime, DB, Railway, Supabase ni secretos.

## Gate
Este PR debe pasar el certificado Sentinel F1. Después del merge se sincroniza Notion y se genera el certificado final `100_COMPLETE` en una rama fresca.