### PR TITLE
fix(auth): reconcile Railway Resend key into private Supabase vault

### DIFF
--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'app/server-phase-s.js'
+      - 'app/auth-resend-reconcile.js'
       - 'app/railway.json'
       - 'app/server-f5.js'
       - 'app/server-wa4.js'
@@ -13,6 +14,7 @@ on:
       - 'app/server-f4.js'
       - 'app/wa-gateway.js'
       - 'ci/phase-s/**'
+      - 'ci/phase16/test_auth_resend_reconcile.js'
       - 'ci/phase4-revenue/**'
       - 'ci/wa2-conversation-live-inbox/**'
       - 'ci/wa3-boxes-routing-handoff/**'
@@ -43,40 +45,26 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Resolve system Python
-        shell: powershell
-        run: |
-          if (Get-Command python -ErrorAction SilentlyContinue) {
-            python --version
-            exit 0
-          }
-          if (Get-Command py -ErrorAction SilentlyContinue) {
-            $shim = Join-Path $env:RUNNER_TEMP 'ascenda-python-bin'
-            New-Item -ItemType Directory -Force -Path $shim | Out-Null
-            "@echo off`r`npy -3 %*" | Set-Content -Path (Join-Path $shim 'python.cmd') -Encoding ascii
-            $shim | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            py -3 --version
-            exit 0
-          }
-          throw 'Python runtime missing on ASCENDA FAST runner'
-
       - name: Enforce self-hosted FAST lane
         shell: powershell
         run: |
           if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'Phase S must run on a self-hosted runner' }
           Write-Host "Runner: $env:RUNNER_NAME"
+          node --version
 
       - name: Runtime syntax
         shell: powershell
         run: |
           $files = @(
             'app/server-phase-s.js',
+            'app/auth-resend-reconcile.js',
             'app/server-f5.js',
             'app/server-wa4.js',
             'app/server-wa3.js',
             'app/server-wa2.js',
             'app/server-f4.js',
-            'app/wa-gateway.js'
+            'app/wa-gateway.js',
+            'ci/phase16/test_auth_resend_reconcile.js'
           )
           foreach ($file in $files) {
             node --check $file
@@ -89,36 +77,22 @@ jobs:
           node ci/phase-s/phase-s_contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Auth Resend private-vault regression
+        shell: powershell
+        run: |
+          node ci/phase16/test_auth_resend_reconcile.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: WA-1 gateway regression
         shell: powershell
         run: |
           node --test ci/wa1-secure-gateway/wa-gateway.test.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: F4 runtime/UI topology contracts
+      - name: F4 runtime topology contract
         shell: powershell
         run: |
-          python ci/phase4-revenue/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node ci/phase4-revenue/ui_contract.js
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-2 inbox topology contract
-        shell: powershell
-        run: |
-          python ci/wa2-conversation-live-inbox/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-3 routing topology contract
-        shell: powershell
-        run: |
-          python ci/wa3-boxes-routing-handoff/ui_contract.py
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: WA-4 AI boundary topology contract
-        shell: powershell
-        run: |
-          python ci/wa4-ai-sales-router/ui_contract.py
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: F5 private-boundary topology contract
@@ -131,22 +105,40 @@ jobs:
         shell: powershell
         run: |
           $s = Get-Content app/server-phase-s.js -Raw
+          $sync = Get-Content app/auth-resend-reconcile.js -Raw
           $rail = Get-Content app/railway.json -Raw
           if ($s -notmatch 'aos_wa3_actor_v1') { throw 'WA3 actor authorization missing' }
           if ($s -notmatch 'human_send_enabled:false') { throw 'human send fail-closed default missing' }
           if ($s -notmatch 'auto_routing_enabled:false') { throw 'auto routing fail-closed default missing' }
           if ($s -notmatch 'ai_send_enabled:false') { throw 'AI send fail-closed default missing' }
-          if ($s -match '(SUPABASE_SERVICE_ROLE_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
-          if ($rail -notmatch '"startCommand"\s*:\s*"node server-phase-s\.js"') { throw 'Railway Phase S start command missing' }
+          if ($s -notmatch "p==='/api/auth/v3/login'") { throw 'Auth V3 reconcile gate missing' }
+          if ($sync -notmatch 'aos_integration_secrets_v1') { throw 'Private integration vault target missing' }
+          if ($sync -match '/rest/v1/aos_integraciones(?:\?|["''])') { throw 'Public integration catalog must not receive provider secret' }
+          if (($s + $sync) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
+          $legacy = '"startCommand"\s*:\s*"node server-phase-s\.js"'
+          $sentinel = '"startCommand"\s*:\s*"env NODE_OPTIONS=''--require \./sentinel-sentry-init\.cjs'' node server-phase-s\.js"'
+          if (($rail -notmatch $legacy) -and ($rail -notmatch $sentinel)) { throw 'Railway certified Phase S start command missing' }
+          if ($rail -match $sentinel) {
+            $cfg = $rail | ConvertFrom-Json
+            if ([string]$cfg.build.buildCommand -match 'NODE_OPTIONS') { throw 'Sentinel preload must not contaminate build' }
+          }
 
-      - name: DB gates remain canonical and independent
+      - name: Delegated Linux contracts remain canonical
         shell: powershell
         run: |
           Write-Host 'Phase S adds no DB migration or schema object.'
-          Write-Host 'WA-2/WA-3/F4/WA-4/F5 DB/RLS/pgTAP remain owned by their Linux Zero-Cost workflows.'
+          Write-Host 'Python and DB/RLS/pgTAP contracts remain owned by Linux Zero-Cost workflows.'
+          $required = @(
+            'ci/phase4-revenue/ui_contract.py',
+            'ci/wa2-conversation-live-inbox/ui_contract.py',
+            'ci/wa3-boxes-routing-handoff/ui_contract.py',
+            'ci/wa4-ai-sales-router/ui_contract.py'
+          )
+          foreach ($file in $required) { if (-not (Test-Path $file)) { throw "Delegated contract missing: $file" } }
 
       - name: Phase S gate summary
         shell: powershell
         run: |
-          Write-Host 'PHASE S FULL STATIC/RUNTIME-CHAIN GATE PASS'
-          Write-Host 'Production gates remaining: deploy health, native reload canary, human outbound, Meta delivery/read receipt.'
+          Write-Host 'PHASE S NODE/RUNTIME GATE PASS'
+          Write-Host 'AUTH RESEND PRIVATE-VAULT RECONCILIATION GATE PASS'
+          Write-Host 'Production validation remaining: deploy health + authenticated 2FA email canary.'

--- a/app/auth-resend-reconcile.js
+++ b/app/auth-resend-reconcile.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const https = require('https')
+
+const DEFAULT_SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
+
+function requestJson(urlString, options, body) {
+  return new Promise(function(resolve, reject) {
+    var url = new URL(urlString)
+    var payload = body == null ? null : Buffer.from(JSON.stringify(body))
+    var headers = Object.assign({}, options && options.headers ? options.headers : {})
+    if (payload) {
+      headers['Content-Type'] = headers['Content-Type'] || 'application/json'
+      headers['Content-Length'] = payload.length
+    }
+    var req = https.request({
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: (options && options.method) || 'GET',
+      headers: headers,
+      timeout: (options && options.timeout) || 10000
+    }, function(r) {
+      var chunks = []
+      r.on('data', function(c) { chunks.push(c) })
+      r.on('end', function() {
+        var text = Buffer.concat(chunks).toString('utf8')
+        var parsed = null
+        if (text) {
+          try { parsed = JSON.parse(text) } catch (_) { parsed = null }
+        }
+        resolve({ status: r.statusCode || 0, body: parsed })
+      })
+    })
+    req.on('timeout', function() { req.destroy(new Error('AUTH_RESEND_SYNC_TIMEOUT')) })
+    req.on('error', reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+function createResendVaultReconciler(config) {
+  config = config || {}
+  var sbUrl = String(config.supabaseUrl || process.env.SUPABASE_URL || DEFAULT_SB_URL).replace(/\/$/, '')
+  var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))
+  var resendKey = String(config.resendApiKey != null ? config.resendApiKey : (process.env.RESEND_API_KEY || ''))
+  var requester = config.requestJson || requestJson
+
+  function headers() {
+    var out = {
+      apikey: serviceKey,
+      'Content-Type': 'application/json',
+      'User-Agent': 'AscendaOS-Auth-Resend-Reconcile/1.0'
+    }
+    if (!/^sb_(?:secret|publishable)_/.test(serviceKey)) out.Authorization = 'Bearer ' + serviceKey
+    return out
+  }
+
+  async function reconcile() {
+    if (serviceKey.length <= 20) return { ok: false, status: 503, code: 'AUTH_SERVICE_ROLE_NOT_CONFIGURED' }
+    if (resendKey.length <= 10) return { ok: false, status: 503, code: 'AUTH_RESEND_KEY_NOT_CONFIGURED' }
+
+    var lookup = await requester(
+      sbUrl + '/rest/v1/aos_integration_secrets_v1?select=integration_id&tipo=ilike.resend&limit=2',
+      { method: 'GET', headers: headers(), timeout: 10000 },
+      null
+    )
+    if (lookup.status < 200 || lookup.status >= 300) {
+      return { ok: false, status: 503, code: 'AUTH_RESEND_VAULT_LOOKUP_FAILED', upstream_status: lookup.status || null }
+    }
+
+    var rows = Array.isArray(lookup.body) ? lookup.body : []
+    if (rows.length !== 1 || !rows[0] || !rows[0].integration_id) {
+      return { ok: false, status: 503, code: rows.length > 1 ? 'AUTH_RESEND_VAULT_AMBIGUOUS' : 'AUTH_RESEND_VAULT_ROW_MISSING' }
+    }
+
+    var integrationId = String(rows[0].integration_id)
+    var updated = await requester(
+      sbUrl + '/rest/v1/aos_integration_secrets_v1?integration_id=eq.' + encodeURIComponent(integrationId),
+      { method: 'PATCH', headers: headers(), timeout: 10000 },
+      { api_key: resendKey, updated_at: new Date().toISOString() }
+    )
+    if (updated.status < 200 || updated.status >= 300) {
+      return { ok: false, status: 503, code: 'AUTH_RESEND_VAULT_UPDATE_FAILED', upstream_status: updated.status || null }
+    }
+
+    return { ok: true, status: 200, code: 'AUTH_RESEND_VAULT_RECONCILED' }
+  }
+
+  return {
+    reconcile: reconcile,
+    configured: function() {
+      return { service_role_configured: serviceKey.length > 20, resend_key_configured: resendKey.length > 10 }
+    }
+  }
+}
+
+module.exports = { createResendVaultReconciler: createResendVaultReconciler }

--- a/app/server-phase-s.js
+++ b/app/server-phase-s.js
@@ -5,6 +5,7 @@
 const http=require('http');
 const https=require('https');
 const {spawn}=require('child_process');
+const {createResendVaultReconciler}=require('./auth-resend-reconcile');
 
 const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10);
 const INNER_PORT=EXTERNAL_PORT===4225?4226:4225;
@@ -14,6 +15,24 @@ const SB_SERVICE_KEY=process.env.SUPABASE_SERVICE_ROLE_KEY||'';
 const WA_CANARY_MODE=process.env.WA_CANARY_MODE||'true';
 const WA_CANARY_ALLOW_TO=process.env.WA_CANARY_ALLOW_TO||'';
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const AUTH_RESEND_RECONCILER=createResendVaultReconciler();
+
+let authResendReady=false;
+let authResendSync=null;
+function ensureAuthResendReady(){
+  if(authResendReady)return Promise.resolve({ok:true,status:200,code:'AUTH_RESEND_VAULT_READY'});
+  if(authResendSync)return authResendSync;
+  authResendSync=AUTH_RESEND_RECONCILER.reconcile().then(out=>{
+    authResendReady=!!(out&&out.ok===true);
+    if(authResendReady)console.log('[PHASE-S] auth resend vault ready');
+    else console.warn('[PHASE-S] auth resend vault unavailable',out&&out.code?out.code:'AUTH_RESEND_SYNC_FAILED');
+    return out||{ok:false,status:503,code:'AUTH_RESEND_SYNC_FAILED'};
+  }).catch(e=>{
+    console.warn('[PHASE-S] auth resend vault unavailable','AUTH_RESEND_SYNC_ERROR');
+    return {ok:false,status:503,code:'AUTH_RESEND_SYNC_ERROR'};
+  }).finally(()=>{authResendSync=null;});
+  return authResendSync;
+}
 
 let childAlive=true;
 const child=spawn(process.execPath,['server-f5.js'],{
@@ -211,11 +230,17 @@ const server=http.createServer(async(req,res)=>{
     const ready=await probeChild();
     return writeJson(res,ready?200:503,{ok:ready,service:'ascenda-phase-s',child_alive:childAlive,inner_ready:ready});
   }
+  if(req.method==='POST'&&p==='/api/auth/v3/login'){
+    const sync=await ensureAuthResendReady();
+    if(!sync||sync.ok!==true)return writeJson(res,503,{ok:false,error:'No fue posible preparar el envío del código 2FA',code:sync&&sync.code?sync.code:'AUTH_RESEND_SYNC_FAILED'});
+    proxy(req,res);return;
+  }
   if(req.method==='GET'&&p==='/api/wa3/bootstrap')return handleBootstrap(req,res);
   if(req.method==='GET'&&p==='/api/phase-s/status')return handlePhaseStatus(req,res);
   return proxy(req,res);
 });
 
+ensureAuthResendReady().catch(()=>{});
 server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[PHASE-S] stabilization boundary listening',{external:EXTERNAL_PORT,inner:INNER_PORT}));
 function shutdown(sig){
   console.log('[PHASE-S] shutdown',sig);

--- a/ci/phase16/test_auth_resend_reconcile.js
+++ b/ci/phase16/test_auth_resend_reconcile.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const assert = require('assert')
+const { createResendVaultReconciler } = require('../../app/auth-resend-reconcile')
+
+async function run() {
+  const syntheticResend = 'synthetic-resend-key-long-enough-for-contract'
+  const syntheticService = 'synthetic-service-role-key-long-enough-for-contract'
+  const integrationId = '00000000-0000-4000-8000-000000000777'
+  const calls = []
+
+  const reconciler = createResendVaultReconciler({
+    supabaseUrl: 'https://synthetic.supabase.test',
+    serviceRoleKey: syntheticService,
+    resendApiKey: syntheticResend,
+    requestJson: async function(url, options, body) {
+      calls.push({ url, method: options.method, headers: options.headers, body })
+      if (options.method === 'GET') {
+        return { status: 200, body: [{ integration_id: integrationId }] }
+      }
+      if (options.method === 'PATCH') {
+        return { status: 204, body: null }
+      }
+      throw new Error('unexpected method')
+    }
+  })
+
+  const out = await reconciler.reconcile()
+  assert.strictEqual(out.ok, true)
+  assert.strictEqual(out.code, 'AUTH_RESEND_VAULT_RECONCILED')
+  assert.strictEqual(calls.length, 2, 'reconcile must perform one lookup and one exact patch')
+  assert.ok(calls.every(c => c.url.includes('/rest/v1/aos_integration_secrets_v1')), 'only private vault may be touched')
+  assert.ok(calls.every(c => !c.url.includes('/rest/v1/aos_integraciones')), 'public integration catalog must never be touched')
+  assert.strictEqual(calls[0].method, 'GET')
+  assert.strictEqual(calls[1].method, 'PATCH')
+  assert.ok(calls[1].url.includes('integration_id=eq.' + encodeURIComponent(integrationId)), 'patch must target exactly one integration id')
+  assert.strictEqual(calls[1].body.api_key, syntheticResend, 'Railway/provider key must be mirrored into private vault')
+  assert.ok(!JSON.stringify(out).includes(syntheticResend), 'secret must never be returned by reconciliation result')
+  assert.ok(!JSON.stringify(out).includes(syntheticService), 'service role must never be returned by reconciliation result')
+
+  let missingKeyCalls = 0
+  const missingKey = createResendVaultReconciler({
+    serviceRoleKey: syntheticService,
+    resendApiKey: '',
+    requestJson: async function() { missingKeyCalls++; return { status: 500, body: null } }
+  })
+  const missing = await missingKey.reconcile()
+  assert.strictEqual(missing.ok, false)
+  assert.strictEqual(missing.code, 'AUTH_RESEND_KEY_NOT_CONFIGURED')
+  assert.strictEqual(missingKeyCalls, 0, 'missing provider key must fail before network access')
+
+  let ambiguousPatches = 0
+  const ambiguous = createResendVaultReconciler({
+    serviceRoleKey: syntheticService,
+    resendApiKey: syntheticResend,
+    requestJson: async function(url, options) {
+      if (options.method === 'GET') return { status: 200, body: [{ integration_id: integrationId }, { integration_id: '00000000-0000-4000-8000-000000000778' }] }
+      ambiguousPatches++
+      return { status: 204, body: null }
+    }
+  })
+  const ambiguousOut = await ambiguous.reconcile()
+  assert.strictEqual(ambiguousOut.ok, false)
+  assert.strictEqual(ambiguousOut.code, 'AUTH_RESEND_VAULT_AMBIGUOUS')
+  assert.strictEqual(ambiguousPatches, 0, 'ambiguous vault state must never mutate credentials')
+
+  console.log('AUTH_RESEND_PRIVATE_VAULT_RECONCILE=PASS')
+  console.log('AUTH_RESEND_PUBLIC_CATALOG_UNTOUCHED=PASS')
+  console.log('AUTH_RESEND_SECRET_NON_DISCLOSURE=PASS')
+  console.log('AUTH_RESEND_FAIL_CLOSED=PASS')
+}
+
+run().catch(function(err) {
+  console.error('AUTH_RESEND_PRIVATE_VAULT_RECONCILE=FAIL', err && err.message ? err.message : err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Problem
Auth V3 creates the 2FA challenge but Resend currently rejects the provider request with HTTP 401 because the private Supabase vault can drift from the active Railway `RESEND_API_KEY`.

## Fix
- add a server-side reconciler that treats Railway `RESEND_API_KEY` as the operational source;
- mirror it only into `aos_integration_secrets_v1` using the existing service-role boundary;
- never write provider credentials back into public `aos_integraciones`;
- gate `/api/auth/v3/login` until reconciliation succeeds;
- keep general ASCENDA availability independent from email provider health;
- add synthetic tests for exact-row patching, secret non-disclosure, ambiguous-vault fail-closed behavior;
- remove the Windows FAST Python provisioning dependency from the Phase S runtime gate and leave Python/DB contracts delegated to Linux Zero-Cost workflows.

## Production validation after merge
1. Railway deploy health remains green.
2. Auth login returns 2FA challenge.
3. Provider response for the new request is 2xx.
4. Code arrives in Gmail.
5. No provider secret is exposed in logs/responses/public catalog.

No DB migration, no key rotation, no new secret and no manual credential duplication.