### PR TITLE
F17 V10: legacy WhatsApp gateway cutover preparation

### DIFF
--- a/.github/workflows/f17-multichannel.yml
+++ b/.github/workflows/f17-multichannel.yml
@@ -28,6 +28,9 @@ jobs:
       DB_URL: postgresql://postgres:postgres@127.0.0.1:59722/postgres
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: supabase/setup-cli@v1
         with:
           version: 2.101.0

--- a/.github/workflows/f17-multichannel.yml
+++ b/.github/workflows/f17-multichannel.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'app/f17-whatsapp-legacy-gateway.js'
       - 'supabase/migrations/*f17_*'
       - 'supabase/rollbacks/*f17_*'
       - 'ci/f17-multichannel/**'
@@ -36,6 +37,13 @@ jobs:
           set -euo pipefail
           test "${{ runner.environment }}" = "self-hosted"
           python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Validate server-authoritative legacy WhatsApp gateway
+        run: |
+          set -euo pipefail
+          node --check app/f17-whatsapp-legacy-gateway.js
+          node --check ci/f17-multichannel/test_legacy_whatsapp_gateway.js
+          node ci/f17-multichannel/test_legacy_whatsapp_gateway.js
 
       - name: Configure isolated Supabase
         working-directory: ci/zero-cost-staging

--- a/app/f17-whatsapp-legacy-gateway.js
+++ b/app/f17-whatsapp-legacy-gateway.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const https = require('https')
+
+const DEFAULT_SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
+
+function jsonResponse(res, status, body) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff'
+  })
+  res.end(JSON.stringify(body))
+}
+
+function requestJson(urlString, options) {
+  return new Promise(function(resolve, reject) {
+    var url = new URL(urlString)
+    var req = https.request({
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: (options && options.method) || 'GET',
+      headers: (options && options.headers) || {},
+      timeout: (options && options.timeout) || 15000
+    }, function(r) {
+      var chunks = []
+      r.on('data', function(c) { chunks.push(c) })
+      r.on('end', function() {
+        var text = Buffer.concat(chunks).toString('utf8')
+        var parsed = null
+        if (text) {
+          try { parsed = JSON.parse(text) } catch (_) { parsed = null }
+        }
+        resolve({ status: r.statusCode || 0, body: parsed })
+      })
+    })
+    req.on('timeout', function() { req.destroy(new Error('UPSTREAM_TIMEOUT')) })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+function createLegacyWhatsAppGateway(config) {
+  config = config || {}
+  var sbUrl = String(config.supabaseUrl || process.env.SUPABASE_URL || DEFAULT_SB_URL).replace(/\/$/, '')
+  var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))
+  var verifyApp = config.verifyApp
+  var requester = config.requestJson || requestJson
+
+  function configured() {
+    return serviceKey.length > 20 && typeof verifyApp === 'function'
+  }
+
+  async function listTemplates(token) {
+    if (!configured()) return { ok: false, status: 503, error: 'WHATSAPP_GATEWAY_NOT_CONFIGURED' }
+    var actor = await verifyApp(String(token || ''))
+    if (!actor || actor.ok !== true) return { ok: false, status: actor && actor.status ? actor.status : 401, error: 'UNAUTHORIZED' }
+
+    var headers = { apikey: serviceKey }
+    if (!/^sb_(?:secret|publishable)_/.test(serviceKey)) headers.Authorization = 'Bearer ' + serviceKey
+    var query = '/rest/v1/aos_plantillas_whatsapp?select=id,nombre,icono,color,contexto,mensaje,orden&activo=eq.true&order=orden.asc'
+    var result = await requester(sbUrl + query, { method: 'GET', headers: headers, timeout: 15000 })
+    if (!result || result.status < 200 || result.status >= 300 || !Array.isArray(result.body)) {
+      return { ok: false, status: 502, error: 'WHATSAPP_TEMPLATE_READ_FAILED' }
+    }
+
+    var templates = result.body.map(function(row) {
+      return {
+        id: row.id,
+        nombre: row.nombre || '',
+        icono: row.icono || '',
+        color: row.color || '',
+        contexto: row.contexto || '',
+        mensaje: row.mensaje || '',
+        orden: Number.isFinite(Number(row.orden)) ? Number(row.orden) : 0
+      }
+    })
+    return { ok: true, templates: templates }
+  }
+
+  async function handle(req, res) {
+    if (req.method !== 'GET') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
+    try {
+      var token = String(req.headers['x-ascenda-session'] || '')
+      var out = await listTemplates(token)
+      return jsonResponse(res, out.ok ? 200 : (out.status || 400), out)
+    } catch (_) {
+      return jsonResponse(res, 500, { ok: false, error: 'WHATSAPP_GATEWAY_ERROR' })
+    }
+  }
+
+  return {
+    configured: configured,
+    listTemplates: listTemplates,
+    handle: handle
+  }
+}
+
+module.exports = {
+  createLegacyWhatsAppGateway: createLegacyWhatsAppGateway
+}

--- a/ci/f17-multichannel/test_legacy_whatsapp_gateway.js
+++ b/ci/f17-multichannel/test_legacy_whatsapp_gateway.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const assert = require('assert')
+const { createLegacyWhatsAppGateway } = require('../../app/f17-whatsapp-legacy-gateway')
+
+async function run() {
+  var calls = []
+  var gateway = createLegacyWhatsAppGateway({
+    supabaseUrl: 'https://example.invalid',
+    serviceRoleKey: 'service-role-test-value-long-enough',
+    verifyApp: async function(token) {
+      return token === 'valid-session-token-that-is-long-enough'
+        ? { ok: true, user_id: 'synthetic-user', rol: 'ASESOR' }
+        : { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    },
+    requestJson: async function(url, options) {
+      calls.push({ url: url, options: options })
+      return {
+        status: 200,
+        body: [{ id: 'tpl-1', nombre: 'Synthetic', icono: 'x', color: '#fff', contexto: 'NO_CONTESTA', mensaje: 'synthetic-template-body', orden: 1 }]
+      }
+    }
+  })
+
+  var denied = await gateway.listTemplates('invalid')
+  assert.strictEqual(denied.ok, false)
+  assert.strictEqual(denied.status, 401)
+  assert.strictEqual(calls.length, 0, 'unauthorized request must not touch Supabase')
+
+  var allowed = await gateway.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(allowed.ok, true)
+  assert.strictEqual(allowed.templates.length, 1)
+  assert.strictEqual(calls.length, 1)
+  assert.ok(calls[0].url.includes('/rest/v1/aos_plantillas_whatsapp?'))
+  assert.ok(calls[0].url.includes('activo=eq.true'))
+  assert.ok(calls[0].url.includes('select=id,nombre,icono,color,contexto,mensaje,orden'))
+  assert.strictEqual(calls[0].options.headers.apikey, 'service-role-test-value-long-enough')
+  assert.strictEqual(allowed.templates[0].mensaje, 'synthetic-template-body')
+
+  var missingConfig = createLegacyWhatsAppGateway({
+    serviceRoleKey: '',
+    verifyApp: async function() { return { ok: true, user_id: 'synthetic-user' } },
+    requestJson: async function() { throw new Error('must not be called') }
+  })
+  var unavailable = await missingConfig.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(unavailable.ok, false)
+  assert.strictEqual(unavailable.status, 503)
+
+  var upstreamFailure = createLegacyWhatsAppGateway({
+    serviceRoleKey: 'service-role-test-value-long-enough',
+    verifyApp: async function() { return { ok: true, user_id: 'synthetic-user' } },
+    requestJson: async function() { return { status: 500, body: { error: 'synthetic' } } }
+  })
+  var failed = await upstreamFailure.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(failed.ok, false)
+  assert.strictEqual(failed.status, 502)
+
+  console.log('F17 legacy WhatsApp gateway contract: PASS')
+}
+
+run().catch(function(err) {
+  console.error(err && err.stack ? err.stack : err)
+  process.exit(1)
+})

--- a/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V10.md
+++ b/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V10.md
@@ -1,0 +1,54 @@
+# CIA V3 F17 — Impact Report V10
+
+Date: 2026-08-16 (Lima)
+Baseline: `main@2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0`
+Branch: `feature/cia-phase17-multichannel-20260816-v10`
+Risk: CRITICAL
+
+## Objective
+Continue F17 — SMS / WhatsApp / Future Channels from CURRENT main after the compatibility-preserving P0 legacy WhatsApp ACL hardening. Preserve one canonical Audience/Activation/identity truth and keep providers/transports interchangeable.
+
+## Fresh authoritative entry gate
+Production `public.aos_cia_email_f17_readiness_v1()` returns exactly `READY_F17_EMAIL_CERTIFIED` with `ready_for_f17=true`; all F16 release gates are true. GitHub Issue #104 is CLOSED/completed.
+
+## Fresh F17 production state
+Production `public.aos_cia_f18_readiness_v1()` remains `IN_PROGRESS_MULTICHANNEL_GOVERNANCE` with `ready_for_f18=false`.
+
+Passing gates:
+- `contracts_active=true`
+- `whatsapp_bridge_validated=true`
+
+Open gates:
+- `outbound_policy_validated=false`
+- `webhook_replay_validated=false`
+- `canary_passed=false`
+- `rollback_verified=false`
+
+## Fresh legacy WhatsApp ACL state after V9/P0
+Production metadata now confirms browser mutation privileges are removed from both legacy tables checked:
+- `aos_plantillas_whatsapp`: anon/authenticated SELECT=true; INSERT/UPDATE/DELETE=false; RLS=false; FORCE RLS=false.
+- `aos_whatsapp_mensajes`: anon/authenticated SELECT=true; INSERT/UPDATE/DELETE=false; RLS=false; FORCE RLS=false.
+
+Issue #173 therefore remains OPEN but has narrowed materially: the remaining security/architecture work is browser SELECT retirement/gateway cutover plus RLS/FORCE RLS or explicit legacy retirement, not further browser mutation hardening.
+
+## V10 allowed scope
+1. Inventory every repository consumer of `aos_plantillas_whatsapp` and `aos_whatsapp_mensajes` from CURRENT main.
+2. Design a server-authoritative read gateway/RPC/API contract for the minimum template data required by current UI consumers.
+3. Add synthetic negative tests proving browser roles cannot mutate governed or legacy messaging configuration and cannot bypass the new gateway after cutover.
+4. Preserve current UI compatibility until the gateway consumer smoke is proven.
+5. Only after exact-head CI is green and read-only production preflight confirms compatibility, perform a controlled additive gateway/cutover migration and then remove legacy browser SELECT.
+6. Validate outbound policy, webhook replay/idempotency, controlled canary, rollback/recovery and zero-residue as separate evidence-backed release gates.
+7. Keep SMS provider activation/spend OFF and do not broad-send WhatsApp during certification.
+
+## Hard invariants
+- Same canonical Audience Engine for Email/SMS/WhatsApp/future channels.
+- No channel-specific audience/customer/lead/patient truth.
+- Canonical contact identity remains the linkage key.
+- Unknown consent/suppression fails closed.
+- Provider webhooks are signed/replay-safe where applicable and all event ingestion is idempotent.
+- Secrets remain environment-only.
+- Governed tables remain RLS + FORCE RLS and server/service-role authoritative.
+- No PII/PHI, phone numbers, message content, tokens or secrets in CI/issues/logs.
+
+## Production certification gate
+F17 may be marked `100_COMPLETE / PRODUCTION CERTIFIED` only when production `aos_cia_f18_readiness_v1()` returns exactly `READY_F18_MULTICHANNEL_CERTIFIED` with `ready_for_f18=true`, all release gates are true, Issue #173 is closed, exact-head repository gates are green, rollback/recovery and zero-residue evidence are proven, and the final release is merged according to governance.


### PR DESCRIPTION
## CIA V3 F17 — V10 from CURRENT main

Fresh base: `main@2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0`.
Impact Report committed before code/schema changes: `docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V10.md`.

### Fresh authoritative state
- F16 production remains certified: `READY_F17_EMAIL_CERTIFIED`, `ready_for_f17=true`, all F16 gates=true; #104 CLOSED/completed.
- F17 production remains `IN_PROGRESS_MULTICHANNEL_GOVERNANCE`, `ready_for_f18=false`.
- Passing: contracts active + WhatsApp bridge validated.
- Pending: outbound policy, webhook replay/idempotency, canary, rollback.

### #173 narrowed after V9/P0
Fresh production metadata confirms browser INSERT/UPDATE/DELETE are now removed from `aos_plantillas_whatsapp`; both checked legacy tables remain SELECT-only for browser roles with RLS/FORCE RLS disabled. The remaining work is server-authoritative gateway/cutover and safe retirement of browser SELECT/RLS exposure.

### V10 scope
Discovery/design/CI-first gateway cutover only. No destructive ACL closure until all consumers are inventoried and compatibility smoke is proven. No SMS provider activation/spend, no broad WhatsApp send, no PII/PHI/message content/secrets in CI.

### Hard invariant
One canonical Audience/Activation/identity truth. No duplicated audience/customer/lead/patient truth per channel.

Keep DRAFT until exact-head CI is green and the gateway/cutover implementation plus synthetic negatives are ready for controlled production preflight.