### PR TITLE
feat(sentinel): bootstrap CREACTIVE observer automatically

### DIFF
--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -61,7 +61,7 @@ jobs:
           bash -n sentinel/availability/creactive/start-observer.sh
           bash -n sentinel/availability/creactive/install-observer.sh
           bash -n sentinel/availability/creactive/bootstrap-observer.sh
-          sentinel/availability/creactive/bootstrap-observer.sh --help >/tmp/sentinel-f5-bootstrap-help.txt
+          bash sentinel/availability/creactive/bootstrap-observer.sh --help >/tmp/sentinel-f5-bootstrap-help.txt
           python3 -m py_compile sentinel/availability/local-observer-agent.py
           python3 - <<'PY'
           import importlib.util

--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -11,7 +11,7 @@ on:
       - 'docs/control/SENTINEL_ROADMAP_V1.md'
       - '.github/workflows/sentinel-phase5-availability.yml'
   push:
-    branches: ['feature/**','fix/**']
+    branches: ['main','feature/**','fix/**']
     paths: *f5_paths
 
 permissions:
@@ -62,7 +62,6 @@ jobs:
           bash -n sentinel/availability/creactive/install-observer.sh
           bash -n sentinel/availability/creactive/bootstrap-observer.sh
           sentinel/availability/creactive/bootstrap-observer.sh --help >/tmp/sentinel-f5-bootstrap-help.txt
-          grep -q 'one' /dev/null 2>/dev/null || true
           python3 -m py_compile sentinel/availability/local-observer-agent.py
           python3 - <<'PY'
           import importlib.util
@@ -123,3 +122,34 @@ jobs:
           if [ -n "${KUMA_NAME:-}" ]; then docker rm -f "$KUMA_NAME" >/dev/null 2>&1 || true; fi
           if [ -n "${KUMA_VOLUME:-}" ]; then docker volume rm -f "$KUMA_VOLUME" >/dev/null 2>&1 || true; fi
           if [ -n "${KUMA_NAME:-}" ]; then test -z "$(docker ps -aq --filter name=^/${KUMA_NAME}$)" || exit 1; fi
+
+  deploy-creactive-local-observer:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'CREACTIVE bootstrap')
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 10
+    needs: [uptime-kuma-container-smoke]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bootstrap persistent CREACTIVE observer
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$(hostname)" = "CREACTIVE"
+          docker version >/dev/null
+          python3 --version
+          bash sentinel/availability/creactive/bootstrap-observer.sh
+      - name: Verify persistent observer state
+        run: |
+          set -euo pipefail
+          test "$(docker inspect -f '{{.State.Running}}' sentinel-uptime-kuma)" = "true"
+          test -s "$HOME/.local/share/ascenda-sentinel/availability/state/resume-report.json"
+          python3 - <<'PY'
+          import json, pathlib
+          p=pathlib.Path.home()/'.local/share/ascenda-sentinel/availability/state/resume-report.json'
+          d=json.loads(p.read_text())
+          assert d['observer']=='CREACTIVE'
+          assert d['local_observer_state']=='ONLINE'
+          assert d['retroactive_claims_forbidden'] is True
+          assert d['current_health'] in ('HEALTHY','DEGRADED')
+          print('SENTINEL_F5_CREACTIVE_PERSISTENT_OBSERVER=PASS')
+          PY

--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -55,11 +55,14 @@ jobs:
           test "$RUNNER_OS" = "Linux"
           docker version >/dev/null
           python3 --version
-      - name: Validate local observer scripts and gap fixtures
+      - name: Validate local observer scripts, bootstrap and gap fixtures
         run: |
           set -euo pipefail
           bash -n sentinel/availability/creactive/start-observer.sh
           bash -n sentinel/availability/creactive/install-observer.sh
+          bash -n sentinel/availability/creactive/bootstrap-observer.sh
+          sentinel/availability/creactive/bootstrap-observer.sh --help >/tmp/sentinel-f5-bootstrap-help.txt
+          grep -q 'one' /dev/null 2>/dev/null || true
           python3 -m py_compile sentinel/availability/local-observer-agent.py
           python3 - <<'PY'
           import importlib.util
@@ -118,5 +121,5 @@ jobs:
         if: always()
         run: |
           if [ -n "${KUMA_NAME:-}" ]; then docker rm -f "$KUMA_NAME" >/dev/null 2>&1 || true; fi
-          if [ -n "${KUMA_VOLUME:-}" ]; then docker volume rm "$KUMA_VOLUME" >/dev/null 2>&1 || true; fi
+          if [ -n "${KUMA_VOLUME:-}" ]; then docker volume rm -f "$KUMA_VOLUME" >/dev/null 2>&1 || true; fi
           if [ -n "${KUMA_NAME:-}" ]; then test -z "$(docker ps -aq --filter name=^/${KUMA_NAME}$)" || exit 1; fi

--- a/ci/sentinel/phase5_availability_contract.js
+++ b/ci/sentinel/phase5_availability_contract.js
@@ -13,6 +13,7 @@ const compose=read('sentinel/availability/compose.yaml');
 const phaseS=read('app/server-phase-s.js');
 const startObserver=read('sentinel/availability/creactive/start-observer.sh');
 const installObserver=read('sentinel/availability/creactive/install-observer.sh');
+const bootstrap=read('sentinel/availability/creactive/bootstrap-observer.sh');
 const installTask=read('sentinel/availability/creactive/Install-SentinelCreactiveTask.ps1');
 const localAgent=read('sentinel/availability/local-observer-agent.py');
 const sm=require(path.join(ROOT,'sentinel/availability/state-machine.cjs'));
@@ -81,6 +82,12 @@ ok(installObserver.includes('.local/share/ascenda-sentinel/availability'),'F5_LO
 ok(installTask.includes('AtLogOn'),'F5_WINDOWS_LOGON_TRIGGER_MISSING');
 ok(installTask.includes('RunLevel Limited'),'F5_WINDOWS_ELEVATION_FORBIDDEN');
 ok(installTask.includes('IgnoreNew'),'F5_WINDOWS_DUPLICATE_INSTANCE_GUARD_MISSING');
+ok(installTask.includes('Start-ScheduledTask'),'F5_WINDOWS_START_NOW_MISSING');
+ok(bootstrap.includes('bash "$SCRIPT_DIR/install-observer.sh"'),'F5_BOOTSTRAP_INSTALL_CHAIN_MISSING');
+ok(bootstrap.includes('powershell.exe'),'F5_BOOTSTRAP_WINDOWS_INTEROP_MISSING');
+ok(bootstrap.includes('-PlanOnly'),'F5_BOOTSTRAP_PLAN_MODE_MISSING');
+ok(bootstrap.includes('-StartNow'),'F5_BOOTSTRAP_START_MODE_MISSING');
+ok(bootstrap.includes('resume-report.json'),'F5_BOOTSTRAP_RESUME_REPORT_CHECK_MISSING');
 ok(localAgent.includes("'retroactive_health_claim': False"),'F5_GAP_FALSE_GREEN_GUARD_MISSING');
 ok(localAgent.includes("'history_location': 'Sentry Monitors/Uptime'"),'F5_CLOUD_HISTORY_REFERENCE_MISSING');
 ok(localAgent.includes('urllib.request'),'F5_AGENT_NOT_STDLIB_HTTP');
@@ -103,7 +110,7 @@ ok(sm.sentinelHealthState('DOWN')==='INCIDENT','F5_SENTINEL_DOWN_MAP');
 ok(sm.sentinelHealthState('UNKNOWN')==='UNKNOWN','F5_SENTINEL_UNKNOWN_MAP');
 ok(sm.availabilityFingerprint({environment:'production',monitorId:'ascenda-production-health'})==='availability:production:ascenda-production-health','F5_FINGERPRINT_DRIFT');
 
-const serialized=[JSON.stringify(f5),compose,startObserver,installObserver,installTask,localAgent].join('\n');
+const serialized=[JSON.stringify(f5),compose,startObserver,installObserver,bootstrap,installTask,localAgent].join('\n');
 const secretPatterns=[
   /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
   /\b(?:eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/,
@@ -125,6 +132,7 @@ console.log(JSON.stringify({
   cloud_provider:f5.continuous_coverage.provider,
   local_observer:f5.observer.host,
   local_agent_runtime:'python3-stdlib',
+  one_command_bootstrap:true,
   local_offline_semantics:f5.observer.offline_semantics,
   gap_reconciliation:true,
   zero_phi_pii:true,

--- a/sentinel/availability/creactive/Install-SentinelCreactiveTask.ps1
+++ b/sentinel/availability/creactive/Install-SentinelCreactiveTask.ps1
@@ -1,7 +1,8 @@
 param(
   [string]$WslDistribution = 'Ubuntu',
   [string]$TaskName = 'ASCENDA Sentinel Local Observer',
-  [switch]$PlanOnly
+  [switch]$PlanOnly,
+  [switch]$StartNow
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,9 +22,11 @@ $plan = [ordered]@{
   secrets = $false
   highest_privileges = $false
   multiple_instances = 'IgnoreNew'
+  start_now = [bool]$StartNow
 }
 
 if ($PlanOnly) {
+  $plan.status = 'PLAN_ONLY'
   $plan | ConvertTo-Json -Depth 4
   exit 0
 }
@@ -38,5 +41,13 @@ Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Se
 $task = Get-ScheduledTask -TaskName $TaskName
 if ($task.TaskName -ne $TaskName) { throw 'TASK_REGISTRATION_FAILED' }
 
+if ($StartNow) {
+  Start-ScheduledTask -TaskName $TaskName
+  Start-Sleep -Seconds 2
+}
+
+$taskInfo = Get-ScheduledTaskInfo -TaskName $TaskName
 $plan.status = 'REGISTERED'
+$plan.task_state = (Get-ScheduledTask -TaskName $TaskName).State.ToString()
+$plan.last_task_result = $taskInfo.LastTaskResult
 $plan | ConvertTo-Json -Depth 4

--- a/sentinel/availability/creactive/bootstrap-observer.sh
+++ b/sentinel/availability/creactive/bootstrap-observer.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAN_ONLY=0
+START_NOW=1
+WSL_DISTRO="${SENTINEL_WSL_DISTRO:-Ubuntu}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --plan-only) PLAN_ONLY=1; START_NOW=0 ;;
+    --no-start) START_NOW=0 ;;
+    --help)
+      cat <<'EOF'
+Usage: bash bootstrap-observer.sh [--plan-only] [--no-start]
+
+Installs Sentinel local observer files into the current WSL user profile and,
+unless --plan-only is used, registers a limited Windows logon task through WSL interop.
+No secrets are read or written.
+EOF
+      exit 0
+      ;;
+    *) echo "UNKNOWN_ARGUMENT:$arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo 'SENTINEL_BOOTSTRAP_PYTHON_MISSING' >&2
+  exit 20
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo 'SENTINEL_BOOTSTRAP_DOCKER_MISSING' >&2
+  exit 21
+fi
+if ! command -v powershell.exe >/dev/null 2>&1; then
+  echo 'SENTINEL_BOOTSTRAP_WSL_INTEROP_MISSING' >&2
+  exit 22
+fi
+if ! command -v wslpath >/dev/null 2>&1; then
+  echo 'SENTINEL_BOOTSTRAP_WSLPATH_MISSING' >&2
+  exit 23
+fi
+
+bash "$SCRIPT_DIR/install-observer.sh"
+
+PS_SCRIPT_WIN="$(wslpath -w "$SCRIPT_DIR/Install-SentinelCreactiveTask.ps1")"
+PS_ARGS=(-NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN" -WslDistribution "$WSL_DISTRO")
+if [ "$PLAN_ONLY" = 1 ]; then PS_ARGS+=(-PlanOnly); fi
+if [ "$START_NOW" = 1 ]; then PS_ARGS+=(-StartNow); fi
+
+powershell.exe "${PS_ARGS[@]}"
+
+if [ "$PLAN_ONLY" = 1 ]; then
+  echo 'SENTINEL_CREACTIVE_BOOTSTRAP=PLAN_ONLY_PASS'
+  exit 0
+fi
+
+STATE_DIR="${SENTINEL_LOCAL_STATE_DIR:-$HOME/.local/share/ascenda-sentinel/availability/state}"
+for i in $(seq 1 30); do
+  if [ -s "$STATE_DIR/resume-report.json" ]; then
+    echo 'SENTINEL_CREACTIVE_BOOTSTRAP=PASS'
+    echo "RESUME_REPORT=$STATE_DIR/resume-report.json"
+    echo 'KUMA_UI=http://127.0.0.1:3001'
+    exit 0
+  fi
+  sleep 2
+done
+
+echo 'SENTINEL_CREACTIVE_BOOTSTRAP=TASK_REGISTERED_WAITING_FOR_REPORT'
+echo "RESUME_REPORT=$STATE_DIR/resume-report.json"
+exit 0


### PR DESCRIPTION
## Sentinel F5 — CREACTIVE one-command / auto bootstrap

This PR reduces the remaining workstation human boundary.

### Adds
- `bootstrap-observer.sh`: installs persistent local observer files and registers the limited Windows logon task through WSL interop.
- PowerShell `-StartNow` support.
- Main-merge deployment job restricted to CREACTIVE / `ascenda-zero-cost-v2`, triggered only when the merge commit contains `CREACTIVE bootstrap`.
- Persistent post-bootstrap verification: Kuma running + safe `resume-report.json` present.

### Safety
- No secrets read or written.
- No admin/elevated Windows task.
- Kuma remains localhost-only.
- No ASCENDA runtime/DB/Supabase/Railway changes.
- Local observer failure cannot block ASCENDA.

### Goal
If CI passes, merge with a commit title containing `CREACTIVE bootstrap`; the main workflow will attempt the persistent local installation automatically. If WSL/Task Scheduler interop fails, the failure becomes the exact remaining workstation human boundary.