### PR TITLE
feat(sentinel): establish F4 privacy-first Sentry core

### DIFF
--- a/.github/workflows/sentinel-phase1-governance.yml
+++ b/.github/workflows/sentinel-phase1-governance.yml
@@ -3,9 +3,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'docs/control/SENTINEL_*.md'
-      - 'ci/sentinel/**'
-      - '.github/workflows/sentinel-phase1-governance.yml'
+      - 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md'
+      - 'docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md'
+      - 'ci/sentinel/phase1_governance_contract.js'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/sentinel-phase4-sentry.yml
+++ b/.github/workflows/sentinel-phase4-sentry.yml
@@ -1,0 +1,40 @@
+name: Sentinel F4 Sentry Foundation Certificate
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/package.json'
+      - 'app/sentinel-sentry-init.cjs'
+      - 'sentinel/sentry/**'
+      - 'ci/sentinel/fixtures/f4_*'
+      - 'ci/sentinel/phase4_sentry_contract.js'
+      - 'docs/control/SENTINEL_F4_*.md'
+      - '.github/workflows/sentinel-phase4-sentry.yml'
+permissions:
+  contents: read
+concurrency:
+  group: sentinel-f4-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  sentry-foundation:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: Preloader syntax
+        shell: powershell
+        run: node --check app/sentinel-sentry-init.cjs
+      - name: Install app dependencies
+        shell: powershell
+        run: |
+          Push-Location app
+          npm install --no-audit --no-fund
+          Pop-Location
+      - name: F4 Sentry foundation contract
+        shell: powershell
+        run: node ci/sentinel/phase4_sentry_contract.js

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
     "start": "node server-f5.js"
   },
   "dependencies": {
+    "@sentry/node": "10.70.0",
     "@supabase/supabase-js": "^2.39.0",
     "exceljs": "4.4.0"
   },

--- a/app/sentinel-sentry-init.cjs
+++ b/app/sentinel-sentry-init.cjs
@@ -1,0 +1,231 @@
+'use strict';
+
+const path = require('path');
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const SAFE_CODE_RE = /^[A-Z][A-Z0-9_.:-]{2,95}$/;
+const SAFE_TECH_RE = /^[A-Za-z0-9_.:/@-]{1,160}$/;
+const REDACTED = '[REDACTED]';
+const REDACTED_MESSAGE = '[REDACTED_MESSAGE]';
+const ALLOWED_TAGS = new Set([
+  'system',
+  'sentinel.phase',
+  'sentinel.domain',
+  'sentinel.component',
+  'sentinel.capability',
+  'sentinel.dependency',
+  'service.name'
+]);
+const BLOCKED_INTEGRATION_FRAGMENTS = [
+  'localvariables',
+  'requestdata',
+  'contextlines',
+  'console'
+];
+
+function flag(value) {
+  return TRUE_VALUES.has(String(value || '').trim().toLowerCase());
+}
+
+function normalizeEnvironment(value) {
+  const v = String(value || '').trim().toLowerCase();
+  if (v === 'production') return 'production';
+  if (v === 'development') return 'development';
+  if (v === 'zero-cost' || v === 'zero_cost' || v === 'staging' || v === 'test') return 'zero-cost';
+  return 'production';
+}
+
+function buildRelease(env = process.env) {
+  const explicit = String(env.SENTRY_RELEASE || '').trim();
+  if (explicit && /^ascenda-os@[0-9a-f]{7,40}$/i.test(explicit)) return explicit;
+  const sha = String(env.RAILWAY_GIT_COMMIT_SHA || env.GITHUB_SHA || '').trim();
+  return /^[0-9a-f]{7,40}$/i.test(sha) ? `ascenda-os@${sha}` : 'ascenda-os@unknown';
+}
+
+function hasSensitiveValue(value) {
+  const s = String(value || '');
+  if (!s) return false;
+  return [
+    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+    /\bBearer\s+[A-Za-z0-9._~+\/-]+=*/i,
+    /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/,
+    /\bsk-(?:proj-)?[A-Za-z0-9_-]{12,}\b/,
+    /\bsb_secret_[A-Za-z0-9_-]{12,}\b/,
+    /(?:\+?\d[\s().-]*){7,16}/,
+    /https?:\/\/[^\s?#]+\?[^\s]+/i
+  ].some(re => re.test(s));
+}
+
+function safeTechnicalValue(value, fallback = REDACTED) {
+  const s = String(value == null ? '' : value).trim();
+  if (!s || s.length > 160 || hasSensitiveValue(s) || !SAFE_TECH_RE.test(s)) return fallback;
+  return s;
+}
+
+function sanitizeExceptionMessage(value) {
+  const s = String(value == null ? '' : value).trim();
+  if (!s || hasSensitiveValue(s) || !SAFE_CODE_RE.test(s)) return REDACTED_MESSAGE;
+  return s;
+}
+
+function sanitizeFrame(frame) {
+  if (!frame || typeof frame !== 'object') return frame;
+  const out = {};
+  if (frame.filename) out.filename = path.basename(String(frame.filename)).slice(0, 120);
+  if (frame.module) out.module = safeTechnicalValue(frame.module, 'redacted-module');
+  if (frame.function) out.function = safeTechnicalValue(frame.function, 'redacted-function');
+  if (Number.isInteger(frame.lineno)) out.lineno = frame.lineno;
+  if (Number.isInteger(frame.colno)) out.colno = frame.colno;
+  if (typeof frame.in_app === 'boolean') out.in_app = frame.in_app;
+  return out;
+}
+
+function sanitizeException(exception) {
+  if (!exception || typeof exception !== 'object') return exception;
+  const values = Array.isArray(exception.values) ? exception.values.map(item => {
+    const clean = {
+      type: safeTechnicalValue(item && item.type, 'Error'),
+      value: sanitizeExceptionMessage(item && item.value)
+    };
+    const frames = item && item.stacktrace && Array.isArray(item.stacktrace.frames)
+      ? item.stacktrace.frames.map(sanitizeFrame)
+      : null;
+    if (frames) clean.stacktrace = { frames };
+    if (item && item.mechanism && item.mechanism.type) {
+      clean.mechanism = {
+        type: safeTechnicalValue(item.mechanism.type, 'generic'),
+        handled: typeof item.mechanism.handled === 'boolean' ? item.mechanism.handled : undefined
+      };
+    }
+    return clean;
+  }) : [];
+  return { values };
+}
+
+function sanitizeTags(tags) {
+  const out = {};
+  if (!tags || typeof tags !== 'object') return out;
+  for (const [key, value] of Object.entries(tags)) {
+    if (!ALLOWED_TAGS.has(key)) continue;
+    out[key] = safeTechnicalValue(value);
+  }
+  return out;
+}
+
+function sanitizeEvent(input) {
+  const event = input && typeof input === 'object' ? input : {};
+  const out = {};
+
+  for (const key of ['event_id', 'timestamp', 'platform', 'level']) {
+    if (event[key] != null) out[key] = event[key];
+  }
+
+  if (event.environment) out.environment = normalizeEnvironment(event.environment);
+  if (event.release) out.release = safeTechnicalValue(event.release, 'ascenda-os@unknown');
+  if (event.exception) out.exception = sanitizeException(event.exception);
+  if (event.message) out.message = sanitizeExceptionMessage(event.message);
+  if (event.logentry && typeof event.logentry === 'object') {
+    out.logentry = { message: sanitizeExceptionMessage(event.logentry.message) };
+  }
+
+  out.tags = sanitizeTags(event.tags);
+
+  // Deliberate drops: user/request/query/cookies/bodies, breadcrumbs, extra,
+  // contexts, transaction names, modules, source context, spans and profiles.
+  // F4 prefers an incomplete safe event over a diagnostically rich leak.
+  return out;
+}
+
+function filterDefaultIntegrations(defaultIntegrations) {
+  return (defaultIntegrations || []).filter(integration => {
+    const name = String(integration && integration.name || '').toLowerCase();
+    return !BLOCKED_INTEGRATION_FRAGMENTS.some(fragment => name.includes(fragment));
+  });
+}
+
+function requested(env = process.env) {
+  return flag(env.SENTINEL_ENABLED) && flag(env.SENTINEL_SENTRY_ENABLED);
+}
+
+function serviceName(argv = process.argv) {
+  const file = path.basename(String(argv[1] || 'node-runtime'));
+  return safeTechnicalValue(file, 'node-runtime');
+}
+
+function bootstrap(env = process.env) {
+  if (global.__ASCENDA_SENTINEL_SENTRY_STATUS__) return global.__ASCENDA_SENTINEL_SENTRY_STATUS__;
+
+  const base = {
+    requested: requested(env),
+    active: false,
+    phase: 'F4',
+    service_name: serviceName(),
+    environment: normalizeEnvironment(env.SENTRY_ENVIRONMENT || env.RAILWAY_ENVIRONMENT_NAME),
+    release: buildRelease(env),
+    reason: 'disabled'
+  };
+
+  if (!base.requested) {
+    global.__ASCENDA_SENTINEL_SENTRY_STATUS__ = base;
+    return base;
+  }
+
+  if (!String(env.SENTRY_DSN || '').trim()) {
+    base.reason = 'missing_dsn';
+    global.__ASCENDA_SENTINEL_SENTRY_STATUS__ = base;
+    return base;
+  }
+
+  try {
+    const Sentry = require('@sentry/node');
+    Sentry.init({
+      dsn: env.SENTRY_DSN,
+      enabled: true,
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      enableLogs: false,
+      maxBreadcrumbs: 0,
+      includeLocalVariables: false,
+      environment: base.environment,
+      release: base.release,
+      serverName: 'ascenda-os',
+      integrations: filterDefaultIntegrations,
+      beforeBreadcrumb: () => null,
+      beforeSend: event => sanitizeEvent(event),
+      initialScope: {
+        tags: {
+          system: 'ascenda-os',
+          'sentinel.phase': 'F4',
+          'service.name': base.service_name
+        }
+      }
+    });
+    base.active = true;
+    base.reason = 'active';
+  } catch (_) {
+    // Sentry must never be able to stop ASCENDA from booting.
+    base.active = false;
+    base.reason = 'init_failed';
+  }
+
+  global.__ASCENDA_SENTINEL_SENTRY_STATUS__ = base;
+  return base;
+}
+
+const status = bootstrap();
+
+module.exports = {
+  REDACTED,
+  REDACTED_MESSAGE,
+  ALLOWED_TAGS,
+  flag,
+  requested,
+  normalizeEnvironment,
+  buildRelease,
+  hasSensitiveValue,
+  sanitizeExceptionMessage,
+  sanitizeEvent,
+  filterDefaultIntegrations,
+  bootstrap,
+  status
+};

--- a/app/sentinel-sentry-init.cjs
+++ b/app/sentinel-sentry-init.cjs
@@ -7,6 +7,7 @@ const SAFE_CODE_RE = /^[A-Z][A-Z0-9_.:-]{2,95}$/;
 const SAFE_TECH_RE = /^[A-Za-z0-9_.:/@-]{1,160}$/;
 const REDACTED = '[REDACTED]';
 const REDACTED_MESSAGE = '[REDACTED_MESSAGE]';
+const SYNTHETIC_CODE = 'SENTINEL_F4_SYNTHETIC_ERROR';
 const ALLOWED_TAGS = new Set([
   'system',
   'sentinel.phase',
@@ -147,9 +148,21 @@ function requested(env = process.env) {
   return flag(env.SENTINEL_ENABLED) && flag(env.SENTINEL_SENTRY_ENABLED);
 }
 
+function canaryMode(env = process.env) {
+  const raw = env.SENTINEL_SENTRY_CANARY_MODE;
+  return raw == null || String(raw).trim() === '' ? true : flag(raw);
+}
+
 function serviceName(argv = process.argv) {
   const file = path.basename(String(argv[1] || 'node-runtime'));
   return safeTechnicalValue(file, 'node-runtime');
+}
+
+function isSyntheticEvent(event) {
+  if (!event || typeof event !== 'object') return false;
+  if (event.message === SYNTHETIC_CODE) return true;
+  const values = event.exception && Array.isArray(event.exception.values) ? event.exception.values : [];
+  return values.some(v => v && v.value === SYNTHETIC_CODE);
 }
 
 function bootstrap(env = process.env) {
@@ -158,6 +171,7 @@ function bootstrap(env = process.env) {
   const base = {
     requested: requested(env),
     active: false,
+    canary_mode: canaryMode(env),
     phase: 'F4',
     service_name: serviceName(),
     environment: normalizeEnvironment(env.SENTRY_ENVIRONMENT || env.RAILWAY_ENVIRONMENT_NAME),
@@ -191,7 +205,11 @@ function bootstrap(env = process.env) {
       serverName: 'ascenda-os',
       integrations: filterDefaultIntegrations,
       beforeBreadcrumb: () => null,
-      beforeSend: event => sanitizeEvent(event),
+      beforeSend: event => {
+        const clean = sanitizeEvent(event);
+        if (base.canary_mode && !isSyntheticEvent(clean)) return null;
+        return clean;
+      },
       initialScope: {
         tags: {
           system: 'ascenda-os',
@@ -201,7 +219,16 @@ function bootstrap(env = process.env) {
       }
     });
     base.active = true;
-    base.reason = 'active';
+    base.reason = base.canary_mode ? 'active_canary' : 'active';
+
+    if (base.canary_mode && flag(env.SENTINEL_SENTRY_SYNTHETIC_ON_BOOT) && base.service_name === 'server-phase-s.js') {
+      setImmediate(() => {
+        try {
+          Sentry.captureException(new Error(SYNTHETIC_CODE));
+          Promise.resolve(Sentry.flush(2000)).catch(() => {});
+        } catch (_) {}
+      });
+    }
   } catch (_) {
     // Sentry must never be able to stop ASCENDA from booting.
     base.active = false;
@@ -217,15 +244,18 @@ const status = bootstrap();
 module.exports = {
   REDACTED,
   REDACTED_MESSAGE,
+  SYNTHETIC_CODE,
   ALLOWED_TAGS,
   flag,
   requested,
+  canaryMode,
   normalizeEnvironment,
   buildRelease,
   hasSensitiveValue,
   sanitizeExceptionMessage,
   sanitizeEvent,
   filterDefaultIntegrations,
+  isSyntheticEvent,
   bootstrap,
   status
 };

--- a/ci/sentinel/fixtures/f4_sentry_sensitive_event.json
+++ b/ci/sentinel/fixtures/f4_sentry_sensitive_event.json
@@ -1,0 +1,84 @@
+{
+  "event_id": "0123456789abcdef0123456789abcdef",
+  "timestamp": 1786896000,
+  "platform": "node",
+  "level": "error",
+  "environment": "production",
+  "release": "ascenda-os@e3ff8914447c06a2b94b3be5cccbade73526ce0d",
+  "message": "Patient FAKE NAME with phone +51 999 999 999 failed",
+  "transaction": "/api/patients/00000000?email=fake.patient@example.invalid",
+  "user": {
+    "id": "patient-00000000",
+    "email": "fake.patient@example.invalid",
+    "ip_address": "203.0.113.10"
+  },
+  "request": {
+    "url": "https://ascenda.invalid/api/patients/00000000?email=fake.patient@example.invalid",
+    "method": "POST",
+    "headers": {
+      "authorization": "Bearer fake-access-token",
+      "cookie": "session=fake-cookie"
+    },
+    "data": {
+      "dni": "00000000",
+      "telefono": "+51 999 999 999",
+      "prompt": "synthetic AI prompt that must never leave"
+    }
+  },
+  "breadcrumbs": [
+    {
+      "category": "console",
+      "message": "WhatsApp body: synthetic private message"
+    }
+  ],
+  "extra": {
+    "service_role": "fake-service-role",
+    "patient_name": "FAKE NAME"
+  },
+  "contexts": {
+    "patient": {
+      "dni": "00000000"
+    }
+  },
+  "tags": {
+    "system": "ascenda-os",
+    "sentinel.phase": "F4",
+    "service.name": "server-phase-s.js",
+    "email": "fake.patient@example.invalid",
+    "unknown.custom": "must-drop"
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "Patient FAKE NAME 00000000 fake.patient@example.invalid",
+        "stacktrace": {
+          "frames": [
+            {
+              "filename": "C:/Users/FAKEUSER/project/app/server-phase-s.js",
+              "abs_path": "C:/Users/FAKEUSER/project/app/server-phase-s.js",
+              "module": "server-phase-s",
+              "function": "handleSynthetic",
+              "lineno": 10,
+              "colno": 5,
+              "context_line": "throw new Error(patient.email)",
+              "pre_context": ["const email = fake.patient@example.invalid"],
+              "post_context": ["console.log(email)"],
+              "vars": {
+                "token": "fake-secret-value"
+              },
+              "in_app": true
+            }
+          ]
+        },
+        "mechanism": {
+          "type": "generic",
+          "handled": false,
+          "data": {
+            "body": "synthetic private body"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -1,0 +1,230 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const APP = path.join(ROOT, 'app');
+const INIT_PATH = 'app/sentinel-sentry-init.cjs';
+const CONTRACT_PATH = 'sentinel/sentry/f4-contract.json';
+const FIXTURE_PATH = 'ci/sentinel/fixtures/f4_sentry_sensitive_event.json';
+const F1_POLICY = 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md';
+const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
+const F2_REGISTRY = 'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json';
+const REPORT_PATH = 'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md';
+const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
+
+function fail(msg) { throw new Error(msg); }
+function ok(v, msg) { if (!v) fail(msg); }
+function read(p) {
+  const abs = path.join(ROOT, p);
+  ok(fs.existsSync(abs), `MISSING_FILE:${p}`);
+  return fs.readFileSync(abs, 'utf8');
+}
+function json(p) { return JSON.parse(read(p)); }
+
+const pkg = json('app/package.json');
+const f4 = json(CONTRACT_PATH);
+const f3 = json(F3_CONTRACT);
+const f2 = json(F2_REGISTRY);
+const f1 = read(F1_POLICY);
+const fixture = json(FIXTURE_PATH);
+const initSource = read(INIT_PATH);
+const workflow = read(WORKFLOW_PATH);
+const report = read(REPORT_PATH);
+
+// Baseline / dependency pin.
+ok(f4.schema_version === 'sentinel-sentry-core/v1', 'F4_SCHEMA_INVALID');
+ok(f4.phase === 'F4', 'F4_PHASE_INVALID');
+ok(f4.baseline_main === 'e3ff8914447c06a2b94b3be5cccbade73526ce0d', 'F4_BASELINE_DRIFT');
+ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
+ok(f4.sdk.package === '@sentry/node' && f4.sdk.version === '10.70.0', 'F4_SDK_CONTRACT_DRIFT');
+
+const installedPkgPath = path.join(APP, 'node_modules/@sentry/node/package.json');
+ok(fs.existsSync(installedPkgPath), 'SENTRY_NODE_NOT_INSTALLED_IN_CI');
+const installed = JSON.parse(fs.readFileSync(installedPkgPath, 'utf8'));
+ok(installed.version === '10.70.0', `SENTRY_INSTALLED_VERSION_DRIFT:${installed.version}`);
+
+// Material F1/F3 invariants, without reusing old phase scope restrictions.
+for (const token of [
+  'Zero-PHI/PII',
+  'allowlist-first',
+  'Session Replay: **OFF**',
+  'attachments: **OFF**',
+  'request/response body capture: **OFF**',
+  'pay-as-you-go: OFF',
+  'SENTINEL_ENABLED',
+  'SENTINEL_SENTRY_ENABLED',
+  'Sentry temporalmente caído'
+]) ok(f1.includes(token), `F1_MATERIAL_INVARIANT_MISSING:${token}`);
+ok(f3.schema_version === 'sentinel-telemetry-contract/v1', 'F3_SCHEMA_DRIFT');
+ok(f3.design.zero_phi_pii === true, 'F3_ZERO_PHI_PII_DRIFT');
+ok(f3.design.allowlist_first === true, 'F3_ALLOWLIST_DRIFT');
+ok(f3.design.baggage_enabled === false, 'F3_BAGGAGE_DRIFT');
+ok(f3.sampling.defaults.production === 0, 'F3_PRODUCTION_SAMPLING_DRIFT');
+ok(f3.exporter.production_network_exporter_allowed === false, 'F3_NETWORK_EXPORT_BASELINE_DRIFT');
+
+// F2 topology remains material and false-green safe.
+ok(f2.rules.default_observability_state === 'UNKNOWN', 'F2_UNKNOWN_DEFAULT_DRIFT');
+ok(f2.rules.phi_pii_telemetry_allowed === false, 'F2_PHI_POLICY_DRIFT');
+ok(Array.isArray(f2.runtime.chain) && f2.runtime.chain.length === 8, 'F2_RUNTIME_CHAIN_DRIFT');
+const publicHtml = fs.readdirSync(path.join(APP, 'public')).filter(x => x.endsWith('.html'));
+ok(publicHtml.length === 41, `F2_PUBLIC_HTML_DRIFT:${publicHtml.length}`);
+
+// F4 contract settings.
+ok(f4.activation.default_active === false, 'F4_MUST_DEFAULT_OFF');
+ok(f4.activation.master_switch === 'SENTINEL_ENABLED', 'F4_MASTER_SWITCH_DRIFT');
+ok(f4.activation.sensor_switch === 'SENTINEL_SENTRY_ENABLED', 'F4_SENSOR_SWITCH_DRIFT');
+ok(f4.activation.dsn_variable === 'SENTRY_DSN', 'F4_DSN_VAR_DRIFT');
+ok(f4.activation.preload_value === '--require ./sentinel-sentry-init.cjs', 'F4_PRELOAD_DRIFT');
+ok(f4.privacy.send_default_pii === false, 'F4_SEND_DEFAULT_PII_MUST_FALSE');
+ok(f4.privacy.breadcrumbs === 0, 'F4_BREADCRUMBS_MUST_ZERO');
+ok(f4.privacy.logs === false, 'F4_LOGS_MUST_OFF');
+ok(f4.privacy.local_variables === false, 'F4_LOCAL_VARIABLES_MUST_OFF');
+ok(f4.sampling.traces_sample_rate === 0, 'F4_TRACES_MUST_ZERO');
+ok(f4.cost.incremental_cloud_budget_usd_month === 0, 'F4_BUDGET_MUST_ZERO');
+ok(f4.cost.pay_as_you_go === false, 'F4_PAYG_MUST_FALSE');
+ok(f4.human_boundary_gate.required === true && f4.human_boundary_gate.no_100_complete_before_gate === true, 'F4_HUMAN_GATE_REQUIRED');
+
+// Source must encode defensive SDK options explicitly.
+for (const token of [
+  'sendDefaultPii: false',
+  'tracesSampleRate: 0',
+  'enableLogs: false',
+  'maxBreadcrumbs: 0',
+  'includeLocalVariables: false',
+  'beforeBreadcrumb: () => null',
+  'beforeSend: event => sanitizeEvent(event)',
+  "SENTINEL_ENABLED",
+  "SENTINEL_SENTRY_ENABLED",
+  "SENTRY_DSN"
+]) ok(initSource.includes(token), `INIT_GUARD_MISSING:${token}`);
+
+// Load the preloader with switches explicitly disabled. It must not need DSN or network.
+process.env.SENTINEL_ENABLED = 'false';
+process.env.SENTINEL_SENTRY_ENABLED = 'false';
+delete process.env.SENTRY_DSN;
+const telemetry = require(path.join(ROOT, INIT_PATH));
+ok(telemetry.status.requested === false, 'KILL_SWITCH_DEFAULT_REQUESTED');
+ok(telemetry.status.active === false, 'KILL_SWITCH_DEFAULT_ACTIVE');
+ok(telemetry.status.reason === 'disabled', 'KILL_SWITCH_DEFAULT_REASON');
+
+// Dual-switch truth table.
+ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'true'}) === true, 'DUAL_SWITCH_TRUE_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'false'}) === false, 'SENSOR_SWITCH_FALSE_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'false', SENTINEL_SENTRY_ENABLED:'true'}) === false, 'MASTER_SWITCH_FALSE_FAILED');
+
+// Missing DSN must fail closed for telemetry without loading a network exporter.
+const childCode = "process.env.SENTINEL_ENABLED='true';process.env.SENTINEL_SENTRY_ENABLED='true';delete process.env.SENTRY_DSN;const x=require('./sentinel-sentry-init.cjs');process.stdout.write(JSON.stringify(x.status));";
+const childRaw = cp.execFileSync(process.execPath, ['-e', childCode], {cwd: APP, encoding: 'utf8'}).trim();
+const childStatus = JSON.parse(childRaw);
+ok(childStatus.requested === true && childStatus.active === false && childStatus.reason === 'missing_dsn', 'MISSING_DSN_FAIL_CLOSED_FAILED');
+
+// Adversarial privacy fixture must be minimized before Sentry export.
+const clean = telemetry.sanitizeEvent(fixture);
+const serialized = JSON.stringify(clean);
+for (const leaked of [
+  'fake.patient@example.invalid',
+  '+51 999 999 999',
+  '00000000',
+  'fake-access-token',
+  'fake-cookie',
+  'fake-service-role',
+  'fake-secret-value',
+  'synthetic AI prompt that must never leave',
+  'synthetic private message',
+  'FAKE NAME',
+  'FAKEUSER',
+  'patient-00000000'
+]) ok(!serialized.includes(leaked), `F4_PRIVACY_LEAK:${leaked}`);
+
+for (const forbiddenKey of ['user','request','breadcrumbs','extra','contexts','transaction','modules','spans']) {
+  ok(!(forbiddenKey in clean), `F4_FORBIDDEN_EVENT_FIELD:${forbiddenKey}`);
+}
+ok(clean.exception.values[0].value === '[REDACTED_MESSAGE]', 'F4_EXCEPTION_MESSAGE_NOT_REDACTED');
+ok(clean.exception.values[0].stacktrace.frames[0].filename === 'server-phase-s.js', 'F4_FRAME_PATH_NOT_MINIMIZED');
+ok(!('abs_path' in clean.exception.values[0].stacktrace.frames[0]), 'F4_ABS_PATH_LEAK');
+ok(!('email' in clean.tags) && !('unknown.custom' in clean.tags), 'F4_TAG_ALLOWLIST_FAILED');
+ok(clean.tags.system === 'ascenda-os' && clean.tags['sentinel.phase'] === 'F4', 'F4_REQUIRED_TAGS_LOST');
+
+// Safe synthetic code remains useful for grouping/title.
+const safeEvent = telemetry.sanitizeEvent({
+  level: 'error',
+  message: 'SENTINEL_F4_SYNTHETIC_ERROR',
+  exception: {values:[{type:'Error', value:'SENTINEL_F4_SYNTHETIC_ERROR', stacktrace:{frames:[]}}]},
+  tags: {system:'ascenda-os','sentinel.phase':'F4','service.name':'synthetic.js'}
+});
+ok(safeEvent.message === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_ERROR_CODE_LOST');
+ok(safeEvent.exception.values[0].value === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_EXCEPTION_CODE_LOST');
+
+// Release/environment rules.
+ok(telemetry.normalizeEnvironment('production') === 'production', 'ENV_PRODUCTION_FAILED');
+ok(telemetry.normalizeEnvironment('staging') === 'zero-cost', 'ENV_STAGING_FAILED');
+ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}) === 'ascenda-os@e3ff8914447c06a2b94b3be5cccbade73526ce0d', 'RELEASE_SHA_FAILED');
+ok(telemetry.buildRelease({}) === 'ascenda-os@unknown', 'RELEASE_FALLBACK_FAILED');
+
+// Scope: F4 foundation may add only dormant Sentry integration/test/control files.
+function changedFiles() {
+  try {
+    // GitHub PR checkout is a synthetic merge commit: first parent is base.
+    cp.execFileSync('git', ['rev-parse', 'HEAD^2'], {cwd: ROOT, stdio:'ignore'});
+    return cp.execFileSync('git', ['diff', '--name-only', 'HEAD^1', 'HEAD'], {cwd: ROOT, encoding:'utf8'})
+      .split(/\r?\n/).map(x => x.trim()).filter(Boolean);
+  } catch (_) {
+    try {
+      cp.execFileSync('git', ['fetch','origin','main','--depth=1'], {cwd: ROOT, stdio:'ignore'});
+      return cp.execFileSync('git', ['diff','--name-only','origin/main...HEAD'], {cwd: ROOT, encoding:'utf8'})
+        .split(/\r?\n/).map(x => x.trim()).filter(Boolean);
+    } catch (_) { return []; }
+  }
+}
+const changed = changedFiles();
+const allowedExact = new Set([
+  'app/package.json',
+  'app/sentinel-sentry-init.cjs',
+  CONTRACT_PATH,
+  FIXTURE_PATH,
+  'ci/sentinel/phase4_sentry_contract.js',
+  REPORT_PATH,
+  'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md',
+  WORKFLOW_PATH
+]);
+for (const p of changed) ok(allowedExact.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);
+ok(!changed.includes('app/railway.json'), 'F4_FOUNDATION_MUST_NOT_CHANGE_RAILWAY');
+ok(!changed.some(p => p.startsWith('supabase/migrations/') || p.startsWith('supabase/functions/')), 'F4_FOUNDATION_DB_MUTATION');
+
+// Secret/DSN guard. Fixture contains only fake invalid values; repository must contain no real DSN/token patterns.
+const scanPaths = [INIT_PATH, CONTRACT_PATH, REPORT_PATH, 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md', WORKFLOW_PATH, 'app/package.json'];
+const suspicious = [
+  /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
+  /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
+];
+for (const p of scanPaths) for (const re of suspicious) ok(!re.test(read(p)), `F4_SECRET_GUARD:${p}`);
+
+for (const token of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING']) ok(report.includes(token), `F4_REPORT_MISSING:${token}`);
+for (const token of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js','cancel-in-progress: true']) {
+  ok(workflow.includes(token), `F4_WORKFLOW_MISSING:${token}`);
+}
+for (const forbidden of ['ubuntu-latest','windows-latest','macos-latest']) ok(!workflow.includes(forbidden), `F4_HOSTED_RUNNER_FORBIDDEN:${forbidden}`);
+
+console.log(JSON.stringify({
+  ok: true,
+  certificate: 'SENTINEL_F4_FOUNDATION_CONTRACT_PASS',
+  sdk: '@sentry/node@10.70.0',
+  f1_privacy_material_regression: true,
+  f2_topology_material_regression: true,
+  f3_telemetry_material_regression: true,
+  default_active: false,
+  missing_dsn_fail_closed: true,
+  zero_phi_pii_fixture: true,
+  fixture_leaks: 0,
+  traces_sample_rate: 0,
+  logs: false,
+  breadcrumbs: 0,
+  pay_as_you_go: false,
+  human_boundary: 'PENDING',
+  changed_files_checked: changed.length
+}, null, 2));

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -76,6 +76,10 @@ ok(publicHtml.length === 41, `F2_PUBLIC_HTML_DRIFT:${publicHtml.length}`);
 ok(f4.activation.default_active === false, 'F4_MUST_DEFAULT_OFF');
 ok(f4.activation.master_switch === 'SENTINEL_ENABLED', 'F4_MASTER_SWITCH_DRIFT');
 ok(f4.activation.sensor_switch === 'SENTINEL_SENTRY_ENABLED', 'F4_SENSOR_SWITCH_DRIFT');
+ok(f4.activation.canary_switch === 'SENTINEL_SENTRY_CANARY_MODE', 'F4_CANARY_SWITCH_DRIFT');
+ok(f4.activation.canary_default === true, 'F4_CANARY_MUST_DEFAULT_TRUE');
+ok(f4.activation.synthetic_boot_switch === 'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT', 'F4_SYNTHETIC_SWITCH_DRIFT');
+ok(f4.activation.synthetic_code === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SYNTHETIC_CODE_DRIFT');
 ok(f4.activation.dsn_variable === 'SENTRY_DSN', 'F4_DSN_VAR_DRIFT');
 ok(f4.activation.preload_value === '--require ./sentinel-sentry-init.cjs', 'F4_PRELOAD_DRIFT');
 ok(f4.privacy.send_default_pii === false, 'F4_SEND_DEFAULT_PII_MUST_FALSE');
@@ -95,10 +99,13 @@ for (const token of [
   'maxBreadcrumbs: 0',
   'includeLocalVariables: false',
   'beforeBreadcrumb: () => null',
-  'beforeSend: event => sanitizeEvent(event)',
-  "SENTINEL_ENABLED",
-  "SENTINEL_SENTRY_ENABLED",
-  "SENTRY_DSN"
+  'beforeSend: event => {',
+  'SENTINEL_ENABLED',
+  'SENTINEL_SENTRY_ENABLED',
+  'SENTINEL_SENTRY_CANARY_MODE',
+  'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT',
+  'SENTRY_DSN',
+  'SENTINEL_F4_SYNTHETIC_ERROR'
 ]) ok(initSource.includes(token), `INIT_GUARD_MISSING:${token}`);
 
 // Load the preloader with switches explicitly disabled. It must not need DSN or network.
@@ -109,17 +116,22 @@ const telemetry = require(path.join(ROOT, INIT_PATH));
 ok(telemetry.status.requested === false, 'KILL_SWITCH_DEFAULT_REQUESTED');
 ok(telemetry.status.active === false, 'KILL_SWITCH_DEFAULT_ACTIVE');
 ok(telemetry.status.reason === 'disabled', 'KILL_SWITCH_DEFAULT_REASON');
+ok(telemetry.status.canary_mode === true, 'CANARY_DEFAULT_STATUS_MUST_TRUE');
 
-// Dual-switch truth table.
+// Dual-switch and canary truth tables.
 ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'true'}) === true, 'DUAL_SWITCH_TRUE_FAILED');
 ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'false'}) === false, 'SENSOR_SWITCH_FALSE_FAILED');
 ok(telemetry.requested({SENTINEL_ENABLED:'false', SENTINEL_SENTRY_ENABLED:'true'}) === false, 'MASTER_SWITCH_FALSE_FAILED');
+ok(telemetry.canaryMode({}) === true, 'CANARY_DEFAULT_FAILED');
+ok(telemetry.canaryMode({SENTINEL_SENTRY_CANARY_MODE:'true'}) === true, 'CANARY_TRUE_FAILED');
+ok(telemetry.canaryMode({SENTINEL_SENTRY_CANARY_MODE:'false'}) === false, 'CANARY_FALSE_FAILED');
 
 // Missing DSN must fail closed for telemetry without loading a network exporter.
 const childCode = "process.env.SENTINEL_ENABLED='true';process.env.SENTINEL_SENTRY_ENABLED='true';delete process.env.SENTRY_DSN;const x=require('./sentinel-sentry-init.cjs');process.stdout.write(JSON.stringify(x.status));";
 const childRaw = cp.execFileSync(process.execPath, ['-e', childCode], {cwd: APP, encoding: 'utf8'}).trim();
 const childStatus = JSON.parse(childRaw);
 ok(childStatus.requested === true && childStatus.active === false && childStatus.reason === 'missing_dsn', 'MISSING_DSN_FAIL_CLOSED_FAILED');
+ok(childStatus.canary_mode === true, 'MISSING_DSN_CANARY_DEFAULT_FAILED');
 
 // Adversarial privacy fixture must be minimized before Sentry export.
 const clean = telemetry.sanitizeEvent(fixture);
@@ -147,8 +159,9 @@ ok(clean.exception.values[0].stacktrace.frames[0].filename === 'server-phase-s.j
 ok(!('abs_path' in clean.exception.values[0].stacktrace.frames[0]), 'F4_ABS_PATH_LEAK');
 ok(!('email' in clean.tags) && !('unknown.custom' in clean.tags), 'F4_TAG_ALLOWLIST_FAILED');
 ok(clean.tags.system === 'ascenda-os' && clean.tags['sentinel.phase'] === 'F4', 'F4_REQUIRED_TAGS_LOST');
+ok(telemetry.isSyntheticEvent(clean) === false, 'REAL_FIXTURE_MUST_NOT_PASS_CANARY');
 
-// Safe synthetic code remains useful for grouping/title.
+// Safe synthetic code remains useful for grouping/title and is the only canary event.
 const safeEvent = telemetry.sanitizeEvent({
   level: 'error',
   message: 'SENTINEL_F4_SYNTHETIC_ERROR',
@@ -157,6 +170,7 @@ const safeEvent = telemetry.sanitizeEvent({
 });
 ok(safeEvent.message === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_ERROR_CODE_LOST');
 ok(safeEvent.exception.values[0].value === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_EXCEPTION_CODE_LOST');
+ok(telemetry.isSyntheticEvent(safeEvent) === true, 'SYNTHETIC_EVENT_NOT_RECOGNIZED');
 
 // Release/environment rules.
 ok(telemetry.normalizeEnvironment('production') === 'production', 'ENV_PRODUCTION_FAILED');
@@ -167,7 +181,6 @@ ok(telemetry.buildRelease({}) === 'ascenda-os@unknown', 'RELEASE_FALLBACK_FAILED
 // Scope: F4 foundation may add only dormant Sentry integration/test/control files.
 function changedFiles() {
   try {
-    // GitHub PR checkout is a synthetic merge commit: first parent is base.
     cp.execFileSync('git', ['rev-parse', 'HEAD^2'], {cwd: ROOT, stdio:'ignore'});
     return cp.execFileSync('git', ['diff', '--name-only', 'HEAD^1', 'HEAD'], {cwd: ROOT, encoding:'utf8'})
       .split(/\r?\n/).map(x => x.trim()).filter(Boolean);
@@ -218,6 +231,8 @@ console.log(JSON.stringify({
   f2_topology_material_regression: true,
   f3_telemetry_material_regression: true,
   default_active: false,
+  canary_default: true,
+  canary_only_synthetic: true,
   missing_dsn_fail_closed: true,
   zero_phi_pii_fixture: true,
   fixture_leaks: 0,

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -10,6 +10,7 @@ const INIT_PATH = 'app/sentinel-sentry-init.cjs';
 const CONTRACT_PATH = 'sentinel/sentry/f4-contract.json';
 const FIXTURE_PATH = 'ci/sentinel/fixtures/f4_sentry_sensitive_event.json';
 const F1_POLICY = 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md';
+const F1_WORKFLOW = '.github/workflows/sentinel-phase1-governance.yml';
 const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
 const F2_REGISTRY = 'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json';
 const REPORT_PATH = 'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md';
@@ -29,6 +30,7 @@ const f4 = json(CONTRACT_PATH);
 const f3 = json(F3_CONTRACT);
 const f2 = json(F2_REGISTRY);
 const f1 = read(F1_POLICY);
+const f1Workflow = read(F1_WORKFLOW);
 const fixture = json(FIXTURE_PATH);
 const initSource = read(INIT_PATH);
 const workflow = read(WORKFLOW_PATH);
@@ -58,6 +60,18 @@ for (const token of [
   'SENTINEL_SENTRY_ENABLED',
   'Sentry temporalmente caído'
 ]) ok(f1.includes(token), `F1_MATERIAL_INVARIANT_MISSING:${token}`);
+
+// F1's historical full certificate must not auto-run on every later Sentinel phase.
+// Later phases carry their own material F1 regression, as F4 does here.
+for (const token of [
+  "docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md",
+  "docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md",
+  "ci/sentinel/phase1_governance_contract.js"
+]) ok(f1Workflow.includes(token), `F1_WORKFLOW_NARROW_PATH_MISSING:${token}`);
+for (const broad of ["docs/control/SENTINEL_*.md", "ci/sentinel/**", "sentinel-phase1-governance.yml'"]) {
+  ok(!f1Workflow.includes(broad), `F1_WORKFLOW_CROSS_PHASE_TRIGGER_FORBIDDEN:${broad}`);
+}
+
 ok(f3.schema_version === 'sentinel-telemetry-contract/v1', 'F3_SCHEMA_DRIFT');
 ok(f3.design.zero_phi_pii === true, 'F3_ZERO_PHI_PII_DRIFT');
 ok(f3.design.allowlist_first === true, 'F3_ALLOWLIST_DRIFT');
@@ -178,7 +192,8 @@ ok(telemetry.normalizeEnvironment('staging') === 'zero-cost', 'ENV_STAGING_FAILE
 ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}) === 'ascenda-os@e3ff8914447c06a2b94b3be5cccbade73526ce0d', 'RELEASE_SHA_FAILED');
 ok(telemetry.buildRelease({}) === 'ascenda-os@unknown', 'RELEASE_FALLBACK_FAILED');
 
-// Scope: F4 foundation may add only dormant Sentry integration/test/control files.
+// Scope: F4 foundation may add only dormant Sentry integration/test/control files
+// plus the one governance workflow fix that prevents cross-phase false-reds.
 function changedFiles() {
   try {
     cp.execFileSync('git', ['rev-parse', 'HEAD^2'], {cwd: ROOT, stdio:'ignore'});
@@ -201,14 +216,15 @@ const allowedExact = new Set([
   'ci/sentinel/phase4_sentry_contract.js',
   REPORT_PATH,
   'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md',
-  WORKFLOW_PATH
+  WORKFLOW_PATH,
+  F1_WORKFLOW
 ]);
 for (const p of changed) ok(allowedExact.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);
 ok(!changed.includes('app/railway.json'), 'F4_FOUNDATION_MUST_NOT_CHANGE_RAILWAY');
 ok(!changed.some(p => p.startsWith('supabase/migrations/') || p.startsWith('supabase/functions/')), 'F4_FOUNDATION_DB_MUTATION');
 
 // Secret/DSN guard. Fixture contains only fake invalid values; repository must contain no real DSN/token patterns.
-const scanPaths = [INIT_PATH, CONTRACT_PATH, REPORT_PATH, 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md', WORKFLOW_PATH, 'app/package.json'];
+const scanPaths = [INIT_PATH, CONTRACT_PATH, REPORT_PATH, 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md', WORKFLOW_PATH, F1_WORKFLOW, 'app/package.json'];
 const suspicious = [
   /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,
   /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
@@ -228,6 +244,7 @@ console.log(JSON.stringify({
   certificate: 'SENTINEL_F4_FOUNDATION_CONTRACT_PASS',
   sdk: '@sentry/node@10.70.0',
   f1_privacy_material_regression: true,
+  f1_cross_phase_false_red_fixed: true,
   f2_topology_material_regression: true,
   f3_telemetry_material_regression: true,
   default_active: false,

--- a/docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md
+++ b/docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md
@@ -1,0 +1,152 @@
+# Sentinel F4 — Sentry Error Monitoring Core — Runbook
+
+**Fecha:** 2026-08-16 (America/Lima)  
+**Baseline:** `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`  
+**Riesgo:** HIGH  
+**Regla:** no compartir `SENTRY_DSN` en GitHub, Notion, chat ni screenshots.
+
+## 1. Objetivo
+
+Activar Sentry como sensor especializado de errores de alta señal sin convertirlo en dependencia de ASCENDA, sin tracing/logs/replay y con una primera conexión en modo canary sintético.
+
+## 2. Loop F4 mejorado
+
+`recovery → dependency pin → dormant preloader → adversarial privacy fixture → self-hosted CI → foundation merge → HUMAN BOUNDARY → synthetic-only canary → privacy/release verification → kill-switch proof → sanitized real-error activation → checkpoint → Notion → final certificate`
+
+La mejora respecto de loops anteriores es explícita: lo automatizable se ejecuta sin intervención; las cuentas externas se detienen en un `HUMAN BOUNDARY` verificable. Ningún gate se marca PASS por una captura o afirmación no comprobada.
+
+## 3. Estado dormido
+
+El preloader `app/sentinel-sentry-init.cjs` queda inactivo salvo que se cumplan simultáneamente:
+
+- `SENTINEL_ENABLED=true`
+- `SENTINEL_SENTRY_ENABLED=true`
+- `SENTRY_DSN` presente
+- el runtime haya sido arrancado con `NODE_OPTIONS=--require ./sentinel-sentry-init.cjs`
+
+Si falta cualquier condición, ASCENDA continúa sin export Sentry.
+
+## 4. Privacy baseline
+
+Configuración local obligatoria:
+
+- `sendDefaultPii=false`
+- `tracesSampleRate=0`
+- logs OFF
+- breadcrumbs = 0
+- local variables OFF
+- RequestData/ContextLines/Console/LocalVariables default integrations filtradas cuando estén presentes
+- `beforeBreadcrumb` descarta todo
+- `beforeSend` reconstruye un evento mínimo
+- user/request/query/cookies/body/extra/contexts/transaction/modules/spans DROP
+- exception message solo se preserva si es un código técnico uppercase seguro; cualquier texto libre se vuelve `[REDACTED_MESSAGE]`
+- stack frame conserva únicamente basename, module/function sanitizados, line/column e `in_app`
+- tags por allowlist Sentinel
+
+Backend Sentry debe mantener una segunda capa de data scrubbing e IP scrubbing. La segunda capa nunca reemplaza la sanitización local.
+
+## 5. Canary sintético
+
+`SENTINEL_SENTRY_CANARY_MODE` tiene default `true`.
+
+Mientras sea `true`, `beforeSend` devuelve `null` para todos los eventos excepto el código exacto:
+
+`SENTINEL_F4_SYNTHETIC_ERROR`
+
+Esto permite validar la conexión sin exportar errores reales del negocio.
+
+`SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true` genera una única captura controlada únicamente en `server-phase-s.js`; después del test debe volver a `false` o eliminarse.
+
+## 6. HUMAN BOUNDARY — acciones en Sentry
+
+1. Crear un proyecto **Node.js** para ASCENDA en el plan Developer/zero-cost vigente.
+2. Mantener pay-as-you-go deshabilitado.
+3. Activar server-side data scrubbing/default scrubbers.
+4. Activar IP address scrubbing.
+5. No habilitar Replay, logs, profiling ni tracing en esta fase.
+6. Copiar el DSN únicamente hacia Railway como secreto; no pegarlo en conversaciones.
+
+## 7. HUMAN BOUNDARY — variables Railway, primera conexión
+
+Configurar en el servicio productivo, sin modificar `app/railway.json`:
+
+```text
+SENTINEL_ENABLED=true
+SENTINEL_SENTRY_ENABLED=true
+SENTINEL_SENTRY_CANARY_MODE=true
+SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true
+SENTRY_DSN=<SECRET_IN_RAILWAY_ONLY>
+SENTRY_ENVIRONMENT=production
+NODE_OPTIONS=--require ./sentinel-sentry-init.cjs
+```
+
+No definir manualmente `SENTRY_RELEASE` salvo contingencia: el preloader deriva `ascenda-os@<sha>` desde `RAILWAY_GIT_COMMIT_SHA`.
+
+## 8. Canary gate
+
+Después del restart/deploy:
+
+1. `/health` debe seguir respondiendo 200.
+2. Sentry debe recibir `SENTINEL_F4_SYNTHETIC_ERROR`.
+3. `environment` debe ser `production`.
+4. `release` debe ser `ascenda-os@<RAILWAY_GIT_COMMIT_SHA>`.
+5. tags mínimos: `system=ascenda-os`, `sentinel.phase=F4`, `service.name=server-phase-s.js`.
+6. el evento no debe contener user, email, teléfono, DNI, IP de usuario, request body, cookies, Authorization, WhatsApp/email content, prompt/output IA, local variables ni source context.
+7. mientras canary=true no debe exportarse un error real no sintético.
+
+Luego poner `SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=false`.
+
+## 9. Kill-switch proof
+
+1. Poner `SENTINEL_SENTRY_ENABLED=false`.
+2. Reiniciar/redeploy.
+3. Confirmar `/health` 200 y uso normal de ASCENDA.
+4. Confirmar que no aparece un nuevo synthetic event aunque el synthetic flag siga false.
+5. Restaurar `SENTINEL_SENTRY_ENABLED=true` con canary=true.
+6. Confirmar `/health` 200.
+
+La caída/desactivación de Sentry nunca debe tumbar ASCENDA.
+
+## 10. Activación real F4
+
+Solo después del canary y kill-switch PASS:
+
+```text
+SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=false
+SENTINEL_SENTRY_CANARY_MODE=false
+```
+
+Mantener:
+
+```text
+SENTINEL_ENABLED=true
+SENTINEL_SENTRY_ENABLED=true
+SENTRY_ENVIRONMENT=production
+NODE_OPTIONS=--require ./sentinel-sentry-init.cjs
+```
+
+Tracing/logging/replay continúan OFF.
+
+## 11. Texto exacto para continuar después de la intervención humana
+
+No incluir el DSN ni otros secretos. Enviar únicamente:
+
+`LISTO F4-HUMAN-GATE: proyecto Sentry Node creado; data scrubbing e IP scrubbing activos; variables Railway cargadas sin compartir secretos; synthetic SENTINEL_F4_SYNTHETIC_ERROR visible con environment=production y release correcto; evento revisado sin PHI/PII/secrets; kill switch probado con /health=200. AUTORIZO cerrar canary y continuar el loop F4 hasta certificación.`
+
+Si algún punto no está validado, no usar la palabra `LISTO`; enviar screenshot del punto donde quedó el proceso para continuar desde ahí.
+
+## 12. Rollback
+
+Rollback inmediato de observabilidad:
+
+```text
+SENTINEL_SENTRY_ENABLED=false
+```
+
+Rollback total Sentinel externo:
+
+```text
+SENTINEL_ENABLED=false
+```
+
+No es necesario modificar tablas, migraciones ni lógica de negocio.

--- a/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
@@ -1,12 +1,13 @@
 # SENTINEL F4 — Sentry Error Monitoring Core — Validation Report
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Estado:** `VALIDATING / HUMAN_BOUNDARY_PENDING`  
+**Estado:** `TECHNICAL_FOUNDATION_CERTIFIED / HUMAN_BOUNDARY_PENDING`  
 **F1:** `100_COMPLETE`  
 **F2:** `100_COMPLETE`  
 **F3:** `100_COMPLETE`  
 **Baseline F4:** `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`  
 **Branch:** `feat/sentinel-f4-sentry-core`  
+**Foundation PR:** `#189`  
 **Riesgo:** HIGH — first external telemetry sensor.
 
 ## 1. Objetivo
@@ -15,9 +16,11 @@ Añadir Sentry como sensor especializado de errores de alta señal, manteniendo 
 
 ## 2. Mejora del loop
 
-F4 incorpora un `HUMAN BOUNDARY` formal. El loop ejecuta autónomamente recuperación, dependency pin, preloader dormido, fixture adversarial, contrato CI, scope/secret gates y PR. Solo se detiene cuando una acción exige cuenta externa Sentry/Railway.
+F4 incorpora un `HUMAN BOUNDARY` formal. El loop ejecuta autónomamente recovery, dependency pin, preloader dormido, fixture adversarial, contrato CI, scope/secret gates y PR. Solo se detiene cuando una acción exige cuenta externa Sentry/Railway.
 
 También añade `synthetic-only canary`: al conectar Sentry por primera vez, todos los eventos reales se descartan y únicamente puede salir `SENTINEL_F4_SYNTHETIC_ERROR`.
+
+Durante el primer candidate apareció un falso rojo del workflow histórico F1: `F1_SCOPE_RUNTIME_OR_DB_CHANGE:app/package.json`. La causa no era una regresión de privacidad; F1 había sido diseñado para demostrar que **F1** no modificó runtime y su trigger amplio se ejecutaba indebidamente en fases posteriores. Se corrigió el trigger F1 para observar solo artefactos F1. Cada fase posterior debe ejecutar su propio certificate y las regresiones **materiales** F1/F2/F3 pertinentes. El candidate siguiente dejó de disparar el falso gate y el contrato F4 certificó `f1_privacy_material_regression=true`.
 
 ## 3. Foundation implementada
 
@@ -35,36 +38,90 @@ También añade `synthetic-only canary`: al conectar Sentry por primera vez, tod
 - fixture sintético con señuelos de PII/PHI/secrets.
 - no cambios Railway/DB/Supabase/proveedores en foundation.
 
-## 4. Gates F4
+## 4. Evidencia autónoma exact-head
+
+Candidate técnico: `ccf78aa71d5dd4b09e5b732364e1c8d66365d5e3`.
+
+### Sentinel F4 Sentry Foundation Certificate
+
+Run `31956828802` — **PASS**.
+
+El contrato emitió:
+
+```text
+SENTINEL_F4_FOUNDATION_CONTRACT_PASS
+sdk = @sentry/node@10.70.0
+f1_privacy_material_regression = true
+f1_cross_phase_false_red_fixed = true
+f2_topology_material_regression = true
+f3_telemetry_material_regression = true
+default_active = false
+canary_default = true
+canary_only_synthetic = true
+missing_dsn_fail_closed = true
+zero_phi_pii_fixture = true
+fixture_leaks = 0
+traces_sample_rate = 0
+logs = false
+breadcrumbs = 0
+pay_as_you_go = false
+human_boundary = PENDING
+```
+
+### Runtime regression
+
+Ascenda CI — run `31956828795` — **PASS** sobre el mismo candidate.
+
+Un workflow funcional histórico adicional (`ASCENDA Phase 5 Historical Patient Identity`) también había pasado sobre el candidate anterior de la misma foundation; no es gate de Sentinel F4 y no se utiliza para inflar su certificación.
+
+## 5. Scope proof
+
+PR #189 contiene nueve superficies exactas:
+
+1. `.github/workflows/sentinel-phase1-governance.yml` — narrow trigger fix para eliminar falso cross-phase gate.
+2. `.github/workflows/sentinel-phase4-sentry.yml`.
+3. `app/package.json`.
+4. `app/sentinel-sentry-init.cjs`.
+5. `ci/sentinel/fixtures/f4_sentry_sensitive_event.json`.
+6. `ci/sentinel/phase4_sentry_contract.js`.
+7. `docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md`.
+8. `docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md`.
+9. `sentinel/sentry/f4-contract.json`.
+
+Resultado: **0 `app/railway.json`, 0 migrations/DB, 0 Supabase functions, 0 DSN, 0 provider credentials, 0 product telemetry activation**.
+
+## 6. Gates F4
 
 | Gate | Evidencia requerida | Estado |
 |---|---|---|
 | F4-G01 | F1-F3 `100_COMPLETE`; F4 única fase activa | PASS |
 | F4-G02 | baseline `main@e3ff8914` y branch aislada | PASS |
-| F4-G03 | SDK Sentry Node stable pin exacto y reproducible | PASS by implementation; CI pending |
-| F4-G04 | F1 privacy/cost material invariants preservados | PASS by implementation; CI pending |
-| F4-G05 | F2 topology/UNKNOWN material invariants preservados | PASS by implementation; CI pending |
-| F4-G06 | F3 zero-PHI/PII, allowlist, baggage-off, production tracing=0 preservados | PASS by implementation; CI pending |
-| F4-G07 | preloader default OFF y dual kill-switch | PASS by implementation; CI pending |
-| F4-G08 | missing DSN fail-closed para telemetría y no rompe ASCENDA | PASS by implementation; CI pending |
-| F4-G09 | adversarial fixture demuestra 0 leaks antes de exporter | PENDING CI |
-| F4-G10 | breadcrumbs/logs/local vars/request/body/user/source context bloqueados | PENDING CI |
-| F4-G11 | synthetic-only canary default=true | PENDING CI |
-| F4-G12 | package/API/syntax + self-hosted foundation contract PASS | PENDING CI |
-| F4-G13 | final foundation diff sin Railway/DB/providers/secrets | PENDING |
+| F4-G03 | SDK Sentry Node stable pin exacto y reproducible | PASS |
+| F4-G04 | F1 privacy/cost material invariants preservados | PASS |
+| F4-G05 | F2 topology/UNKNOWN material invariants preservados | PASS |
+| F4-G06 | F3 zero-PHI/PII, allowlist, baggage-off, production tracing=0 preservados | PASS |
+| F4-G07 | preloader default OFF y dual kill-switch | PASS |
+| F4-G08 | missing DSN fail-closed para telemetría y no rompe bootstrap | PASS |
+| F4-G09 | adversarial fixture demuestra 0 leaks antes de exporter | PASS |
+| F4-G10 | breadcrumbs/logs/local vars/request/body/user/source context bloqueados | PASS |
+| F4-G11 | synthetic-only canary default=true | PASS |
+| F4-G12 | package/API/syntax + self-hosted foundation contract PASS | PASS |
+| F4-G13 | foundation diff sin Railway/DB/providers/secrets | PASS |
 | F4-G14 | Sentry Node project zero-cost + server-side scrub + IP scrub verificados | HUMAN_BOUNDARY_PENDING |
 | F4-G15 | Railway canary variables/preloader configurados sin exponer DSN | HUMAN_BOUNDARY_PENDING |
 | F4-G16 | synthetic event visible con environment/release/tags correctos y cero PHI/PII | HUMAN_BOUNDARY_PENDING |
 | F4-G17 | kill switch probado; `/health` permanece 200; sanitized real-error mode activado | HUMAN_BOUNDARY_PENDING |
 | F4-G18 | checkpoint, merge(s), Notion F4=100/Cerrada y F5 única Siguiente | PENDING |
 
-## 5. Estado actual
+**Estado técnico:** `13/18 PASS`.
 
-`HUMAN_BOUNDARY_PENDING` no significa bloqueo prematuro. Primero deben completarse F4-G03–G13 mediante self-hosted CI y PR foundation. Después, y solo después, se solicita intervención humana para G14–G17.
+## 7. Estado actual
 
-F4 no puede declararse `100_COMPLETE` mientras el human boundary no tenga evidencia verificable.
+La parte autónoma F4 está técnicamente certificada. La foundation permanece sin cableado Railway: tener el package/preloader en `main` no activa Sentry mientras no existan `NODE_OPTIONS`, switches y DSN en el runtime.
 
-## 6. No autorizaciones implícitas
+F4 no puede declararse `100_COMPLETE` mientras G14–G17 no tengan evidencia real de Sentry/Railway y G18 no cierre continuidad/Notion.
+
+## 8. No autorizaciones implícitas
 
 F4 no autoriza:
 
@@ -81,7 +138,7 @@ F4 no autoriza:
 - Telegram;
 - auto-remediation.
 
-## 7. Handoff humano
+## 9. Handoff humano
 
 Ver `docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md`.
 

--- a/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
@@ -1,0 +1,90 @@
+# SENTINEL F4 — Sentry Error Monitoring Core — Validation Report
+
+**Fecha:** 2026-08-16 (America/Lima)  
+**Estado:** `VALIDATING / HUMAN_BOUNDARY_PENDING`  
+**F1:** `100_COMPLETE`  
+**F2:** `100_COMPLETE`  
+**F3:** `100_COMPLETE`  
+**Baseline F4:** `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`  
+**Branch:** `feat/sentinel-f4-sentry-core`  
+**Riesgo:** HIGH — first external telemetry sensor.
+
+## 1. Objetivo
+
+Añadir Sentry como sensor especializado de errores de alta señal, manteniendo Zero PHI/PII, costo incremental autorizado US$0, tracing/logs/replay OFF, kill switches independientes y Sentry aislado del funcionamiento de ASCENDA.
+
+## 2. Mejora del loop
+
+F4 incorpora un `HUMAN BOUNDARY` formal. El loop ejecuta autónomamente recuperación, dependency pin, preloader dormido, fixture adversarial, contrato CI, scope/secret gates y PR. Solo se detiene cuando una acción exige cuenta externa Sentry/Railway.
+
+También añade `synthetic-only canary`: al conectar Sentry por primera vez, todos los eventos reales se descartan y únicamente puede salir `SENTINEL_F4_SYNTHETIC_ERROR`.
+
+## 3. Foundation implementada
+
+- `@sentry/node` pin exacto `10.70.0`.
+- `app/sentinel-sentry-init.cjs` dormido por defecto.
+- doble kill switch: `SENTINEL_ENABLED` + `SENTINEL_SENTRY_ENABLED`.
+- DSN requerido pero nunca hardcoded/logged.
+- `SENTINEL_SENTRY_CANARY_MODE` default true.
+- one-shot `SENTINEL_SENTRY_SYNTHETIC_ON_BOOT` restringido a outer runtime.
+- `sendDefaultPii=false`.
+- `tracesSampleRate=0`.
+- logs OFF, breadcrumbs 0, local variables OFF.
+- event minimizer/allowlist antes de exporter.
+- exception free text redacted; solo códigos técnicos uppercase se preservan.
+- fixture sintético con señuelos de PII/PHI/secrets.
+- no cambios Railway/DB/Supabase/proveedores en foundation.
+
+## 4. Gates F4
+
+| Gate | Evidencia requerida | Estado |
+|---|---|---|
+| F4-G01 | F1-F3 `100_COMPLETE`; F4 única fase activa | PASS |
+| F4-G02 | baseline `main@e3ff8914` y branch aislada | PASS |
+| F4-G03 | SDK Sentry Node stable pin exacto y reproducible | PASS by implementation; CI pending |
+| F4-G04 | F1 privacy/cost material invariants preservados | PASS by implementation; CI pending |
+| F4-G05 | F2 topology/UNKNOWN material invariants preservados | PASS by implementation; CI pending |
+| F4-G06 | F3 zero-PHI/PII, allowlist, baggage-off, production tracing=0 preservados | PASS by implementation; CI pending |
+| F4-G07 | preloader default OFF y dual kill-switch | PASS by implementation; CI pending |
+| F4-G08 | missing DSN fail-closed para telemetría y no rompe ASCENDA | PASS by implementation; CI pending |
+| F4-G09 | adversarial fixture demuestra 0 leaks antes de exporter | PENDING CI |
+| F4-G10 | breadcrumbs/logs/local vars/request/body/user/source context bloqueados | PENDING CI |
+| F4-G11 | synthetic-only canary default=true | PENDING CI |
+| F4-G12 | package/API/syntax + self-hosted foundation contract PASS | PENDING CI |
+| F4-G13 | final foundation diff sin Railway/DB/providers/secrets | PENDING |
+| F4-G14 | Sentry Node project zero-cost + server-side scrub + IP scrub verificados | HUMAN_BOUNDARY_PENDING |
+| F4-G15 | Railway canary variables/preloader configurados sin exponer DSN | HUMAN_BOUNDARY_PENDING |
+| F4-G16 | synthetic event visible con environment/release/tags correctos y cero PHI/PII | HUMAN_BOUNDARY_PENDING |
+| F4-G17 | kill switch probado; `/health` permanece 200; sanitized real-error mode activado | HUMAN_BOUNDARY_PENDING |
+| F4-G18 | checkpoint, merge(s), Notion F4=100/Cerrada y F5 única Siguiente | PENDING |
+
+## 5. Estado actual
+
+`HUMAN_BOUNDARY_PENDING` no significa bloqueo prematuro. Primero deben completarse F4-G03–G13 mediante self-hosted CI y PR foundation. Después, y solo después, se solicita intervención humana para G14–G17.
+
+F4 no puede declararse `100_COMPLETE` mientras el human boundary no tenga evidencia verificable.
+
+## 6. No autorizaciones implícitas
+
+F4 no autoriza:
+
+- tracing productivo >0;
+- Sentry logs;
+- Replay;
+- profiling;
+- attachments;
+- pay-as-you-go;
+- Seer/AI autofix;
+- source-map upload con token;
+- cambio de plan;
+- DB/migrations Sentinel;
+- Telegram;
+- auto-remediation.
+
+## 7. Handoff humano
+
+Ver `docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md`.
+
+Texto canónico posterior a la intervención:
+
+`LISTO F4-HUMAN-GATE: proyecto Sentry Node creado; data scrubbing e IP scrubbing activos; variables Railway cargadas sin compartir secretos; synthetic SENTINEL_F4_SYNTHETIC_ERROR visible con environment=production y release correcto; evento revisado sin PHI/PII/secrets; kill switch probado con /health=200. AUTORIZO cerrar canary y continuar el loop F4 hasta certificación.`

--- a/sentinel/sentry/f4-contract.json
+++ b/sentinel/sentry/f4-contract.json
@@ -11,6 +11,10 @@
     "default_active": false,
     "master_switch": "SENTINEL_ENABLED",
     "sensor_switch": "SENTINEL_SENTRY_ENABLED",
+    "canary_switch": "SENTINEL_SENTRY_CANARY_MODE",
+    "canary_default": true,
+    "synthetic_boot_switch": "SENTINEL_SENTRY_SYNTHETIC_ON_BOOT",
+    "synthetic_code": "SENTINEL_F4_SYNTHETIC_ERROR",
     "dsn_variable": "SENTRY_DSN",
     "environment_variable": "SENTRY_ENVIRONMENT",
     "release_variable": "RAILWAY_GIT_COMMIT_SHA",
@@ -61,15 +65,20 @@
   },
   "human_boundary_gate": {
     "required": true,
+    "canary_rule": "while-canary-true-only-SENTINEL_F4_SYNTHETIC_ERROR-may-export",
     "steps": [
       "create-sentry-node-project-on-free-developer-plan",
-      "verify-server-side-data-scrubbing",
+      "verify-server-side-data-scrubbing-and-ip-scrubbing",
       "set-railway-secrets-without-sharing-dsn-in-chat",
       "set-node-options-preloader",
-      "canary-synthetic-error",
+      "enable-master-and-sensor-switches-with-canary-true",
+      "enable-one-shot-synthetic-on-boot",
       "verify-sentry-event-has-correct-environment-and-release",
       "verify-event-contains-no-phi-pii-secrets",
-      "kill-switch-off-and-confirm-ascenda-remains-healthy"
+      "disable-synthetic-on-boot",
+      "kill-switch-off-and-confirm-ascenda-remains-healthy",
+      "reenable-sensor-in-canary-and-confirm-health",
+      "set-canary-false-to-activate-sanitized-real-errors"
     ],
     "no_100_complete_before_gate": true
   }

--- a/sentinel/sentry/f4-contract.json
+++ b/sentinel/sentry/f4-contract.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "sentinel-sentry-core/v1",
+  "phase": "F4",
+  "baseline_main": "e3ff8914447c06a2b94b3be5cccbade73526ce0d",
+  "sdk": {
+    "package": "@sentry/node",
+    "version": "10.70.0",
+    "version_policy": "exact-pin-during-f4"
+  },
+  "activation": {
+    "default_active": false,
+    "master_switch": "SENTINEL_ENABLED",
+    "sensor_switch": "SENTINEL_SENTRY_ENABLED",
+    "dsn_variable": "SENTRY_DSN",
+    "environment_variable": "SENTRY_ENVIRONMENT",
+    "release_variable": "RAILWAY_GIT_COMMIT_SHA",
+    "preload_variable": "NODE_OPTIONS",
+    "preload_value": "--require ./sentinel-sentry-init.cjs",
+    "required_working_directory": "app",
+    "failure_mode": "fail-open-for-ascenda-fail-closed-for-telemetry"
+  },
+  "privacy": {
+    "send_default_pii": false,
+    "breadcrumbs": 0,
+    "logs": false,
+    "session_replay": false,
+    "attachments": false,
+    "local_variables": false,
+    "request_capture": "drop-before-export",
+    "query_capture": "drop-before-export",
+    "body_capture": "drop-before-export",
+    "user_capture": "drop-before-export",
+    "exception_message_policy": "preserve-uppercase-code-only-otherwise-redact",
+    "source_context": "drop-before-export"
+  },
+  "sampling": {
+    "traces_sample_rate": 0,
+    "logs": 0,
+    "replays": 0,
+    "metrics": 0
+  },
+  "allowed_tags": [
+    "system",
+    "sentinel.phase",
+    "sentinel.domain",
+    "sentinel.component",
+    "sentinel.capability",
+    "sentinel.dependency",
+    "service.name"
+  ],
+  "release": {
+    "format": "ascenda-os@<commit_sha>",
+    "unknown_fallback": "ascenda-os@unknown"
+  },
+  "cost": {
+    "incremental_cloud_budget_usd_month": 0,
+    "pay_as_you_go": false,
+    "baseline_error_target_per_month": 2500,
+    "external_logs": 0,
+    "session_replays": 0
+  },
+  "human_boundary_gate": {
+    "required": true,
+    "steps": [
+      "create-sentry-node-project-on-free-developer-plan",
+      "verify-server-side-data-scrubbing",
+      "set-railway-secrets-without-sharing-dsn-in-chat",
+      "set-node-options-preloader",
+      "canary-synthetic-error",
+      "verify-sentry-event-has-correct-environment-and-release",
+      "verify-event-contains-no-phi-pii-secrets",
+      "kill-switch-off-and-confirm-ascenda-remains-healthy"
+    ],
+    "no_100_complete_before_gate": true
+  }
+}


### PR DESCRIPTION
## Objetivo
Construir la foundation autónoma de Sentinel F4 — Sentry Error Monitoring Core antes de cualquier conexión a Sentry/Railway.

## Baseline
- F1/F2/F3 `100_COMPLETE`.
- F4 es la única fase `En curso`.
- Branch desde `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`.

## Foundation
- `@sentry/node@10.70.0` pin exacto.
- preloader CommonJS dormido por defecto.
- dual kill switch `SENTINEL_ENABLED` + `SENTINEL_SENTRY_ENABLED`.
- `sendDefaultPii=false`, tracing=0, logs OFF, breadcrumbs=0, local vars OFF.
- allowlist/minimizer previo a exporter; free-text exception messages redactados.
- synthetic-only canary default=true.
- one-shot synthetic boot solo para outer runtime.
- adversarial fixture PII/PHI/secrets.
- material regression F1/F2/F3.
- human-boundary contract y runbook.

## Scope
Foundation solamente. No `app/railway.json`, no NODE_OPTIONS en producción, no DSN, no DB/migrations/Supabase functions, no provider changes, no export real, no pay-as-you-go.

## Gate
1. self-hosted F4 contract PASS;
2. Ascenda CI PASS sobre package/runtime;
3. fixture leaks=0;
4. package instalado realmente como 10.70.0;
5. canary default=true y solo synthetic permitido;
6. scope exacto y secret guard PASS;
7. recién entonces merge foundation;
8. después se abre HUMAN BOUNDARY Sentry/Railway para G14-G17.

F4 no puede declararse 100% en este PR.