### PR TITLE
fix(sentinel): make CREACTIVE observer Docker-native

### DIFF
--- a/.github/workflows/sentinel-phase5-availability.yml
+++ b/.github/workflows/sentinel-phase5-availability.yml
@@ -32,12 +32,11 @@ jobs:
       - name: Diff hygiene
         shell: powershell
         run: git diff --check
-      - name: State and Windows task syntax
+      - name: State syntax
         shell: powershell
         run: |
           node --check sentinel/availability/state-machine.cjs
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $null = [scriptblock]::Create((Get-Content -Raw 'sentinel/availability/creactive/Install-SentinelCreactiveTask.ps1'))
       - name: F5 hybrid availability contract
         shell: powershell
         run: node ci/sentinel/phase5_availability_contract.js
@@ -55,13 +54,10 @@ jobs:
           test "$RUNNER_OS" = "Linux"
           docker version >/dev/null
           python3 --version
-      - name: Validate local observer scripts, bootstrap and gap fixtures
+      - name: Validate local observer scripts and gap fixtures
         run: |
           set -euo pipefail
-          bash -n sentinel/availability/creactive/start-observer.sh
-          bash -n sentinel/availability/creactive/install-observer.sh
-          bash -n sentinel/availability/creactive/bootstrap-observer.sh
-          bash sentinel/availability/creactive/bootstrap-observer.sh --help >/tmp/sentinel-f5-bootstrap-help.txt
+          bash -n sentinel/availability/creactive/deploy-docker-observer.sh
           python3 -m py_compile sentinel/availability/local-observer-agent.py
           python3 - <<'PY'
           import importlib.util
@@ -103,17 +99,13 @@ jobs:
             "$KUMA_IMAGE" >/tmp/sentinel-f5-container-id.txt
           PORT="$(docker inspect -f '{{(index (index .NetworkSettings.Ports "3001/tcp") 0).HostPort}}' "$NAME")"
           test -n "$PORT"
-          echo "KUMA_PORT=$PORT" >> "$GITHUB_ENV"
           ok=0
           for i in $(seq 1 60); do
             if curl -fsS --max-time 3 "http://127.0.0.1:${PORT}/" >/tmp/sentinel-f5-kuma.html; then ok=1; break; fi
             if ! docker ps --format '{{.Names}}' | grep -qx "$NAME"; then break; fi
             sleep 2
           done
-          if [ "$ok" != 1 ]; then
-            docker logs "$NAME" || true
-            exit 1
-          fi
+          test "$ok" = 1
           test -s /tmp/sentinel-f5-kuma.html
           echo 'SENTINEL_F5_KUMA_CONTAINER_SMOKE=PASS'
       - name: Destroy disposable observer and volume
@@ -121,28 +113,29 @@ jobs:
         run: |
           if [ -n "${KUMA_NAME:-}" ]; then docker rm -f "$KUMA_NAME" >/dev/null 2>&1 || true; fi
           if [ -n "${KUMA_VOLUME:-}" ]; then docker volume rm -f "$KUMA_VOLUME" >/dev/null 2>&1 || true; fi
-          if [ -n "${KUMA_NAME:-}" ]; then test -z "$(docker ps -aq --filter name=^/${KUMA_NAME}$)" || exit 1; fi
 
   deploy-creactive-local-observer:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'CREACTIVE bootstrap')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
-    timeout-minutes: 10
+    timeout-minutes: 12
     needs: [uptime-kuma-container-smoke]
     steps:
       - uses: actions/checkout@v4
-      - name: Bootstrap persistent CREACTIVE observer
+      - name: Deploy persistent Docker-native observer
         run: |
           set -euo pipefail
           test "$RUNNER_OS" = "Linux"
           test "$(hostname)" = "CREACTIVE"
           docker version >/dev/null
           python3 --version
-          bash sentinel/availability/creactive/bootstrap-observer.sh
+          bash sentinel/availability/creactive/deploy-docker-observer.sh
       - name: Verify persistent observer state
         run: |
           set -euo pipefail
           test "$(docker inspect -f '{{.State.Running}}' sentinel-uptime-kuma)" = "true"
+          test "$(docker inspect -f '{{.State.Running}}' sentinel-local-observer)" = "true"
           test -s "$HOME/.local/share/ascenda-sentinel/availability/state/resume-report.json"
+          curl -fsS --max-time 5 http://127.0.0.1:3001/ >/dev/null
           python3 - <<'PY'
           import json, pathlib
           p=pathlib.Path.home()/'.local/share/ascenda-sentinel/availability/state/resume-report.json'

--- a/ci/sentinel/phase5_availability_contract.js
+++ b/ci/sentinel/phase5_availability_contract.js
@@ -11,16 +11,13 @@ const f4=read('docs/control/SENTINEL_F4_VALIDATION_REPORT_20260816.md');
 const f5=json('sentinel/availability/f5-contract.json');
 const compose=read('sentinel/availability/compose.yaml');
 const phaseS=read('app/server-phase-s.js');
-const startObserver=read('sentinel/availability/creactive/start-observer.sh');
-const installObserver=read('sentinel/availability/creactive/install-observer.sh');
-const bootstrap=read('sentinel/availability/creactive/bootstrap-observer.sh');
-const installTask=read('sentinel/availability/creactive/Install-SentinelCreactiveTask.ps1');
+const dockerDeploy=read('sentinel/availability/creactive/deploy-docker-observer.sh');
 const localAgent=read('sentinel/availability/local-observer-agent.py');
 const sm=require(path.join(ROOT,'sentinel/availability/state-machine.cjs'));
 
 ok(f4.includes('**F4:** `100_COMPLETE`'),'F4_NOT_CERTIFIED');
 ok(f4.includes('**Resultado:** `18/18 PASS`'),'F4_GATES_NOT_COMPLETE');
-ok(f5.schema_version==='sentinel-availability/v1.1'&&f5.phase==='F5','F5_CONTRACT_INVALID');
+ok(f5.schema_version==='sentinel-availability/v1.2'&&f5.phase==='F5','F5_CONTRACT_INVALID');
 ok(f5.availability_architecture==='hybrid-cloud-plus-local','F5_HYBRID_ARCHITECTURE_DRIFT');
 
 ok(f5.continuous_coverage.required===true,'F5_CONTINUOUS_COVERAGE_REQUIRED');
@@ -32,13 +29,17 @@ ok(f5.continuous_coverage.api_dependency_for_sentinel_core===false,'F5_CLOUD_API
 
 ok(f5.observer.engine==='uptime-kuma','F5_ENGINE_DRIFT');
 ok(f5.observer.docker_image==='louislam/uptime-kuma:2','F5_IMAGE_DRIFT');
+ok(f5.observer.agent_image==='python:3.14-alpine','F5_AGENT_IMAGE_DRIFT');
 ok(f5.observer.mode==='intermittent-workstation-observer','F5_LOCAL_MODE_DRIFT');
 ok(f5.observer.host==='CREACTIVE','F5_LOCAL_HOST_DRIFT');
+ok(f5.observer.runtime==='Ubuntu/Docker on CREACTIVE','F5_LOCAL_RUNTIME_DRIFT');
 ok(f5.observer.must_be_independent_from_ascenda_railway_runtime===true,'F5_OBSERVER_INDEPENDENCE_REQUIRED');
 ok(f5.observer.same_railway_service_forbidden===true,'F5_SAME_RUNTIME_FORBIDDEN');
 ok(f5.observer.public_admin_ui_default===false,'F5_ADMIN_UI_MUST_NOT_DEFAULT_PUBLIC');
 ok(f5.observer.restart_policy==='unless-stopped','F5_RESTART_POLICY_DRIFT');
 ok(f5.observer.offline_semantics==='UNKNOWN'&&f5.observer.offline_is_not_ascenda_down===true,'F5_LOCAL_OFFLINE_SEMANTICS_DRIFT');
+ok(f5.observer.windows_task_required_for_f5_baseline===false,'F5_WINDOWS_TASK_MUST_BE_OPTIONAL');
+ok(Array.isArray(f5.observer.baseline_autostart_chain)&&f5.observer.baseline_autostart_chain.some(v=>v.includes('Docker restart policy restores Uptime Kuma')),'F5_DOCKER_AUTOSTART_CHAIN_DRIFT');
 
 ok(f5.gap_reconciliation.enabled===true,'F5_GAP_RECONCILIATION_DISABLED');
 ok(f5.gap_reconciliation.coverage_gap_state==='UNKNOWN','F5_GAP_STATE_DRIFT');
@@ -72,22 +73,14 @@ ok(!/\b(?:SENTRY_DSN|SUPABASE_SERVICE_ROLE_KEY|SUPABASE_ANON_KEY|RESEND_API_KEY|
 ok(!compose.includes('network_mode: host'),'F5_HOST_NETWORK_FORBIDDEN');
 ok(!compose.includes('/var/run/docker.sock'),'F5_DOCKER_SOCKET_FORBIDDEN');
 
-ok(startObserver.includes('wait_for_docker'),'F5_LOCAL_DOCKER_WAIT_MISSING');
-ok(startObserver.includes('--restart unless-stopped'),'F5_LOCAL_KUMA_RESTART_MISSING');
-ok(startObserver.includes('127.0.0.1:3001:3001'),'F5_LOCAL_KUMA_UI_EXPOSURE_DRIFT');
-ok(startObserver.includes('exec python3 "$AGENT"'),'F5_LOCAL_AGENT_FOREGROUND_MISSING');
-ok(startObserver.includes('SENTINEL_LOCAL_OBSERVER_PYTHON_MISSING'),'F5_LOCAL_PYTHON_GUARD_MISSING');
-ok(installObserver.includes('local-observer-agent.py'),'F5_LOCAL_INSTALL_AGENT_DRIFT');
-ok(installObserver.includes('.local/share/ascenda-sentinel/availability'),'F5_LOCAL_INSTALL_PATH_DRIFT');
-ok(installTask.includes('AtLogOn'),'F5_WINDOWS_LOGON_TRIGGER_MISSING');
-ok(installTask.includes('RunLevel Limited'),'F5_WINDOWS_ELEVATION_FORBIDDEN');
-ok(installTask.includes('IgnoreNew'),'F5_WINDOWS_DUPLICATE_INSTANCE_GUARD_MISSING');
-ok(installTask.includes('Start-ScheduledTask'),'F5_WINDOWS_START_NOW_MISSING');
-ok(bootstrap.includes('bash "$SCRIPT_DIR/install-observer.sh"'),'F5_BOOTSTRAP_INSTALL_CHAIN_MISSING');
-ok(bootstrap.includes('powershell.exe'),'F5_BOOTSTRAP_WINDOWS_INTEROP_MISSING');
-ok(bootstrap.includes('-PlanOnly'),'F5_BOOTSTRAP_PLAN_MODE_MISSING');
-ok(bootstrap.includes('-StartNow'),'F5_BOOTSTRAP_START_MODE_MISSING');
-ok(bootstrap.includes('resume-report.json'),'F5_BOOTSTRAP_RESUME_REPORT_CHECK_MISSING');
+ok(dockerDeploy.includes('sentinel-uptime-kuma'),'F5_DOCKER_KUMA_NAME_MISSING');
+ok(dockerDeploy.includes('sentinel-local-observer'),'F5_DOCKER_AGENT_NAME_MISSING');
+ok(dockerDeploy.includes('--restart unless-stopped'),'F5_DOCKER_RESTART_POLICY_MISSING');
+ok(dockerDeploy.includes('--read-only'),'F5_AGENT_READ_ONLY_MISSING');
+ok(dockerDeploy.includes('--cap-drop ALL'),'F5_DOCKER_CAP_DROP_MISSING');
+ok(dockerDeploy.includes('127.0.0.1:3001:3001'),'F5_DOCKER_KUMA_EXPOSURE_DRIFT');
+ok(dockerDeploy.includes('python:3.14-alpine'),'F5_DOCKER_AGENT_IMAGE_MISSING');
+ok(dockerDeploy.includes('resume-report.json'),'F5_DOCKER_RESUME_VERIFY_MISSING');
 ok(localAgent.includes("'retroactive_health_claim': False"),'F5_GAP_FALSE_GREEN_GUARD_MISSING');
 ok(localAgent.includes("'history_location': 'Sentry Monitors/Uptime'"),'F5_CLOUD_HISTORY_REFERENCE_MISSING');
 ok(localAgent.includes('urllib.request'),'F5_AGENT_NOT_STDLIB_HTTP');
@@ -110,7 +103,7 @@ ok(sm.sentinelHealthState('DOWN')==='INCIDENT','F5_SENTINEL_DOWN_MAP');
 ok(sm.sentinelHealthState('UNKNOWN')==='UNKNOWN','F5_SENTINEL_UNKNOWN_MAP');
 ok(sm.availabilityFingerprint({environment:'production',monitorId:'ascenda-production-health'})==='availability:production:ascenda-production-health','F5_FINGERPRINT_DRIFT');
 
-const serialized=[JSON.stringify(f5),compose,startObserver,installObserver,bootstrap,installTask,localAgent].join('\n');
+const serialized=[JSON.stringify(f5),compose,dockerDeploy,localAgent].join('\n');
 const secretPatterns=[
   /\bsb_secret_[A-Za-z0-9_-]{20,}\b/,
   /\b(?:eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/,
@@ -126,13 +119,13 @@ ok(!Object.prototype.hasOwnProperty.call(mon,'username')&&!Object.prototype.hasO
 
 console.log(JSON.stringify({
   ok:true,
-  certificate:'SENTINEL_F5_HYBRID_OBSERVER_CONTRACT_PASS',
+  certificate:'SENTINEL_F5_DOCKER_NATIVE_OBSERVER_CONTRACT_PASS',
   f4_complete:true,
   architecture:f5.availability_architecture,
   cloud_provider:f5.continuous_coverage.provider,
   local_observer:f5.observer.host,
-  local_agent_runtime:'python3-stdlib',
-  one_command_bootstrap:true,
+  local_runtime:'docker-native',
+  windows_task_required:false,
   local_offline_semantics:f5.observer.offline_semantics,
   gap_reconciliation:true,
   zero_phi_pii:true,

--- a/docs/control/SENTINEL_F5_HYBRID_OBSERVER_PLAN_20260816.md
+++ b/docs/control/SENTINEL_F5_HYBRID_OBSERVER_PLAN_20260816.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-08-16 (America/Lima)  
 **Estado:** `HYBRID_IMPLEMENTATION_IN_PROGRESS`  
-**Baseline:** `main@d81863d46f4f4fe54deb4c017968aac5b19b310d`  
+**Baseline:** `main@28dfdeafbf66cfa79f6fcec132e607d40529ee37`  
 **Costo incremental objetivo:** `US$0/mes`
 
 ## Decisión
@@ -10,25 +10,26 @@
 F5 adopta dos capas independientes:
 
 1. **Cloud Coverage — Sentry Uptime**: un monitor cloud sobre `GET /health`, usando el monitor incluido en el plan Developer. Esta capa cubre períodos en los que CREACTIVE está apagada.
-2. **Local Deep Observer — Uptime Kuma en CREACTIVE**: observador intermitente en Windows + WSL2 Ubuntu + Docker. Cuando CREACTIVE está apagada, la capa local es `UNKNOWN`; no se interpreta como caída de ASCENDA.
+2. **Local Deep Observer — Docker en CREACTIVE**: Uptime Kuma + Sentinel Local Observer se ejecutan como contenedores persistentes `restart: unless-stopped`. Cuando CREACTIVE/Ubuntu/Docker está apagado, la capa local es `UNKNOWN`; no se interpreta como caída de ASCENDA.
 
 Sentinel Core no dependerá de la API de Sentry para operar. El historial cloud se conserva en Sentry; la correlación automática con incidentes pertenece a F7/F8/F11.
 
 ## Autoarranque CREACTIVE
 
-Cadena objetivo:
+Baseline certificable:
 
-`Windows logon → Task Scheduler → wsl.exe Ubuntu → wait Docker → Uptime Kuma → local observer agent`
+`CREACTIVE encendida → Ubuntu/Docker disponible → Docker restart policy → Kuma + Local Observer`
 
 Propiedades:
 
-- tarea de usuario, sin privilegios elevados;
-- una sola instancia (`IgnoreNew`);
+- no requiere `powershell.exe`, WSL interop ni Task Scheduler para la baseline;
 - Kuma en `127.0.0.1:3001`;
-- `restart: unless-stopped`;
-- volumen Docker persistente `uptime-kuma-data`;
-- si Docker tarda en iniciar, el script espera hasta 180 segundos;
-- si CREACTIVE está apagada, ASCENDA continúa sin dependencia local.
+- Kuma y observer con `restart: unless-stopped`;
+- volumen Docker persistente para Kuma;
+- estado/historial técnico persistente en `~/.local/share/ascenda-sentinel/availability/state`;
+- observer en contenedor Python read-only, `cap-drop ALL`, no-new-privileges;
+- si CREACTIVE está apagada, ASCENDA continúa sin dependencia local;
+- una tarea Windows de logon puede añadirse después como comodidad, pero no es gate F5.
 
 ## Gap reconciliation
 
@@ -60,13 +61,13 @@ Campos locales permitidos: timestamp, HTTP status, duración, booleanos de healt
 | G07 | Linux disposable Kuma smoke | PASS |
 | G08 | cleanup + zero-cost | PASS |
 | G09 | arquitectura híbrida autorizada; CREACTIVE local + Sentry cloud | PASS |
-| G10 | Sentry Uptime monitor configurado + local observer instalado/autoarranque | PENDING HUMAN UI/WORKSTATION |
-| G11 | shutdown/resume + coverage-gap + outage/recovery sintético | PENDING |
+| G10 | Sentry Uptime monitor configurado + observer Docker persistente desplegado | PENDING CLOUD UI / AUTO-DEPLOY |
+| G11 | restart/gap + outage/recovery sintético | PENDING |
 | G12 | certificado final + Notion + F6 siguiente | PENDING |
 
-**Progreso lógico:** `9/12 = 75%`.
+**Progreso lógico actual:** `9/12 = 75%`.
 
-## Human boundaries restantes
+## Human boundary restante
 
 ### F5-CLOUD-01
 En Sentry → Monitors → Uptime, crear/verificar un único monitor sobre:
@@ -76,13 +77,13 @@ En Sentry → Monitors → Uptime, crear/verificar un único monitor sobre:
 Sin headers, body, cookies ni credenciales.
 
 ### F5-LOCAL-01
-En CREACTIVE ejecutar el installer Linux y registrar la tarea de autoarranque Windows. No requiere secretos.
+Se intenta automáticamente desde GitHub sobre CREACTIVE mediante `deploy-docker-observer.sh`. No requiere secretos ni cambios de Windows. Si Docker está disponible, el gate puede cerrarse sin intervención humana.
 
 ### F5-RECOVERY-01
 Validar:
 
 - Kuma accesible solo en `localhost:3001`;
-- apagado/reinicio del observer produce `UNKNOWN / coverage_gap`;
+- restart del observer produce/reconoce `UNKNOWN / coverage_gap` cuando corresponde;
 - retorno genera resume report;
 - outage sintético del target/fixture atraviesa DEGRADED → DOWN y recuperación sin spam.
 

--- a/sentinel/availability/creactive/deploy-docker-observer.sh
+++ b/sentinel/availability/creactive/deploy-docker-observer.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${SENTINEL_INSTALL_BASE:-$HOME/.local/share/ascenda-sentinel/availability}"
+RUNTIME_DIR="$BASE/runtime"
+STATE_DIR="$BASE/state"
+KUMA_NAME="sentinel-uptime-kuma"
+OBSERVER_NAME="sentinel-local-observer"
+KUMA_IMAGE="louislam/uptime-kuma:2"
+OBSERVER_IMAGE="python:3.14-alpine"
+KUMA_VOLUME="uptime-kuma-data"
+TARGET="${SENTINEL_HEALTH_URL:-https://ascenda-os-production.up.railway.app/health}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AVAIL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+mkdir -p "$RUNTIME_DIR" "$STATE_DIR"
+install -m 700 "$AVAIL_DIR/local-observer-agent.py" "$RUNTIME_DIR/local-observer-agent.py"
+install -m 600 "$AVAIL_DIR/compose.yaml" "$RUNTIME_DIR/compose.yaml"
+chmod 700 "$STATE_DIR"
+
+docker version >/dev/null
+
+docker volume create "$KUMA_VOLUME" >/dev/null
+
+ensure_kuma(){
+  if docker inspect "$KUMA_NAME" >/dev/null 2>&1; then
+    docker start "$KUMA_NAME" >/dev/null 2>&1 || true
+  else
+    docker run -d \
+      --name "$KUMA_NAME" \
+      --restart unless-stopped \
+      --security-opt no-new-privileges:true \
+      --cap-drop ALL \
+      -p 127.0.0.1:3001:3001 \
+      -v "$KUMA_VOLUME:/app/data" \
+      "$KUMA_IMAGE" >/dev/null
+  fi
+}
+
+ensure_observer(){
+  docker rm -f "$OBSERVER_NAME" >/dev/null 2>&1 || true
+  docker run -d \
+    --name "$OBSERVER_NAME" \
+    --restart unless-stopped \
+    --security-opt no-new-privileges:true \
+    --cap-drop ALL \
+    --read-only \
+    --tmpfs /tmp:rw,noexec,nosuid,size=16m \
+    -e SENTINEL_LOCAL_STATE_DIR=/var/lib/ascenda-sentinel \
+    -e SENTINEL_HEALTH_URL="$TARGET" \
+    -e SENTINEL_LOCAL_INTERVAL_SECONDS=60 \
+    -e SENTINEL_GAP_THRESHOLD_SECONDS=120 \
+    -v "$RUNTIME_DIR/local-observer-agent.py:/opt/sentinel/local-observer-agent.py:ro" \
+    -v "$STATE_DIR:/var/lib/ascenda-sentinel" \
+    "$OBSERVER_IMAGE" python3 /opt/sentinel/local-observer-agent.py >/dev/null
+}
+
+ensure_kuma
+ensure_observer
+
+ok=0
+for i in $(seq 1 45); do
+  if curl -fsS --max-time 3 http://127.0.0.1:3001/ >/dev/null 2>&1 && [ -s "$STATE_DIR/resume-report.json" ]; then
+    ok=1; break
+  fi
+  sleep 2
+done
+
+if [ "$ok" != 1 ]; then
+  echo 'SENTINEL_CREACTIVE_DOCKER_OBSERVER_VERIFY_FAILED' >&2
+  docker logs --tail 50 "$KUMA_NAME" || true
+  docker logs --tail 50 "$OBSERVER_NAME" || true
+  exit 31
+fi
+
+test "$(docker inspect -f '{{.State.Running}}' "$KUMA_NAME")" = "true"
+test "$(docker inspect -f '{{.State.Running}}' "$OBSERVER_NAME")" = "true"
+
+python3 - <<PY
+import json, pathlib
+p=pathlib.Path(${STATE_DIR@Q})/'resume-report.json'
+d=json.loads(p.read_text())
+assert d['observer']=='CREACTIVE'
+assert d['local_observer_state']=='ONLINE'
+assert d['retroactive_claims_forbidden'] is True
+assert d['current_health'] in ('HEALTHY','DEGRADED')
+print(json.dumps({'observer':d['observer'],'current_health':d['current_health'],'coverage_gap_semantics':d['coverage_gap_semantics']}))
+PY
+
+echo 'SENTINEL_CREACTIVE_DOCKER_OBSERVER=PASS'
+echo 'KUMA_UI=http://127.0.0.1:3001'

--- a/sentinel/availability/f5-contract.json
+++ b/sentinel/availability/f5-contract.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "sentinel-availability/v1.1",
+  "schema_version": "sentinel-availability/v1.2",
   "phase": "F5",
-  "baseline_main": "d81863d46f4f4fe54deb4c017968aac5b19b310d",
+  "baseline_main": "28dfdeafbf66cfa79f6fcec132e607d40529ee37",
   "availability_architecture": "hybrid-cloud-plus-local",
   "continuous_coverage": {
     "required": true,
@@ -18,11 +18,12 @@
   "observer": {
     "engine": "uptime-kuma",
     "docker_image": "louislam/uptime-kuma:2",
+    "agent_image": "python:3.14-alpine",
     "verified_release_at_design_time": "2.3.2",
     "verified_on": "2026-08-16",
     "mode": "intermittent-workstation-observer",
     "host": "CREACTIVE",
-    "runtime": "Windows + WSL2 Ubuntu + Docker",
+    "runtime": "Ubuntu/Docker on CREACTIVE",
     "must_be_independent_from_ascenda_railway_runtime": true,
     "same_railway_service_forbidden": true,
     "public_admin_ui_default": false,
@@ -32,14 +33,14 @@
     "restart_policy": "unless-stopped",
     "offline_semantics": "UNKNOWN",
     "offline_is_not_ascenda_down": true,
-    "autostart_chain": [
-      "Windows user logon",
-      "Task Scheduler",
-      "wsl.exe Ubuntu",
-      "wait for Docker",
-      "start/reuse Uptime Kuma",
-      "start local observer agent"
-    ]
+    "baseline_autostart_chain": [
+      "CREACTIVE powered on",
+      "Ubuntu/Docker available",
+      "Docker restart policy restores Uptime Kuma",
+      "Docker restart policy restores Sentinel local observer"
+    ],
+    "optional_windows_logon_task": true,
+    "windows_task_required_for_f5_baseline": false
   },
   "gap_reconciliation": {
     "enabled": true,
@@ -125,6 +126,7 @@
     "ci_must_destroy_container_and_volume": true,
     "persistent_local_deploy_authorized": true,
     "local_host": "CREACTIVE",
+    "persistent_local_runtime": "docker-native",
     "cloud_monitor_gate": "F5-CLOUD-01",
     "local_install_gate": "F5-LOCAL-01",
     "outage_recovery_gate": "F5-RECOVERY-01"


### PR DESCRIPTION
## Sentinel F5 — Docker-native CREACTIVE observer

The first persistent bootstrap attempt proved that the Linux GitHub runner cannot use Windows `powershell.exe`/WSL interop. This PR removes that requirement from the F5 baseline.

### New baseline
- `sentinel-uptime-kuma` container — localhost UI, persistent volume, restart unless-stopped.
- `sentinel-local-observer` container — Python stdlib agent, read-only filesystem, cap-drop ALL, no-new-privileges, persistent safe state, restart unless-stopped.
- CREACTIVE offline remains `UNKNOWN`, never ASCENDA `DOWN`.
- Windows Task Scheduler becomes optional convenience only.

### Auto deployment
On every F5 main push, after disposable smoke passes, GitHub reconciles the two persistent containers on CREACTIVE and verifies `resume-report.json`.

### Safety
No app runtime, DB, Supabase, Railway, credentials, PHI/PII or paid hosting changes.