### PR TITLE
feat(sentinel): establish F5 availability foundation

### DIFF
--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -1,0 +1,95 @@
+name: Sentinel F5 Availability Foundation Certificate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/server-phase-s.js'
+      - 'sentinel/availability/**'
+      - 'ci/sentinel/phase5_availability_contract.js'
+      - 'docs/control/SENTINEL_F5_*.md'
+      - 'docs/control/SENTINEL_ROADMAP_V1.md'
+      - '.github/workflows/sentinel-phase5-availability.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sentinel-f5-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-fast:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: State machine syntax
+        shell: powershell
+        run: node --check sentinel/availability/state-machine.cjs
+      - name: F5 availability contract
+        shell: powershell
+        run: node ci/sentinel/phase5_availability_contract.js
+
+  uptime-kuma-container-smoke:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 15
+    env:
+      KUMA_IMAGE: louislam/uptime-kuma:2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce Zero-Cost runner policy
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          docker version >/dev/null
+      - name: Validate versioned compose artifact statically
+        run: |
+          set -euo pipefail
+          grep -q 'image: louislam/uptime-kuma:2' sentinel/availability/compose.yaml
+          grep -q '127.0.0.1:3001:3001' sentinel/availability/compose.yaml
+          grep -q 'uptime-kuma-data:/app/data' sentinel/availability/compose.yaml
+          grep -q 'no-new-privileges:true' sentinel/availability/compose.yaml
+          ! grep -Eq '(SENTRY_DSN|SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|Bearer )' sentinel/availability/compose.yaml
+          ! grep -q 'network_mode: host' sentinel/availability/compose.yaml
+          ! grep -q '/var/run/docker.sock' sentinel/availability/compose.yaml
+      - name: Start disposable Uptime Kuma with Docker
+        run: |
+          set -euo pipefail
+          NAME="sentinel-f5-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          VOLUME="${NAME}-data"
+          echo "KUMA_NAME=$NAME" >> "$GITHUB_ENV"
+          echo "KUMA_VOLUME=$VOLUME" >> "$GITHUB_ENV"
+          docker volume create "$VOLUME" >/dev/null
+          docker run -d \
+            --name "$NAME" \
+            --security-opt no-new-privileges:true \
+            -p 127.0.0.1::3001 \
+            -v "$VOLUME:/app/data" \
+            "$KUMA_IMAGE" >/tmp/sentinel-f5-container-id.txt
+          PORT="$(docker inspect -f '{{(index (index .NetworkSettings.Ports "3001/tcp") 0).HostPort}}' "$NAME")"
+          test -n "$PORT"
+          echo "KUMA_PORT=$PORT" >> "$GITHUB_ENV"
+          ok=0
+          for i in $(seq 1 60); do
+            if curl -fsS --max-time 3 "http://127.0.0.1:${PORT}/" >/tmp/sentinel-f5-kuma.html; then ok=1; break; fi
+            if ! docker ps --format '{{.Names}}' | grep -qx "$NAME"; then break; fi
+            sleep 2
+          done
+          if [ "$ok" != 1 ]; then
+            docker logs "$NAME" || true
+            exit 1
+          fi
+          test -s /tmp/sentinel-f5-kuma.html
+          echo 'SENTINEL_F5_KUMA_CONTAINER_SMOKE=PASS'
+      - name: Destroy disposable observer and volume
+        if: always()
+        run: |
+          if [ -n "${KUMA_NAME:-}" ]; then docker rm -f "$KUMA_NAME" >/dev/null 2>&1 || true; fi
+          if [ -n "${KUMA_VOLUME:-}" ]; then docker volume rm "$KUMA_VOLUME" >/dev/null 2>&1 || true; fi
+          if [ -n "${KUMA_NAME:-}" ]; then test -z "$(docker ps -aq --filter name=^/${KUMA_NAME}$)" || exit 1; fi

--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -3,13 +3,16 @@ name: Sentinel F5 Availability Foundation Certificate
 on:
   pull_request:
     branches: [main]
-    paths:
+    paths: &f5_paths
       - 'app/server-phase-s.js'
       - 'sentinel/availability/**'
       - 'ci/sentinel/phase5_availability_contract.js'
       - 'docs/control/SENTINEL_F5_*.md'
       - 'docs/control/SENTINEL_ROADMAP_V1.md'
       - '.github/workflows/sentinel-phase5-availability.yml'
+  push:
+    branches: ['feature/**','fix/**']
+    paths: *f5_paths
 
 permissions:
   contents: read

--- a/ci/sentinel/phase5_availability_contract.js
+++ b/ci/sentinel/phase5_availability_contract.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs=require('fs');
+const path=require('path');
+const ROOT=path.resolve(__dirname,'../..');
+const read=p=>fs.readFileSync(path.join(ROOT,p),'utf8');
+const json=p=>JSON.parse(read(p));
+const ok=(v,m)=>{if(!v)throw new Error(m);};
+
+const f4=read('docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md');
+const f5=json('sentinel/availability/f5-contract.json');
+const compose=read('sentinel/availability/compose.yaml');
+const phaseS=read('app/server-phase-s.js');
+const sm=require(path.join(ROOT,'sentinel/availability/state-machine.cjs'));
+
+ok(f4.includes('**F4:** `100_COMPLETE`'),'F4_NOT_CERTIFIED');
+ok(f4.includes('**Resultado:** `18/18 PASS`'),'F4_GATES_NOT_COMPLETE');
+ok(f5.schema_version==='sentinel-availability/v1'&&f5.phase==='F5','F5_CONTRACT_INVALID');
+ok(f5.observer.engine==='uptime-kuma','F5_ENGINE_DRIFT');
+ok(f5.observer.docker_image==='louislam/uptime-kuma:2','F5_IMAGE_DRIFT');
+ok(f5.observer.must_be_independent_from_ascenda_railway_runtime===true,'F5_OBSERVER_INDEPENDENCE_REQUIRED');
+ok(f5.observer.same_railway_service_forbidden===true,'F5_SAME_RUNTIME_FORBIDDEN');
+ok(f5.observer.public_admin_ui_default===false,'F5_ADMIN_UI_MUST_NOT_DEFAULT_PUBLIC');
+ok(f5.privacy.zero_phi_pii===true&&f5.privacy.no_auth_headers===true&&f5.privacy.no_tokens===true,'F5_PRIVACY_DRIFT');
+ok(f5.privacy.no_patient_identifiers===true&&f5.privacy.no_message_content===true&&f5.privacy.no_request_bodies===true,'F5_DATA_BOUNDARY_DRIFT');
+ok(f5.privacy.no_provider_secrets_in_monitor_config===true,'F5_PROVIDER_SECRET_BOUNDARY_DRIFT');
+ok(f5.cost.software_license_cost_usd_month===0&&f5.cost.automatic_paid_hosting===false,'F5_COST_GUARD_DRIFT');
+ok(f5.deployment.production_deploy_in_f5_foundation===false,'F5_PROD_DEPLOY_FORBIDDEN_IN_FOUNDATION');
+ok(f5.anti_flapping.failure_samples_required===3&&f5.anti_flapping.recovery_samples_required===2,'F5_ANTI_FLAP_DRIFT');
+ok(f5.anti_flapping.direct_notification_from_uptime_kuma===false&&f5.anti_flapping.notifications_owned_by_phase==='F9','F5_ALERT_SCOPE_DRIFT');
+
+ok(Array.isArray(f5.baseline_monitors)&&f5.baseline_monitors.length===1,'F5_BASELINE_MONITOR_COUNT');
+const mon=f5.baseline_monitors[0];
+ok(mon.url==='https://ascenda-os-production.up.railway.app/health','F5_HEALTH_URL_DRIFT');
+ok(mon.method==='GET'&&mon.expected_http_status===200,'F5_HEALTH_METHOD_STATUS_DRIFT');
+ok(mon.expected_json?.ok===true&&mon.expected_json?.service==='ascenda-phase-s'&&mon.expected_json?.child_alive===true&&mon.expected_json?.inner_ready===true,'F5_EXPECTED_HEALTH_DRIFT');
+ok(mon.contains_phi_pii===false,'F5_MONITOR_PRIVACY_DRIFT');
+
+ok(phaseS.includes("p==='/health'"),'F5_HEALTH_ROUTE_MISSING');
+ok(phaseS.includes("{ok:ready,service:'ascenda-phase-s',child_alive:childAlive,inner_ready:ready}"),'F5_HEALTH_RESPONSE_DRIFT');
+
+ok(compose.includes('image: louislam/uptime-kuma:2'),'F5_COMPOSE_IMAGE_DRIFT');
+ok(compose.includes('127.0.0.1:3001:3001'),'F5_KUMA_UI_NOT_LOCALHOST_BOUND');
+ok(compose.includes('uptime-kuma-data:/app/data'),'F5_LOCAL_PERSISTENT_VOLUME_MISSING');
+ok(!/\b(?:SENTRY_DSN|SUPABASE_SERVICE_ROLE_KEY|SUPABASE_ANON_KEY|RESEND_API_KEY|Authorization|apikey)\b/.test(compose),'F5_SECRET_MATERIAL_IN_COMPOSE');
+ok(!compose.includes('network_mode: host'),'F5_HOST_NETWORK_FORBIDDEN');
+ok(!compose.includes('/var/run/docker.sock'),'F5_DOCKER_SOCKET_FORBIDDEN');
+
+const c=sm.classifyAvailability;
+ok(c({observerFresh:false,consecutiveSuccesses:10})==='UNKNOWN','F5_UNKNOWN_OBSERVER_STALE');
+ok(c({observerFresh:true,consecutiveSuccesses:1})==='UNKNOWN','F5_INITIAL_UNKNOWN_DRIFT');
+ok(c({observerFresh:true,consecutiveSuccesses:2})==='UP','F5_UP_THRESHOLD_DRIFT');
+ok(c({observerFresh:true,consecutiveFailures:1})==='DEGRADED','F5_DEGRADED_DRIFT');
+ok(c({observerFresh:true,consecutiveFailures:2})==='DEGRADED','F5_DEGRADED_BEFORE_THRESHOLD_DRIFT');
+ok(c({observerFresh:true,consecutiveFailures:3})==='DOWN','F5_DOWN_THRESHOLD_DRIFT');
+ok(sm.sentinelHealthState('UP')==='HEALTHY','F5_SENTINEL_UP_MAP');
+ok(sm.sentinelHealthState('DEGRADED')==='DEGRADED','F5_SENTINEL_DEGRADED_MAP');
+ok(sm.sentinelHealthState('DOWN')==='INCIDENT','F5_SENTINEL_DOWN_MAP');
+ok(sm.sentinelHealthState('UNKNOWN')==='UNKNOWN','F5_SENTINEL_UNKNOWN_MAP');
+ok(sm.availabilityFingerprint({environment:'production',monitorId:'ascenda-production-health'})==='availability:production:ascenda-production-health','F5_FINGERPRINT_DRIFT');
+
+const serialized=JSON.stringify(f5);
+const secretPatterns=[
+  /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
+  /\b(?:eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/,
+  /\bBearer\s+[A-Za-z0-9._~-]{20,}\b/i,
+  /https:\/\/[A-Za-z0-9_-]{16,}@[A-Za-z0-9.-]+\.ingest(?:\.[A-Za-z0-9.-]+)?\.sentry\.io\/\d+/i,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  /\b(?:sk-(?:proj-)?|xox[baprs]-)[A-Za-z0-9_-]{20,}\b/
+];
+for(const re of secretPatterns)ok(!re.test(serialized),`F5_CONTRACT_MATERIAL_SECRET:${re}`);
+ok(!Object.prototype.hasOwnProperty.call(mon,'headers'),'F5_MONITOR_HEADERS_FORBIDDEN');
+ok(!Object.prototype.hasOwnProperty.call(mon,'body'),'F5_MONITOR_BODY_FORBIDDEN');
+ok(!Object.prototype.hasOwnProperty.call(mon,'username')&&!Object.prototype.hasOwnProperty.call(mon,'password'),'F5_MONITOR_CREDENTIAL_FIELDS_FORBIDDEN');
+
+console.log(JSON.stringify({
+  ok:true,
+  certificate:'SENTINEL_F5_AVAILABILITY_FOUNDATION_PASS',
+  f4_complete:true,
+  observer:'uptime-kuma',
+  production_host:'PENDING_APPROVAL',
+  production_deploy:false,
+  monitor_count:f5.baseline_monitors.length,
+  zero_phi_pii:true,
+  material_secret_patterns:0,
+  anti_flapping:true,
+  direct_notifications:false,
+  state_machine:true
+},null,2));

--- a/docs/control/SENTINEL_F5_AVAILABILITY_PLAN.md
+++ b/docs/control/SENTINEL_F5_AVAILABILITY_PLAN.md
@@ -1,0 +1,181 @@
+# Sentinel F5 — Availability Layer / Uptime Kuma
+
+**Fecha:** 2026-08-16 (America/Lima)  
+**Estado inicial:** `FOUNDATION_IN_PROGRESS`  
+**Dependencia:** F4 `100_COMPLETE / 18/18 PASS`  
+**Baseline main:** `00797fe87869f4cee8a11414de1f1de262e8c109`  
+**Costo cloud incremental autorizado en foundation:** `US$0`
+
+## 1. Objetivo
+
+Añadir un observador externo capaz de detectar que ASCENDA no responde aunque el runtime interno no pueda reportar su propio fallo. F5 no reemplaza Sentry y no introduce todavía Business Health, Telegram ni Incident Engine.
+
+## 2. Decisión de observador
+
+Se adopta Uptime Kuma como engine self-hosted de disponibilidad.
+
+Verificación técnica al 2026-08-16:
+
+- rama mayor oficial: `2`;
+- release estable observada al diseñar F5: `2.3.2`;
+- compose oficial usa `louislam/uptime-kuma:2`;
+- almacenamiento `/app/data` requiere volumen/local filesystem compatible con file locking; NFS no se admite para esta baseline.
+
+El artefacto ASCENDA mantiene `:2` como major soportado oficialmente. Actualizaciones de major/minor no se consideran automáticas ni forman parte de F5.
+
+## 3. Principio de independencia
+
+El observer 24/7 debe cumplir:
+
+1. no ejecutarse dentro del proceso ASCENDA;
+2. no ejecutarse en el mismo Railway service;
+3. idealmente no depender de Railway como proveedor de cómputo;
+4. si el observer queda sin heartbeat, Sentinel debe mostrar `UNKNOWN`, nunca `HEALTHY`;
+5. la caída del observer no puede bloquear ASCENDA.
+
+## 4. Probe baseline autorizado
+
+### `ascenda-production-health`
+
+```text
+GET https://ascenda-os-production.up.railway.app/health
+```
+
+Esperado:
+
+```json
+{
+  "ok": true,
+  "service": "ascenda-phase-s",
+  "child_alive": true,
+  "inner_ready": true
+}
+```
+
+Política:
+
+- interval: 60 s;
+- timeout: 10 s;
+- 3 muestras fallidas consecutivas para `DOWN`;
+- 1–2 fallos consecutivos ⇒ `DEGRADED`;
+- 2 éxitos consecutivos para recuperar `UP`;
+- observador stale/no evidence ⇒ `UNKNOWN`.
+
+No se fija todavía SLA por latencia; primero se recogerá baseline real antes de convertir latencia en severidad.
+
+## 5. Endpoints expresamente excluidos de Kuma en F5
+
+- `/api/phase-s/status` por requerir sesión/token;
+- endpoints clínicos;
+- endpoints de WhatsApp/email con contenido;
+- Supabase REST/RPC que requieran `apikey`, bearer o service role;
+- bodies de login/2FA;
+- cualquier probe que necesite identidad de paciente/persona.
+
+Dependency health profundo corresponde a F6/F7 mediante probes sanitizados, no credenciales pegadas en Uptime Kuma.
+
+## 6. Privacidad
+
+Kuma recibe únicamente información de disponibilidad técnica. Prohibido almacenar:
+
+- PHI/PII;
+- nombres, teléfonos, DNI, emails de pacientes;
+- mensajes WhatsApp/email;
+- cookies/tokens;
+- `service_role`;
+- request bodies;
+- credenciales de proveedores.
+
+La UI de Kuma se liga inicialmente a localhost `127.0.0.1:3001`. Cualquier exposición remota futura debe tener autenticación, 2FA/reverse proxy seguro y gate específico.
+
+## 7. Noise / anti-flapping
+
+F5 produce señal de disponibilidad, no alerta final.
+
+- Kuma notifications: OFF en baseline;
+- Telegram: reservado a F9;
+- fingerprint baseline: `availability:production:ascenda-production-health`;
+- maintenance windows deben poder suprimir transición a incidente;
+- repetición del mismo outage mantiene un solo fingerprint/caso lógico;
+- recovery requiere estabilidad de dos muestras.
+
+## 8. Estados
+
+| Kuma/F5 | Sentinel |
+|---|---|
+| UP | HEALTHY |
+| partial failures | DEGRADED |
+| DOWN | INCIDENT |
+| observer stale / insufficient evidence | UNKNOWN |
+
+F5 todavía no asigna `CRITICAL`; esa severidad requiere contexto de impacto/Incident Engine.
+
+## 9. Deployment artifact
+
+Archivo: `sentinel/availability/compose.yaml`
+
+Propiedades:
+
+- `louislam/uptime-kuma:2`;
+- restart `unless-stopped`;
+- UI localhost-only;
+- volumen persistente local;
+- `no-new-privileges`;
+- sin secretos en código;
+- sin Docker socket montado.
+
+CI puede levantarlo temporalmente y destruir contenedor + volumen. Eso certifica el artefacto sin convertir CI en monitor 24/7.
+
+## 10. Host decision — F5-HOST-01
+
+F5 no desplegará automáticamente infraestructura pagada. El host productivo debe elegirse entre una opción realmente independiente y disponible 24/7.
+
+Criterios obligatorios:
+
+- encendido 24/7;
+- salida HTTPS hacia Railway;
+- storage local persistente;
+- Docker/Compose o Docker equivalente versionado;
+- backup de `/app/data`;
+- administración restringida;
+- no introducir costo no autorizado;
+- no usar el mismo Railway service observado.
+
+Posibles categorías:
+
+1. host Linux propio siempre encendido;
+2. nodo FORGE futuro 24/7;
+3. VPS pequeño aprobado expresamente;
+4. otro host independiente documentado.
+
+Un runner CI que se apaga al terminar el trabajo no cuenta como observer 24/7.
+
+## 11. Gates F5
+
+| Gate | Evidencia | Estado inicial |
+|---|---|---|
+| F5-G01 | F4 `100_COMPLETE / 18/18` | PASS |
+| F5-G02 | contrato `sentinel-availability/v1` | EN CI |
+| F5-G03 | Zero-PHI/PII + sin credenciales materiales | EN CI |
+| F5-G04 | `/health` probe seguro versionado | EN CI |
+| F5-G05 | state mapping + UNKNOWN explícito | EN CI |
+| F5-G06 | anti-flapping + fingerprint | EN CI |
+| F5-G07 | Docker Compose localhost-only | EN CI |
+| F5-G08 | disposable Kuma container smoke | EN CI |
+| F5-G09 | host 24/7 independiente seleccionado/aprobado | PENDING HUMAN BOUNDARY |
+| F5-G10 | deployment persistente + observer heartbeat | PENDING |
+| F5-G11 | outage sintético + recovery + dedup | PENDING |
+| F5-G12 | checkpoint final + Notion F5=100 + F6 siguiente | PENDING |
+
+## 12. Definition of Done
+
+F5 cierra solo cuando:
+
+- el observer independiente funciona 24/7;
+- `/health` puede declararse DOWN sin depender de Sentry;
+- observer failure produce UNKNOWN;
+- outage/recovery sintéticos respetan anti-flapping;
+- no existen PHI/PII/secrets en configuración/evidencia;
+- costo incremental está dentro de lo autorizado;
+- GitHub y Notion coinciden;
+- F6 queda como única fase siguiente.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -359,6 +359,7 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 - Fase 1: `CERRADA / 100_COMPLETE`.
 - Fase 2: `CERRADA / 100_COMPLETE`.
 - Fase 3: `CERRADA / 100_COMPLETE`.
-- Fase 4: `SIGUIENTE`.
-- Fases 5–13: `PENDIENTE`.
-- Ningún sensor productivo queda autorizado por el cierre de F3; F4 debe ejecutar privacy gate, synthetic error gate y kill-switch antes de activarse.
+- Fase 4: `CERRADA / 100_COMPLETE / 18/18 PASS`.
+- Fase 5: `EN CURSO — Availability Foundation`.
+- Fases 6–13: `PENDIENTE`.
+- F5 no autoriza gasto automático ni despliegue 24/7 hasta resolver `F5-HOST-01`; la foundation puede certificarse íntegramente en CI Zero-Cost.

--- a/sentinel/availability/compose.yaml
+++ b/sentinel/availability/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: sentinel-uptime-kuma
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3001:3001"
+    volumes:
+      - uptime-kuma-data:/app/data
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  uptime-kuma-data:

--- a/sentinel/availability/f5-contract.json
+++ b/sentinel/availability/f5-contract.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "sentinel-availability/v1",
+  "phase": "F5",
+  "baseline_main": "00797fe87869f4cee8a11414de1f1de262e8c109",
+  "observer": {
+    "engine": "uptime-kuma",
+    "docker_image": "louislam/uptime-kuma:2",
+    "verified_release_at_design_time": "2.3.2",
+    "verified_on": "2026-08-16",
+    "production_host_required": true,
+    "must_be_independent_from_ascenda_railway_runtime": true,
+    "same_railway_service_forbidden": true,
+    "public_admin_ui_default": false,
+    "bind_admin_ui": "127.0.0.1:3001",
+    "data_volume": "local-persistent-volume",
+    "nfs_forbidden": true
+  },
+  "privacy": {
+    "zero_phi_pii": true,
+    "no_auth_headers": true,
+    "no_tokens": true,
+    "no_patient_identifiers": true,
+    "no_message_content": true,
+    "no_request_bodies": true,
+    "no_provider_secrets_in_monitor_config": true
+  },
+  "baseline_monitors": [
+    {
+      "id": "ascenda-production-health",
+      "type": "http-json",
+      "method": "GET",
+      "url": "https://ascenda-os-production.up.railway.app/health",
+      "environment": "production",
+      "interval_seconds": 60,
+      "timeout_seconds": 10,
+      "retries_before_down": 2,
+      "recovery_successes": 2,
+      "expected_http_status": 200,
+      "expected_json": {
+        "ok": true,
+        "service": "ascenda-phase-s",
+        "child_alive": true,
+        "inner_ready": true
+      },
+      "contains_phi_pii": false
+    }
+  ],
+  "state_translation": {
+    "observer_stale": "UNKNOWN",
+    "initial_or_insufficient_samples": "UNKNOWN",
+    "healthy_after_success_threshold": "UP",
+    "partial_failure_before_down_threshold": "DEGRADED",
+    "failure_threshold_reached": "DOWN"
+  },
+  "anti_flapping": {
+    "failure_samples_required": 3,
+    "recovery_samples_required": 2,
+    "direct_notification_from_uptime_kuma": false,
+    "notifications_owned_by_phase": "F9",
+    "maintenance_suppression_required": true
+  },
+  "cost": {
+    "software_license_cost_usd_month": 0,
+    "automatic_paid_hosting": false,
+    "hosting_must_be_approved_before_24x7_deploy": true
+  },
+  "deployment": {
+    "ci_container_smoke_allowed": true,
+    "ci_must_destroy_container_and_volume": true,
+    "production_deploy_in_f5_foundation": false,
+    "host_decision_gate": "F5-HOST-01"
+  },
+  "forbidden_external_probes": [
+    "/api/phase-s/status",
+    "authenticated endpoints",
+    "Supabase endpoints requiring apikey/service_role",
+    "WhatsApp or email content endpoints",
+    "clinical endpoints"
+  ]
+}

--- a/sentinel/availability/state-machine.cjs
+++ b/sentinel/availability/state-machine.cjs
@@ -1,0 +1,38 @@
+'use strict';
+
+const STATES=Object.freeze({
+  UP:'UP',
+  DEGRADED:'DEGRADED',
+  DOWN:'DOWN',
+  UNKNOWN:'UNKNOWN'
+});
+
+function classifyAvailability(input={}){
+  const observerFresh=input.observerFresh===true;
+  const consecutiveFailures=Number.isInteger(input.consecutiveFailures)?Math.max(0,input.consecutiveFailures):0;
+  const consecutiveSuccesses=Number.isInteger(input.consecutiveSuccesses)?Math.max(0,input.consecutiveSuccesses):0;
+  const failureThreshold=Number.isInteger(input.failureThreshold)?Math.max(1,input.failureThreshold):3;
+  const recoveryThreshold=Number.isInteger(input.recoveryThreshold)?Math.max(1,input.recoveryThreshold):2;
+
+  if(!observerFresh)return STATES.UNKNOWN;
+  if(consecutiveFailures>=failureThreshold)return STATES.DOWN;
+  if(consecutiveFailures>0)return STATES.DEGRADED;
+  if(consecutiveSuccesses>=recoveryThreshold)return STATES.UP;
+  return STATES.UNKNOWN;
+}
+
+function sentinelHealthState(availabilityState){
+  switch(availabilityState){
+    case STATES.UP:return 'HEALTHY';
+    case STATES.DEGRADED:return 'DEGRADED';
+    case STATES.DOWN:return 'INCIDENT';
+    default:return 'UNKNOWN';
+  }
+}
+
+function availabilityFingerprint({environment='unknown',monitorId='unknown'}={}){
+  const safe=s=>String(s||'unknown').toLowerCase().replace(/[^a-z0-9._-]+/g,'-').replace(/^-+|-+$/g,'')||'unknown';
+  return `availability:${safe(environment)}:${safe(monitorId)}`;
+}
+
+module.exports={STATES,classifyAvailability,sentinelHealthState,availabilityFingerprint};


### PR DESCRIPTION
## Sentinel F5 — Availability foundation

Clean F5-only replacement for superseded PR #194, based on certified main after F4 closure (#195).

### Adds
- `sentinel-availability/v1` contract.
- Uptime Kuma `louislam/uptime-kuma:2` deployment artifact, localhost-only admin UI.
- Safe production `/health` baseline monitor with no auth headers/body/secrets.
- UP / DEGRADED / DOWN / UNKNOWN state machine and stable availability fingerprint.
- Anti-flapping thresholds; direct notifications remain OFF and reserved for F9.
- Zero-Cost FAST contract and Linux disposable Docker smoke.
- F5 execution plan and canonical roadmap transition.

### Safety / cost
- No DB or Supabase changes.
- No ASCENDA production runtime changes.
- No secrets.
- No PHI/PII.
- No external Uptime Kuma deployment yet.
- No Telegram/alert routing yet.
- No automatic paid hosting.
- Incremental cloud cost for this foundation: US$0.

### Human boundary
F5-G09 (`F5-HOST-01`) remains explicit: choose/approve an independent always-on 24/7 host before any persistent deployment.