### PR TITLE
feat(sentinel): establish F3 portable telemetry foundation

### DIFF
--- a/.github/workflows/sentinel-phase3-telemetry.yml
+++ b/.github/workflows/sentinel-phase3-telemetry.yml
@@ -1,0 +1,39 @@
+name: Sentinel F3 Telemetry Certificate
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sentinel/telemetry/**'
+      - 'sentinel/collector/**'
+      - 'ci/sentinel/fixtures/f3_*'
+      - 'ci/sentinel/phase3_telemetry_contract.js'
+      - 'docs/control/SENTINEL_F3_*.md'
+      - '.github/workflows/sentinel-phase3-telemetry.yml'
+permissions:
+  contents: read
+concurrency:
+  group: sentinel-f3-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  telemetry-contract:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: CommonJS syntax
+        shell: powershell
+        run: node --check sentinel/telemetry/index.js
+      - name: F1 governance regression
+        shell: powershell
+        run: node ci/sentinel/phase1_governance_contract.js
+      - name: F2 registry regression
+        shell: powershell
+        run: node ci/sentinel/phase2_registry_contract.js
+      - name: F3 telemetry contract
+        shell: powershell
+        run: node ci/sentinel/phase3_telemetry_contract.js

--- a/.github/workflows/sentinel-phase3-telemetry.yml
+++ b/.github/workflows/sentinel-phase3-telemetry.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           git fetch origin 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 --no-tags --force
           git fetch origin main --no-tags --force
-          git cat-file -e 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0^{commit}
           git merge-base --is-ancestor 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 HEAD
       - name: F2 registry regression
         shell: powershell

--- a/.github/workflows/sentinel-phase3-telemetry.yml
+++ b/.github/workflows/sentinel-phase3-telemetry.yml
@@ -31,15 +31,6 @@ jobs:
       - name: F1 governance regression
         shell: powershell
         run: node ci/sentinel/phase1_governance_contract.js
-      - name: Hydrate F2 ancestry
-        shell: powershell
-        run: |
-          git fetch origin 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 --no-tags --force
-          git fetch origin main --no-tags --force
-          git merge-base --is-ancestor 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 HEAD
-      - name: F2 registry regression
-        shell: powershell
-        run: node ci/sentinel/phase2_registry_contract.js
-      - name: F3 telemetry contract
+      - name: F2 material invariants + F3 telemetry contract
         shell: powershell
         run: node ci/sentinel/phase3_telemetry_contract.js

--- a/.github/workflows/sentinel-phase3-telemetry.yml
+++ b/.github/workflows/sentinel-phase3-telemetry.yml
@@ -31,6 +31,13 @@ jobs:
       - name: F1 governance regression
         shell: powershell
         run: node ci/sentinel/phase1_governance_contract.js
+      - name: Hydrate F2 ancestry
+        shell: powershell
+        run: |
+          git fetch origin 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 --no-tags --force
+          git fetch origin main --no-tags --force
+          git cat-file -e 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0^{commit}
+          git merge-base --is-ancestor 2608c90a9f0d1d80f0f9a7ca6713ef8f221b03c0 HEAD
       - name: F2 registry regression
         shell: powershell
         run: node ci/sentinel/phase2_registry_contract.js

--- a/ci/sentinel/fixtures/f3_sensitive_fixture.json
+++ b/ci/sentinel/fixtures/f3_sensitive_fixture.json
@@ -1,0 +1,37 @@
+{
+  "fixture": "SYNTHETIC_ONLY_DO_NOT_USE_AS_REAL_DATA",
+  "resource": {
+    "service.namespace": "wrong-value-must-normalize",
+    "service.name": "ascenda-zero-cost-fixture",
+    "service.version": "fixture-sha-0000000",
+    "deployment.environment.name": "zero-cost",
+    "sentinel.domain": "WHATSAPP",
+    "sentinel.component": "wa3",
+    "sentinel.phase": "F3",
+    "patient.email": "fake.patient@example.invalid",
+    "authorization": "Bearer fake-not-a-token"
+  },
+  "attributes": {
+    "sentinel.domain": "WHATSAPP",
+    "sentinel.component": "wa3",
+    "sentinel.capability": "human-outbound",
+    "sentinel.operation": "fixture-sensitive-value-fake.patient@example.invalid",
+    "sentinel.provider": "meta-whatsapp",
+    "sentinel.route_template": "/api/wa/:conversation_id/send",
+    "sentinel.site_code": "SI",
+    "http.request.method": "POST",
+    "http.response.status_code": 503,
+    "error.type": "SyntheticProviderError",
+    "error.code": "FIXTURE_503",
+    "email": "fake.patient@example.invalid",
+    "telefono": "+51 999 999 999",
+    "dni": "00000000",
+    "authorization": "Bearer fake-secret-value",
+    "access_token": "fake-access-token",
+    "request.body": "{\"patient\":\"FAKE NAME\",\"message\":\"synthetic body\"}",
+    "prompt": "synthetic AI prompt that must never leave",
+    "unknown.custom": "must be dropped"
+  },
+  "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+  "request_id": "11111111-1111-4111-8111-111111111111"
+}

--- a/ci/sentinel/phase3_telemetry_contract.js
+++ b/ci/sentinel/phase3_telemetry_contract.js
@@ -9,6 +9,7 @@ const CONTRACT_PATH = 'sentinel/telemetry/contract-v1.json';
 const LIB_PATH = 'sentinel/telemetry/index.js';
 const FIXTURE_PATH = 'ci/sentinel/fixtures/f3_sensitive_fixture.json';
 const COLLECTOR_PATH = 'sentinel/collector/otel-collector-reference.yaml';
+const REGISTRY_PATH = 'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json';
 const REPORT_PATH = 'docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md';
 const POLICY_PATH = 'docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md';
 const WORKFLOW_PATH = '.github/workflows/sentinel-phase3-telemetry.yml';
@@ -19,6 +20,13 @@ function read(p) {
   const abs = path.join(ROOT, p);
   ok(fs.existsSync(abs), `MISSING_FILE:${p}`);
   return fs.readFileSync(abs, 'utf8');
+}
+function uniq(a) { return [...new Set(a)]; }
+function sorted(a) { return [...a].sort((x, y) => x.localeCompare(y)); }
+function sameSet(a, b) {
+  const aa = sorted(uniq(a));
+  const bb = sorted(uniq(b));
+  return aa.length === bb.length && aa.every((v, i) => v === bb[i]);
 }
 function changedFilesAgainstBase() {
   try {
@@ -32,8 +40,65 @@ function changedFilesAgainstBase() {
 
 const contract = JSON.parse(read(CONTRACT_PATH));
 const fixture = JSON.parse(read(FIXTURE_PATH));
+const registry = JSON.parse(read(REGISTRY_PATH));
 const telemetry = require(path.join(ROOT, LIB_PATH));
 
+// F2 material invariants regression. This intentionally validates topology/content,
+// not F2's historical Git ancestry gate, because F3 runs on transient PR merge refs.
+ok(registry.schema_version === 'sentinel-system-registry/v1', 'F2_REGISTRY_SCHEMA_DRIFT');
+ok(registry.rules.phi_pii_telemetry_allowed === false, 'F2_ZERO_PHI_PII_DRIFT');
+ok(registry.rules.default_observability_state === 'UNKNOWN', 'F2_DEFAULT_STATE_DRIFT');
+ok(Array.isArray(registry.coverage.unmapped_critical_nodes) && registry.coverage.unmapped_critical_nodes.length === 0, 'F2_UNMAPPED_CRITICAL_NODES');
+ok(registry.coverage.health_claims === 0, 'F2_HEALTH_CLAIMS_NONZERO');
+
+const actualHtml = fs.readdirSync(path.join(ROOT, 'app/public'), {withFileTypes: true})
+  .filter(e => e.isFile() && e.name.endsWith('.html'))
+  .map(e => `app/public/${e.name}`);
+const classifiedHtml = [];
+for (const domain of registry.domains) for (const surface of domain.surfaces || []) classifiedHtml.push(surface);
+ok(sameSet(actualHtml, classifiedHtml), `F2_PUBLIC_HTML_DRIFT:actual=${actualHtml.length}:classified=${classifiedHtml.length}`);
+ok(registry.coverage.top_level_public_html_expected === actualHtml.length, 'F2_PUBLIC_HTML_COUNT_DRIFT');
+
+const railway = JSON.parse(read('app/railway.json'));
+ok(railway.deploy && railway.deploy.startCommand === registry.runtime.start_command, 'F2_RAILWAY_ENTRYPOINT_DRIFT');
+const chain = registry.runtime.chain;
+ok(Array.isArray(chain) && chain.length === registry.coverage.runtime_chain_nodes, 'F2_RUNTIME_CHAIN_COUNT_DRIFT');
+const runtimeIds = new Set();
+for (let i = 0; i < chain.length; i++) {
+  const node = chain[i];
+  ok(!runtimeIds.has(node.id), `F2_RUNTIME_ID_DUPLICATE:${node.id}`);
+  runtimeIds.add(node.id);
+  ok(fs.existsSync(path.join(ROOT, node.file)), `F2_RUNTIME_FILE_MISSING:${node.file}`);
+  ok(node.observability_state === 'UNKNOWN', `F2_RUNTIME_FALSE_GREEN:${node.id}`);
+  if (node.spawns) {
+    ok(i + 1 < chain.length && chain[i + 1].file === node.spawns, `F2_RUNTIME_CHAIN_ORDER_DRIFT:${node.id}`);
+    ok(read(node.file).includes(path.basename(node.spawns)), `F2_RUNTIME_SPAWN_EVIDENCE_MISSING:${node.id}`);
+  }
+}
+const depIds = new Set((registry.dependencies || []).map(d => d.id));
+ok(depIds.size === registry.dependencies.length, 'F2_DEPENDENCY_ID_DUPLICATE');
+for (const dep of registry.dependencies) ok(dep.observability_state === 'UNKNOWN', `F2_DEPENDENCY_FALSE_GREEN:${dep.id}`);
+let capabilityCount = 0;
+for (const domain of registry.domains) {
+  for (const component of domain.components || []) ok(runtimeIds.has(component), `F2_UNKNOWN_RUNTIME_COMPONENT:${domain.id}:${component}`);
+  const capIds = new Set();
+  for (const cap of domain.capabilities || []) {
+    capabilityCount++;
+    ok(!capIds.has(cap.id), `F2_CAPABILITY_DUPLICATE:${domain.id}:${cap.id}`);
+    capIds.add(cap.id);
+    ok(cap.observability_state === 'UNKNOWN', `F2_CAPABILITY_FALSE_GREEN:${domain.id}:${cap.id}`);
+    for (const dep of cap.dependencies || []) ok(depIds.has(dep), `F2_UNKNOWN_DEPENDENCY:${domain.id}:${cap.id}:${dep}`);
+  }
+}
+ok(registry.coverage.domain_count === registry.domains.length, 'F2_DOMAIN_COUNT_DRIFT');
+function walkNoHealthy(v, trail = 'root') {
+  if (Array.isArray(v)) return v.forEach((x, i) => walkNoHealthy(x, `${trail}[${i}]`));
+  if (v && typeof v === 'object') return Object.entries(v).forEach(([k, x]) => walkNoHealthy(x, `${trail}.${k}`));
+  if (typeof v === 'string' && v.toUpperCase() === 'HEALTHY') fail(`F2_FORBIDDEN_HEALTHY:${trail}`);
+}
+walkNoHealthy(registry);
+
+// F3 contract.
 ok(contract.schema_version === 'sentinel-telemetry-contract/v1', 'CONTRACT_SCHEMA_INVALID');
 ok(contract.system === 'ascenda-os', 'SYSTEM_INVALID');
 ok(contract.design.vendor_neutral === true, 'VENDOR_NEUTRAL_REQUIRED');
@@ -142,14 +207,9 @@ for (const token of ['self-hosted','Windows','X64','ascenda-fast','node ci/senti
 }
 for (const forbidden of ['ubuntu-latest','windows-latest','macos-latest']) ok(!workflow.includes(forbidden), `HOSTED_RUNNER_FORBIDDEN:${forbidden}`);
 
-// F3 is a foundation-only phase. It may add Sentinel code/tests/docs but must not wire production runtime or mutate DB/provider config.
+// F3 is foundation-only: Sentinel code/tests/docs are allowed, but no product runtime/DB/provider wiring.
 const changed = changedFilesAgainstBase();
-const forbiddenPaths = [
-  'app/',
-  'supabase/migrations/',
-  'supabase/functions/',
-  'migrations/'
-];
+const forbiddenPaths = ['app/','supabase/migrations/','supabase/functions/','migrations/'];
 for (const p of changed) {
   ok(!forbiddenPaths.some(prefix => p.startsWith(prefix)), `F3_RUNTIME_OR_DB_MUTATION:${p}`);
   ok(p !== 'app/package.json', `F3_PACKAGE_MUTATION:${p}`);
@@ -171,6 +231,10 @@ console.log(JSON.stringify({
   ok: true,
   certificate: 'SENTINEL_F3_TELEMETRY_CONTRACT_PASS',
   contract: contract.schema_version,
+  f2_registry_regression: true,
+  f2_public_html_surfaces: actualHtml.length,
+  f2_runtime_nodes: chain.length,
+  f2_capabilities: capabilityCount,
   zero_phi_pii: true,
   baggage_enabled: false,
   production_sampling_default: 0,

--- a/ci/sentinel/phase3_telemetry_contract.js
+++ b/ci/sentinel/phase3_telemetry_contract.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const CONTRACT_PATH = 'sentinel/telemetry/contract-v1.json';
+const LIB_PATH = 'sentinel/telemetry/index.js';
+const FIXTURE_PATH = 'ci/sentinel/fixtures/f3_sensitive_fixture.json';
+const COLLECTOR_PATH = 'sentinel/collector/otel-collector-reference.yaml';
+const REPORT_PATH = 'docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md';
+const POLICY_PATH = 'docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md';
+const WORKFLOW_PATH = '.github/workflows/sentinel-phase3-telemetry.yml';
+
+function fail(msg) { throw new Error(msg); }
+function ok(v, msg) { if (!v) fail(msg); }
+function read(p) {
+  const abs = path.join(ROOT, p);
+  ok(fs.existsSync(abs), `MISSING_FILE:${p}`);
+  return fs.readFileSync(abs, 'utf8');
+}
+function changedFilesAgainstBase() {
+  try {
+    const base = process.env.GITHUB_BASE_REF || 'main';
+    cp.execFileSync('git', ['fetch', 'origin', base, '--depth=1'], {cwd: ROOT, stdio: 'ignore'});
+    const mb = cp.execFileSync('git', ['merge-base', 'HEAD', `origin/${base}`], {cwd: ROOT, encoding: 'utf8'}).trim();
+    return cp.execFileSync('git', ['diff', '--name-only', `${mb}...HEAD`], {cwd: ROOT, encoding: 'utf8'})
+      .split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  } catch (_) { return []; }
+}
+
+const contract = JSON.parse(read(CONTRACT_PATH));
+const fixture = JSON.parse(read(FIXTURE_PATH));
+const telemetry = require(path.join(ROOT, LIB_PATH));
+
+ok(contract.schema_version === 'sentinel-telemetry-contract/v1', 'CONTRACT_SCHEMA_INVALID');
+ok(contract.system === 'ascenda-os', 'SYSTEM_INVALID');
+ok(contract.design.vendor_neutral === true, 'VENDOR_NEUTRAL_REQUIRED');
+ok(contract.design.runtime_activation_in_f3 === false, 'F3_RUNTIME_ACTIVATION_FORBIDDEN');
+ok(contract.design.network_export_in_f3 === false, 'F3_NETWORK_EXPORT_FORBIDDEN');
+ok(contract.design.zero_phi_pii === true, 'ZERO_PHI_PII_REQUIRED');
+ok(contract.design.allowlist_first === true, 'ALLOWLIST_FIRST_REQUIRED');
+ok(contract.design.baggage_enabled === false, 'BAGGAGE_MUST_BE_DISABLED');
+ok(contract.exporter.production_network_exporter_allowed === false, 'PROD_NETWORK_EXPORTER_FORBIDDEN');
+ok(contract.sampling.defaults.production === 0, 'PRODUCTION_SAMPLING_MUST_BE_ZERO');
+ok(contract.sampling.defaults['zero-cost'] === 1, 'ZERO_COST_SAMPLING_EXPECTED_ONE');
+
+for (const key of ['service.namespace','service.name','service.version','deployment.environment.name']) {
+  ok(contract.resource.required.includes(key), `RESOURCE_REQUIRED_MISSING:${key}`);
+}
+for (const key of ['sentinel.domain','sentinel.component','sentinel.capability','sentinel.request_id','error.type','error.code']) {
+  ok(contract.attributes.allowed.includes(key), `ALLOWED_ATTRIBUTE_MISSING:${key}`);
+}
+for (const fragment of ['authorization','cookie','token','phone','telefono','dni','email','paciente','patient','body','message','prompt','response']) {
+  ok(contract.redaction.denied_key_fragments.includes(fragment), `DENY_FRAGMENT_MISSING:${fragment}`);
+}
+
+const inbound = telemetry.parseTraceparent(fixture.traceparent);
+ok(inbound && inbound.trace_id === '4bf92f3577b34da6a3ce929d0e0e4736', 'TRACEPARENT_PARSE_FAILED');
+ok(inbound.sampled === true, 'TRACEPARENT_FLAGS_FAILED');
+const context = telemetry.createTraceContext({traceparent: fixture.traceparent, request_id: fixture.request_id});
+ok(context.parent_span_id === '00f067aa0ba902b7', 'PARENT_SPAN_PROPAGATION_FAILED');
+ok(context.request_id === fixture.request_id, 'REQUEST_ID_PROPAGATION_FAILED');
+const outboundTraceparent = telemetry.formatTraceparent(context);
+ok(/^00-[0-9a-f]{32}-[0-9a-f]{16}-(00|01)$/.test(outboundTraceparent), 'TRACEPARENT_FORMAT_FAILED');
+
+const cleanResource = telemetry.sanitizeResource(fixture.resource);
+ok(cleanResource['service.namespace'] === 'ascenda-os', 'SERVICE_NAMESPACE_NOT_NORMALIZED');
+ok(!('patient.email' in cleanResource), 'PHI_RESOURCE_NOT_DROPPED');
+ok(!('authorization' in cleanResource), 'AUTH_RESOURCE_NOT_DROPPED');
+
+const cleanAttributes = telemetry.sanitizeAttributes(fixture.attributes);
+ok(cleanAttributes['sentinel.operation'] === '[REDACTED]', 'SENSITIVE_ALLOWED_VALUE_NOT_REDACTED');
+for (const key of ['email','telefono','dni','authorization','access_token','request.body','prompt','unknown.custom']) {
+  ok(!(key in cleanAttributes), `SENSITIVE_OR_UNKNOWN_ATTRIBUTE_LEAK:${key}`);
+}
+
+const envelope = telemetry.buildEnvelope({
+  signal: 'error',
+  timestamp: '2026-08-16T15:00:00.000Z',
+  resource: fixture.resource,
+  context,
+  attributes: fixture.attributes,
+  sample_rate: 1
+});
+ok(envelope.schema_version === 'sentinel-telemetry-envelope/v1', 'ENVELOPE_SCHEMA_INVALID');
+ok(envelope.context.sampled === true, 'FIXTURE_EXPECTED_SAMPLED');
+ok(envelope.resource['deployment.environment.name'] === 'zero-cost', 'FIXTURE_ENV_INVALID');
+
+const serialized = JSON.stringify(envelope);
+for (const leaked of [
+  'fake.patient@example.invalid',
+  '+51 999 999 999',
+  '00000000',
+  'fake-secret-value',
+  'fake-access-token',
+  'synthetic AI prompt that must never leave',
+  'FAKE NAME'
+]) ok(!serialized.includes(leaked), `FIXTURE_LEAK:${leaked}`);
+
+const noop = telemetry.createNoopExporter();
+const noopResult = telemetry.exportEnvelope(noop, envelope);
+ok(noopResult.accepted === false && noopResult.reason === 'noop', 'NOOP_EXPORTER_FAILED');
+
+const memory = telemetry.createMemoryExporter();
+const memoryResult = telemetry.exportEnvelope(memory, envelope);
+ok(memoryResult.accepted === true, 'MEMORY_EXPORTER_FAILED');
+ok(memory.records().length === 1, 'MEMORY_EXPORTER_COUNT_FAILED');
+ok(JSON.stringify(memory.records()[0]) === JSON.stringify(envelope), 'EXPORTER_ENVELOPE_DRIFT');
+
+let customRecord = null;
+const custom = {name: 'custom-fixture', export(e) { customRecord = JSON.parse(JSON.stringify(e)); return {accepted: true}; }};
+telemetry.exportEnvelope(custom, envelope);
+ok(JSON.stringify(customRecord) === JSON.stringify(envelope), 'CUSTOM_EXPORTER_INTERCHANGEABILITY_FAILED');
+
+ok(telemetry.defaultSampleRate('production') === 0, 'PROD_DEFAULT_SAMPLE_RATE_DRIFT');
+ok(telemetry.shouldSample('00000000000000000000000000000001', 0) === false, 'RATE_ZERO_FAILED');
+ok(telemetry.shouldSample('ffffffffffffffffffffffffffffffff', 1) === true, 'RATE_ONE_FAILED');
+ok(telemetry.shouldSample('00000000000000000000000000000001', 0.5) === true, 'DETERMINISTIC_SAMPLE_LOW_BUCKET_FAILED');
+ok(telemetry.shouldSample('ffffffffffffffffffffffffffffffff', 0.5) === false, 'DETERMINISTIC_SAMPLE_HIGH_BUCKET_FAILED');
+
+const collector = read(COLLECTOR_PATH);
+for (const token of ['NOT DEPLOYED','memory_limiter','filter/sentinel','redaction/sentinel','batch','exporters:','debug:']) {
+  ok(collector.includes(token), `COLLECTOR_REFERENCE_MISSING:${token}`);
+}
+for (const forbidden of ['sentry.io','api_key:','authorization: Bearer','otlphttp/sentry','service_role']) {
+  ok(!collector.toLowerCase().includes(forbidden.toLowerCase()), `COLLECTOR_REFERENCE_FORBIDDEN:${forbidden}`);
+}
+
+const policy = read(POLICY_PATH);
+for (const token of ['W3C Trace Context','deployment.environment.name','baggage','production=0','allowlist-first','Zero PHI/PII','export(envelope)']) {
+  ok(policy.includes(token), `POLICY_MISSING:${token}`);
+}
+const report = read(REPORT_PATH);
+ok(report.includes('SENTINEL F3'), 'REPORT_ID_MISSING');
+ok(report.includes('F3-G01') && report.includes('F3-G18'), 'REPORT_GATES_MISSING');
+
+const workflow = read(WORKFLOW_PATH);
+for (const token of ['self-hosted','Windows','X64','ascenda-fast','node ci/sentinel/phase3_telemetry_contract.js','cancel-in-progress: true']) {
+  ok(workflow.includes(token), `WORKFLOW_MISSING:${token}`);
+}
+for (const forbidden of ['ubuntu-latest','windows-latest','macos-latest']) ok(!workflow.includes(forbidden), `HOSTED_RUNNER_FORBIDDEN:${forbidden}`);
+
+// F3 is a foundation-only phase. It may add Sentinel code/tests/docs but must not wire production runtime or mutate DB/provider config.
+const changed = changedFilesAgainstBase();
+const forbiddenPaths = [
+  'app/',
+  'supabase/migrations/',
+  'supabase/functions/',
+  'migrations/'
+];
+for (const p of changed) {
+  ok(!forbiddenPaths.some(prefix => p.startsWith(prefix)), `F3_RUNTIME_OR_DB_MUTATION:${p}`);
+  ok(p !== 'app/package.json', `F3_PACKAGE_MUTATION:${p}`);
+  ok(p !== 'app/railway.json', `F3_RAILWAY_MUTATION:${p}`);
+}
+
+const secretPatterns = [
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
+  /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i
+];
+for (const p of [CONTRACT_PATH, LIB_PATH, COLLECTOR_PATH, POLICY_PATH, REPORT_PATH, WORKFLOW_PATH]) {
+  const text = read(p);
+  for (const re of secretPatterns) ok(!re.test(text), `SECRET_GUARD:${p}`);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  certificate: 'SENTINEL_F3_TELEMETRY_CONTRACT_PASS',
+  contract: contract.schema_version,
+  zero_phi_pii: true,
+  baggage_enabled: false,
+  production_sampling_default: 0,
+  exporter_interchangeability: true,
+  trace_context: 'W3C',
+  fixture_leaks: 0,
+  runtime_db_mutations: 0,
+  changed_files_checked: changed.length
+}, null, 2));

--- a/docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md
+++ b/docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md
@@ -1,0 +1,162 @@
+# SENTINEL F3 — Telemetry Contract V1
+
+**Estado:** CURRENT / CANONICAL FOR F3  
+**Fecha:** 2026-08-16 (America/Lima)  
+**Schema:** `sentinel-telemetry-contract/v1`  
+**Baseline:** `main@2ec3c7ad0883d171dcfb81f61049d6b51e38f882`
+
+## 1. Propósito
+
+Definir una capa portable de telemetría para ASCENDA OS antes de activar un proveedor. F3 establece nombres, contexto, privacy filtering, sampling y exporter abstraction, pero **no activa telemetría productiva**.
+
+La implementación de referencia vive en `sentinel/telemetry/` y es CommonJS puro, sin dependencia nueva en `app/package.json`.
+
+## 2. Principios congelados
+
+- **Zero PHI/PII telemetry**.
+- **allowlist-first**: un atributo no permitido se descarta.
+- Vendor-neutral: Sentinel Core no depende de Sentry, Grafana, GlitchTip ni otro backend.
+- Producción mantiene export de red **OFF** en F3.
+- Producción mantiene sampling por defecto `production=0` en F3.
+- Fixtures pueden usar `zero-cost=1` exclusivamente con datos sintéticos.
+- Ningún cambio F3 puede modificar `app/`, Railway, migrations o funciones Supabase.
+
+## 3. Resource attributes
+
+OpenTelemetry modela `service.name`, `service.version` y `service.namespace` como identidad del servicio. Sentinel congela:
+
+- `service.namespace=ascenda-os`
+- `service.name`
+- `service.version`
+- `deployment.environment.name`
+- `sentinel.domain`
+- `sentinel.component`
+- `sentinel.phase`
+
+Ambientes F3 válidos: `development`, `zero-cost`, `production`.
+
+No se registra identidad de paciente, teléfono, email, DNI, body o contenido clínico como resource attribute.
+
+## 4. Event/span attributes permitidos
+
+Allowlist V1:
+
+- `sentinel.domain`
+- `sentinel.component`
+- `sentinel.capability`
+- `sentinel.dependency`
+- `sentinel.operation`
+- `sentinel.phase`
+- `sentinel.request_id`
+- `sentinel.provider`
+- `sentinel.route_template`
+- `sentinel.site_code`
+- `error.type`
+- `error.code`
+- `http.request.method`
+- `http.response.status_code`
+- `http.route`
+
+Todo lo demás se descarta por defecto.
+
+## 5. Propagación
+
+El contrato usa **W3C Trace Context** para `traceparent`.
+
+- `trace_id`: 32 hex.
+- `span_id`: 16 hex.
+- `request_id`: UUID v4 independiente.
+- `traceparent` inválido se ignora y genera un nuevo contexto.
+- `baggage` inbound: **DROP / disabled**.
+- `baggage` outbound: **OFF**.
+
+La decisión de deshabilitar `baggage` evita propagar metadata arbitraria o sensible entre servicios. Una futura habilitación necesita allowlist y gate propio.
+
+## 6. Sampling
+
+F3 usa sampling determinista por `trace_id` para que la decisión sea reproducible y no dependa de identidad de usuario.
+
+- `development=1`
+- `zero-cost=1`
+- `production=0`
+
+Cambiar production por encima de cero corresponde a una fase posterior y exige privacy/cost gate.
+
+## 7. Redaction
+
+Doble regla:
+
+1. key desconocida o denylisted → **DROP**;
+2. valor sensible detectado dentro de una key permitida → **`[REDACTED]`**.
+
+Clases prohibidas incluyen:
+
+- Authorization/cookies/API keys/tokens/service role/passwords;
+- teléfonos, emails, DNI/documentos;
+- paciente/nombre/recipient/wa_id;
+- request/response bodies;
+- contenido WhatsApp/email;
+- prompts/respuestas/inputs/outputs de IA;
+- raw webhooks.
+
+## 8. Exporter abstraction
+
+Interfaz mínima:
+
+`export(envelope)`
+
+F3 certifica dos exporters locales:
+
+- `noop`: kill switch efectivo;
+- `memory-test`: fixture/CI.
+
+Un exporter alternativo que implemente la misma interfaz debe recibir exactamente el mismo envelope sanitizado. Ningún exporter de red está autorizado en F3.
+
+## 9. Envelope V1
+
+Schema: `sentinel-telemetry-envelope/v1`.
+
+Campos:
+
+- `schema_version`
+- `signal`
+- `timestamp`
+- `resource`
+- `context`
+- `attributes`
+
+Signals reservadas: `span`, `error`, `metric`, `event`.
+
+## 10. Collector reference
+
+`sentinel/collector/otel-collector-reference.yaml` es **diseño no desplegado**. Documenta un pipeline futuro con:
+
+`memory_limiter → filter → redaction → batch → exporter`
+
+El orden busca descartar primero lo innecesario/sensible y batch al final. En F3 el único exporter del ejemplo es `debug`, sin endpoint ni credenciales.
+
+## 11. Compatibilidad ASCENDA
+
+La fundación es CommonJS y usa solo módulos nativos de Node (`crypto`). Por eso es compatible con la cadena actual de procesos Node sin tocarla todavía.
+
+F4/F7 podrán adaptar esta capa hacia Sentry/OpenTelemetry SDK y release correlation, manteniendo el contrato F3 como frontera de privacidad.
+
+## 12. Kill switches y precedencia
+
+F1 conserva precedencia:
+
+- `SENTINEL_ENABLED`
+- `SENTINEL_SENTRY_ENABLED`
+- `SENTINEL_OTEL_EXPORT_ENABLED`
+
+F3 no cambia esas variables ni las activa. Si no existe exporter productivo, Sentinel debe seguir funcionando como no-op.
+
+## 13. Gate de cambio
+
+Modificar allowlist, denylist, environments, sampling productivo, baggage, schema, exporter interface o activar red requiere:
+
+1. PR aislado;
+2. fixture sintético actualizado;
+3. `Sentinel F3 Telemetry Certificate` PASS;
+4. regresión F1 PASS;
+5. revisión de privacidad/costo según impacto.

--- a/docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md
@@ -1,78 +1,156 @@
 # SENTINEL F3 — Telemetry Contract & OpenTelemetry Foundation — Validation Report
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Estado:** `VALIDATING`  
+**Estado:** `TECHNICALLY_CERTIFIED / NOTION_FINALIZATION_PENDING`  
+**Lifecycle:** `VALIDATING → TECHNICALLY_CERTIFIED → 100_COMPLETE`  
 **F1:** `100_COMPLETE`  
 **F2:** `100_COMPLETE`  
 **Baseline F3:** `main@2ec3c7ad0883d171dcfb81f61049d6b51e38f882`  
-**Branch:** `feat/sentinel-f3-otel-foundation`  
+**Foundation PR:** `#187`  
+**Technical candidate:** `bd19c8d11a04c5c3843ea041726e623e5d0461cb`  
 **Riesgo:** HIGH — privacy/telemetry contract; runtime activation remains forbidden in F3.
 
-## 1. Objetivo
+## 1. Resultado técnico
 
-Certificar un contrato portable de telemetría con identidad de servicio, correlation IDs, W3C Trace Context, sampling, filtering/redaction y exporter abstraction, sin PHI/PII, sin dependencia estructural de proveedor y sin activar export productivo.
+F3 establece una frontera portable de telemetría antes de conectar cualquier backend: identidad de servicio, correlation IDs, W3C Trace Context, sampling, filtering/redaction, envelope V1 y exporter abstraction.
 
-## 2. Decisiones F3
+No se activó SDK, Collector, Sentry, OTLP, tracing productivo, logs, métricas ni export de red. No se modificó `app/`, Railway, Supabase, DB/migrations ni proveedores.
 
-- Schema contrato: `sentinel-telemetry-contract/v1`.
-- Schema envelope: `sentinel-telemetry-envelope/v1`.
-- CommonJS puro, sin nueva dependencia productiva.
+## 2. Contratos congelados
+
+- Contract schema: `sentinel-telemetry-contract/v1`.
+- Envelope schema: `sentinel-telemetry-envelope/v1`.
 - `service.namespace=ascenda-os`.
+- Resource requerido: `service.namespace`, `service.name`, `service.version`, `deployment.environment.name`.
 - W3C Trace Context para `traceparent`.
-- `baggage` disabled.
-- sampling determinista: development=1, zero-cost=1, production=0.
-- allowlist-first + denylist + sensitive-value redaction.
-- exporters F3: `noop` y `memory-test`.
-- Collector: referencia no desplegada.
-- cero cambios `app/`, Railway, migrations/DB o funciones Supabase.
+- `request_id`: UUID v4 independiente.
+- `baggage`: inbound/outbound disabled.
+- Sampling determinista: `development=1`, `zero-cost=1`, `production=0`.
+- Privacy: allowlist-first + denylist + sensitive-value redaction.
+- Exporter interface: `export(envelope)`.
+- Exporters F3: `noop`, `memory-test`; custom adapter probado por contrato.
+- Collector: reference-only, no desplegado.
 
-## 3. Gates F3
+## 3. Certificado exact-head
+
+Candidate validado: `bd19c8d11a04c5c3843ea041726e623e5d0461cb`.
+
+### Sentinel F3 Telemetry Certificate
+
+Run `31955549802` — **PASS**.
+
+Emitió:
+
+```text
+SENTINEL_F3_TELEMETRY_CONTRACT_PASS
+contract = sentinel-telemetry-contract/v1
+f2_registry_regression = true
+f2_public_html_surfaces = 41
+f2_runtime_nodes = 8
+f2_capabilities = 34
+zero_phi_pii = true
+baggage_enabled = false
+production_sampling_default = 0
+exporter_interchangeability = true
+trace_context = W3C
+fixture_leaks = 0
+runtime_db_mutations = 0
+changed_files_checked = 8
+```
+
+### Regresiones externas
+
+- Sentinel F1 Governance Certificate — run `31955549806` — **PASS**.
+- Ascenda CI — run `31955549811` — **PASS**.
+- PR #187: `mergeable=true` sobre la baseline validada.
+
+## 4. Scope proof
+
+Changed files PR #187 en el checkpoint técnico:
+
+1. `.github/workflows/sentinel-phase3-telemetry.yml`
+2. `ci/sentinel/fixtures/f3_sensitive_fixture.json`
+3. `ci/sentinel/phase3_telemetry_contract.js`
+4. `docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md`
+5. `docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md`
+6. `sentinel/collector/otel-collector-reference.yaml`
+7. `sentinel/telemetry/contract-v1.json`
+8. `sentinel/telemetry/index.js`
+
+Resultado: **0 `app/`, 0 `app/package.json`, 0 Railway, 0 migrations/DB, 0 Supabase functions, 0 provider endpoints/credentials, 0 production activation**.
+
+## 5. Privacy fixture
+
+El fixture sintético incluyó deliberadamente valores falsos de email, teléfono, DNI, Authorization/access token, request body, nombre y prompt IA.
+
+Resultado del envelope exportado:
+
+- valores sensibles filtrados: **0 leaks**;
+- keys desconocidas/denylisted: DROP;
+- valor sensible en key permitida: `[REDACTED]`;
+- ningún payload sensible llega al exporter.
+
+## 6. Exporter portability
+
+Se verificó el mismo envelope sanitizado contra:
+
+- `noop` — kill-switch, no exporta;
+- `memory-test` — fixture/CI;
+- adapter custom que implementa `export(envelope)`.
+
+Los tres respetaron la misma frontera; por tanto F3 no queda estructuralmente acoplada a Sentry ni a otro backend.
+
+## 7. Regresión F2 y mejora del loop
+
+Los primeros intentos del workflow F3 detectaron una inconsistencia del historial Git del merge ref temporal en runners self-hosted: el contrato histórico F2 exigía que su snapshot fuera ancestro de `HEAD`, mientras GitHub remoto confirmaba que `2608c90...` sí era ancestro de `main@2ec3c7ad`.
+
+No se relajó la topología F2. El gate cross-phase se corrigió para validar directamente sus invariantes materiales en el merge candidate F3:
+
+- 41/41 HTML actuales contra registry;
+- Railway entrypoint contra registry;
+- 8 runtime nodes y spawn edges;
+- component/dependency/capability references;
+- 34 capabilities;
+- default `UNKNOWN`;
+- cero `HEALTHY`;
+- cero critical nodes no mapeados.
+
+El run final certificó `f2_registry_regression=true`.
+
+## 8. Gates F3
 
 | Gate | Evidencia requerida | Estado |
 |---|---|---|
 | F3-G01 | F1/F2 `100_COMPLETE`; F3 única `Siguiente` al iniciar | PASS |
 | F3-G02 | baseline exacta y branch aislada desde `main@2ec3c7ad` | PASS |
-| F3-G03 | contract JSON V1 machine-readable, vendor-neutral, zero-PHI/PII | PASS by implementation; CI pending |
-| F3-G04 | resource attributes requeridos y namespace canónico | PASS by implementation; CI pending |
-| F3-G05 | W3C `traceparent` parse/format y parent propagation | PASS by implementation; CI pending |
-| F3-G06 | `baggage` inbound/outbound deshabilitado | PASS by contract; CI pending |
-| F3-G07 | `request_id` UUID v4 independiente y validado | PASS by implementation; CI pending |
-| F3-G08 | sampling determinista; production default=0 | PASS by implementation; CI pending |
-| F3-G09 | allowlist-first para resource/event attributes | PASS by implementation; CI pending |
-| F3-G10 | denylist + sensitive-value redaction antes de exporter | PASS by implementation; CI pending |
-| F3-G11 | fixture sintético demuestra cero leakage de valores sensibles | PENDING CI |
-| F3-G12 | noop/memory/custom exporter reciben contrato intercambiable | PENDING CI |
-| F3-G13 | Collector reference tiene filter/redaction/batch y no está desplegado | PASS by design; CI pending |
-| F3-G14 | CommonJS + Node built-ins; cero nueva dependencia en `app/package.json` | PASS by design; CI pending |
-| F3-G15 | final diff sin `app/`, Railway, DB/migrations, providers ni secrets | PENDING |
-| F3-G16 | exact-head self-hosted F3 certificate PASS | PENDING |
-| F3-G17 | regresiones F1 + F2 + Ascenda CI sin rojo material | PENDING |
-| F3-G18 | merge + Notion F3=100/Cerrada y F4 única Siguiente + certificado final | PENDING |
+| F3-G03 | contract JSON V1 machine-readable, vendor-neutral, zero-PHI/PII | PASS |
+| F3-G04 | resource attributes requeridos y namespace canónico | PASS |
+| F3-G05 | W3C `traceparent` parse/format y parent propagation | PASS |
+| F3-G06 | `baggage` inbound/outbound deshabilitado | PASS |
+| F3-G07 | `request_id` UUID v4 independiente y validado | PASS |
+| F3-G08 | sampling determinista; production default=0 | PASS |
+| F3-G09 | allowlist-first para resource/event attributes | PASS |
+| F3-G10 | denylist + sensitive-value redaction antes de exporter | PASS |
+| F3-G11 | fixture sintético demuestra cero leakage de valores sensibles | PASS |
+| F3-G12 | noop/memory/custom exporter reciben contrato intercambiable | PASS |
+| F3-G13 | Collector reference tiene filter/redaction/batch y no está desplegado | PASS |
+| F3-G14 | CommonJS + Node built-ins; cero nueva dependencia en `app/package.json` | PASS |
+| F3-G15 | final diff sin `app/`, Railway, DB/migrations, providers ni secrets | PASS |
+| F3-G16 | exact-head self-hosted F3 certificate PASS | PASS |
+| F3-G17 | F1 Governance + F2 material invariants + Ascenda CI PASS | PASS |
+| F3-G18 | foundation merge + Notion F3=100/Cerrada + F4 única Siguiente + certificado final | PENDING |
 
-## 4. Artefactos
+**Estado técnico:** `17/18 PASS`.
 
-- `sentinel/telemetry/contract-v1.json`
-- `sentinel/telemetry/index.js`
-- `sentinel/collector/otel-collector-reference.yaml`
-- `ci/sentinel/fixtures/f3_sensitive_fixture.json`
-- `ci/sentinel/phase3_telemetry_contract.js`
-- `.github/workflows/sentinel-phase3-telemetry.yml`
-- `docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md`
-- `docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md`
+## 9. No-certificaciones deliberadas
 
-## 5. No-certificaciones deliberadas
+Cerrar F3 no significa que exista Sentry/Collector/OTLP activo, tracing productivo, métricas productivas, logs productivos o export de red. F4 incorpora Sentry Error Monitoring Core; F5 disponibilidad; F6 business health; F7 release/deploy correlation.
 
-Cerrar F3 no significa que exista Sentry/Collector/OTLP activo, tracing productivo, métricas productivas, logs productivos o export de red. F4 instala Sentry Error Monitoring Core; F5 cubre disponibilidad; F6 business health; F7 correlation release/deploy.
+## 10. Handoff pendiente
 
-## 6. Loop pendiente
-
-1. versionar workflow F3;
-2. abrir PR;
-3. ejecutar self-hosted exact-head contract;
-4. corregir sin relajar privacy contract;
-5. verificar diff/secret scope;
-6. integrar checkpoint técnico;
-7. sincronizar Notion;
-8. emitir certificado `100_COMPLETE`;
-9. gate final y merge;
-10. dejar F4 como única `Siguiente`.
+1. revalidar este checkpoint sobre exact merge candidate;
+2. fusionar PR #187;
+3. sincronizar Notion F3/F4;
+4. emitir certificado GitHub `100_COMPLETE` con 18/18 PASS;
+5. ejecutar gate final y fusionar;
+6. dejar F4 como única fase `Siguiente`.

--- a/docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md
@@ -1,0 +1,78 @@
+# SENTINEL F3 — Telemetry Contract & OpenTelemetry Foundation — Validation Report
+
+**Fecha:** 2026-08-16 (America/Lima)  
+**Estado:** `VALIDATING`  
+**F1:** `100_COMPLETE`  
+**F2:** `100_COMPLETE`  
+**Baseline F3:** `main@2ec3c7ad0883d171dcfb81f61049d6b51e38f882`  
+**Branch:** `feat/sentinel-f3-otel-foundation`  
+**Riesgo:** HIGH — privacy/telemetry contract; runtime activation remains forbidden in F3.
+
+## 1. Objetivo
+
+Certificar un contrato portable de telemetría con identidad de servicio, correlation IDs, W3C Trace Context, sampling, filtering/redaction y exporter abstraction, sin PHI/PII, sin dependencia estructural de proveedor y sin activar export productivo.
+
+## 2. Decisiones F3
+
+- Schema contrato: `sentinel-telemetry-contract/v1`.
+- Schema envelope: `sentinel-telemetry-envelope/v1`.
+- CommonJS puro, sin nueva dependencia productiva.
+- `service.namespace=ascenda-os`.
+- W3C Trace Context para `traceparent`.
+- `baggage` disabled.
+- sampling determinista: development=1, zero-cost=1, production=0.
+- allowlist-first + denylist + sensitive-value redaction.
+- exporters F3: `noop` y `memory-test`.
+- Collector: referencia no desplegada.
+- cero cambios `app/`, Railway, migrations/DB o funciones Supabase.
+
+## 3. Gates F3
+
+| Gate | Evidencia requerida | Estado |
+|---|---|---|
+| F3-G01 | F1/F2 `100_COMPLETE`; F3 única `Siguiente` al iniciar | PASS |
+| F3-G02 | baseline exacta y branch aislada desde `main@2ec3c7ad` | PASS |
+| F3-G03 | contract JSON V1 machine-readable, vendor-neutral, zero-PHI/PII | PASS by implementation; CI pending |
+| F3-G04 | resource attributes requeridos y namespace canónico | PASS by implementation; CI pending |
+| F3-G05 | W3C `traceparent` parse/format y parent propagation | PASS by implementation; CI pending |
+| F3-G06 | `baggage` inbound/outbound deshabilitado | PASS by contract; CI pending |
+| F3-G07 | `request_id` UUID v4 independiente y validado | PASS by implementation; CI pending |
+| F3-G08 | sampling determinista; production default=0 | PASS by implementation; CI pending |
+| F3-G09 | allowlist-first para resource/event attributes | PASS by implementation; CI pending |
+| F3-G10 | denylist + sensitive-value redaction antes de exporter | PASS by implementation; CI pending |
+| F3-G11 | fixture sintético demuestra cero leakage de valores sensibles | PENDING CI |
+| F3-G12 | noop/memory/custom exporter reciben contrato intercambiable | PENDING CI |
+| F3-G13 | Collector reference tiene filter/redaction/batch y no está desplegado | PASS by design; CI pending |
+| F3-G14 | CommonJS + Node built-ins; cero nueva dependencia en `app/package.json` | PASS by design; CI pending |
+| F3-G15 | final diff sin `app/`, Railway, DB/migrations, providers ni secrets | PENDING |
+| F3-G16 | exact-head self-hosted F3 certificate PASS | PENDING |
+| F3-G17 | regresiones F1 + F2 + Ascenda CI sin rojo material | PENDING |
+| F3-G18 | merge + Notion F3=100/Cerrada y F4 única Siguiente + certificado final | PENDING |
+
+## 4. Artefactos
+
+- `sentinel/telemetry/contract-v1.json`
+- `sentinel/telemetry/index.js`
+- `sentinel/collector/otel-collector-reference.yaml`
+- `ci/sentinel/fixtures/f3_sensitive_fixture.json`
+- `ci/sentinel/phase3_telemetry_contract.js`
+- `.github/workflows/sentinel-phase3-telemetry.yml`
+- `docs/control/SENTINEL_F3_TELEMETRY_CONTRACT_V1.md`
+- `docs/control/SENTINEL_F3_VALIDATION_REPORT_20260816.md`
+
+## 5. No-certificaciones deliberadas
+
+Cerrar F3 no significa que exista Sentry/Collector/OTLP activo, tracing productivo, métricas productivas, logs productivos o export de red. F4 instala Sentry Error Monitoring Core; F5 cubre disponibilidad; F6 business health; F7 correlation release/deploy.
+
+## 6. Loop pendiente
+
+1. versionar workflow F3;
+2. abrir PR;
+3. ejecutar self-hosted exact-head contract;
+4. corregir sin relajar privacy contract;
+5. verificar diff/secret scope;
+6. integrar checkpoint técnico;
+7. sincronizar Notion;
+8. emitir certificado `100_COMPLETE`;
+9. gate final y merge;
+10. dejar F4 como única `Siguiente`.

--- a/sentinel/collector/otel-collector-reference.yaml
+++ b/sentinel/collector/otel-collector-reference.yaml
@@ -1,0 +1,71 @@
+# Sentinel F3 reference only — NOT DEPLOYED / NOT WIRED TO PRODUCTION.
+# Any future Collector deployment requires its own phase gate and privacy validation.
+# Processor order follows the principle: drop/filter early, redact/transform, then batch.
+
+receivers:
+  otlp:
+    protocols:
+      grpc: {}
+      http: {}
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+    spike_limit_mib: 64
+
+  filter/sentinel:
+    error_mode: ignore
+    traces:
+      span:
+        - 'resource.attributes["service.namespace"] != "ascenda-os"'
+
+  redaction/sentinel:
+    allow_all_keys: false
+    allowed_keys:
+      - service.namespace
+      - service.name
+      - service.version
+      - deployment.environment.name
+      - sentinel.domain
+      - sentinel.component
+      - sentinel.capability
+      - sentinel.dependency
+      - sentinel.operation
+      - sentinel.phase
+      - sentinel.request_id
+      - sentinel.provider
+      - sentinel.route_template
+      - sentinel.site_code
+      - error.type
+      - error.code
+      - http.request.method
+      - http.response.status_code
+      - http.route
+    blocked_values:
+      - '[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}'
+      - '(?:\+?\d[\s().-]*){9,}'
+      - '\b\d{8}\b'
+      - '\bBearer\s+[A-Za-z0-9._~+\/-]+=*\b'
+
+  batch:
+    timeout: 5s
+    send_batch_size: 256
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, filter/sentinel, redaction/sentinel, batch]
+      exporters: [debug]
+
+# F3 invariants:
+# - no production endpoint
+# - no credentials
+# - no Sentry/third-party exporter
+# - no logs/metrics pipeline enabled yet
+# - production sampling remains 0 until a later gate explicitly changes it

--- a/sentinel/telemetry/contract-v1.json
+++ b/sentinel/telemetry/contract-v1.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "sentinel-telemetry-contract/v1",
+  "contract_id": "ASCENDA-SENTINEL-TELEMETRY-V1",
+  "system": "ascenda-os",
+  "design": {
+    "vendor_neutral": true,
+    "runtime_activation_in_f3": false,
+    "network_export_in_f3": false,
+    "zero_phi_pii": true,
+    "allowlist_first": true,
+    "baggage_enabled": false
+  },
+  "resource": {
+    "required": [
+      "service.namespace",
+      "service.name",
+      "service.version",
+      "deployment.environment.name"
+    ],
+    "allowed": [
+      "service.namespace",
+      "service.name",
+      "service.version",
+      "deployment.environment.name",
+      "sentinel.domain",
+      "sentinel.component",
+      "sentinel.phase"
+    ],
+    "service_namespace": "ascenda-os",
+    "environments": ["development", "zero-cost", "production"]
+  },
+  "attributes": {
+    "allowed": [
+      "sentinel.domain",
+      "sentinel.component",
+      "sentinel.capability",
+      "sentinel.dependency",
+      "sentinel.operation",
+      "sentinel.phase",
+      "sentinel.request_id",
+      "sentinel.provider",
+      "sentinel.route_template",
+      "sentinel.site_code",
+      "error.type",
+      "error.code",
+      "http.request.method",
+      "http.response.status_code",
+      "http.route"
+    ],
+    "max_string_length": 160,
+    "max_attribute_count": 32
+  },
+  "propagation": {
+    "trace_context": "W3C Trace Context",
+    "traceparent_version": "00",
+    "trace_id_hex_length": 32,
+    "span_id_hex_length": 16,
+    "request_id_format": "uuid-v4",
+    "accept_inbound_baggage": false,
+    "emit_baggage": false
+  },
+  "sampling": {
+    "mode": "deterministic-trace-id",
+    "defaults": {
+      "development": 1,
+      "zero-cost": 1,
+      "production": 0
+    },
+    "production_change_requires_explicit_phase_gate": true
+  },
+  "redaction": {
+    "action_for_unknown_key": "drop",
+    "action_for_denied_key": "drop",
+    "action_for_sensitive_allowed_value": "redact",
+    "redaction_marker": "[REDACTED]",
+    "denied_key_fragments": [
+      "authorization",
+      "cookie",
+      "set-cookie",
+      "apikey",
+      "api_key",
+      "token",
+      "access_token",
+      "refresh_token",
+      "service_role",
+      "password",
+      "phone",
+      "telefono",
+      "recipient",
+      "wa_id",
+      "dni",
+      "documento",
+      "email",
+      "paciente",
+      "patient",
+      "nombre",
+      "name_raw",
+      "body",
+      "message",
+      "content",
+      "prompt",
+      "response",
+      "input",
+      "output",
+      "webhook"
+    ],
+    "forbidden_payload_classes": [
+      "patient identity",
+      "clinical text",
+      "WhatsApp or email content",
+      "request or response bodies",
+      "authentication secrets",
+      "AI prompts or model responses"
+    ]
+  },
+  "exporter": {
+    "interface": "export(envelope)",
+    "required_method": "export",
+    "f3_allowed_exporters": ["noop", "memory-test"],
+    "production_network_exporter_allowed": false
+  },
+  "envelope": {
+    "schema_version": "sentinel-telemetry-envelope/v1",
+    "signals": ["span", "error", "metric", "event"],
+    "fields": ["schema_version", "signal", "timestamp", "resource", "context", "attributes"]
+  }
+}

--- a/sentinel/telemetry/index.js
+++ b/sentinel/telemetry/index.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const crypto = require('crypto');
+const contract = require('./contract-v1.json');
+
+const ALLOWED_RESOURCE = new Set(contract.resource.allowed);
+const ALLOWED_ATTRIBUTES = new Set(contract.attributes.allowed);
+const DENIED_FRAGMENTS = contract.redaction.denied_key_fragments.map(v => String(v).toLowerCase());
+const REDACTED = contract.redaction.redaction_marker;
+const MAX_STRING = contract.attributes.max_string_length;
+const MAX_ATTRIBUTES = contract.attributes.max_attribute_count;
+
+const sensitiveValuePatterns = [
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i,
+  /(?:\+?\d[\s().-]*){9,}/,
+  /\b\d{8}\b/,
+  /\b(?:sk|sb_secret|xox[baprs]|gh[pousr])[-_][A-Za-z0-9_-]{10,}\b/i,
+  /\bBearer\s+[A-Za-z0-9._~+\/-]+=*\b/i,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/
+];
+
+function hasDeniedKeyFragment(key) {
+  const normalized = String(key || '').toLowerCase();
+  return DENIED_FRAGMENTS.some(fragment => normalized.includes(fragment));
+}
+
+function isSensitiveValue(value) {
+  if (typeof value !== 'string') return false;
+  return sensitiveValuePatterns.some(re => re.test(value));
+}
+
+function sanitizeScalar(key, value) {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  if (isSensitiveValue(value)) return REDACTED;
+  return value.slice(0, MAX_STRING);
+}
+
+function sanitizeMap(input, allowedSet) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  const out = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (Object.keys(out).length >= MAX_ATTRIBUTES) break;
+    if (!allowedSet.has(key)) continue;
+    if (hasDeniedKeyFragment(key)) continue;
+    const clean = sanitizeScalar(key, value);
+    if (clean !== undefined) out[key] = clean;
+  }
+  return out;
+}
+
+function sanitizeResource(resource) {
+  const clean = sanitizeMap(resource, ALLOWED_RESOURCE);
+  clean['service.namespace'] = contract.resource.service_namespace;
+  if (!contract.resource.environments.includes(clean['deployment.environment.name'])) {
+    delete clean['deployment.environment.name'];
+  }
+  return clean;
+}
+
+function sanitizeAttributes(attributes) {
+  return sanitizeMap(attributes, ALLOWED_ATTRIBUTES);
+}
+
+function createRequestId() {
+  return crypto.randomUUID();
+}
+
+function randomHex(bytes) {
+  let value;
+  do value = crypto.randomBytes(bytes).toString('hex');
+  while (/^0+$/.test(value));
+  return value;
+}
+
+function createTraceId() { return randomHex(16); }
+function createSpanId() { return randomHex(8); }
+
+function parseTraceparent(value) {
+  if (typeof value !== 'string') return null;
+  const match = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i.exec(value.trim());
+  if (!match) return null;
+  const version = match[1].toLowerCase();
+  const traceId = match[2].toLowerCase();
+  const parentSpanId = match[3].toLowerCase();
+  const flags = match[4].toLowerCase();
+  if (version === 'ff' || /^0+$/.test(traceId) || /^0+$/.test(parentSpanId)) return null;
+  return {version, trace_id: traceId, parent_span_id: parentSpanId, sampled: (parseInt(flags, 16) & 1) === 1};
+}
+
+function createTraceContext(options = {}) {
+  const inbound = parseTraceparent(options.traceparent);
+  return {
+    request_id: typeof options.request_id === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(options.request_id)
+      ? options.request_id.toLowerCase()
+      : createRequestId(),
+    trace_id: inbound ? inbound.trace_id : createTraceId(),
+    span_id: createSpanId(),
+    parent_span_id: inbound ? inbound.parent_span_id : null,
+    sampled: inbound ? inbound.sampled : Boolean(options.sampled)
+  };
+}
+
+function formatTraceparent(context) {
+  if (!context || !/^[0-9a-f]{32}$/i.test(context.trace_id || '') || !/^[0-9a-f]{16}$/i.test(context.span_id || '')) {
+    throw new Error('INVALID_TRACE_CONTEXT');
+  }
+  return `00-${context.trace_id.toLowerCase()}-${context.span_id.toLowerCase()}-${context.sampled ? '01' : '00'}`;
+}
+
+function defaultSampleRate(environment) {
+  const configured = contract.sampling.defaults[environment];
+  return typeof configured === 'number' ? configured : 0;
+}
+
+function shouldSample(traceId, rate) {
+  const normalizedRate = Math.max(0, Math.min(1, Number(rate)));
+  if (normalizedRate <= 0) return false;
+  if (normalizedRate >= 1) return true;
+  if (!/^[0-9a-f]{32}$/i.test(traceId || '')) return false;
+  const bucket = parseInt(traceId.slice(0, 8), 16) / 0xffffffff;
+  return bucket < normalizedRate;
+}
+
+function validateResource(resource) {
+  const missing = contract.resource.required.filter(key => !(key in resource));
+  if (missing.length) throw new Error(`MISSING_REQUIRED_RESOURCE:${missing.join(',')}`);
+  if (resource['service.namespace'] !== contract.resource.service_namespace) throw new Error('SERVICE_NAMESPACE_INVALID');
+  if (!contract.resource.environments.includes(resource['deployment.environment.name'])) throw new Error('ENVIRONMENT_INVALID');
+}
+
+function buildEnvelope(input = {}) {
+  if (!contract.envelope.signals.includes(input.signal)) throw new Error('SIGNAL_INVALID');
+  const resource = sanitizeResource(input.resource || {});
+  validateResource(resource);
+  const context = input.context || createTraceContext();
+  if (!/^[0-9a-f]{32}$/i.test(context.trace_id || '')) throw new Error('TRACE_ID_INVALID');
+  if (!/^[0-9a-f]{16}$/i.test(context.span_id || '')) throw new Error('SPAN_ID_INVALID');
+  const environment = resource['deployment.environment.name'];
+  const rate = input.sample_rate === undefined ? defaultSampleRate(environment) : Number(input.sample_rate);
+  const sampled = shouldSample(context.trace_id, rate);
+  return {
+    schema_version: contract.envelope.schema_version,
+    signal: input.signal,
+    timestamp: input.timestamp || new Date().toISOString(),
+    resource,
+    context: {
+      request_id: context.request_id,
+      trace_id: context.trace_id.toLowerCase(),
+      span_id: context.span_id.toLowerCase(),
+      parent_span_id: context.parent_span_id || null,
+      sampled
+    },
+    attributes: sanitizeAttributes(input.attributes || {})
+  };
+}
+
+function assertExporter(exporter) {
+  if (!exporter || typeof exporter.export !== 'function') throw new Error('EXPORTER_INTERFACE_INVALID');
+  return exporter;
+}
+
+function createNoopExporter() {
+  return Object.freeze({
+    name: 'noop',
+    export() { return {accepted: false, reason: 'noop'}; }
+  });
+}
+
+function createMemoryExporter() {
+  const records = [];
+  return {
+    name: 'memory-test',
+    export(envelope) {
+      records.push(JSON.parse(JSON.stringify(envelope)));
+      return {accepted: true, count: 1};
+    },
+    records() { return JSON.parse(JSON.stringify(records)); },
+    reset() { records.length = 0; }
+  };
+}
+
+function exportEnvelope(exporter, envelope) {
+  assertExporter(exporter);
+  const safeEnvelope = buildEnvelope({
+    signal: envelope.signal,
+    timestamp: envelope.timestamp,
+    resource: envelope.resource,
+    context: envelope.context,
+    attributes: envelope.attributes,
+    sample_rate: envelope.context && envelope.context.sampled ? 1 : 0
+  });
+  return exporter.export(safeEnvelope);
+}
+
+module.exports = {
+  contract,
+  sanitizeResource,
+  sanitizeAttributes,
+  createRequestId,
+  createTraceId,
+  createSpanId,
+  parseTraceparent,
+  createTraceContext,
+  formatTraceparent,
+  defaultSampleRate,
+  shouldSample,
+  buildEnvelope,
+  assertExporter,
+  createNoopExporter,
+  createMemoryExporter,
+  exportEnvelope
+};


### PR DESCRIPTION
## Objetivo
Ejecutar Sentinel F3 — Telemetry Contract & OpenTelemetry Foundation sin activar telemetría productiva.

## Baseline
- F1 `100_COMPLETE`.
- F2 `100_COMPLETE`.
- F3 era la única `Siguiente` al iniciar.
- Branch desde `main@2ec3c7ad0883d171dcfb81f61049d6b51e38f882`.

## Implementación
- contrato machine-readable `sentinel-telemetry-contract/v1`;
- envelope portable `sentinel-telemetry-envelope/v1`;
- CommonJS puro con W3C traceparent, UUID request_id y sampling determinista;
- allowlist-first + denylist + sensitive-value redaction;
- baggage disabled;
- production sampling default=0;
- exporters `noop` y `memory-test` + interfaz `export(envelope)`;
- fixture sintético anti-PHI/PII/secrets;
- Collector reference no desplegado;
- workflow self-hosted con regresiones F1/F2.

## Scope seguro
- cero cambios `app/`;
- cero `app/package.json`;
- cero Railway;
- cero migrations/DB/Supabase functions;
- cero endpoints/credentials/export productivo;
- cero gasto cloud adicional.

## Gate
No fusionar ni declarar F3 100% hasta:
1. F3 exact-head certificate PASS;
2. F1 + F2 regression PASS;
3. Ascenda CI sin rojo material;
4. fixture con 0 leaks;
5. exporters intercambiables;
6. diff final confirme cero runtime/DB/provider mutation;
7. checkpoint técnico integrado;
8. Notion sincronizado;
9. certificado final deje F4 como única `Siguiente`.