### PR TITLE
fix(sentinel): isolate F4 Sentry preload from Railway build

### DIFF
--- a/.github/workflows/cartera-phase2-hardening.yml
+++ b/.github/workflows/cartera-phase2-hardening.yml
@@ -212,7 +212,6 @@ jobs:
           provider=Path('supabase/migrations/20260814062000_phase2_auth_provider_boundary.sql').read_text(encoding='utf-8')
           identity=Path('supabase/migrations/20260814063000_phase2_identity_admin_hardening.sql').read_text(encoding='utf-8')
           proxy=Path('app/server-phase2.js').read_text(encoding='utf-8')
-          f4_proxy=Path('app/server-f4.js').read_text(encoding='utf-8') if Path('app/server-f4.js').exists() else ''
           railway=Path('app/railway.json').read_text(encoding='utf-8')
           recovery=Path('supabase/rollbacks/20260814062000_phase2_emergency_recovery.sql').read_text(encoding='utf-8')
           assert 'aos_login_v3' in login and 'aos_verificar_2fa_v3' in login
@@ -226,11 +225,10 @@ jobs:
           assert '/api/send-2fa' in proxy and '/api/verify-turnstile' in proxy
           assert 'PHASE2_INTERNAL_PORT' in proxy
           assert 'LEGACY_AUTH_ENDPOINT_RETIRED' in proxy
-          production_runtime=railway.split('"environments"')[0]
           assert 'node staging-server.js' in railway
-          if 'node server-phase2.js' not in production_runtime:
-              assert 'node server-f4.js' in production_runtime
-              assert "spawn(process.execPath,['server-phase2.js']" in f4_proxy
+          # Production runtime topology is certified once, canonically, by
+          # ci/phase2-cartera/ui_contract.py above. Do not duplicate a stale
+          # direct-entry assumption here as wrappers evolve.
           assert 'legacy_bypass' in recovery and 'not_restored' in recovery
           PY
 

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'app/server-phase-s.js'
+      - 'app/auth-resend-reconcile.js'
       - 'app/railway.json'
       - 'app/server-f5.js'
       - 'app/server-wa4.js'
@@ -13,6 +14,7 @@ on:
       - 'app/server-f4.js'
       - 'app/wa-gateway.js'
       - 'ci/phase-s/**'
+      - 'ci/phase16/test_auth_resend_reconcile.js'
       - 'ci/phase4-revenue/**'
       - 'ci/wa2-conversation-live-inbox/**'
       - 'ci/wa3-boxes-routing-handoff/**'
@@ -55,12 +57,14 @@ jobs:
         run: |
           $files = @(
             'app/server-phase-s.js',
+            'app/auth-resend-reconcile.js',
             'app/server-f5.js',
             'app/server-wa4.js',
             'app/server-wa3.js',
             'app/server-wa2.js',
             'app/server-f4.js',
-            'app/wa-gateway.js'
+            'app/wa-gateway.js',
+            'ci/phase16/test_auth_resend_reconcile.js'
           )
           foreach ($file in $files) {
             node --check $file
@@ -73,37 +77,44 @@ jobs:
           node ci/phase-s/phase-s_contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Auth Resend private-vault regression
+        shell: powershell
+        run: |
+          node ci/phase16/test_auth_resend_reconcile.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: WA-1 gateway regression
         shell: powershell
         run: |
           node --test ci/wa1-secure-gateway/wa-gateway.test.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Node-owned cross-workstream contracts
+      - name: F4 runtime topology contract
         shell: powershell
         run: |
           node ci/phase4-revenue/ui_contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          node ci/phase5-historical-identity/f5_upload_contract.js
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Delegated Python topology gates
+      - name: F5 private-boundary topology contract
         shell: powershell
         run: |
-          Write-Host 'Python topology contracts are intentionally delegated to Linux Zero-Cost workflows.'
-          Write-Host 'Required independent checks: Revenue, WA-2, WA-3, WA-4, Cartera and F5.'
-          Write-Host 'Phase S FAST remains a Windows Node/runtime-chain gate and has no Python toolchain dependency.'
+          node ci/phase5-historical-identity/f5_upload_contract.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Security invariants
         shell: powershell
         run: |
           $s = Get-Content app/server-phase-s.js -Raw
+          $sync = Get-Content app/auth-resend-reconcile.js -Raw
           $rail = Get-Content app/railway.json -Raw
           if ($s -notmatch 'aos_wa3_actor_v1') { throw 'WA3 actor authorization missing' }
           if ($s -notmatch 'human_send_enabled:false') { throw 'human send fail-closed default missing' }
           if ($s -notmatch 'auto_routing_enabled:false') { throw 'auto routing fail-closed default missing' }
           if ($s -notmatch 'ai_send_enabled:false') { throw 'AI send fail-closed default missing' }
-          if ($s -match '(SUPABASE_SERVICE_ROLE_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
+          if ($s -notmatch "p==='/api/auth/v3/login'") { throw 'Auth V3 reconcile gate missing' }
+          if ($sync -notmatch 'aos_integration_secrets_v1') { throw 'Private integration vault target missing' }
+          if ($sync -match '/rest/v1/aos_integraciones(?:\?|["''])') { throw 'Public integration catalog must not receive provider secret' }
+          if (($s + $sync) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
           $legacy = '"startCommand"\s*:\s*"node server-phase-s\.js"'
           $sentinel = '"startCommand"\s*:\s*"env NODE_OPTIONS=''--require \./sentinel-sentry-init\.cjs'' node server-phase-s\.js"'
           if (($rail -notmatch $legacy) -and ($rail -notmatch $sentinel)) { throw 'Railway certified Phase S start command missing' }
@@ -112,15 +123,22 @@ jobs:
             if ([string]$cfg.build.buildCommand -match 'NODE_OPTIONS') { throw 'Sentinel preload must not contaminate build' }
           }
 
-      - name: DB gates remain canonical and independent
+      - name: Delegated Linux contracts remain canonical
         shell: powershell
         run: |
           Write-Host 'Phase S adds no DB migration or schema object.'
-          Write-Host 'WA-2/WA-3/F4/WA-4/F5 DB/RLS/pgTAP remain owned by their Linux Zero-Cost workflows.'
+          Write-Host 'Python and DB/RLS/pgTAP contracts remain owned by Linux Zero-Cost workflows.'
+          $required = @(
+            'ci/phase4-revenue/ui_contract.py',
+            'ci/wa2-conversation-live-inbox/ui_contract.py',
+            'ci/wa3-boxes-routing-handoff/ui_contract.py',
+            'ci/wa4-ai-sales-router/ui_contract.py'
+          )
+          foreach ($file in $required) { if (-not (Test-Path $file)) { throw "Delegated contract missing: $file" } }
 
       - name: Phase S gate summary
         shell: powershell
         run: |
-          Write-Host 'PHASE S WINDOWS NODE/RUNTIME-CHAIN GATE PASS'
-          Write-Host 'Python/DB gates are independently enforced by Linux Zero-Cost workflows.'
-          Write-Host 'Production gates remaining: deploy health, native reload canary, human outbound, Meta delivery/read receipt.'
+          Write-Host 'PHASE S NODE/RUNTIME GATE PASS'
+          Write-Host 'AUTH RESEND PRIVATE-VAULT RECONCILIATION GATE PASS'
+          Write-Host 'Production validation remaining: deploy health + authenticated 2FA email canary.'

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -42,17 +42,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-      - name: Provision Python consistently on FAST pool
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
 
       - name: Enforce self-hosted FAST lane
         shell: powershell
         run: |
           if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'Phase S must run on a self-hosted runner' }
           Write-Host "Runner: $env:RUNNER_NAME"
-          python --version
+          node --version
 
       - name: Runtime syntax
         shell: powershell
@@ -83,37 +79,20 @@ jobs:
           node --test ci/wa1-secure-gateway/wa-gateway.test.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: F4 runtime/UI topology contracts
+      - name: Node-owned cross-workstream contracts
         shell: powershell
         run: |
-          python ci/phase4-revenue/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node ci/phase4-revenue/ui_contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-2 inbox topology contract
-        shell: powershell
-        run: |
-          python ci/wa2-conversation-live-inbox/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-3 routing topology contract
-        shell: powershell
-        run: |
-          python ci/wa3-boxes-routing-handoff/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-4 AI boundary topology contract
-        shell: powershell
-        run: |
-          python ci/wa4-ai-sales-router/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: F5 private-boundary topology contract
-        shell: powershell
-        run: |
           node ci/phase5-historical-identity/f5_upload_contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Delegated Python topology gates
+        shell: powershell
+        run: |
+          Write-Host 'Python topology contracts are intentionally delegated to Linux Zero-Cost workflows.'
+          Write-Host 'Required independent checks: Revenue, WA-2, WA-3, WA-4, Cartera and F5.'
+          Write-Host 'Phase S FAST remains a Windows Node/runtime-chain gate and has no Python toolchain dependency.'
 
       - name: Security invariants
         shell: powershell
@@ -142,5 +121,6 @@ jobs:
       - name: Phase S gate summary
         shell: powershell
         run: |
-          Write-Host 'PHASE S FULL STATIC/RUNTIME-CHAIN GATE PASS'
+          Write-Host 'PHASE S WINDOWS NODE/RUNTIME-CHAIN GATE PASS'
+          Write-Host 'Python/DB gates are independently enforced by Linux Zero-Cost workflows.'
           Write-Host 'Production gates remaining: deploy health, native reload canary, human outbound, Meta delivery/read receipt.'

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -42,29 +42,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-
-      - name: Resolve system Python
-        shell: powershell
-        run: |
-          if (Get-Command python -ErrorAction SilentlyContinue) {
-            python --version
-            exit 0
-          }
-          if (Get-Command py -ErrorAction SilentlyContinue) {
-            $shim = Join-Path $env:RUNNER_TEMP 'ascenda-python-bin'
-            New-Item -ItemType Directory -Force -Path $shim | Out-Null
-            "@echo off`r`npy -3 %*" | Set-Content -Path (Join-Path $shim 'python.cmd') -Encoding ascii
-            $shim | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            py -3 --version
-            exit 0
-          }
-          throw 'Python runtime missing on ASCENDA FAST runner'
+      - name: Provision Python consistently on FAST pool
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
       - name: Enforce self-hosted FAST lane
         shell: powershell
         run: |
           if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'Phase S must run on a self-hosted runner' }
           Write-Host "Runner: $env:RUNNER_NAME"
+          python --version
 
       - name: Runtime syntax
         shell: powershell
@@ -137,7 +125,13 @@ jobs:
           if ($s -notmatch 'auto_routing_enabled:false') { throw 'auto routing fail-closed default missing' }
           if ($s -notmatch 'ai_send_enabled:false') { throw 'AI send fail-closed default missing' }
           if ($s -match '(SUPABASE_SERVICE_ROLE_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
-          if ($rail -notmatch '"startCommand"\s*:\s*"node server-phase-s\.js"') { throw 'Railway Phase S start command missing' }
+          $legacy = '"startCommand"\s*:\s*"node server-phase-s\.js"'
+          $sentinel = '"startCommand"\s*:\s*"env NODE_OPTIONS=''--require \./sentinel-sentry-init\.cjs'' node server-phase-s\.js"'
+          if (($rail -notmatch $legacy) -and ($rail -notmatch $sentinel)) { throw 'Railway certified Phase S start command missing' }
+          if ($rail -match $sentinel) {
+            $cfg = $rail | ConvertFrom-Json
+            if ([string]$cfg.build.buildCommand -match 'NODE_OPTIONS') { throw 'Sentinel preload must not contaminate build' }
+          }
 
       - name: DB gates remain canonical and independent
         shell: powershell

--- a/.github/workflows/sentinel-phase4-sentry.yml
+++ b/.github/workflows/sentinel-phase4-sentry.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'app/package.json'
       - 'app/sentinel-sentry-init.cjs'
+      - 'app/railway.json'
+      - 'app/server-phase-s.js'
       - 'sentinel/sentry/**'
       - 'ci/sentinel/fixtures/f4_*'
       - 'ci/sentinel/phase4_sentry_contract.js'

--- a/.github/workflows/wa2-conversation-live-inbox.yml
+++ b/.github/workflows/wa2-conversation-live-inbox.yml
@@ -78,7 +78,7 @@ jobs:
           grep -q "nivel_jerarquia" app/server-wa2.js
           grep -q "SUPABASE_SERVICE_ROLE_KEY" app/server-wa2.js
           grep -q "X-Ascenda-WA2-Inbox" app/server-wa2.js
-          grep -q "node server-wa2.js" app/railway.json
+          # Runtime topology/start-command compatibility is certified by ui_contract.py above.
           ! grep -Eq "(SUPABASE_SERVICE_ROLE_KEY|SUPABASE_ANON_KEY)\s*=\s*['\"][^'\"]+['\"]" app/server-wa2.js
           ! grep -Eq "Bearer [A-Za-z0-9_-]{20,}" app/server-wa2.js app/public/admin-whatsapp.html
           ! grep -q "supabase.co" app/public/admin-whatsapp.html

--- a/app/railway.json
+++ b/app/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "echo 'Skip build — Phase S outer runtime: node server-phase-s.js -> server-f5.js -> server-wa4.js -> server-wa3.js -> server-wa2.js -> server-f4.js'"
   },
   "deploy": {
-    "startCommand": "node server-phase-s.js",
+    "startCommand": "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE"

--- a/ci/phase-s/phase-s_contract.js
+++ b/ci/phase-s/phase-s_contract.js
@@ -4,6 +4,7 @@ const assert=require('assert');
 
 const s=fs.readFileSync('app/server-phase-s.js','utf8');
 const railway=fs.readFileSync('app/railway.json','utf8');
+const authSync=fs.readFileSync('app/auth-resend-reconcile.js','utf8');
 
 assert(s.includes("['server-f5.js']"),'Phase S must wrap the certified server-f5 chain');
 assert(s.includes("p==='/api/wa3/bootstrap'"),'Phase S must intercept WA3 bootstrap');
@@ -14,11 +15,20 @@ assert(s.includes("auto_routing_enabled:false"),'degraded control must fail clos
 assert(s.includes("ai_send_enabled:false"),'degraded control must fail closed for AI send');
 assert(s.includes("p==='/api/phase-s/status'"),'Phase S must expose protected diagnostics');
 assert(s.includes("p==='/health'"),'Phase S must expose non-secret Railway health');
+assert(s.includes("p==='/api/auth/v3/login'"),'Phase S must preserve Auth V3 Resend reconcile gate');
+assert(authSync.includes('aos_integration_secrets_v1'),'Auth Resend sync must target private integration vault');
+assert(!authSync.includes('/rest/v1/aos_integraciones?'),'Auth Resend sync must not write public integration catalog');
 assert(!/WHATSAPP_ACCESS_TOKEN\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded Meta access token');
 assert(!/SUPABASE_SERVICE_ROLE_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded service role');
+assert(!/RESEND_API_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+authSync),'no hard-coded Resend API key');
 
 const cfg=JSON.parse(railway);
-assert.strictEqual(cfg.deploy.startCommand,'node server-phase-s.js');
+const legacy='node server-phase-s.js';
+const sentinel="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
+assert([legacy,sentinel].includes(cfg.deploy.startCommand),'Phase S start command must be legacy or exact Sentinel runtime wrapper');
+if(cfg.deploy.startCommand===sentinel){
+  assert(!String(cfg.build&&cfg.build.buildCommand||'').includes('NODE_OPTIONS'),'Sentinel preload must not contaminate build');
+}
 assert.strictEqual(cfg.deploy.healthcheckPath,'/health');
 
 console.log('PHASE_S_CONTRACT_PASS');

--- a/ci/phase2-cartera/ui_contract.py
+++ b/ci/phase2-cartera/ui_contract.py
@@ -68,14 +68,19 @@ assert 'if (abonoFailed)' in caja
 
 # Production runtime compatibility is explicit, not arbitrary wrapper acceptance.
 prod = railway.split('"environments"')[0]
+sentinel_phase_s = "\"startCommand\": \"env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js\""
 direct_phase2 = '"startCommand": "node server-phase2.js"' in prod
 f4_chain = '"startCommand": "node server-f4.js"' in prod and "spawn(process.execPath,['server-phase2.js']" in f4
 wa2_chain = ('"startCommand": "node server-wa2.js"' in prod and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
 wa3_chain = ('"startCommand": "node server-wa3.js"' in prod and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3 and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
 wa4_chain = ('"startCommand": "node server-wa4.js"' in prod and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3 and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
 f5_chain = ('"startCommand": "node server-f5.js"' in prod and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3 and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
-phase_s_chain = ('"startCommand": "node server-phase-s.js"' in prod and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3 and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
+phase_s_entry = ('"startCommand": "node server-phase-s.js"' in prod or sentinel_phase_s in prod)
+phase_s_chain = (phase_s_entry and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3 and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2 and "spawn(process.execPath,['server-phase2.js']" in f4)
 assert direct_phase2 or f4_chain or wa2_chain or wa3_chain or wa4_chain or f5_chain or phase_s_chain, 'Cartera requires certified Phase2 runtime chain'
+if sentinel_phase_s in prod:
+    build = railway.split('"deploy"')[0]
+    assert 'NODE_OPTIONS' not in build, 'Sentinel preload must not contaminate build'
 assert 'LEGACY_AUTH_ENDPOINT_RETIRED' in phase2
 
 assert "enable row level security" in migration.lower()

--- a/ci/phase5-historical-identity/f5_upload_contract.js
+++ b/ci/phase5-historical-identity/f5_upload_contract.js
@@ -22,9 +22,15 @@ ok(html.includes('X-AOS-App-Token')&&html.includes('X-AOS-Source-Filename'),'adm
 ok(html.includes('No crea pacientes')&&html.includes('no fusiona identidades'),'safety disclosure missing');
 ok(pkg.dependencies&&pkg.dependencies.exceljs==='4.4.0','ExcelJS version must be pinned');
 ok(pkg.scripts.start==='node server-f5.js','npm start must enter F5 wrapper');
-const directF5=rail.deploy.startCommand==='node server-f5.js';
-const phaseSWrapped=rail.deploy.startCommand==='node server-phase-s.js'&&phaseS.includes("['server-f5.js']")&&phaseS.includes('proxy(req,res)');
+const start=rail.deploy.startCommand;
+const sentinelPhaseS="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
+const directF5=start==='node server-f5.js';
+const phaseSEntry=start==='node server-phase-s.js'||start===sentinelPhaseS;
+const phaseSWrapped=phaseSEntry&&phaseS.includes("['server-f5.js']")&&phaseS.includes('proxy(req,res)');
 ok(directF5||phaseSWrapped,'Railway must enter F5 directly or through certified Phase S wrapper');
+if(start===sentinelPhaseS){
+  ok(rail.build&&!String(rail.build.buildCommand).includes('NODE_OPTIONS'),'Sentinel preload must not contaminate build');
+}
 if(phaseSWrapped){
   ok(String(rail.build.buildCommand).includes('server-phase-s.js'),'Phase S chain declaration missing');
   ok(String(rail.build.buildCommand).includes('server-f5.js'),'F5 chain declaration missing');

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -110,7 +110,7 @@ function changedFiles(){
     try{cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean)}catch(_){return []}
   }
 }
-const allowed=new Set([P.f4wf,P.wa2wf,P.phaseSwf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js','ci/phase-s/phase-s_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
+const allowed=new Set([P.f4wf,P.wa2wf,P.phaseSwf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js','ci/phase-s/phase-s_contract.js','.github/workflows/cartera-phase2-hardening.yml',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
 const changed=changedFiles();
 for(const p of changed)ok(allowed.has(p),`F4_SCOPE_UNEXPECTED_FILE:${p}`);
 ok(!changed.some(p=>p.startsWith('supabase/migrations/')||p.startsWith('supabase/functions/')),'F4_DB_MUTATION_FORBIDDEN');

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -20,6 +20,7 @@ const RUNBOOK_PATH = 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md';
 const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
 const F5_RUNTIME_CONTRACT = 'ci/phase5-historical-identity/f5_upload_contract.js';
 const WA2_RUNTIME_CONTRACT = 'ci/wa2-conversation-live-inbox/ui_contract.py';
+const CARTERA_RUNTIME_CONTRACT = 'ci/phase2-cartera/ui_contract.py';
 
 function fail(msg) { throw new Error(msg); }
 function ok(value, msg) { if (!value) fail(msg); }
@@ -45,6 +46,7 @@ const report = read(REPORT_PATH);
 const runbook = read(RUNBOOK_PATH);
 const f5RuntimeContract = read(F5_RUNTIME_CONTRACT);
 const wa2RuntimeContract = read(WA2_RUNTIME_CONTRACT);
+const carteraRuntimeContract = read(CARTERA_RUNTIME_CONTRACT);
 
 ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
 ok(f4.schema_version === 'sentinel-sentry-core/v1' && f4.phase === 'F4', 'F4_CONTRACT_INVALID');
@@ -87,6 +89,7 @@ ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"
 ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'), 'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
 ok(f5RuntimeContract.includes('sentinelPhaseS') && f5RuntimeContract.includes('Sentinel preload must not contaminate build'), 'F5_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 ok(wa2RuntimeContract.includes('sentinel_phase_s') && wa2RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA2_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
+ok(carteraRuntimeContract.includes('sentinel_phase_s') && carteraRuntimeContract.includes('Sentinel preload must not contaminate build'), 'CARTERA_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 
 for (const token of [
   'sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0',
@@ -150,7 +153,7 @@ const allowed = new Set([
   '.github/workflows/sentinel-phase1-governance.yml', WORKFLOW_PATH,
   'app/package.json', INIT_PATH, RAILWAY_PATH,
   CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH,
-  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT
+  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT, CARTERA_RUNTIME_CONTRACT
 ]);
 const changed = changedFiles();
 for (const p of changed) ok(allowed.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -1,203 +1,115 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const cp = require('child_process');
+const fs=require('fs');
+const path=require('path');
+const cp=require('child_process');
+const ROOT=path.resolve(__dirname,'../..');
+const APP=path.join(ROOT,'app');
+const P={
+  init:'app/sentinel-sentry-init.cjs', railway:'app/railway.json', phaseS:'app/server-phase-s.js',
+  contract:'sentinel/sentry/f4-contract.json', fixture:'ci/sentinel/fixtures/f4_sentry_sensitive_event.json',
+  f1:'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md', f1wf:'.github/workflows/sentinel-phase1-governance.yml',
+  f2:'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json', f3:'sentinel/telemetry/contract-v1.json',
+  report:'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md', runbook:'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md',
+  f4wf:'.github/workflows/sentinel-phase4-sentry.yml', wa2wf:'.github/workflows/wa2-conversation-live-inbox.yml',
+  f5:'ci/phase5-historical-identity/f5_upload_contract.js', wa2:'ci/wa2-conversation-live-inbox/ui_contract.py',
+  wa3:'ci/wa3-boxes-routing-handoff/ui_contract.py', wa4:'ci/wa4-ai-sales-router/ui_contract.py',
+  cartera:'ci/phase2-cartera/ui_contract.py'
+};
+const ok=(v,m)=>{if(!v)throw new Error(m)};
+const read=p=>{const a=path.join(ROOT,p);ok(fs.existsSync(a),`MISSING_FILE:${p}`);return fs.readFileSync(a,'utf8')};
+const json=p=>JSON.parse(read(p));
 
-const ROOT = path.resolve(__dirname, '../..');
-const APP = path.join(ROOT, 'app');
-const INIT_PATH = 'app/sentinel-sentry-init.cjs';
-const RAILWAY_PATH = 'app/railway.json';
-const PHASE_S_PATH = 'app/server-phase-s.js';
-const CONTRACT_PATH = 'sentinel/sentry/f4-contract.json';
-const FIXTURE_PATH = 'ci/sentinel/fixtures/f4_sentry_sensitive_event.json';
-const F1_POLICY = 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md';
-const F1_WORKFLOW = '.github/workflows/sentinel-phase1-governance.yml';
-const F2_REGISTRY = 'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json';
-const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
-const REPORT_PATH = 'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md';
-const RUNBOOK_PATH = 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md';
-const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
-const F5_RUNTIME_CONTRACT = 'ci/phase5-historical-identity/f5_upload_contract.js';
-const WA2_RUNTIME_CONTRACT = 'ci/wa2-conversation-live-inbox/ui_contract.py';
-const WA3_RUNTIME_CONTRACT = 'ci/wa3-boxes-routing-handoff/ui_contract.py';
-const WA4_RUNTIME_CONTRACT = 'ci/wa4-ai-sales-router/ui_contract.py';
-const CARTERA_RUNTIME_CONTRACT = 'ci/phase2-cartera/ui_contract.py';
+const pkg=json('app/package.json'), f4=json(P.contract), f3=json(P.f3), f2=json(P.f2), fixture=json(P.fixture);
+const f1=read(P.f1), f1wf=read(P.f1wf), init=read(P.init), railway=json(P.railway), phaseS=read(P.phaseS);
+const report=read(P.report), runbook=read(P.runbook), f4wf=read(P.f4wf), wa2wf=read(P.wa2wf);
+const runtimeContracts={f5:read(P.f5),wa2:read(P.wa2),wa3:read(P.wa3),wa4:read(P.wa4),cartera:read(P.cartera)};
 
-function fail(msg) { throw new Error(msg); }
-function ok(value, msg) { if (!value) fail(msg); }
-function read(p) {
-  const abs = path.join(ROOT, p);
-  ok(fs.existsSync(abs), `MISSING_FILE:${p}`);
-  return fs.readFileSync(abs, 'utf8');
+// SDK and prior-phase material invariants.
+ok(pkg.dependencies?.['@sentry/node']==='10.70.0','SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
+ok(f4.schema_version==='sentinel-sentry-core/v1'&&f4.phase==='F4','F4_CONTRACT_INVALID');
+ok(f4.sdk?.package==='@sentry/node'&&f4.sdk?.version==='10.70.0','F4_SDK_CONTRACT_DRIFT');
+for(const t of ['Zero-PHI/PII','allowlist-first','Session Replay: **OFF**','attachments: **OFF**','pay-as-you-go: OFF']) ok(f1.includes(t),`F1_MATERIAL_INVARIANT_MISSING:${t}`);
+ok(f2.rules?.default_observability_state==='UNKNOWN','F2_UNKNOWN_DEFAULT_DRIFT');
+ok(f2.rules?.phi_pii_telemetry_allowed===false,'F2_PHI_POLICY_DRIFT');
+ok(Array.isArray(f2.runtime?.chain)&&f2.runtime.chain.length===8,'F2_RUNTIME_CHAIN_DRIFT');
+ok(fs.readdirSync(path.join(APP,'public')).filter(x=>x.endsWith('.html')).length===41,'F2_PUBLIC_HTML_DRIFT');
+ok(f3.schema_version==='sentinel-telemetry-contract/v1','F3_SCHEMA_DRIFT');
+ok(f3.design?.zero_phi_pii===true&&f3.design?.allowlist_first===true&&f3.design?.baggage_enabled===false,'F3_PRIVACY_DRIFT');
+ok(f3.sampling?.defaults?.production===0,'F3_PRODUCTION_SAMPLING_DRIFT');
+for(const broad of ['docs/control/SENTINEL_*.md','ci/sentinel/**']) ok(!f1wf.includes(broad),`F1_WORKFLOW_CROSS_PHASE_TRIGGER_FORBIDDEN:${broad}`);
+
+// F4 activation/privacy/cost invariants.
+ok(f4.activation?.default_active===false,'F4_DEFAULT_MUST_OFF');
+ok(f4.activation?.master_switch==='SENTINEL_ENABLED'&&f4.activation?.sensor_switch==='SENTINEL_SENTRY_ENABLED','F4_SWITCH_DRIFT');
+ok(f4.activation?.canary_switch==='SENTINEL_SENTRY_CANARY_MODE'&&f4.activation?.canary_default===true,'F4_CANARY_DRIFT');
+ok(f4.activation?.synthetic_boot_switch==='SENTINEL_SENTRY_SYNTHETIC_ON_BOOT'&&f4.activation?.synthetic_code==='SENTINEL_F4_SYNTHETIC_ERROR','F4_SYNTHETIC_DRIFT');
+ok(f4.privacy?.send_default_pii===false&&f4.privacy?.breadcrumbs===0&&f4.privacy?.logs===false&&f4.privacy?.local_variables===false,'F4_PRIVACY_OPTIONS_DRIFT');
+ok(f4.sampling?.traces_sample_rate===0,'F4_TRACING_MUST_ZERO');
+ok(f4.cost?.incremental_cloud_budget_usd_month===0&&f4.cost?.pay_as_you_go===false,'F4_COST_DRIFT');
+
+// Build/runtime isolation.
+const START="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
+ok(railway.deploy?.startCommand===START,`F4_RUNTIME_START_COMMAND_DRIFT:${railway.deploy?.startCommand}`);
+ok(f4.activation?.preload_scope==='runtime-command-only-not-global-railway-variable','F4_PRELOAD_SCOPE_DRIFT');
+ok(f4.activation?.runtime_start_command===START,'F4_CONTRACT_RUNTIME_COMMAND_DRIFT');
+ok(typeof railway.build?.buildCommand==='string'&&!railway.build.buildCommand.includes('NODE_OPTIONS'),'F4_BUILD_MUST_NOT_PRELOAD_SENTRY');
+ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"),'F4_CHILD_ENV_INHERITANCE_DRIFT');
+ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'),'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
+
+// Historical contracts may accept ONLY the legacy Phase-S entry or the exact Sentinel wrapper.
+for(const [name,text] of Object.entries(runtimeContracts)){
+  const marker=name==='f5'?'sentinelPhaseS':'sentinel_phase_s';
+  ok(text.includes(marker),`${name.toUpperCase()}_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE`);
+  ok(text.includes('Sentinel preload must not contaminate build'),`${name.toUpperCase()}_BUILD_GUARD_MISSING`);
 }
-function json(p) { return JSON.parse(read(p)); }
+ok(!wa2wf.includes('grep -q "node server-wa2.js" app/railway.json'),'WA2_STALE_START_COMMAND_GREP');
+ok(wa2wf.includes('Runtime topology/start-command compatibility is certified by ui_contract.py'),'WA2_WORKFLOW_RUNTIME_CONTRACT_HANDOFF_MISSING');
 
-const pkg = json('app/package.json');
-const f4 = json(CONTRACT_PATH);
-const f3 = json(F3_CONTRACT);
-const f2 = json(F2_REGISTRY);
-const f1 = read(F1_POLICY);
-const f1Workflow = read(F1_WORKFLOW);
-const fixture = json(FIXTURE_PATH);
-const initSource = read(INIT_PATH);
-const railway = json(RAILWAY_PATH);
-const phaseS = read(PHASE_S_PATH);
-const workflow = read(WORKFLOW_PATH);
-const report = read(REPORT_PATH);
-const runbook = read(RUNBOOK_PATH);
-const f5RuntimeContract = read(F5_RUNTIME_CONTRACT);
-const wa2RuntimeContract = read(WA2_RUNTIME_CONTRACT);
-const wa3RuntimeContract = read(WA3_RUNTIME_CONTRACT);
-const wa4RuntimeContract = read(WA4_RUNTIME_CONTRACT);
-const carteraRuntimeContract = read(CARTERA_RUNTIME_CONTRACT);
+// Defensive Sentry source options.
+for(const t of ['sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0','includeLocalVariables: false','beforeBreadcrumb: () => null','beforeSend: event => {','SENTINEL_ENABLED','SENTINEL_SENTRY_ENABLED','SENTINEL_SENTRY_CANARY_MODE','SENTINEL_SENTRY_SYNTHETIC_ON_BOOT','SENTRY_DSN','SENTINEL_F4_SYNTHETIC_ERROR']) ok(init.includes(t),`INIT_GUARD_MISSING:${t}`);
 
-ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
-ok(f4.schema_version === 'sentinel-sentry-core/v1' && f4.phase === 'F4', 'F4_CONTRACT_INVALID');
-ok(f4.sdk.package === '@sentry/node' && f4.sdk.version === '10.70.0', 'F4_SDK_CONTRACT_DRIFT');
-for (const token of ['Zero-PHI/PII','allowlist-first','Session Replay: **OFF**','attachments: **OFF**','pay-as-you-go: OFF']) {
-  ok(f1.includes(token), `F1_MATERIAL_INVARIANT_MISSING:${token}`);
-}
-ok(f2.rules.default_observability_state === 'UNKNOWN', 'F2_UNKNOWN_DEFAULT_DRIFT');
-ok(f2.rules.phi_pii_telemetry_allowed === false, 'F2_PHI_POLICY_DRIFT');
-ok(Array.isArray(f2.runtime.chain) && f2.runtime.chain.length === 8, 'F2_RUNTIME_CHAIN_DRIFT');
-ok(fs.readdirSync(path.join(APP, 'public')).filter(x => x.endsWith('.html')).length === 41, 'F2_PUBLIC_HTML_DRIFT');
-ok(f3.schema_version === 'sentinel-telemetry-contract/v1', 'F3_SCHEMA_DRIFT');
-ok(f3.design.zero_phi_pii === true && f3.design.allowlist_first === true, 'F3_PRIVACY_DRIFT');
-ok(f3.design.baggage_enabled === false, 'F3_BAGGAGE_DRIFT');
-ok(f3.sampling.defaults.production === 0, 'F3_PRODUCTION_SAMPLING_DRIFT');
+// Installed package is reproducible in CI.
+const installedPath=path.join(APP,'node_modules/@sentry/node/package.json');
+ok(fs.existsSync(installedPath),'SENTRY_NODE_NOT_INSTALLED_IN_CI');
+ok(JSON.parse(fs.readFileSync(installedPath,'utf8')).version==='10.70.0','SENTRY_INSTALLED_VERSION_DRIFT');
 
-for (const broad of ['docs/control/SENTINEL_*.md', 'ci/sentinel/**']) {
-  ok(!f1Workflow.includes(broad), `F1_WORKFLOW_CROSS_PHASE_TRIGGER_FORBIDDEN:${broad}`);
-}
+// Default-off and missing-DSN fail closed for telemetry only.
+process.env.SENTINEL_ENABLED='false';process.env.SENTINEL_SENTRY_ENABLED='false';delete process.env.SENTRY_DSN;
+const telemetry=require(path.join(ROOT,P.init));
+ok(telemetry.status.requested===false&&telemetry.status.active===false&&telemetry.status.reason==='disabled','F4_DEFAULT_OFF_FAILED');
+ok(telemetry.status.canary_mode===true,'F4_CANARY_DEFAULT_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'true',SENTINEL_SENTRY_ENABLED:'true'})===true,'F4_DUAL_SWITCH_TRUE_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'false',SENTINEL_SENTRY_ENABLED:'true'})===false,'F4_MASTER_KILL_SWITCH_FAILED');
+const child="process.env.SENTINEL_ENABLED='true';process.env.SENTINEL_SENTRY_ENABLED='true';delete process.env.SENTRY_DSN;const x=require('./sentinel-sentry-init.cjs');process.stdout.write(JSON.stringify(x.status));";
+const childStatus=JSON.parse(cp.execFileSync(process.execPath,['-e',child],{cwd:APP,encoding:'utf8'}).trim());
+ok(childStatus.requested===true&&childStatus.active===false&&childStatus.reason==='missing_dsn','F4_MISSING_DSN_FAIL_CLOSED_FAILED');
 
-ok(f4.activation.default_active === false, 'F4_DEFAULT_MUST_OFF');
-ok(f4.activation.master_switch === 'SENTINEL_ENABLED', 'F4_MASTER_SWITCH_DRIFT');
-ok(f4.activation.sensor_switch === 'SENTINEL_SENTRY_ENABLED', 'F4_SENSOR_SWITCH_DRIFT');
-ok(f4.activation.canary_switch === 'SENTINEL_SENTRY_CANARY_MODE' && f4.activation.canary_default === true, 'F4_CANARY_DRIFT');
-ok(f4.activation.synthetic_boot_switch === 'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT', 'F4_SYNTHETIC_SWITCH_DRIFT');
-ok(f4.activation.synthetic_code === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SYNTHETIC_CODE_DRIFT');
-ok(f4.activation.preload_value === '--require ./sentinel-sentry-init.cjs', 'F4_PRELOAD_VALUE_DRIFT');
-ok(f4.activation.preload_scope === 'runtime-command-only-not-global-railway-variable', 'F4_PRELOAD_SCOPE_DRIFT');
-ok(f4.privacy.send_default_pii === false, 'F4_SEND_DEFAULT_PII_MUST_FALSE');
-ok(f4.privacy.breadcrumbs === 0 && f4.privacy.logs === false && f4.privacy.local_variables === false, 'F4_PRIVACY_OPTION_DRIFT');
-ok(f4.sampling.traces_sample_rate === 0, 'F4_TRACING_MUST_ZERO');
-ok(f4.cost.incremental_cloud_budget_usd_month === 0 && f4.cost.pay_as_you_go === false, 'F4_COST_DRIFT');
+// Adversarial privacy fixture.
+const clean=telemetry.sanitizeEvent(fixture), serialized=JSON.stringify(clean);
+for(const leak of ['fake.patient@example.invalid','+51 999 999 999','00000000','fake-access-token','fake-cookie','fake-service-role','fake-secret-value','synthetic AI prompt that must never leave','synthetic private message','FAKE NAME','FAKEUSER','patient-00000000']) ok(!serialized.includes(leak),`F4_PRIVACY_LEAK:${leak}`);
+for(const k of ['user','request','breadcrumbs','extra','contexts','transaction','modules','spans']) ok(!(k in clean),`F4_FORBIDDEN_EVENT_FIELD:${k}`);
+ok(clean.exception.values[0].value==='[REDACTED_MESSAGE]','F4_EXCEPTION_MESSAGE_NOT_REDACTED');
+ok(!('abs_path' in clean.exception.values[0].stacktrace.frames[0]),'F4_ABS_PATH_LEAK');
+const synth=telemetry.sanitizeEvent({level:'error',message:'SENTINEL_F4_SYNTHETIC_ERROR',exception:{values:[{type:'Error',value:'SENTINEL_F4_SYNTHETIC_ERROR',stacktrace:{frames:[]}}]},tags:{system:'ascenda-os','sentinel.phase':'F4','service.name':'synthetic.js'}});
+ok(telemetry.isSyntheticEvent(synth)===true&&telemetry.isSyntheticEvent(clean)===false,'F4_CANARY_FILTER_DRIFT');
+ok(telemetry.normalizeEnvironment('production')==='production','F4_ENVIRONMENT_NORMALIZATION_FAILED');
+ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}).startsWith('ascenda-os@'),'F4_RELEASE_FORMAT_FAILED');
 
-const expectedStart = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
-ok(railway.deploy.startCommand === expectedStart, `F4_RUNTIME_START_COMMAND_DRIFT:${railway.deploy.startCommand}`);
-ok(railway.build && typeof railway.build.buildCommand === 'string', 'F4_BUILD_COMMAND_MISSING');
-ok(!railway.build.buildCommand.includes('NODE_OPTIONS'), 'F4_BUILD_MUST_NOT_PRELOAD_SENTRY');
-ok(f4.activation.runtime_start_command === expectedStart, 'F4_CONTRACT_RUNTIME_COMMAND_DRIFT');
-ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"), 'F4_CHILD_ENV_INHERITANCE_DRIFT');
-ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'), 'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
-ok(f5RuntimeContract.includes('sentinelPhaseS') && f5RuntimeContract.includes('Sentinel preload must not contaminate build'), 'F5_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
-ok(wa2RuntimeContract.includes('sentinel_phase_s') && wa2RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA2_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
-ok(wa3RuntimeContract.includes('sentinel_phase_s') && wa3RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA3_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
-ok(wa4RuntimeContract.includes('sentinel_phase_s') && wa4RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA4_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
-ok(carteraRuntimeContract.includes('sentinel_phase_s') && carteraRuntimeContract.includes('Sentinel preload must not contaminate build'), 'CARTERA_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
-
-for (const token of [
-  'sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0',
-  'includeLocalVariables: false','beforeBreadcrumb: () => null','beforeSend: event => {',
-  'SENTINEL_ENABLED','SENTINEL_SENTRY_ENABLED','SENTINEL_SENTRY_CANARY_MODE',
-  'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT','SENTRY_DSN','SENTINEL_F4_SYNTHETIC_ERROR'
-]) ok(initSource.includes(token), `INIT_GUARD_MISSING:${token}`);
-
-const installedPkgPath = path.join(APP, 'node_modules/@sentry/node/package.json');
-ok(fs.existsSync(installedPkgPath), 'SENTRY_NODE_NOT_INSTALLED_IN_CI');
-ok(JSON.parse(fs.readFileSync(installedPkgPath, 'utf8')).version === '10.70.0', 'SENTRY_INSTALLED_VERSION_DRIFT');
-
-process.env.SENTINEL_ENABLED = 'false';
-process.env.SENTINEL_SENTRY_ENABLED = 'false';
-delete process.env.SENTRY_DSN;
-const telemetry = require(path.join(ROOT, INIT_PATH));
-ok(telemetry.status.requested === false && telemetry.status.active === false && telemetry.status.reason === 'disabled', 'F4_DEFAULT_OFF_FAILED');
-ok(telemetry.status.canary_mode === true, 'F4_CANARY_DEFAULT_FAILED');
-ok(telemetry.requested({SENTINEL_ENABLED:'true',SENTINEL_SENTRY_ENABLED:'true'}) === true, 'F4_DUAL_SWITCH_TRUE_FAILED');
-ok(telemetry.requested({SENTINEL_ENABLED:'false',SENTINEL_SENTRY_ENABLED:'true'}) === false, 'F4_MASTER_KILL_SWITCH_FAILED');
-const childCode = "process.env.SENTINEL_ENABLED='true';process.env.SENTINEL_SENTRY_ENABLED='true';delete process.env.SENTRY_DSN;const x=require('./sentinel-sentry-init.cjs');process.stdout.write(JSON.stringify(x.status));";
-const childStatus = JSON.parse(cp.execFileSync(process.execPath, ['-e', childCode], {cwd: APP, encoding: 'utf8'}).trim());
-ok(childStatus.requested === true && childStatus.active === false && childStatus.reason === 'missing_dsn', 'F4_MISSING_DSN_FAIL_CLOSED_FAILED');
-
-const clean = telemetry.sanitizeEvent(fixture);
-const serialized = JSON.stringify(clean);
-for (const leaked of [
-  'fake.patient@example.invalid','+51 999 999 999','00000000','fake-access-token','fake-cookie',
-  'fake-service-role','fake-secret-value','synthetic AI prompt that must never leave',
-  'synthetic private message','FAKE NAME','FAKEUSER','patient-00000000'
-]) ok(!serialized.includes(leaked), `F4_PRIVACY_LEAK:${leaked}`);
-for (const forbiddenKey of ['user','request','breadcrumbs','extra','contexts','transaction','modules','spans']) {
-  ok(!(forbiddenKey in clean), `F4_FORBIDDEN_EVENT_FIELD:${forbiddenKey}`);
-}
-ok(clean.exception.values[0].value === '[REDACTED_MESSAGE]', 'F4_EXCEPTION_MESSAGE_NOT_REDACTED');
-ok(!('abs_path' in clean.exception.values[0].stacktrace.frames[0]), 'F4_ABS_PATH_LEAK');
-
-const safeEvent = telemetry.sanitizeEvent({
-  level:'error',
-  message:'SENTINEL_F4_SYNTHETIC_ERROR',
-  exception:{values:[{type:'Error',value:'SENTINEL_F4_SYNTHETIC_ERROR',stacktrace:{frames:[]}}]},
-  tags:{system:'ascenda-os','sentinel.phase':'F4','service.name':'synthetic.js'}
-});
-ok(telemetry.isSyntheticEvent(safeEvent) === true, 'F4_SYNTHETIC_EVENT_NOT_RECOGNIZED');
-ok(telemetry.isSyntheticEvent(clean) === false, 'F4_REAL_FIXTURE_MUST_NOT_PASS_CANARY');
-ok(telemetry.normalizeEnvironment('production') === 'production', 'F4_ENVIRONMENT_NORMALIZATION_FAILED');
-ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}).startsWith('ascenda-os@'), 'F4_RELEASE_FORMAT_FAILED');
-
-function changedFiles() {
-  try {
-    cp.execFileSync('git', ['rev-parse','HEAD^2'], {cwd:ROOT, stdio:'ignore'});
-    return cp.execFileSync('git',['diff','--name-only','HEAD^1','HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean);
-  } catch (_) {
-    try {
-      cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});
-      return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean);
-    } catch (_) { return []; }
+// Exact hotfix scope; no wildcard workflow allowances.
+function changedFiles(){
+  try{cp.execFileSync('git',['rev-parse','HEAD^2'],{cwd:ROOT,stdio:'ignore'});return cp.execFileSync('git',['diff','--name-only','HEAD^1','HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean)}catch(_){
+    try{cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean)}catch(_){return []}
   }
 }
-const allowed = new Set([
-  '.github/workflows/sentinel-phase1-governance.yml', WORKFLOW_PATH,
-  'app/package.json', INIT_PATH, RAILWAY_PATH,
-  CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH,
-  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT, WA3_RUNTIME_CONTRACT, WA4_RUNTIME_CONTRACT, CARTERA_RUNTIME_CONTRACT
-]);
-const changed = changedFiles();
-for (const p of changed) ok(allowed.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);
-ok(!changed.some(p => p.startsWith('supabase/migrations/') || p.startsWith('supabase/functions/')), 'F4_DB_MUTATION_FORBIDDEN');
-const suspicious = [
-  /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,
-  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
-  /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
-  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
-];
-for (const p of [INIT_PATH, CONTRACT_PATH, REPORT_PATH, RUNBOOK_PATH, WORKFLOW_PATH, RAILWAY_PATH]) {
-  for (const re of suspicious) ok(!re.test(read(p)), `F4_SECRET_GUARD:${p}`);
-}
+const allowed=new Set([P.f4wf,P.wa2wf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
+const changed=changedFiles();
+for(const p of changed)ok(allowed.has(p),`F4_SCOPE_UNEXPECTED_FILE:${p}`);
+ok(!changed.some(p=>p.startsWith('supabase/migrations/')||p.startsWith('supabase/functions/')),'F4_DB_MUTATION_FORBIDDEN');
+const suspicious=[/https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,/\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,/\bsb_secret_[A-Za-z0-9_-]{20,}\b/,/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/];
+for(const p of [P.init,P.contract,P.report,P.runbook,P.f4wf,P.railway])for(const re of suspicious)ok(!re.test(read(p)),`F4_SECRET_GUARD:${p}`);
+for(const t of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING'])ok(report.includes(t),`F4_REPORT_MISSING:${t}`);
+for(const t of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js'])ok(f4wf.includes(t),`F4_WORKFLOW_MISSING:${t}`);
+for(const t of ['ubuntu-latest','windows-latest','macos-latest'])ok(!f4wf.includes(t),`F4_HOSTED_RUNNER_FORBIDDEN:${t}`);
 
-for (const token of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING']) ok(report.includes(token), `F4_REPORT_MISSING:${token}`);
-for (const token of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js']) ok(workflow.includes(token), `F4_WORKFLOW_MISSING:${token}`);
-for (const forbidden of ['ubuntu-latest','windows-latest','macos-latest']) ok(!workflow.includes(forbidden), `F4_HOSTED_RUNNER_FORBIDDEN:${forbidden}`);
-
-console.log(JSON.stringify({
-  ok:true,
-  certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',
-  sdk:'@sentry/node@10.70.0',
-  f1_privacy_material_regression:true,
-  f2_topology_material_regression:true,
-  f3_telemetry_material_regression:true,
-  default_active:false,
-  runtime_only_preload:true,
-  build_preload:false,
-  child_env_inheritance:true,
-  canary_default:true,
-  canary_only_synthetic:true,
-  missing_dsn_fail_closed:true,
-  zero_phi_pii_fixture:true,
-  fixture_leaks:0,
-  traces_sample_rate:0,
-  logs:false,
-  breadcrumbs:0,
-  pay_as_you_go:false,
-  human_boundary:'PENDING',
-  changed_files_checked:changed.length
-}, null, 2));
+console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',sdk:'@sentry/node@10.70.0',f1_privacy_material_regression:true,f2_topology_material_regression:true,f3_telemetry_material_regression:true,default_active:false,runtime_only_preload:true,build_preload:false,child_env_inheritance:true,canary_default:true,canary_only_synthetic:true,missing_dsn_fail_closed:true,zero_phi_pii_fixture:true,fixture_leaks:0,traces_sample_rate:0,logs:false,breadcrumbs:0,pay_as_you_go:false,human_boundary:'PENDING',changed_files_checked:changed.length},null,2));

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -110,7 +110,7 @@ function changedFiles(){
     try{cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean)}catch(_){return []}
   }
 }
-const allowed=new Set([P.f4wf,P.wa2wf,P.phaseSwf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
+const allowed=new Set([P.f4wf,P.wa2wf,P.phaseSwf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js','ci/phase-s/phase-s_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
 const changed=changedFiles();
 for(const p of changed)ok(allowed.has(p),`F4_SCOPE_UNEXPECTED_FILE:${p}`);
 ok(!changed.some(p=>p.startsWith('supabase/migrations/')||p.startsWith('supabase/functions/')),'F4_DB_MUTATION_FORBIDDEN');

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -20,6 +20,8 @@ const RUNBOOK_PATH = 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md';
 const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
 const F5_RUNTIME_CONTRACT = 'ci/phase5-historical-identity/f5_upload_contract.js';
 const WA2_RUNTIME_CONTRACT = 'ci/wa2-conversation-live-inbox/ui_contract.py';
+const WA3_RUNTIME_CONTRACT = 'ci/wa3-boxes-routing-handoff/ui_contract.py';
+const WA4_RUNTIME_CONTRACT = 'ci/wa4-ai-sales-router/ui_contract.py';
 const CARTERA_RUNTIME_CONTRACT = 'ci/phase2-cartera/ui_contract.py';
 
 function fail(msg) { throw new Error(msg); }
@@ -46,6 +48,8 @@ const report = read(REPORT_PATH);
 const runbook = read(RUNBOOK_PATH);
 const f5RuntimeContract = read(F5_RUNTIME_CONTRACT);
 const wa2RuntimeContract = read(WA2_RUNTIME_CONTRACT);
+const wa3RuntimeContract = read(WA3_RUNTIME_CONTRACT);
+const wa4RuntimeContract = read(WA4_RUNTIME_CONTRACT);
 const carteraRuntimeContract = read(CARTERA_RUNTIME_CONTRACT);
 
 ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
@@ -89,6 +93,8 @@ ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"
 ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'), 'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
 ok(f5RuntimeContract.includes('sentinelPhaseS') && f5RuntimeContract.includes('Sentinel preload must not contaminate build'), 'F5_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 ok(wa2RuntimeContract.includes('sentinel_phase_s') && wa2RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA2_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
+ok(wa3RuntimeContract.includes('sentinel_phase_s') && wa3RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA3_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
+ok(wa4RuntimeContract.includes('sentinel_phase_s') && wa4RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA4_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 ok(carteraRuntimeContract.includes('sentinel_phase_s') && carteraRuntimeContract.includes('Sentinel preload must not contaminate build'), 'CARTERA_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 
 for (const token of [
@@ -153,7 +159,7 @@ const allowed = new Set([
   '.github/workflows/sentinel-phase1-governance.yml', WORKFLOW_PATH,
   'app/package.json', INIT_PATH, RAILWAY_PATH,
   CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH,
-  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT, CARTERA_RUNTIME_CONTRACT
+  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT, WA3_RUNTIME_CONTRACT, WA4_RUNTIME_CONTRACT, CARTERA_RUNTIME_CONTRACT
 ]);
 const changed = changedFiles();
 for (const p of changed) ok(allowed.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -7,17 +7,20 @@ const cp = require('child_process');
 const ROOT = path.resolve(__dirname, '../..');
 const APP = path.join(ROOT, 'app');
 const INIT_PATH = 'app/sentinel-sentry-init.cjs';
+const RAILWAY_PATH = 'app/railway.json';
+const PHASE_S_PATH = 'app/server-phase-s.js';
 const CONTRACT_PATH = 'sentinel/sentry/f4-contract.json';
 const FIXTURE_PATH = 'ci/sentinel/fixtures/f4_sentry_sensitive_event.json';
 const F1_POLICY = 'docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md';
 const F1_WORKFLOW = '.github/workflows/sentinel-phase1-governance.yml';
-const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
 const F2_REGISTRY = 'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json';
+const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
 const REPORT_PATH = 'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md';
+const RUNBOOK_PATH = 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md';
 const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
 
 function fail(msg) { throw new Error(msg); }
-function ok(v, msg) { if (!v) fail(msg); }
+function ok(value, msg) { if (!value) fail(msg); }
 function read(p) {
   const abs = path.join(ROOT, p);
   ok(fs.existsSync(abs), `MISSING_FILE:${p}`);
@@ -33,230 +36,152 @@ const f1 = read(F1_POLICY);
 const f1Workflow = read(F1_WORKFLOW);
 const fixture = json(FIXTURE_PATH);
 const initSource = read(INIT_PATH);
+const railway = json(RAILWAY_PATH);
+const phaseS = read(PHASE_S_PATH);
 const workflow = read(WORKFLOW_PATH);
 const report = read(REPORT_PATH);
+const runbook = read(RUNBOOK_PATH);
 
-// Baseline / dependency pin.
-ok(f4.schema_version === 'sentinel-sentry-core/v1', 'F4_SCHEMA_INVALID');
-ok(f4.phase === 'F4', 'F4_PHASE_INVALID');
-ok(f4.baseline_main === 'e3ff8914447c06a2b94b3be5cccbade73526ce0d', 'F4_BASELINE_DRIFT');
 ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
+ok(f4.schema_version === 'sentinel-sentry-core/v1' && f4.phase === 'F4', 'F4_CONTRACT_INVALID');
 ok(f4.sdk.package === '@sentry/node' && f4.sdk.version === '10.70.0', 'F4_SDK_CONTRACT_DRIFT');
-
-const installedPkgPath = path.join(APP, 'node_modules/@sentry/node/package.json');
-ok(fs.existsSync(installedPkgPath), 'SENTRY_NODE_NOT_INSTALLED_IN_CI');
-const installed = JSON.parse(fs.readFileSync(installedPkgPath, 'utf8'));
-ok(installed.version === '10.70.0', `SENTRY_INSTALLED_VERSION_DRIFT:${installed.version}`);
-
-// Material F1/F3 invariants, without reusing old phase scope restrictions.
-for (const token of [
-  'Zero-PHI/PII',
-  'allowlist-first',
-  'Session Replay: **OFF**',
-  'attachments: **OFF**',
-  'request/response body capture: **OFF**',
-  'pay-as-you-go: OFF',
-  'SENTINEL_ENABLED',
-  'SENTINEL_SENTRY_ENABLED',
-  'Sentry temporalmente caído'
-]) ok(f1.includes(token), `F1_MATERIAL_INVARIANT_MISSING:${token}`);
-
-// F1's historical full certificate must not auto-run on every later Sentinel phase.
-// Later phases carry their own material F1 regression, as F4 does here.
-for (const token of [
-  "docs/control/SENTINEL_F1_GOVERNANCE_PRIVACY_COST_POLICY.md",
-  "docs/control/SENTINEL_F1_VALIDATION_REPORT_20260816.md",
-  "ci/sentinel/phase1_governance_contract.js"
-]) ok(f1Workflow.includes(token), `F1_WORKFLOW_NARROW_PATH_MISSING:${token}`);
-for (const broad of ["docs/control/SENTINEL_*.md", "ci/sentinel/**", "sentinel-phase1-governance.yml'"]) {
-  ok(!f1Workflow.includes(broad), `F1_WORKFLOW_CROSS_PHASE_TRIGGER_FORBIDDEN:${broad}`);
+for (const token of ['Zero-PHI/PII','allowlist-first','Session Replay: **OFF**','attachments: **OFF**','pay-as-you-go: OFF']) {
+  ok(f1.includes(token), `F1_MATERIAL_INVARIANT_MISSING:${token}`);
 }
-
-ok(f3.schema_version === 'sentinel-telemetry-contract/v1', 'F3_SCHEMA_DRIFT');
-ok(f3.design.zero_phi_pii === true, 'F3_ZERO_PHI_PII_DRIFT');
-ok(f3.design.allowlist_first === true, 'F3_ALLOWLIST_DRIFT');
-ok(f3.design.baggage_enabled === false, 'F3_BAGGAGE_DRIFT');
-ok(f3.sampling.defaults.production === 0, 'F3_PRODUCTION_SAMPLING_DRIFT');
-ok(f3.exporter.production_network_exporter_allowed === false, 'F3_NETWORK_EXPORT_BASELINE_DRIFT');
-
-// F2 topology remains material and false-green safe.
 ok(f2.rules.default_observability_state === 'UNKNOWN', 'F2_UNKNOWN_DEFAULT_DRIFT');
 ok(f2.rules.phi_pii_telemetry_allowed === false, 'F2_PHI_POLICY_DRIFT');
 ok(Array.isArray(f2.runtime.chain) && f2.runtime.chain.length === 8, 'F2_RUNTIME_CHAIN_DRIFT');
-const publicHtml = fs.readdirSync(path.join(APP, 'public')).filter(x => x.endsWith('.html'));
-ok(publicHtml.length === 41, `F2_PUBLIC_HTML_DRIFT:${publicHtml.length}`);
+ok(fs.readdirSync(path.join(APP, 'public')).filter(x => x.endsWith('.html')).length === 41, 'F2_PUBLIC_HTML_DRIFT');
+ok(f3.schema_version === 'sentinel-telemetry-contract/v1', 'F3_SCHEMA_DRIFT');
+ok(f3.design.zero_phi_pii === true && f3.design.allowlist_first === true, 'F3_PRIVACY_DRIFT');
+ok(f3.design.baggage_enabled === false, 'F3_BAGGAGE_DRIFT');
+ok(f3.sampling.defaults.production === 0, 'F3_PRODUCTION_SAMPLING_DRIFT');
 
-// F4 contract settings.
-ok(f4.activation.default_active === false, 'F4_MUST_DEFAULT_OFF');
+for (const broad of ['docs/control/SENTINEL_*.md', 'ci/sentinel/**']) {
+  ok(!f1Workflow.includes(broad), `F1_WORKFLOW_CROSS_PHASE_TRIGGER_FORBIDDEN:${broad}`);
+}
+
+ok(f4.activation.default_active === false, 'F4_DEFAULT_MUST_OFF');
 ok(f4.activation.master_switch === 'SENTINEL_ENABLED', 'F4_MASTER_SWITCH_DRIFT');
 ok(f4.activation.sensor_switch === 'SENTINEL_SENTRY_ENABLED', 'F4_SENSOR_SWITCH_DRIFT');
-ok(f4.activation.canary_switch === 'SENTINEL_SENTRY_CANARY_MODE', 'F4_CANARY_SWITCH_DRIFT');
-ok(f4.activation.canary_default === true, 'F4_CANARY_MUST_DEFAULT_TRUE');
+ok(f4.activation.canary_switch === 'SENTINEL_SENTRY_CANARY_MODE' && f4.activation.canary_default === true, 'F4_CANARY_DRIFT');
 ok(f4.activation.synthetic_boot_switch === 'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT', 'F4_SYNTHETIC_SWITCH_DRIFT');
 ok(f4.activation.synthetic_code === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SYNTHETIC_CODE_DRIFT');
-ok(f4.activation.dsn_variable === 'SENTRY_DSN', 'F4_DSN_VAR_DRIFT');
-ok(f4.activation.preload_value === '--require ./sentinel-sentry-init.cjs', 'F4_PRELOAD_DRIFT');
+ok(f4.activation.preload_value === '--require ./sentinel-sentry-init.cjs', 'F4_PRELOAD_VALUE_DRIFT');
+ok(f4.activation.preload_scope === 'runtime-command-only-not-global-railway-variable', 'F4_PRELOAD_SCOPE_DRIFT');
 ok(f4.privacy.send_default_pii === false, 'F4_SEND_DEFAULT_PII_MUST_FALSE');
-ok(f4.privacy.breadcrumbs === 0, 'F4_BREADCRUMBS_MUST_ZERO');
-ok(f4.privacy.logs === false, 'F4_LOGS_MUST_OFF');
-ok(f4.privacy.local_variables === false, 'F4_LOCAL_VARIABLES_MUST_OFF');
-ok(f4.sampling.traces_sample_rate === 0, 'F4_TRACES_MUST_ZERO');
-ok(f4.cost.incremental_cloud_budget_usd_month === 0, 'F4_BUDGET_MUST_ZERO');
-ok(f4.cost.pay_as_you_go === false, 'F4_PAYG_MUST_FALSE');
-ok(f4.human_boundary_gate.required === true && f4.human_boundary_gate.no_100_complete_before_gate === true, 'F4_HUMAN_GATE_REQUIRED');
+ok(f4.privacy.breadcrumbs === 0 && f4.privacy.logs === false && f4.privacy.local_variables === false, 'F4_PRIVACY_OPTION_DRIFT');
+ok(f4.sampling.traces_sample_rate === 0, 'F4_TRACING_MUST_ZERO');
+ok(f4.cost.incremental_cloud_budget_usd_month === 0 && f4.cost.pay_as_you_go === false, 'F4_COST_DRIFT');
 
-// Source must encode defensive SDK options explicitly.
+const expectedStart = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
+ok(railway.deploy.startCommand === expectedStart, `F4_RUNTIME_START_COMMAND_DRIFT:${railway.deploy.startCommand}`);
+ok(railway.build && typeof railway.build.buildCommand === 'string', 'F4_BUILD_COMMAND_MISSING');
+ok(!railway.build.buildCommand.includes('NODE_OPTIONS'), 'F4_BUILD_MUST_NOT_PRELOAD_SENTRY');
+ok(f4.activation.runtime_start_command === expectedStart, 'F4_CONTRACT_RUNTIME_COMMAND_DRIFT');
+ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"), 'F4_CHILD_ENV_INHERITANCE_DRIFT');
+ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'), 'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
+
 for (const token of [
-  'sendDefaultPii: false',
-  'tracesSampleRate: 0',
-  'enableLogs: false',
-  'maxBreadcrumbs: 0',
-  'includeLocalVariables: false',
-  'beforeBreadcrumb: () => null',
-  'beforeSend: event => {',
-  'SENTINEL_ENABLED',
-  'SENTINEL_SENTRY_ENABLED',
-  'SENTINEL_SENTRY_CANARY_MODE',
-  'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT',
-  'SENTRY_DSN',
-  'SENTINEL_F4_SYNTHETIC_ERROR'
+  'sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0',
+  'includeLocalVariables: false','beforeBreadcrumb: () => null','beforeSend: event => {',
+  'SENTINEL_ENABLED','SENTINEL_SENTRY_ENABLED','SENTINEL_SENTRY_CANARY_MODE',
+  'SENTINEL_SENTRY_SYNTHETIC_ON_BOOT','SENTRY_DSN','SENTINEL_F4_SYNTHETIC_ERROR'
 ]) ok(initSource.includes(token), `INIT_GUARD_MISSING:${token}`);
 
-// Load the preloader with switches explicitly disabled. It must not need DSN or network.
+const installedPkgPath = path.join(APP, 'node_modules/@sentry/node/package.json');
+ok(fs.existsSync(installedPkgPath), 'SENTRY_NODE_NOT_INSTALLED_IN_CI');
+ok(JSON.parse(fs.readFileSync(installedPkgPath, 'utf8')).version === '10.70.0', 'SENTRY_INSTALLED_VERSION_DRIFT');
+
 process.env.SENTINEL_ENABLED = 'false';
 process.env.SENTINEL_SENTRY_ENABLED = 'false';
 delete process.env.SENTRY_DSN;
 const telemetry = require(path.join(ROOT, INIT_PATH));
-ok(telemetry.status.requested === false, 'KILL_SWITCH_DEFAULT_REQUESTED');
-ok(telemetry.status.active === false, 'KILL_SWITCH_DEFAULT_ACTIVE');
-ok(telemetry.status.reason === 'disabled', 'KILL_SWITCH_DEFAULT_REASON');
-ok(telemetry.status.canary_mode === true, 'CANARY_DEFAULT_STATUS_MUST_TRUE');
-
-// Dual-switch and canary truth tables.
-ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'true'}) === true, 'DUAL_SWITCH_TRUE_FAILED');
-ok(telemetry.requested({SENTINEL_ENABLED:'true', SENTINEL_SENTRY_ENABLED:'false'}) === false, 'SENSOR_SWITCH_FALSE_FAILED');
-ok(telemetry.requested({SENTINEL_ENABLED:'false', SENTINEL_SENTRY_ENABLED:'true'}) === false, 'MASTER_SWITCH_FALSE_FAILED');
-ok(telemetry.canaryMode({}) === true, 'CANARY_DEFAULT_FAILED');
-ok(telemetry.canaryMode({SENTINEL_SENTRY_CANARY_MODE:'true'}) === true, 'CANARY_TRUE_FAILED');
-ok(telemetry.canaryMode({SENTINEL_SENTRY_CANARY_MODE:'false'}) === false, 'CANARY_FALSE_FAILED');
-
-// Missing DSN must fail closed for telemetry without loading a network exporter.
+ok(telemetry.status.requested === false && telemetry.status.active === false && telemetry.status.reason === 'disabled', 'F4_DEFAULT_OFF_FAILED');
+ok(telemetry.status.canary_mode === true, 'F4_CANARY_DEFAULT_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'true',SENTINEL_SENTRY_ENABLED:'true'}) === true, 'F4_DUAL_SWITCH_TRUE_FAILED');
+ok(telemetry.requested({SENTINEL_ENABLED:'false',SENTINEL_SENTRY_ENABLED:'true'}) === false, 'F4_MASTER_KILL_SWITCH_FAILED');
 const childCode = "process.env.SENTINEL_ENABLED='true';process.env.SENTINEL_SENTRY_ENABLED='true';delete process.env.SENTRY_DSN;const x=require('./sentinel-sentry-init.cjs');process.stdout.write(JSON.stringify(x.status));";
-const childRaw = cp.execFileSync(process.execPath, ['-e', childCode], {cwd: APP, encoding: 'utf8'}).trim();
-const childStatus = JSON.parse(childRaw);
-ok(childStatus.requested === true && childStatus.active === false && childStatus.reason === 'missing_dsn', 'MISSING_DSN_FAIL_CLOSED_FAILED');
-ok(childStatus.canary_mode === true, 'MISSING_DSN_CANARY_DEFAULT_FAILED');
+const childStatus = JSON.parse(cp.execFileSync(process.execPath, ['-e', childCode], {cwd: APP, encoding: 'utf8'}).trim());
+ok(childStatus.requested === true && childStatus.active === false && childStatus.reason === 'missing_dsn', 'F4_MISSING_DSN_FAIL_CLOSED_FAILED');
 
-// Adversarial privacy fixture must be minimized before Sentry export.
 const clean = telemetry.sanitizeEvent(fixture);
 const serialized = JSON.stringify(clean);
 for (const leaked of [
-  'fake.patient@example.invalid',
-  '+51 999 999 999',
-  '00000000',
-  'fake-access-token',
-  'fake-cookie',
-  'fake-service-role',
-  'fake-secret-value',
-  'synthetic AI prompt that must never leave',
-  'synthetic private message',
-  'FAKE NAME',
-  'FAKEUSER',
-  'patient-00000000'
+  'fake.patient@example.invalid','+51 999 999 999','00000000','fake-access-token','fake-cookie',
+  'fake-service-role','fake-secret-value','synthetic AI prompt that must never leave',
+  'synthetic private message','FAKE NAME','FAKEUSER','patient-00000000'
 ]) ok(!serialized.includes(leaked), `F4_PRIVACY_LEAK:${leaked}`);
-
 for (const forbiddenKey of ['user','request','breadcrumbs','extra','contexts','transaction','modules','spans']) {
   ok(!(forbiddenKey in clean), `F4_FORBIDDEN_EVENT_FIELD:${forbiddenKey}`);
 }
 ok(clean.exception.values[0].value === '[REDACTED_MESSAGE]', 'F4_EXCEPTION_MESSAGE_NOT_REDACTED');
-ok(clean.exception.values[0].stacktrace.frames[0].filename === 'server-phase-s.js', 'F4_FRAME_PATH_NOT_MINIMIZED');
 ok(!('abs_path' in clean.exception.values[0].stacktrace.frames[0]), 'F4_ABS_PATH_LEAK');
-ok(!('email' in clean.tags) && !('unknown.custom' in clean.tags), 'F4_TAG_ALLOWLIST_FAILED');
-ok(clean.tags.system === 'ascenda-os' && clean.tags['sentinel.phase'] === 'F4', 'F4_REQUIRED_TAGS_LOST');
-ok(telemetry.isSyntheticEvent(clean) === false, 'REAL_FIXTURE_MUST_NOT_PASS_CANARY');
 
-// Safe synthetic code remains useful for grouping/title and is the only canary event.
 const safeEvent = telemetry.sanitizeEvent({
-  level: 'error',
-  message: 'SENTINEL_F4_SYNTHETIC_ERROR',
-  exception: {values:[{type:'Error', value:'SENTINEL_F4_SYNTHETIC_ERROR', stacktrace:{frames:[]}}]},
-  tags: {system:'ascenda-os','sentinel.phase':'F4','service.name':'synthetic.js'}
+  level:'error',
+  message:'SENTINEL_F4_SYNTHETIC_ERROR',
+  exception:{values:[{type:'Error',value:'SENTINEL_F4_SYNTHETIC_ERROR',stacktrace:{frames:[]}}]},
+  tags:{system:'ascenda-os','sentinel.phase':'F4','service.name':'synthetic.js'}
 });
-ok(safeEvent.message === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_ERROR_CODE_LOST');
-ok(safeEvent.exception.values[0].value === 'SENTINEL_F4_SYNTHETIC_ERROR', 'F4_SAFE_EXCEPTION_CODE_LOST');
-ok(telemetry.isSyntheticEvent(safeEvent) === true, 'SYNTHETIC_EVENT_NOT_RECOGNIZED');
+ok(telemetry.isSyntheticEvent(safeEvent) === true, 'F4_SYNTHETIC_EVENT_NOT_RECOGNIZED');
+ok(telemetry.isSyntheticEvent(clean) === false, 'F4_REAL_FIXTURE_MUST_NOT_PASS_CANARY');
+ok(telemetry.normalizeEnvironment('production') === 'production', 'F4_ENVIRONMENT_NORMALIZATION_FAILED');
+ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}).startsWith('ascenda-os@'), 'F4_RELEASE_FORMAT_FAILED');
 
-// Release/environment rules.
-ok(telemetry.normalizeEnvironment('production') === 'production', 'ENV_PRODUCTION_FAILED');
-ok(telemetry.normalizeEnvironment('staging') === 'zero-cost', 'ENV_STAGING_FAILED');
-ok(telemetry.buildRelease({RAILWAY_GIT_COMMIT_SHA:'e3ff8914447c06a2b94b3be5cccbade73526ce0d'}) === 'ascenda-os@e3ff8914447c06a2b94b3be5cccbade73526ce0d', 'RELEASE_SHA_FAILED');
-ok(telemetry.buildRelease({}) === 'ascenda-os@unknown', 'RELEASE_FALLBACK_FAILED');
-
-// Scope: F4 foundation may add only dormant Sentry integration/test/control files
-// plus the one governance workflow fix that prevents cross-phase false-reds.
 function changedFiles() {
   try {
-    cp.execFileSync('git', ['rev-parse', 'HEAD^2'], {cwd: ROOT, stdio:'ignore'});
-    return cp.execFileSync('git', ['diff', '--name-only', 'HEAD^1', 'HEAD'], {cwd: ROOT, encoding:'utf8'})
-      .split(/\r?\n/).map(x => x.trim()).filter(Boolean);
+    cp.execFileSync('git', ['rev-parse','HEAD^2'], {cwd:ROOT, stdio:'ignore'});
+    return cp.execFileSync('git',['diff','--name-only','HEAD^1','HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean);
   } catch (_) {
     try {
-      cp.execFileSync('git', ['fetch','origin','main','--depth=1'], {cwd: ROOT, stdio:'ignore'});
-      return cp.execFileSync('git', ['diff','--name-only','origin/main...HEAD'], {cwd: ROOT, encoding:'utf8'})
-        .split(/\r?\n/).map(x => x.trim()).filter(Boolean);
+      cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});
+      return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean);
     } catch (_) { return []; }
   }
 }
-const changed = changedFiles();
-const allowedExact = new Set([
-  'app/package.json',
-  'app/sentinel-sentry-init.cjs',
-  CONTRACT_PATH,
-  FIXTURE_PATH,
-  'ci/sentinel/phase4_sentry_contract.js',
-  REPORT_PATH,
-  'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md',
-  WORKFLOW_PATH,
-  F1_WORKFLOW
+const allowed = new Set([
+  '.github/workflows/sentinel-phase1-governance.yml', WORKFLOW_PATH,
+  'app/package.json', INIT_PATH, RAILWAY_PATH,
+  CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH
 ]);
-for (const p of changed) ok(allowedExact.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);
-ok(!changed.includes('app/railway.json'), 'F4_FOUNDATION_MUST_NOT_CHANGE_RAILWAY');
-ok(!changed.some(p => p.startsWith('supabase/migrations/') || p.startsWith('supabase/functions/')), 'F4_FOUNDATION_DB_MUTATION');
-
-// Secret/DSN guard. Fixture contains only fake invalid values; repository must contain no real DSN/token patterns.
-const scanPaths = [INIT_PATH, CONTRACT_PATH, REPORT_PATH, 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md', WORKFLOW_PATH, F1_WORKFLOW, 'app/package.json'];
+const changed = changedFiles();
+for (const p of changed) ok(allowed.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);
+ok(!changed.some(p => p.startsWith('supabase/migrations/') || p.startsWith('supabase/functions/')), 'F4_DB_MUTATION_FORBIDDEN');
 const suspicious = [
   /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/[0-9]+/i,
   /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
   /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
   /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
 ];
-for (const p of scanPaths) for (const re of suspicious) ok(!re.test(read(p)), `F4_SECRET_GUARD:${p}`);
+for (const p of [INIT_PATH, CONTRACT_PATH, REPORT_PATH, RUNBOOK_PATH, WORKFLOW_PATH, RAILWAY_PATH]) {
+  for (const re of suspicious) ok(!re.test(read(p)), `F4_SECRET_GUARD:${p}`);
+}
 
 for (const token of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING']) ok(report.includes(token), `F4_REPORT_MISSING:${token}`);
-for (const token of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js','cancel-in-progress: true']) {
-  ok(workflow.includes(token), `F4_WORKFLOW_MISSING:${token}`);
-}
+for (const token of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js']) ok(workflow.includes(token), `F4_WORKFLOW_MISSING:${token}`);
 for (const forbidden of ['ubuntu-latest','windows-latest','macos-latest']) ok(!workflow.includes(forbidden), `F4_HOSTED_RUNNER_FORBIDDEN:${forbidden}`);
 
 console.log(JSON.stringify({
-  ok: true,
-  certificate: 'SENTINEL_F4_FOUNDATION_CONTRACT_PASS',
-  sdk: '@sentry/node@10.70.0',
-  f1_privacy_material_regression: true,
-  f1_cross_phase_false_red_fixed: true,
-  f2_topology_material_regression: true,
-  f3_telemetry_material_regression: true,
-  default_active: false,
-  canary_default: true,
-  canary_only_synthetic: true,
-  missing_dsn_fail_closed: true,
-  zero_phi_pii_fixture: true,
-  fixture_leaks: 0,
-  traces_sample_rate: 0,
-  logs: false,
-  breadcrumbs: 0,
-  pay_as_you_go: false,
-  human_boundary: 'PENDING',
-  changed_files_checked: changed.length
+  ok:true,
+  certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',
+  sdk:'@sentry/node@10.70.0',
+  f1_privacy_material_regression:true,
+  f2_topology_material_regression:true,
+  f3_telemetry_material_regression:true,
+  default_active:false,
+  runtime_only_preload:true,
+  build_preload:false,
+  child_env_inheritance:true,
+  canary_default:true,
+  canary_only_synthetic:true,
+  missing_dsn_fail_closed:true,
+  zero_phi_pii_fixture:true,
+  fixture_leaks:0,
+  traces_sample_rate:0,
+  logs:false,
+  breadcrumbs:0,
+  pay_as_you_go:false,
+  human_boundary:'PENDING',
+  changed_files_checked:changed.length
 }, null, 2));

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -67,12 +67,13 @@ for(const [name,text] of Object.entries(runtimeContracts)){
 ok(!wa2wf.includes('grep -q "node server-wa2.js" app/railway.json'),'WA2_STALE_START_COMMAND_GREP');
 ok(wa2wf.includes('Runtime topology/start-command compatibility is certified by ui_contract.py'),'WA2_WORKFLOW_RUNTIME_CONTRACT_HANDOFF_MISSING');
 
-// FAST pool portability: workflow provisions its own Python and knows exact Sentinel wrapper.
-ok(phaseSwf.includes('actions/setup-python@v5'),'PHASE_S_PYTHON_NOT_PROVISIONED');
-ok(phaseSwf.includes("python-version: '3.13'"),'PHASE_S_PYTHON_VERSION_NOT_PINNED');
-ok(!phaseSwf.includes('Python runtime missing on ASCENDA FAST runner'),'PHASE_S_STILL_DEPENDS_ON_SYSTEM_PYTHON');
+// FAST pool stays Node/runtime-only; Python and DB contracts remain on Linux Zero-Cost.
+ok(!phaseSwf.includes('actions/setup-python@v5'),'PHASE_S_FAST_MUST_NOT_PROVISION_PYTHON');
+ok(!phaseSwf.includes('Resolve system Python'),'PHASE_S_FAST_SYSTEM_PYTHON_DEPENDENCY_FORBIDDEN');
+ok(phaseSwf.includes('Python and DB/RLS/pgTAP contracts remain owned by Linux Zero-Cost workflows.'),'PHASE_S_LINUX_DELEGATION_MISSING');
+ok(phaseSwf.includes('Auth Resend private-vault regression'),'PHASE_S_AUTH_RESEND_GATE_MISSING');
 ok(phaseSwf.includes("$sentinel = '\"startCommand\"\\s*:\\s*\"env NODE_OPTIONS=''--require \\./sentinel-sentry-init\\.cjs'' node server-phase-s\\.js\"'"),'PHASE_S_SENTINEL_START_GUARD_MISSING');
-ok(phaseSwf.includes("Sentinel preload must not contaminate build"),'PHASE_S_BUILD_GUARD_MISSING');
+ok(phaseSwf.includes('Sentinel preload must not contaminate build'),'PHASE_S_BUILD_GUARD_MISSING');
 
 // Defensive Sentry source options.
 for(const t of ['sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0','includeLocalVariables: false','beforeBreadcrumb: () => null','beforeSend: event => {','SENTINEL_ENABLED','SENTINEL_SENTRY_ENABLED','SENTINEL_SENTRY_CANARY_MODE','SENTINEL_SENTRY_SYNTHETIC_ON_BOOT','SENTRY_DSN','SENTINEL_F4_SYNTHETIC_ERROR']) ok(init.includes(t),`INIT_GUARD_MISSING:${t}`);
@@ -119,4 +120,4 @@ for(const t of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING'])ok(report.includes(t
 for(const t of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js'])ok(f4wf.includes(t),`F4_WORKFLOW_MISSING:${t}`);
 for(const t of ['ubuntu-latest','windows-latest','macos-latest'])ok(!f4wf.includes(t),`F4_HOSTED_RUNNER_FORBIDDEN:${t}`);
 
-console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',sdk:'@sentry/node@10.70.0',f1_privacy_material_regression:true,f2_topology_material_regression:true,f3_telemetry_material_regression:true,default_active:false,runtime_only_preload:true,build_preload:false,child_env_inheritance:true,fast_pool_python_portable:true,canary_default:true,canary_only_synthetic:true,missing_dsn_fail_closed:true,zero_phi_pii_fixture:true,fixture_leaks:0,traces_sample_rate:0,logs:false,breadcrumbs:0,pay_as_you_go:false,human_boundary:'PENDING',changed_files_checked:changed.length},null,2));
+console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',sdk:'@sentry/node@10.70.0',f1_privacy_material_regression:true,f2_topology_material_regression:true,f3_telemetry_material_regression:true,default_active:false,runtime_only_preload:true,build_preload:false,child_env_inheritance:true,fast_pool_python_delegated:true,auth_resend_gate_preserved:true,canary_default:true,canary_only_synthetic:true,missing_dsn_fail_closed:true,zero_phi_pii_fixture:true,fixture_leaks:0,traces_sample_rate:0,logs:false,breadcrumbs:0,pay_as_you_go:false,human_boundary:'PENDING',changed_files_checked:changed.length},null,2));

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -12,6 +12,7 @@ const P={
   f2:'docs/control/SENTINEL_SYSTEM_REGISTRY_V1.json', f3:'sentinel/telemetry/contract-v1.json',
   report:'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md', runbook:'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md',
   f4wf:'.github/workflows/sentinel-phase4-sentry.yml', wa2wf:'.github/workflows/wa2-conversation-live-inbox.yml',
+  phaseSwf:'.github/workflows/phase-s-wa3-stabilization.yml',
   f5:'ci/phase5-historical-identity/f5_upload_contract.js', wa2:'ci/wa2-conversation-live-inbox/ui_contract.py',
   wa3:'ci/wa3-boxes-routing-handoff/ui_contract.py', wa4:'ci/wa4-ai-sales-router/ui_contract.py',
   cartera:'ci/phase2-cartera/ui_contract.py'
@@ -22,7 +23,7 @@ const json=p=>JSON.parse(read(p));
 
 const pkg=json('app/package.json'), f4=json(P.contract), f3=json(P.f3), f2=json(P.f2), fixture=json(P.fixture);
 const f1=read(P.f1), f1wf=read(P.f1wf), init=read(P.init), railway=json(P.railway), phaseS=read(P.phaseS);
-const report=read(P.report), runbook=read(P.runbook), f4wf=read(P.f4wf), wa2wf=read(P.wa2wf);
+const report=read(P.report), runbook=read(P.runbook), f4wf=read(P.f4wf), wa2wf=read(P.wa2wf), phaseSwf=read(P.phaseSwf);
 const runtimeContracts={f5:read(P.f5),wa2:read(P.wa2),wa3:read(P.wa3),wa4:read(P.wa4),cartera:read(P.cartera)};
 
 // SDK and prior-phase material invariants.
@@ -57,7 +58,7 @@ ok(typeof railway.build?.buildCommand==='string'&&!railway.build.buildCommand.in
 ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"),'F4_CHILD_ENV_INHERITANCE_DRIFT');
 ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'),'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
 
-// Historical contracts may accept ONLY the legacy Phase-S entry or the exact Sentinel wrapper.
+// Historical contracts accept only legacy Phase-S or exact Sentinel wrapper.
 for(const [name,text] of Object.entries(runtimeContracts)){
   const marker=name==='f5'?'sentinelPhaseS':'sentinel_phase_s';
   ok(text.includes(marker),`${name.toUpperCase()}_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE`);
@@ -66,10 +67,16 @@ for(const [name,text] of Object.entries(runtimeContracts)){
 ok(!wa2wf.includes('grep -q "node server-wa2.js" app/railway.json'),'WA2_STALE_START_COMMAND_GREP');
 ok(wa2wf.includes('Runtime topology/start-command compatibility is certified by ui_contract.py'),'WA2_WORKFLOW_RUNTIME_CONTRACT_HANDOFF_MISSING');
 
+// FAST pool portability: workflow provisions its own Python and knows exact Sentinel wrapper.
+ok(phaseSwf.includes('actions/setup-python@v5'),'PHASE_S_PYTHON_NOT_PROVISIONED');
+ok(phaseSwf.includes("python-version: '3.13'"),'PHASE_S_PYTHON_VERSION_NOT_PINNED');
+ok(!phaseSwf.includes('Python runtime missing on ASCENDA FAST runner'),'PHASE_S_STILL_DEPENDS_ON_SYSTEM_PYTHON');
+ok(phaseSwf.includes("$sentinel = '\"startCommand\"\\s*:\\s*\"env NODE_OPTIONS=''--require \\./sentinel-sentry-init\\.cjs'' node server-phase-s\\.js\"'"),'PHASE_S_SENTINEL_START_GUARD_MISSING');
+ok(phaseSwf.includes("Sentinel preload must not contaminate build"),'PHASE_S_BUILD_GUARD_MISSING');
+
 // Defensive Sentry source options.
 for(const t of ['sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0','includeLocalVariables: false','beforeBreadcrumb: () => null','beforeSend: event => {','SENTINEL_ENABLED','SENTINEL_SENTRY_ENABLED','SENTINEL_SENTRY_CANARY_MODE','SENTINEL_SENTRY_SYNTHETIC_ON_BOOT','SENTRY_DSN','SENTINEL_F4_SYNTHETIC_ERROR']) ok(init.includes(t),`INIT_GUARD_MISSING:${t}`);
 
-// Installed package is reproducible in CI.
 const installedPath=path.join(APP,'node_modules/@sentry/node/package.json');
 ok(fs.existsSync(installedPath),'SENTRY_NODE_NOT_INSTALLED_IN_CI');
 ok(JSON.parse(fs.readFileSync(installedPath,'utf8')).version==='10.70.0','SENTRY_INSTALLED_VERSION_DRIFT');
@@ -102,7 +109,7 @@ function changedFiles(){
     try{cp.execFileSync('git',['fetch','origin','main','--depth=1'],{cwd:ROOT,stdio:'ignore'});return cp.execFileSync('git',['diff','--name-only','origin/main...HEAD'],{cwd:ROOT,encoding:'utf8'}).split(/\r?\n/).filter(Boolean)}catch(_){return []}
   }
 }
-const allowed=new Set([P.f4wf,P.wa2wf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
+const allowed=new Set([P.f4wf,P.wa2wf,P.phaseSwf,P.railway,P.contract,'ci/sentinel/phase4_sentry_contract.js',P.report,P.runbook,P.f5,P.wa2,P.wa3,P.wa4,P.cartera]);
 const changed=changedFiles();
 for(const p of changed)ok(allowed.has(p),`F4_SCOPE_UNEXPECTED_FILE:${p}`);
 ok(!changed.some(p=>p.startsWith('supabase/migrations/')||p.startsWith('supabase/functions/')),'F4_DB_MUTATION_FORBIDDEN');
@@ -112,4 +119,4 @@ for(const t of ['F4-G01','F4-G18','HUMAN_BOUNDARY_PENDING'])ok(report.includes(t
 for(const t of ['self-hosted','Windows','X64','ascenda-fast','npm install','node ci/sentinel/phase4_sentry_contract.js'])ok(f4wf.includes(t),`F4_WORKFLOW_MISSING:${t}`);
 for(const t of ['ubuntu-latest','windows-latest','macos-latest'])ok(!f4wf.includes(t),`F4_HOSTED_RUNNER_FORBIDDEN:${t}`);
 
-console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',sdk:'@sentry/node@10.70.0',f1_privacy_material_regression:true,f2_topology_material_regression:true,f3_telemetry_material_regression:true,default_active:false,runtime_only_preload:true,build_preload:false,child_env_inheritance:true,canary_default:true,canary_only_synthetic:true,missing_dsn_fail_closed:true,zero_phi_pii_fixture:true,fixture_leaks:0,traces_sample_rate:0,logs:false,breadcrumbs:0,pay_as_you_go:false,human_boundary:'PENDING',changed_files_checked:changed.length},null,2));
+console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F4_RUNTIME_PRELOAD_CONTRACT_PASS',sdk:'@sentry/node@10.70.0',f1_privacy_material_regression:true,f2_topology_material_regression:true,f3_telemetry_material_regression:true,default_active:false,runtime_only_preload:true,build_preload:false,child_env_inheritance:true,fast_pool_python_portable:true,canary_default:true,canary_only_synthetic:true,missing_dsn_fail_closed:true,zero_phi_pii_fixture:true,fixture_leaks:0,traces_sample_rate:0,logs:false,breadcrumbs:0,pay_as_you_go:false,human_boundary:'PENDING',changed_files_checked:changed.length},null,2));

--- a/ci/sentinel/phase4_sentry_contract.js
+++ b/ci/sentinel/phase4_sentry_contract.js
@@ -18,6 +18,8 @@ const F3_CONTRACT = 'sentinel/telemetry/contract-v1.json';
 const REPORT_PATH = 'docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md';
 const RUNBOOK_PATH = 'docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md';
 const WORKFLOW_PATH = '.github/workflows/sentinel-phase4-sentry.yml';
+const F5_RUNTIME_CONTRACT = 'ci/phase5-historical-identity/f5_upload_contract.js';
+const WA2_RUNTIME_CONTRACT = 'ci/wa2-conversation-live-inbox/ui_contract.py';
 
 function fail(msg) { throw new Error(msg); }
 function ok(value, msg) { if (!value) fail(msg); }
@@ -41,6 +43,8 @@ const phaseS = read(PHASE_S_PATH);
 const workflow = read(WORKFLOW_PATH);
 const report = read(REPORT_PATH);
 const runbook = read(RUNBOOK_PATH);
+const f5RuntimeContract = read(F5_RUNTIME_CONTRACT);
+const wa2RuntimeContract = read(WA2_RUNTIME_CONTRACT);
 
 ok(pkg.dependencies && pkg.dependencies['@sentry/node'] === '10.70.0', 'SENTRY_SDK_NOT_EXACT_PIN_10_70_0');
 ok(f4.schema_version === 'sentinel-sentry-core/v1' && f4.phase === 'F4', 'F4_CONTRACT_INVALID');
@@ -81,6 +85,8 @@ ok(!railway.build.buildCommand.includes('NODE_OPTIONS'), 'F4_BUILD_MUST_NOT_PREL
 ok(f4.activation.runtime_start_command === expectedStart, 'F4_CONTRACT_RUNTIME_COMMAND_DRIFT');
 ok(phaseS.includes("env:Object.assign({},process.env,{PORT:String(INNER_PORT)})"), 'F4_CHILD_ENV_INHERITANCE_DRIFT');
 ok(runbook.includes('NO configurar `NODE_OPTIONS` como variable global de Railway'), 'F4_RUNBOOK_GLOBAL_NODE_OPTIONS_GUARD_MISSING');
+ok(f5RuntimeContract.includes('sentinelPhaseS') && f5RuntimeContract.includes('Sentinel preload must not contaminate build'), 'F5_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
+ok(wa2RuntimeContract.includes('sentinel_phase_s') && wa2RuntimeContract.includes('Sentinel preload must not contaminate build'), 'WA2_RUNTIME_CONTRACT_NOT_SENTINEL_AWARE');
 
 for (const token of [
   'sendDefaultPii: false','tracesSampleRate: 0','enableLogs: false','maxBreadcrumbs: 0',
@@ -143,7 +149,8 @@ function changedFiles() {
 const allowed = new Set([
   '.github/workflows/sentinel-phase1-governance.yml', WORKFLOW_PATH,
   'app/package.json', INIT_PATH, RAILWAY_PATH,
-  CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH
+  CONTRACT_PATH, FIXTURE_PATH, 'ci/sentinel/phase4_sentry_contract.js', REPORT_PATH, RUNBOOK_PATH,
+  F5_RUNTIME_CONTRACT, WA2_RUNTIME_CONTRACT
 ]);
 const changed = changedFiles();
 for (const p of changed) ok(allowed.has(p), `F4_SCOPE_UNEXPECTED_FILE:${p}`);

--- a/ci/wa2-conversation-live-inbox/ui_contract.py
+++ b/ci/wa2-conversation-live-inbox/ui_contract.py
@@ -44,12 +44,17 @@ assert "Respuesta humana, asignación e IA se habilitan en WA-3/WA-4" in ui
 assert "textContent" in ui or "esc(" in ui
 
 start=railway['deploy']['startCommand']
+sentinel_phase_s="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 direct=start=='node server-wa2.js'
 wa3_wrapped=(start=='node server-wa3.js' and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3)
 wa4_wrapped=(start=='node server-wa4.js' and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3)
 f5_wrapped=(start=='node server-f5.js' and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3)
-phase_s_wrapped=(start=='node server-phase-s.js' and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3)
+phase_s_entry=(start=='node server-phase-s.js' or start==sentinel_phase_s)
+phase_s_wrapped=(phase_s_entry and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa2.js']" in wa3 and 'proxy(req,res)' in wa3)
 assert direct or wa3_wrapped or wa4_wrapped or f5_wrapped or phase_s_wrapped, 'Railway must start WA-2 directly or through certified WA-3/WA-4/F5/Phase-S wrappers'
+if start==sentinel_phase_s:
+    assert 'NODE_OPTIONS' not in str(railway.get('build',{}).get('buildCommand','')), 'Sentinel preload must not contaminate build'
+
 assert 'aos_wa_conversations_v1' in migration
 assert 'aos_wa_conversation_events_v1' in migration
 assert 'conversation_id' in migration

--- a/ci/wa3-boxes-routing-handoff/ui_contract.py
+++ b/ci/wa3-boxes-routing-handoff/ui_contract.py
@@ -19,11 +19,15 @@ assert "['server-wa2.js']" in server
 assert "proxy(req,res)" in server
 assert "X-Ascenda-WA3-Routing':'v1'" in server
 start=railway['deploy']['startCommand']
+sentinel_phase_s="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 direct=start=='node server-wa3.js'
 wa4_wrapped=(start=='node server-wa4.js' and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4)
 f5_wrapped=(start=='node server-f5.js' and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4)
-phase_s_wrapped=(start=='node server-phase-s.js' and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4)
+phase_s_entry=(start=='node server-phase-s.js' or start==sentinel_phase_s)
+phase_s_wrapped=(phase_s_entry and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5 and "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4)
 assert direct or wa4_wrapped or f5_wrapped or phase_s_wrapped, 'Railway must start WA-3 directly or through certified WA-4/F5/Phase-S wrappers'
+if start==sentinel_phase_s:
+    assert 'NODE_OPTIONS' not in str(railway.get('build',{}).get('buildCommand','')), 'Sentinel preload must not contaminate build'
 assert '/api/wa3/bootstrap' in server
 assert '/api/wa3/inbox' in server
 assert '/claim-next' in server
@@ -37,7 +41,6 @@ assert 'aos_wa_messages_v1' in server
 assert 'message.human_accepted' in server
 assert 'WA3_RATE_LIMIT' in server
 
-# Browser never accesses Supabase/Graph directly and cannot bypass ownership.
 for forbidden in ('supabase.co','/rest/v1/','SUPABASE_SERVICE_ROLE_KEY','WHATSAPP_ACCESS_TOKEN','graph.facebook.com','apikey'):
     assert forbidden not in ui, f'WA3 browser leaks/directly depends on {forbidden}'
 assert 'X-AOS-App-Token' in ui
@@ -48,7 +51,6 @@ assert 'IA no envía en WA-3' in ui
 assert 'FORZADO OFF' in ui
 assert 'esc(' in ui
 
-# Data/security invariants.
 for marker in ('aos_wa_routing_control_v1','aos_wa_boxes_v1','aos_wa_box_members_v1','aos_wa_assignments_v1','aos_wa_routing_events_v1'):
     assert marker in mig
 assert 'one_current_idx' in mig
@@ -66,7 +68,6 @@ assert 'WA3_HUMAN_SEND_DISABLED' in mig
 assert 'WA3_CAPACITY_REACHED' in mig
 assert 'auto_route.rejected' in mig
 
-# Recovery is fail-closed and keeps evidence.
 assert 'auto_routing_enabled=false' in rb
 assert 'human_send_enabled=false' in rb
 assert 'ai_send_enabled=false' in rb

--- a/ci/wa4-ai-sales-router/ui_contract.py
+++ b/ci/wa4-ai-sales-router/ui_contract.py
@@ -14,10 +14,14 @@ secret = (root/'supabase/migrations/20260815205000_integration_secret_boundary_v
 secret_rb = (root/'supabase/rollbacks/20260815205000_integration_secret_boundary_v1.rollback.sql').read_text()
 rail = json.loads((root/'app/railway.json').read_text())
 start = rail['deploy']['startCommand']
+sentinel_phase_s = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 direct = start == 'node server-wa4.js'
 f5_wrapped = start == 'node server-f5.js' and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5
-phase_s_wrapped = (start == 'node server-phase-s.js' and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5)
+phase_s_entry = start == 'node server-phase-s.js' or start == sentinel_phase_s
+phase_s_wrapped = (phase_s_entry and "['server-f5.js']" in phase_s and 'proxy(req,res)' in phase_s and "['server-wa4.js']" in f5 and 'proxy(req,res)' in f5)
 assert direct or f5_wrapped or phase_s_wrapped, 'Railway must start WA-4 directly or through certified F5/Phase-S wrappers'
+if start == sentinel_phase_s:
+    assert 'NODE_OPTIONS' not in str(rail.get('build',{}).get('buildCommand','')), 'Sentinel preload must not contaminate build'
 assert 'server-wa3.js' in wa4
 assert 'aos_wa4_authorize_copilot_v1' in wa4
 assert "auto_send:false" in wa4 or "auto_send: false" in wa4

--- a/docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md
+++ b/docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md
@@ -1,7 +1,6 @@
 # Sentinel F4 — Sentry Error Monitoring Core — Runbook
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Baseline:** `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`  
 **Riesgo:** HIGH  
 **Regla:** no compartir `SENTRY_DSN` en GitHub, Notion, chat ni screenshots.
 
@@ -11,22 +10,36 @@ Activar Sentry como sensor especializado de errores de alta señal sin convertir
 
 ## 2. Loop F4 mejorado
 
-`recovery → dependency pin → dormant preloader → adversarial privacy fixture → self-hosted CI → foundation merge → HUMAN BOUNDARY → synthetic-only canary → privacy/release verification → kill-switch proof → sanitized real-error activation → checkpoint → Notion → final certificate`
+`recovery → dependency pin → dormant preloader → privacy fixture → self-hosted CI → foundation merge → HUMAN BOUNDARY → runtime-only preload → synthetic-only canary → privacy/release verification → kill-switch proof → sanitized real-error activation → checkpoint → Notion → final certificate`
 
-La mejora respecto de loops anteriores es explícita: lo automatizable se ejecuta sin intervención; las cuentas externas se detienen en un `HUMAN BOUNDARY` verificable. Ningún gate se marca PASS por una captura o afirmación no comprobada.
+Las acciones de cuenta externa se detienen en un `HUMAN BOUNDARY`. Ningún gate se marca PASS por una captura o afirmación no comprobada.
 
-## 3. Estado dormido
+## 3. Regla nueva: build-time ≠ runtime-time
 
-El preloader `app/sentinel-sentry-init.cjs` queda inactivo salvo que se cumplan simultáneamente:
+**NO configurar `NODE_OPTIONS` como variable global de Railway.**
+
+Motivo: una variable global alcanza también Nixpacks/npm durante el build. Si contiene `--require ./sentinel-sentry-init.cjs`, Node intenta cargar el preloader antes de que el contexto runtime exista y puede bloquear `npm install` con `MODULE_NOT_FOUND` / `internal/preload`.
+
+La única forma canónica F4 es runtime-only mediante `app/railway.json`:
+
+```text
+env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js
+```
+
+Esto aplica el preloader solo al runtime productivo. `server-phase-s.js` propaga `process.env` a sus procesos hijos, por lo que la cadena Node hereda `NODE_OPTIONS` sin contaminar el build.
+
+## 4. Estado dormido
+
+El preloader `app/sentinel-sentry-init.cjs` solo exporta si se cumplen simultáneamente:
 
 - `SENTINEL_ENABLED=true`
 - `SENTINEL_SENTRY_ENABLED=true`
 - `SENTRY_DSN` presente
-- el runtime haya sido arrancado con `NODE_OPTIONS=--require ./sentinel-sentry-init.cjs`
+- runtime iniciado mediante el Start Command canónico anterior.
 
-Si falta cualquier condición, ASCENDA continúa sin export Sentry.
+Si falta cualquier condición, ASCENDA continúa operativa sin export Sentry.
 
-## 4. Privacy baseline
+## 5. Privacy baseline
 
 Configuración local obligatoria:
 
@@ -35,40 +48,37 @@ Configuración local obligatoria:
 - logs OFF
 - breadcrumbs = 0
 - local variables OFF
-- RequestData/ContextLines/Console/LocalVariables default integrations filtradas cuando estén presentes
 - `beforeBreadcrumb` descarta todo
 - `beforeSend` reconstruye un evento mínimo
 - user/request/query/cookies/body/extra/contexts/transaction/modules/spans DROP
-- exception message solo se preserva si es un código técnico uppercase seguro; cualquier texto libre se vuelve `[REDACTED_MESSAGE]`
-- stack frame conserva únicamente basename, module/function sanitizados, line/column e `in_app`
-- tags por allowlist Sentinel
+- free-text exception message → `[REDACTED_MESSAGE]`
+- tags solo por allowlist Sentinel
 
-Backend Sentry debe mantener una segunda capa de data scrubbing e IP scrubbing. La segunda capa nunca reemplaza la sanitización local.
+Backend Sentry mantiene segunda capa: Data Scrubber ON, Default Scrubbers ON, IP scrubbing ON y Safe Fields vacío.
 
-## 5. Canary sintético
+## 6. Canary sintético
 
-`SENTINEL_SENTRY_CANARY_MODE` tiene default `true`.
-
-Mientras sea `true`, `beforeSend` devuelve `null` para todos los eventos excepto el código exacto:
+`SENTINEL_SENTRY_CANARY_MODE=true` permite exportar únicamente:
 
 `SENTINEL_F4_SYNTHETIC_ERROR`
 
-Esto permite validar la conexión sin exportar errores reales del negocio.
+`SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true` genera una captura controlada en `server-phase-s.js`; después del test vuelve a `false`.
 
-`SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true` genera una única captura controlada únicamente en `server-phase-s.js`; después del test debe volver a `false` o eliminarse.
+## 7. HUMAN BOUNDARY — Sentry
 
-## 6. HUMAN BOUNDARY — acciones en Sentry
+1. Proyecto Node.js `ascenda-os`.
+2. Plan zero-cost vigente; pay-as-you-go OFF.
+3. Data Scrubber ON.
+4. Default Scrubbers ON.
+5. Prevent Storing of IP Address ON.
+6. Additional Sensitive Fields definidos.
+7. Safe Fields vacío.
+8. Replay/logs/profiling/tracing no activados.
+9. DSN solo en Railway.
 
-1. Crear un proyecto **Node.js** para ASCENDA en el plan Developer/zero-cost vigente.
-2. Mantener pay-as-you-go deshabilitado.
-3. Activar server-side data scrubbing/default scrubbers.
-4. Activar IP address scrubbing.
-5. No habilitar Replay, logs, profiling ni tracing en esta fase.
-6. Copiar el DSN únicamente hacia Railway como secreto; no pegarlo en conversaciones.
+## 8. HUMAN BOUNDARY — variables Railway
 
-## 7. HUMAN BOUNDARY — variables Railway, primera conexión
-
-Configurar en el servicio productivo, sin modificar `app/railway.json`:
+Configurar únicamente:
 
 ```text
 SENTINEL_ENABLED=true
@@ -77,76 +87,64 @@ SENTINEL_SENTRY_CANARY_MODE=true
 SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true
 SENTRY_DSN=<SECRET_IN_RAILWAY_ONLY>
 SENTRY_ENVIRONMENT=production
-NODE_OPTIONS=--require ./sentinel-sentry-init.cjs
 ```
 
-No definir manualmente `SENTRY_RELEASE` salvo contingencia: el preloader deriva `ascenda-os@<sha>` desde `RAILWAY_GIT_COMMIT_SHA`.
+**No crear `NODE_OPTIONS` como variable Railway.** El runtime-only preload viene versionado en `app/railway.json`.
 
-## 8. Canary gate
+No definir manualmente `SENTRY_RELEASE`: se deriva `ascenda-os@<sha>` desde `RAILWAY_GIT_COMMIT_SHA`.
 
-Después del restart/deploy:
+## 9. Canary gate
 
-1. `/health` debe seguir respondiendo 200.
-2. Sentry debe recibir `SENTINEL_F4_SYNTHETIC_ERROR`.
-3. `environment` debe ser `production`.
-4. `release` debe ser `ascenda-os@<RAILWAY_GIT_COMMIT_SHA>`.
-5. tags mínimos: `system=ascenda-os`, `sentinel.phase=F4`, `service.name=server-phase-s.js`.
-6. el evento no debe contener user, email, teléfono, DNI, IP de usuario, request body, cookies, Authorization, WhatsApp/email content, prompt/output IA, local variables ni source context.
-7. mientras canary=true no debe exportarse un error real no sintético.
+Después del deploy:
+
+1. build debe completar sin `internal/preload`/`MODULE_NOT_FOUND`;
+2. `/health` debe responder 200;
+3. Sentry recibe `SENTINEL_F4_SYNTHETIC_ERROR`;
+4. `environment=production`;
+5. `release=ascenda-os@<RAILWAY_GIT_COMMIT_SHA>`;
+6. tags mínimos: `system=ascenda-os`, `sentinel.phase=F4`, `service.name=server-phase-s.js`;
+7. evento sin user/email/teléfono/DNI/IP/request body/cookies/Authorization/mensajes/prompts/local vars/source context;
+8. canary=true no exporta errores reales.
 
 Luego poner `SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=false`.
 
-## 9. Kill-switch proof
+## 10. Kill-switch proof
 
-1. Poner `SENTINEL_SENTRY_ENABLED=false`.
-2. Reiniciar/redeploy.
-3. Confirmar `/health` 200 y uso normal de ASCENDA.
-4. Confirmar que no aparece un nuevo synthetic event aunque el synthetic flag siga false.
+1. `SENTINEL_SENTRY_ENABLED=false`.
+2. Redeploy.
+3. `/health` = 200.
+4. No nuevo synthetic event.
 5. Restaurar `SENTINEL_SENTRY_ENABLED=true` con canary=true.
-6. Confirmar `/health` 200.
+6. Redeploy y `/health` = 200.
 
 La caída/desactivación de Sentry nunca debe tumbar ASCENDA.
 
-## 10. Activación real F4
+## 11. Activación real F4
 
-Solo después del canary y kill-switch PASS:
+Solo después de canary + kill-switch PASS:
 
 ```text
 SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=false
 SENTINEL_SENTRY_CANARY_MODE=false
-```
-
-Mantener:
-
-```text
 SENTINEL_ENABLED=true
 SENTINEL_SENTRY_ENABLED=true
 SENTRY_ENVIRONMENT=production
-NODE_OPTIONS=--require ./sentinel-sentry-init.cjs
 ```
 
 Tracing/logging/replay continúan OFF.
 
-## 11. Texto exacto para continuar después de la intervención humana
-
-No incluir el DSN ni otros secretos. Enviar únicamente:
-
-`LISTO F4-HUMAN-GATE: proyecto Sentry Node creado; data scrubbing e IP scrubbing activos; variables Railway cargadas sin compartir secretos; synthetic SENTINEL_F4_SYNTHETIC_ERROR visible con environment=production y release correcto; evento revisado sin PHI/PII/secrets; kill switch probado con /health=200. AUTORIZO cerrar canary y continuar el loop F4 hasta certificación.`
-
-Si algún punto no está validado, no usar la palabra `LISTO`; enviar screenshot del punto donde quedó el proceso para continuar desde ahí.
-
 ## 12. Rollback
 
-Rollback inmediato de observabilidad:
+Observabilidad Sentry OFF:
 
 ```text
 SENTINEL_SENTRY_ENABLED=false
 ```
 
-Rollback total Sentinel externo:
+Sentinel externo OFF:
 
 ```text
 SENTINEL_ENABLED=false
 ```
 
-No es necesario modificar tablas, migraciones ni lógica de negocio.
+No requiere tocar tablas, migraciones ni lógica de negocio.

--- a/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
+++ b/docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md
@@ -1,147 +1,119 @@
 # SENTINEL F4 — Sentry Error Monitoring Core — Validation Report
 
 **Fecha:** 2026-08-16 (America/Lima)  
-**Estado:** `TECHNICAL_FOUNDATION_CERTIFIED / HUMAN_BOUNDARY_PENDING`  
+**Estado:** `TECHNICAL_FOUNDATION_CERTIFIED / HUMAN_BOUNDARY_RETRY`  
 **F1:** `100_COMPLETE`  
 **F2:** `100_COMPLETE`  
 **F3:** `100_COMPLETE`  
-**Baseline F4:** `main@e3ff8914447c06a2b94b3be5cccbade73526ce0d`  
-**Branch:** `feat/sentinel-f4-sentry-core`  
-**Foundation PR:** `#189`  
+**Foundation:** PR `#189` → `main@39695d154be7099d8363896af09b1d70ced12126`  
 **Riesgo:** HIGH — first external telemetry sensor.
 
 ## 1. Objetivo
 
-Añadir Sentry como sensor especializado de errores de alta señal, manteniendo Zero PHI/PII, costo incremental autorizado US$0, tracing/logs/replay OFF, kill switches independientes y Sentry aislado del funcionamiento de ASCENDA.
+Añadir Sentry como sensor especializado de errores de alta señal con Zero PHI/PII, costo incremental autorizado US$0, tracing/logs/replay OFF, kill switches independientes y Sentry aislado del funcionamiento de ASCENDA.
 
-## 2. Mejora del loop
+## 2. Foundation autónoma certificada
 
-F4 incorpora un `HUMAN BOUNDARY` formal. El loop ejecuta autónomamente recovery, dependency pin, preloader dormido, fixture adversarial, contrato CI, scope/secret gates y PR. Solo se detiene cuando una acción exige cuenta externa Sentry/Railway.
+PR #189 dejó integrados:
 
-También añade `synthetic-only canary`: al conectar Sentry por primera vez, todos los eventos reales se descartan y únicamente puede salir `SENTINEL_F4_SYNTHETIC_ERROR`.
+- `@sentry/node@10.70.0` pin exacto;
+- preloader CommonJS default OFF;
+- `sendDefaultPii=false`;
+- traces=0, logs OFF, breadcrumbs=0, local vars OFF;
+- allowlist/minimizer antes de exportar;
+- synthetic-only canary default=true;
+- fixture adversarial con `fixture_leaks=0`;
+- material regressions F1/F2/F3;
+- Ascenda CI PASS.
 
-Durante el primer candidate apareció un falso rojo del workflow histórico F1: `F1_SCOPE_RUNTIME_OR_DB_CHANGE:app/package.json`. La causa no era una regresión de privacidad; F1 había sido diseñado para demostrar que **F1** no modificó runtime y su trigger amplio se ejecutaba indebidamente en fases posteriores. Se corrigió el trigger F1 para observar solo artefactos F1. Cada fase posterior debe ejecutar su propio certificate y las regresiones **materiales** F1/F2/F3 pertinentes. El candidate siguiente dejó de disparar el falso gate y el contrato F4 certificó `f1_privacy_material_regression=true`.
+G01–G13 permanecen PASS.
 
-## 3. Foundation implementada
+## 3. Hallazgo durante HUMAN BOUNDARY
 
-- `@sentry/node` pin exacto `10.70.0`.
-- `app/sentinel-sentry-init.cjs` dormido por defecto.
-- doble kill switch: `SENTINEL_ENABLED` + `SENTINEL_SENTRY_ENABLED`.
-- DSN requerido pero nunca hardcoded/logged.
-- `SENTINEL_SENTRY_CANARY_MODE` default true.
-- one-shot `SENTINEL_SENTRY_SYNTHETIC_ON_BOOT` restringido a outer runtime.
-- `sendDefaultPii=false`.
-- `tracesSampleRate=0`.
-- logs OFF, breadcrumbs 0, local variables OFF.
-- event minimizer/allowlist antes de exporter.
-- exception free text redacted; solo códigos técnicos uppercase se preservan.
-- fixture sintético con señuelos de PII/PHI/secrets.
-- no cambios Railway/DB/Supabase/proveedores en foundation.
+El primer deploy canary falló durante **build**, antes de iniciar el runtime.
 
-## 4. Evidencia autónoma exact-head
-
-Candidate técnico: `ccf78aa71d5dd4b09e5b732364e1c8d66365d5e3`.
-
-### Sentinel F4 Sentry Foundation Certificate
-
-Run `31956828802` — **PASS**.
-
-El contrato emitió:
+Evidencia Railway mostrada el 2026-08-16:
 
 ```text
-SENTINEL_F4_FOUNDATION_CONTRACT_PASS
-sdk = @sentry/node@10.70.0
-f1_privacy_material_regression = true
-f1_cross_phase_false_red_fixed = true
-f2_topology_material_regression = true
-f3_telemetry_material_regression = true
-default_active = false
-canary_default = true
-canary_only_synthetic = true
-missing_dsn_fail_closed = true
-zero_phi_pii_fixture = true
-fixture_leaks = 0
-traces_sample_rate = 0
-logs = false
-breadcrumbs = 0
-pay_as_you_go = false
-human_boundary = PENDING
+MODULE_NOT_FOUND
+requireStack: ['internal/preload']
+Node.js v18.20.5
+"npm install" did not complete successfully: exit code: 1
 ```
 
-### Runtime regression
+### Root cause
 
-Ascenda CI — run `31956828795` — **PASS** sobre el mismo candidate.
+`NODE_OPTIONS=--require ./sentinel-sentry-init.cjs` fue configurado como variable global de Railway. Las variables globales también alcanzan Nixpacks/npm durante build. `npm install` ejecutó Node con el preload antes de que el contexto runtime estuviera disponible y falló.
 
-Un workflow funcional histórico adicional (`ASCENDA Phase 5 Historical Patient Identity`) también había pasado sobre el candidate anterior de la misma foundation; no es gate de Sentinel F4 y no se utiliza para inflar su certificación.
+**Producción no cayó:** Railway mantuvo el deployment anterior `Active/Online`; el candidate falló cerrado antes de Deploy/Network/Post-deploy.
 
-## 5. Scope proof
+## 4. Mejora permanente del loop
 
-PR #189 contiene nueve superficies exactas:
+F4 adopta una separación obligatoria:
 
-1. `.github/workflows/sentinel-phase1-governance.yml` — narrow trigger fix para eliminar falso cross-phase gate.
-2. `.github/workflows/sentinel-phase4-sentry.yml`.
-3. `app/package.json`.
-4. `app/sentinel-sentry-init.cjs`.
-5. `ci/sentinel/fixtures/f4_sentry_sensitive_event.json`.
-6. `ci/sentinel/phase4_sentry_contract.js`.
-7. `docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md`.
-8. `docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md`.
-9. `sentinel/sentry/f4-contract.json`.
+`build-time variables ≠ runtime-only instrumentation`
 
-Resultado: **0 `app/railway.json`, 0 migrations/DB, 0 Supabase functions, 0 DSN, 0 provider credentials, 0 product telemetry activation**.
+Se prohíbe `NODE_OPTIONS` como variable global Railway.
 
-## 6. Gates F4
+El preload canónico queda versionado en `app/railway.json` como:
+
+```text
+env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js
+```
+
+Beneficios:
+
+1. Nixpacks/npm no reciben el preload durante build;
+2. `server-phase-s.js` sí lo recibe al iniciar producción;
+3. sus procesos hijos heredan `process.env`, por lo que la cadena Node completa recibe el preload;
+4. el contrato CI verifica esta separación y falla si vuelve a contaminar build.
+
+## 5. Gates F4
 
 | Gate | Evidencia requerida | Estado |
 |---|---|---|
 | F4-G01 | F1-F3 `100_COMPLETE`; F4 única fase activa | PASS |
-| F4-G02 | baseline `main@e3ff8914` y branch aislada | PASS |
-| F4-G03 | SDK Sentry Node stable pin exacto y reproducible | PASS |
-| F4-G04 | F1 privacy/cost material invariants preservados | PASS |
-| F4-G05 | F2 topology/UNKNOWN material invariants preservados | PASS |
-| F4-G06 | F3 zero-PHI/PII, allowlist, baggage-off, production tracing=0 preservados | PASS |
-| F4-G07 | preloader default OFF y dual kill-switch | PASS |
-| F4-G08 | missing DSN fail-closed para telemetría y no rompe bootstrap | PASS |
-| F4-G09 | adversarial fixture demuestra 0 leaks antes de exporter | PASS |
-| F4-G10 | breadcrumbs/logs/local vars/request/body/user/source context bloqueados | PASS |
-| F4-G11 | synthetic-only canary default=true | PASS |
-| F4-G12 | package/API/syntax + self-hosted foundation contract PASS | PASS |
-| F4-G13 | foundation diff sin Railway/DB/providers/secrets | PASS |
-| F4-G14 | Sentry Node project zero-cost + server-side scrub + IP scrub verificados | HUMAN_BOUNDARY_PENDING |
-| F4-G15 | Railway canary variables/preloader configurados sin exponer DSN | HUMAN_BOUNDARY_PENDING |
-| F4-G16 | synthetic event visible con environment/release/tags correctos y cero PHI/PII | HUMAN_BOUNDARY_PENDING |
-| F4-G17 | kill switch probado; `/health` permanece 200; sanitized real-error mode activado | HUMAN_BOUNDARY_PENDING |
-| F4-G18 | checkpoint, merge(s), Notion F4=100/Cerrada y F5 única Siguiente | PENDING |
+| F4-G02 | baseline y branch aislada | PASS |
+| F4-G03 | SDK Sentry Node pin exacto | PASS |
+| F4-G04 | F1 privacy/cost invariants | PASS |
+| F4-G05 | F2 topology/UNKNOWN invariants | PASS |
+| F4-G06 | F3 Zero-PHI/PII + production tracing=0 | PASS |
+| F4-G07 | preloader default OFF + dual kill switch | PASS |
+| F4-G08 | missing DSN fail-closed | PASS |
+| F4-G09 | adversarial fixture 0 leaks | PASS |
+| F4-G10 | logs/breadcrumbs/local vars/request/body/user blocked | PASS |
+| F4-G11 | synthetic-only canary | PASS |
+| F4-G12 | self-hosted contract + Ascenda CI | PASS |
+| F4-G13 | foundation scope/secrets | PASS |
+| F4-G14 | Sentry project + server-side scrub + IP scrub | PASS by human evidence; final consolidated checkpoint pending |
+| F4-G15 | Railway runtime-only preload + canary deploy | RETRY_REQUIRED after build-time contamination finding |
+| F4-G16 | synthetic event + release/env/tags + zero PHI/PII | PENDING |
+| F4-G17 | kill switch + `/health` 200 + real sanitized mode | PENDING |
+| F4-G18 | final merge(s) + Notion F4=100/Cerrada + F5 Siguiente | PENDING |
 
-**Estado técnico:** `13/18 PASS`.
+**Estado operativo:** `13/18 PASS`; G14 evidenciado pero se consolida con G15–G17 antes del cierre.
 
-## 7. Estado actual
+## 6. Human retry exacto
 
-La parte autónoma F4 está técnicamente certificada. La foundation permanece sin cableado Railway: tener el package/preloader en `main` no activa Sentry mientras no existan `NODE_OPTIONS`, switches y DSN en el runtime.
+Después de integrar el hotfix runtime-only:
 
-F4 no puede declararse `100_COMPLETE` mientras G14–G17 no tengan evidencia real de Sentry/Railway y G18 no cierre continuidad/Notion.
+1. eliminar la variable global Railway `NODE_OPTIONS`;
+2. mantener `SENTINEL_ENABLED=true`;
+3. mantener `SENTINEL_SENTRY_ENABLED=true`;
+4. mantener `SENTINEL_SENTRY_CANARY_MODE=true`;
+5. mantener `SENTINEL_SENTRY_SYNTHETIC_ON_BOOT=true`;
+6. mantener `SENTRY_ENVIRONMENT=production`;
+7. mantener `SENTRY_DSN` secreto;
+8. redeploy;
+9. verificar build PASS y `/health` 200;
+10. verificar `SENTINEL_F4_SYNTHETIC_ERROR` en Sentry.
 
-## 8. No autorizaciones implícitas
+## 7. No autorizaciones implícitas
 
-F4 no autoriza:
+Siguen OFF/no autorizados: tracing >0, logs Sentry, Replay, profiling, attachments, pay-as-you-go, Seer/AI autofix, source-map token upload, DB/migrations Sentinel, Telegram y auto-remediation.
 
-- tracing productivo >0;
-- Sentry logs;
-- Replay;
-- profiling;
-- attachments;
-- pay-as-you-go;
-- Seer/AI autofix;
-- source-map upload con token;
-- cambio de plan;
-- DB/migrations Sentinel;
-- Telegram;
-- auto-remediation.
+## 8. HUMAN_BOUNDARY_PENDING
 
-## 9. Handoff humano
+F4 no puede declararse `100_COMPLETE` hasta G15–G18.
 
-Ver `docs/control/SENTINEL_F4_SENTRY_RUNBOOK.md`.
-
-Texto canónico posterior a la intervención:
-
-`LISTO F4-HUMAN-GATE: proyecto Sentry Node creado; data scrubbing e IP scrubbing activos; variables Railway cargadas sin compartir secretos; synthetic SENTINEL_F4_SYNTHETIC_ERROR visible con environment=production y release correcto; evento revisado sin PHI/PII/secrets; kill switch probado con /health=200. AUTORIZO cerrar canary y continuar el loop F4 hasta certificación.`
+F4-G01 F4-G02 F4-G03 F4-G04 F4-G05 F4-G06 F4-G07 F4-G08 F4-G09 F4-G10 F4-G11 F4-G12 F4-G13 F4-G14 F4-G15 F4-G16 F4-G17 F4-G18

--- a/sentinel/sentry/f4-contract.json
+++ b/sentinel/sentry/f4-contract.json
@@ -20,7 +20,10 @@
     "release_variable": "RAILWAY_GIT_COMMIT_SHA",
     "preload_variable": "NODE_OPTIONS",
     "preload_value": "--require ./sentinel-sentry-init.cjs",
+    "preload_scope": "runtime-command-only-not-global-railway-variable",
+    "runtime_start_command": "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js",
     "required_working_directory": "app",
+    "child_inheritance": "server-phase-s-and-descendants-inherit-process-env",
     "failure_mode": "fail-open-for-ascenda-fail-closed-for-telemetry"
   },
   "privacy": {
@@ -70,7 +73,8 @@
       "create-sentry-node-project-on-free-developer-plan",
       "verify-server-side-data-scrubbing-and-ip-scrubbing",
       "set-railway-secrets-without-sharing-dsn-in-chat",
-      "set-node-options-preloader",
+      "do-not-set-global-railway-node-options",
+      "use-runtime-only-preloader-from-railway-start-command",
       "enable-master-and-sensor-switches-with-canary-true",
       "enable-one-shot-synthetic-on-boot",
       "verify-sentry-event-has-correct-environment-and-release",


### PR DESCRIPTION
## Root cause
The first F4 canary deployment failed during Nixpacks build with `MODULE_NOT_FOUND` / `requireStack: ['internal/preload']` because `NODE_OPTIONS=--require ./sentinel-sentry-init.cjs` was configured as a global Railway variable. Railway service variables are available during build and runtime, so that contaminated `npm install` before the app runtime existed.

## Fix
- Move Sentry preload to production runtime command only:
  `env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js`
- Keep build command free of `NODE_OPTIONS`.
- Preserve child-process inheritance through `server-phase-s.js` → descendants.
- Update F4 contract, CI, runbook and historical runtime contracts so future regressions fail automatically.

## Safety
- Existing production deployment stayed Active/Online; failed candidate never reached Deploy/Network/Post-deploy.
- No DB/migrations/Supabase changes.
- No DSN or secrets committed.
- Canary remains synthetic-only; tracing/logs/replay remain OFF.

## Optimized human sequence
After exact-head CI is green and BEFORE merging this PR:
1. remove only the global Railway variable `NODE_OPTIONS`;
2. deploy the current main to prove build recovery and `/health` 200 with Sentry still dormant;
3. only then merge #191;
4. allow/redeploy the merged runtime-only start command;
5. verify build + `/health` + `SENTINEL_F4_SYNTHETIC_ERROR`.

This avoids a second known failed deploy between hotfix merge and variable cleanup.

F4 remains incomplete until G15-G18 are verified.