### PR TITLE
docs(sentinel): certify F1 100 complete and advance F2

### DIFF
--- a/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md
@@ -1,17 +1,20 @@
 # SENTINEL F1 — Governance, Privacy & Cost Guardrails — Validation Report
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Estado:** `TECHNICALLY_CERTIFIED / NOTION_FINALIZATION_PENDING`  
+**Estado:** `100_COMPLETE`  
 **Lifecycle:** `VALIDATING → TECHNICALLY_CERTIFIED → 100_COMPLETE`  
 **Baseline inicial:** `main@d362442cc111cb712cc627a7e8118e3b190c15b5`  
-**Fundación integrada:** PR `#179` → `main@052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`  
-**Riesgo:** HIGH por política de privacidad/telemetría; implementación F1 es governance/docs/CI only.
+**Fundación:** PR `#179` → `052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`  
+**Checkpoint técnico:** PR `#180` → `f791297f88d0372c131ba955e0643542965c0e35`  
+**Riesgo:** HIGH por gobierno de privacidad/telemetría; implementación F1 fue governance/docs/CI only.
 
 ---
 
-## 1. Resultado técnico
+## 1. Certificación
 
-F1 ya dispone de gobierno verificable antes de cualquier export productivo: privacidad allowlist-first, presupuesto incremental US$0, arquitectura vendor-neutral, kill switches definidos, anti-scope explícito y contrato automático self-hosted.
+**SENTINEL F1 — Governance, Privacy & Cost Guardrails queda certificada al 100% para la baseline 2026-08-16.**
+
+F1 establece gobierno verificable antes de cualquier export productivo: privacidad allowlist-first, presupuesto incremental US$0, arquitectura vendor-neutral, kill switches definidos, anti-scope explícito y contrato automático self-hosted.
 
 F1 no instaló sensores ni modificó runtime/DB.
 
@@ -19,16 +22,17 @@ F1 no instaló sensores ni modificó runtime/DB.
 
 - baseline original verificada en `d362442cc111cb712cc627a7e8118e3b190c15b5`;
 - runtime productivo documentado: `server-phase-s.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → server-phase2.js → server.js`;
-- búsqueda sobre la baseline no encontró `SENTRY_DSN`, `@sentry`, inicialización Sentry, OpenTelemetry ni Uptime Kuma en runtime;
-- PR histórico #80/#92 se conserva solo como antecedente de conexión externa, no como instrumentación Sentinel;
-- `SECURITY.md`, `AGENTS.md` y Zero-Cost CI V2 continúan como controles superiores;
-- PR #179 fue fusionado por squash a `052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`.
+- la baseline no tenía instrumentación Sentinel/Sentry/OTel/Kuma en runtime;
+- PR histórico #80/#92 permanece solo como antecedente de conexión externa;
+- `SECURITY.md`, `AGENTS.md` y Zero-Cost CI V2 siguen siendo controles superiores;
+- Control Maestro, Roadmap, política F1, contrato y workflow están integrados en `main`;
+- checkpoint técnico post-merge integrado mediante PR #180.
 
 ## 3. Baseline económico/técnico externo
 
 Baseline consultada el 2026-08-16 y sujeta a reverificación antes de cualquier upgrade/consumo ampliado:
 
-- Sentry Developer se evalúa como sensor gratuito de baseline, pero Sentinel Core no depende de su API;
+- Sentry Developer se evalúa como sensor gratuito de baseline; Sentinel Core no depende de su API;
 - OpenTelemetry define la ruta portable de filtering/redaction/transformation/sampling;
 - Uptime Kuma queda reservado para availability cuando exista observador 24/7 independiente y costo aprobado.
 
@@ -37,15 +41,16 @@ Referencias:
 - `https://opentelemetry.io/docs/collector/architecture/`
 - `https://github.com/louislam/uptime-kuma`
 
-## 4. Evidencia CI exact-head
+## 4. Evidencia CI
 
-Candidate certificado antes del merge: `97f7b50cf56eb1c9d4b8d30f674b115fda6f4f57`.
+Candidate fundacional certificado: `97f7b50cf56eb1c9d4b8d30f674b115fda6f4f57`.
 
 - Sentinel F1 Governance Certificate — run `31932437806` — **PASS**.
 - Ascenda CI — run `31932437815` — **PASS**.
-- Primer intento F1 — run `31932369611` — **FAIL CLOSED** por mismatch de nomenclatura F13; no se debilitó el gate. Se alineó la fuente canónica y el segundo loop pasó.
+- Primer intento — run `31932369611` — **FAIL CLOSED** por mismatch de nomenclatura F13. Se corrigió la fuente canónica; no se debilitó el gate.
+- Checkpoint PR #180 — Sentinel F1 Governance Certificate run `31932583182` — **PASS**.
 
-Scope final PR #179:
+Scope fundacional PR #179:
 
 1. `.github/workflows/sentinel-phase1-governance.yml`
 2. `ci/sentinel/phase1_governance_contract.js`
@@ -54,9 +59,20 @@ Scope final PR #179:
 5. `docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md`
 6. `docs/control/SENTINEL_ROADMAP_V1.md`
 
-Resultado: **0 `app/`, 0 migrations/DB, 0 Supabase runtime, 0 secrets intencionales**.
+Resultado: **0 `app/`, 0 migrations/DB, 0 Supabase runtime, 0 secretos productivos introducidos**.
 
-## 5. Gates F1
+## 5. Evidencia Notion
+
+Sincronización realizada después del checkpoint técnico integrado:
+
+- F1 page `3be0e4fe-8414-8160-844f-dcdc135804b1`: `Estado=Cerrada`, `Progreso=100`.
+- F2 page `3be0e4fe-8414-81b1-95c6-e96c28e200eb`: `Estado=Siguiente`, `Progreso=0`.
+- Fases 3–13 permanecen `Pendiente`.
+- Control Maestro Sentinel permanece bajo ASCENDA OS.
+
+Así se mantiene exactamente una fase siguiente y Notion refleja evidencia técnica ya integrada.
+
+## 6. Gates F1
 
 | Gate | Evidencia requerida | Estado |
 |---|---|---|
@@ -77,19 +93,26 @@ Resultado: **0 `app/`, 0 migrations/DB, 0 Supabase runtime, 0 secrets intenciona
 | F1-G15 | workflow self-hosted FAST, sin hosted fallback | PASS |
 | F1-G16 | exact-head F1 CI PASS | PASS |
 | F1-G17 | diff final demuestra 0 `app/`, 0 migrations/DB, 0 secrets | PASS |
-| F1-G18 | checkpoint de cierre + Notion F1=100/Cerrada, F2 única Siguiente | PENDING |
+| F1-G18 | checkpoint integrado + Notion F1=100/Cerrada + F2 única Siguiente | PASS |
 
-## 6. Regla de cierre
+**Resultado:** `18/18 PASS`.
 
-La capacidad técnica F1 está certificada, pero **no se declara `100_COMPLETE` todavía**. Falta el gate de continuidad G18: checkpoint documental final y sincronización de Notion como último paso.
+## 7. Decisiones congeladas al cerrar F1
 
-No se requiere canary productivo porque F1 no introduce runtime, exporter, schema, secret ni provider call.
+- nombre oficial: `Sentinel`;
+- arquitectura: híbrida, vendor-neutral;
+- external telemetry: allowlist-first y Zero-PHI/PII;
+- Session Replay/log export/tracing productivo: no autorizados por F1;
+- costo incremental autorizado de F1: US$0/mes;
+- pay-as-you-go: OFF;
+- Sentinel Hub/Incident Engine no dependen de API Sentry;
+- ausencia de señal suficiente produce `UNKNOWN`, no false-green;
+- automatización/remediation mantiene fail-closed y gates humanos de producción.
 
-## 7. Siguiente acción exacta
+## 8. Handoff a F2
 
-1. fusionar este checkpoint técnico docs-only después de Sentinel F1 CI;
-2. sincronizar Notion con la evidencia integrada;
-3. generar certificado final `100_COMPLETE` sobre una rama fresca;
-4. ejecutar Sentinel F1 CI final;
-5. fusionar certificado final;
-6. actualizar Notion con el commit/PR final y dejar F2 como única `Siguiente`.
+F2 — `System Registry & Topology Taxonomy` es la única fase `Siguiente`.
+
+F2 debe empezar con recovery desde current `main`, inventario `app/public/`, cadena runtime actual, RPC/tablas por capability y dependencias externas. Su salida debe ser un registry machine-readable verificable, no un diagrama inventado.
+
+Ningún sensor productivo queda habilitado por el cierre de F1; Sentry se instrumenta recién en F4, después de F2/F3.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -356,7 +356,7 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 
 ## Estado actual
 
-- Fase 1: `CLOSING` — capacidad técnica certificada; continuidad/Notion pendiente.
-- Fase 2: `PENDIENTE` hasta cierre final F1.
+- Fase 1: `CERRADA / 100_COMPLETE`.
+- Fase 2: `SIGUIENTE`.
 - Fases 3–13: `PENDIENTE`.
-- Ningún sensor productivo queda autorizado únicamente por este documento; cada fase debe ejecutar sus gates.
+- Ningún sensor productivo queda autorizado por el cierre de F1; cada fase debe ejecutar sus gates.


### PR DESCRIPTION
## Objetivo
Emitir el certificado final de Sentinel F1 después de que la capacidad técnica y Notion estén sincronizados.

## Evidencia cerrada
- PR #179 fundación → `052bbeccb3c499cc4b7a1572cf0bb1a8db66342e`.
- PR #180 checkpoint técnico → `f791297f88d0372c131ba955e0643542965c0e35`.
- Sentinel F1 certificate run `31932437806`: PASS.
- Ascenda CI run `31932437815`: PASS.
- checkpoint run `31932583182`: PASS.
- scope fundacional: 0 app, 0 migrations/DB, 0 runtime mutation.
- Notion F1 = Cerrada / 100%.
- Notion F2 = Siguiente / 0%.

## Cambios
- Validation Report pasa a `100_COMPLETE`, 18/18 gates PASS.
- Roadmap pasa F1 `CERRADA / 100_COMPLETE`, F2 `SIGUIENTE`.

## Scope
Docs-only. Ningún sensor queda activado; Sentry continúa reservado para F4 después de F2/F3.

## Gate final
`Sentinel F1 Governance Certificate` debe pasar sobre este exact head. Después del merge, Notion se actualizará por última vez con el SHA/PR final.