### PR TITLE
F17 V13: reconcile legacy WhatsApp gateway with CURRENT main

### DIFF
--- a/.github/workflows/f17-multichannel.yml
+++ b/.github/workflows/f17-multichannel.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'app/f17-whatsapp-legacy-gateway.js'
       - 'supabase/migrations/*f17_*'
       - 'supabase/rollbacks/*f17_*'
       - 'ci/f17-multichannel/**'
@@ -27,6 +28,9 @@ jobs:
       DB_URL: postgresql://postgres:postgres@127.0.0.1:59722/postgres
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: supabase/setup-cli@v1
         with:
           version: 2.101.0
@@ -36,6 +40,13 @@ jobs:
           set -euo pipefail
           test "${{ runner.environment }}" = "self-hosted"
           python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Validate server-authoritative legacy WhatsApp gateway
+        run: |
+          set -euo pipefail
+          node --check app/f17-whatsapp-legacy-gateway.js
+          node --check ci/f17-multichannel/test_legacy_whatsapp_gateway.js
+          node ci/f17-multichannel/test_legacy_whatsapp_gateway.js
 
       - name: Configure isolated Supabase
         working-directory: ci/zero-cost-staging

--- a/app/f17-whatsapp-legacy-gateway.js
+++ b/app/f17-whatsapp-legacy-gateway.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const https = require('https')
+
+const DEFAULT_SB_URL = 'https://ituyqwstonmhnfshnaqz.supabase.co'
+
+function jsonResponse(res, status, body) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff'
+  })
+  res.end(JSON.stringify(body))
+}
+
+function requestJson(urlString, options) {
+  return new Promise(function(resolve, reject) {
+    var url = new URL(urlString)
+    var req = https.request({
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: (options && options.method) || 'GET',
+      headers: (options && options.headers) || {},
+      timeout: (options && options.timeout) || 15000
+    }, function(r) {
+      var chunks = []
+      r.on('data', function(c) { chunks.push(c) })
+      r.on('end', function() {
+        var text = Buffer.concat(chunks).toString('utf8')
+        var parsed = null
+        if (text) {
+          try { parsed = JSON.parse(text) } catch (_) { parsed = null }
+        }
+        resolve({ status: r.statusCode || 0, body: parsed })
+      })
+    })
+    req.on('timeout', function() { req.destroy(new Error('UPSTREAM_TIMEOUT')) })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+function createLegacyWhatsAppGateway(config) {
+  config = config || {}
+  var sbUrl = String(config.supabaseUrl || process.env.SUPABASE_URL || DEFAULT_SB_URL).replace(/\/$/, '')
+  var serviceKey = String(config.serviceRoleKey != null ? config.serviceRoleKey : (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.service_role || ''))
+  var verifyApp = config.verifyApp
+  var requester = config.requestJson || requestJson
+
+  function configured() {
+    return serviceKey.length > 20 && typeof verifyApp === 'function'
+  }
+
+  async function listTemplates(token) {
+    if (!configured()) return { ok: false, status: 503, error: 'WHATSAPP_GATEWAY_NOT_CONFIGURED' }
+    var actor = await verifyApp(String(token || ''))
+    if (!actor || actor.ok !== true) return { ok: false, status: actor && actor.status ? actor.status : 401, error: 'UNAUTHORIZED' }
+
+    var headers = { apikey: serviceKey }
+    if (!/^sb_(?:secret|publishable)_/.test(serviceKey)) headers.Authorization = 'Bearer ' + serviceKey
+    var query = '/rest/v1/aos_plantillas_whatsapp?select=id,nombre,icono,color,contexto,mensaje,orden&activo=eq.true&order=orden.asc'
+    var result = await requester(sbUrl + query, { method: 'GET', headers: headers, timeout: 15000 })
+    if (!result || result.status < 200 || result.status >= 300 || !Array.isArray(result.body)) {
+      return { ok: false, status: 502, error: 'WHATSAPP_TEMPLATE_READ_FAILED' }
+    }
+
+    var templates = result.body.map(function(row) {
+      return {
+        id: row.id,
+        nombre: row.nombre || '',
+        icono: row.icono || '',
+        color: row.color || '',
+        contexto: row.contexto || '',
+        mensaje: row.mensaje || '',
+        orden: Number.isFinite(Number(row.orden)) ? Number(row.orden) : 0
+      }
+    })
+    return { ok: true, templates: templates }
+  }
+
+  async function handle(req, res) {
+    if (req.method !== 'GET') return jsonResponse(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' })
+    try {
+      var token = String(req.headers['x-ascenda-session'] || '')
+      var out = await listTemplates(token)
+      return jsonResponse(res, out.ok ? 200 : (out.status || 400), out)
+    } catch (_) {
+      return jsonResponse(res, 500, { ok: false, error: 'WHATSAPP_GATEWAY_ERROR' })
+    }
+  }
+
+  return {
+    configured: configured,
+    listTemplates: listTemplates,
+    handle: handle
+  }
+}
+
+module.exports = {
+  createLegacyWhatsAppGateway: createLegacyWhatsAppGateway
+}

--- a/ci/f17-multichannel/test_legacy_whatsapp_gateway.js
+++ b/ci/f17-multichannel/test_legacy_whatsapp_gateway.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const assert = require('assert')
+const { createLegacyWhatsAppGateway } = require('../../app/f17-whatsapp-legacy-gateway')
+
+async function run() {
+  var calls = []
+  var gateway = createLegacyWhatsAppGateway({
+    supabaseUrl: 'https://example.invalid',
+    serviceRoleKey: 'service-role-test-value-long-enough',
+    verifyApp: async function(token) {
+      return token === 'valid-session-token-that-is-long-enough'
+        ? { ok: true, user_id: 'synthetic-user', rol: 'ASESOR' }
+        : { ok: false, status: 401, error: 'UNAUTHORIZED' }
+    },
+    requestJson: async function(url, options) {
+      calls.push({ url: url, options: options })
+      return {
+        status: 200,
+        body: [{ id: 'tpl-1', nombre: 'Synthetic', icono: 'x', color: '#fff', contexto: 'NO_CONTESTA', mensaje: 'synthetic-template-body', orden: 1 }]
+      }
+    }
+  })
+
+  var denied = await gateway.listTemplates('invalid')
+  assert.strictEqual(denied.ok, false)
+  assert.strictEqual(denied.status, 401)
+  assert.strictEqual(calls.length, 0, 'unauthorized request must not touch Supabase')
+
+  var allowed = await gateway.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(allowed.ok, true)
+  assert.strictEqual(allowed.templates.length, 1)
+  assert.strictEqual(calls.length, 1)
+  assert.ok(calls[0].url.includes('/rest/v1/aos_plantillas_whatsapp?'))
+  assert.ok(calls[0].url.includes('activo=eq.true'))
+  assert.ok(calls[0].url.includes('select=id,nombre,icono,color,contexto,mensaje,orden'))
+  assert.strictEqual(calls[0].options.headers.apikey, 'service-role-test-value-long-enough')
+  assert.strictEqual(allowed.templates[0].mensaje, 'synthetic-template-body')
+
+  var missingConfig = createLegacyWhatsAppGateway({
+    serviceRoleKey: '',
+    verifyApp: async function() { return { ok: true, user_id: 'synthetic-user' } },
+    requestJson: async function() { throw new Error('must not be called') }
+  })
+  var unavailable = await missingConfig.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(unavailable.ok, false)
+  assert.strictEqual(unavailable.status, 503)
+
+  var upstreamFailure = createLegacyWhatsAppGateway({
+    serviceRoleKey: 'service-role-test-value-long-enough',
+    verifyApp: async function() { return { ok: true, user_id: 'synthetic-user' } },
+    requestJson: async function() { return { status: 500, body: { error: 'synthetic' } }
+  })
+  var failed = await upstreamFailure.listTemplates('valid-session-token-that-is-long-enough')
+  assert.strictEqual(failed.ok, false)
+  assert.strictEqual(failed.status, 502)
+
+  console.log('F17 legacy WhatsApp gateway contract: PASS')
+}
+
+run().catch(function(err) {
+  console.error(err && err.stack ? err.stack : err)
+  process.exit(1)
+})

--- a/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V13.md
+++ b/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V13.md
@@ -1,0 +1,32 @@
+# CIA V3 F17 — Impact Report V13
+
+Date: 2026-08-16 (America/Lima)
+Base: `main@00797fe87869f4cee8a11414de1f1de262e8c109`
+Branch: `feature/cia-phase17-multichannel-20260816-v13`
+
+## Fresh authoritative preflight
+- F16 production readiness exists and returns exactly `READY_F17_EMAIL_CERTIFIED` with `ready_for_f17=true`.
+- All F16 release gates are true; Issue #104 is CLOSED/completed.
+- F17 production readiness remains `IN_PROGRESS_MULTICHANNEL_GOVERNANCE` with `ready_for_f18=false`.
+- F17 gates currently true: `contracts_active`, `whatsapp_bridge_validated`.
+- F17 gates currently false: `outbound_policy_validated`, `webhook_replay_validated`, `canary_passed`, `rollback_verified`.
+- CRITICAL Issue #173 remains OPEN.
+
+## Why V13
+V12 PR #193 reached 3/3 exact-head workflow SUCCESS at `c53c6f5c9255b4c341e46393ba16306d4278aa79`, but `main` advanced by 29 commits after its base and the PR became non-mergeable. Fresh compare shows the intervening `main` changes do not overlap the V12 gateway/workflow/test paths. V13 therefore starts from CURRENT main and ports only the previously green, branch-only gateway preparation after this Impact Report is committed.
+
+## Scope
+- Reconcile the service-role-only, app-session-authorized legacy WhatsApp template gateway with CURRENT main.
+- Preserve fail-closed authorization and synthetic negative tests.
+- Keep Zero-Cost/self-hosted CI.
+- No destructive production ACL cutover in this report/branch preparation step.
+
+## Hard invariant
+One canonical Audience Engine / Activation / contact identity truth. No duplicated audience, customer, lead, patient, or campaign truth per channel.
+
+## Safety
+- No provider activation or spend.
+- No broad-send.
+- No production mutation before exact-head gates are green and fresh read-only preflight confirms compatibility.
+- No PII/PHI, phone numbers, message bodies, provider tokens, or secrets in CI/issues/logs.
+- #173 remains fail-closed until browser legacy SELECT/RLS retirement is proven with compatibility smoke and rollback.


### PR DESCRIPTION
## CIA V3 F17 — V13 from CURRENT main

Fresh base: `main@00797fe87869f4cee8a11414de1f1de262e8c109`.
Impact Report committed before code/schema changes: `docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260816_V13.md`.

### Fresh authoritative state
- F16 production is certified: `READY_F17_EMAIL_CERTIFIED`, `ready_for_f17=true`, all F16 release gates=true; #104 CLOSED/completed.
- F17 production remains `IN_PROGRESS_MULTICHANNEL_GOVERNANCE`, `ready_for_f18=false`.
- Passing: contracts active + WhatsApp bridge validated.
- Pending: outbound policy, webhook replay/idempotency, canary, rollback.

### Why V13
V12 PR #193 reached 3/3 exact-head SUCCESS at `c53c6f5c9255b4c341e46393ba16306d4278aa79`, but `main` advanced by 29 commits after its base and #193 became non-mergeable. Fresh compare found no overlap between those intervening main changes and the V12 gateway/workflow/test paths. V13 ports only that already-green branch-only preparation onto CURRENT main and requires fresh exact-head evidence.

### #173
CRITICAL #173 remains OPEN. This PR does not perform destructive production ACL closure. It prepares a service-role-only, app-session-authorized legacy template read gateway plus fail-closed synthetic negatives so browser SELECT can later be retired under compatibility/rollback proof.

### Hard invariant
One canonical Audience/Activation/contact identity truth. No duplicated audience/customer/lead/patient truth per channel.

No provider activation/spend, no broad-send, no PII/PHI/message contents/tokens/secrets in CI. Keep DRAFT until exact-head checks are green and production cutover evidence is ready.