### PR TITLE
feat(sentinel): add F7 release deploy correlation layer

### DIFF
--- a/.github/workflows/sentinel-phase7-correlation.yml
+++ b/.github/workflows/sentinel-phase7-correlation.yml
@@ -1,0 +1,73 @@
+name: Sentinel F7 Release Deploy Correlation Certificate
+
+on:
+  pull_request:
+    branches: [main]
+    paths: &f7_paths
+      - 'sentinel/correlation/**'
+      - 'ci/sentinel/phase7_correlation_*.js'
+      - 'docs/control/SENTINEL_F7_*.md'
+      - 'docs/control/SENTINEL_ROADMAP_V1.md'
+      - '.github/workflows/sentinel-phase7-correlation.yml'
+      - 'sentinel/telemetry/**'
+      - 'sentinel/sentry/**'
+      - 'app/sentinel-sentry-init.cjs'
+  push:
+    branches: ['main','feature/**','fix/**']
+    paths: *f7_paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sentinel-f7-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-fast:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - name: FAST runner healthcheck
+        shell: powershell
+        run: node --version
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: Syntax
+        shell: powershell
+        run: |
+          node --check sentinel/correlation/runtime-metadata.cjs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check sentinel/correlation/correlation-engine.cjs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check ci/sentinel/phase7_correlation_contract.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check ci/sentinel/phase7_correlation_synthetic.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: F7 correlation contract
+        shell: powershell
+        run: node ci/sentinel/phase7_correlation_contract.js
+      - name: F7 synthetic incident correlation
+        shell: powershell
+        run: node ci/sentinel/phase7_correlation_synthetic.js
+
+  correlation-linux:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce Zero-Cost runner policy
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          docker version >/dev/null
+      - name: Cross-platform fixtures in disposable Node
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/work:ro" \
+            -w /work \
+            node:22-alpine \
+            sh -lc 'node --version && node --check sentinel/correlation/runtime-metadata.cjs && node --check sentinel/correlation/correlation-engine.cjs && node ci/sentinel/phase7_correlation_contract.js && node ci/sentinel/phase7_correlation_synthetic.js'

--- a/ci/sentinel/phase7_correlation_contract.js
+++ b/ci/sentinel/phase7_correlation_contract.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const fs=require('fs');
+const path=require('path');
+const ROOT=path.resolve(__dirname,'../..');
+const read=p=>fs.readFileSync(path.join(ROOT,p),'utf8');
+const json=p=>JSON.parse(read(p));
+const ok=(v,m)=>{if(!v)throw new Error(m);};
+
+const f6=read('docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md');
+const f3=json('sentinel/telemetry/contract-v1.json');
+const f4=json('sentinel/sentry/f4-contract.json');
+const f7=json('sentinel/correlation/f7-contract.json');
+const runtime=read('sentinel/correlation/runtime-metadata.cjs');
+const engine=read('sentinel/correlation/correlation-engine.cjs');
+
+ok(f6.includes('F6 — Final Certificate'),'F6_CERTIFICATE_MISSING');
+ok(f7.schema_version==='sentinel-correlation/v1'&&f7.phase==='F7','F7_CONTRACT_INVALID');
+ok(f7.design.vendor_neutral===true&&f7.design.read_only===true&&f7.design.zero_phi_pii===true,'F7_DESIGN_DRIFT');
+ok(f7.design.railway_api_required===false,'F7_RAILWAY_API_LOCKIN_FORBIDDEN');
+ok(f7.design.github_write_required===false,'F7_GITHUB_WRITE_FORBIDDEN');
+ok(f7.design.production_runtime_activation_in_f7===false,'F7_RUNTIME_ACTIVATION_FORBIDDEN');
+ok(f7.design.automatic_rollback===false,'F7_AUTOMATIC_ROLLBACK_FORBIDDEN');
+
+ok(f3.propagation.request_id_format==='uuid-v4','F7_F3_REQUEST_ID_CONTRACT_MISSING');
+ok(f3.propagation.trace_id_hex_length===32,'F7_F3_TRACE_ID_CONTRACT_MISSING');
+ok(f3.resource.required.includes('service.version'),'F7_F3_SERVICE_VERSION_REQUIRED');
+ok(f3.resource.required.includes('deployment.environment.name'),'F7_F3_ENV_REQUIRED');
+ok(f4.activation.release_variable==='RAILWAY_GIT_COMMIT_SHA','F7_F4_RELEASE_VARIABLE_DRIFT');
+ok(f4.release.format==='ascenda-os@<commit_sha>','F7_F4_RELEASE_FORMAT_DRIFT');
+
+const allowed=new Set(f7.railway_system_metadata.allowed_variables);
+for(const key of ['RAILWAY_GIT_COMMIT_SHA','RAILWAY_DEPLOYMENT_ID','RAILWAY_ENVIRONMENT_NAME','RAILWAY_SERVICE_NAME','RAILWAY_REPLICA_ID'])ok(allowed.has(key),`F7_RAILWAY_METADATA_MISSING:${key}`);
+const forbidden=new Set(f7.railway_system_metadata.forbidden_variables);
+ok(forbidden.has('RAILWAY_GIT_AUTHOR')&&forbidden.has('RAILWAY_GIT_COMMIT_MESSAGE'),'F7_RAILWAY_FREE_TEXT_NOT_FORBIDDEN');
+
+ok(f7.regression_window.temporal_candidate_is_causality===false,'F7_CAUSALITY_INFERENCE_GUARD_MISSING');
+ok(f7.rollback_policy.never_guess===true&&f7.rollback_policy.action_authorized===false,'F7_ROLLBACK_GUARD_DRIFT');
+ok(f7.rollback_policy.execution_owned_by_phase==='F12','F7_ROLLBACK_EXECUTION_SCOPE_DRIFT');
+ok(f7.privacy.free_text_forbidden===true&&f7.privacy.request_body_forbidden===true&&f7.privacy.message_content_forbidden===true,'F7_PRIVACY_DRIFT');
+ok(f7.privacy.patient_contact_identifiers_forbidden===true&&f7.privacy.auth_material_forbidden===true,'F7_PRIVACY_IDENTITY_DRIFT');
+
+ok(runtime.includes('RAILWAY_GIT_COMMIT_SHA'),'F7_RUNTIME_SHA_SOURCE_MISSING');
+ok(runtime.includes('RAILWAY_DEPLOYMENT_ID'),'F7_RUNTIME_DEPLOYMENT_SOURCE_MISSING');
+ok(runtime.includes('RAILWAY_ENVIRONMENT_NAME'),'F7_RUNTIME_ENV_SOURCE_MISSING');
+ok(!runtime.includes('RAILWAY_GIT_COMMIT_MESSAGE:'),'F7_RUNTIME_FREE_TEXT_CAPTURE');
+ok(engine.includes("causality:'NOT_ESTABLISHED'"),'F7_CAUSALITY_WORDING_MISSING');
+ok(engine.includes("action_authorized:false"),'F7_ROLLBACK_ACTION_GUARD_MISSING');
+ok(engine.includes("NO_PRIOR_KNOWN_GOOD_DEPLOYMENT"),'F7_ROLLBACK_UNKNOWN_GUARD_MISSING');
+
+console.log(JSON.stringify({
+  ok:true,
+  certificate:'SENTINEL_F7_CORRELATION_CONTRACT_PASS',
+  f3_request_trace_contract:true,
+  f4_release_contract:true,
+  railway_system_metadata:true,
+  railway_api_required:false,
+  causality_not_asserted:true,
+  rollback_never_guessed:true,
+  production_runtime_activation:false,
+  zero_phi_pii:true
+},null,2));

--- a/ci/sentinel/phase7_correlation_synthetic.js
+++ b/ci/sentinel/phase7_correlation_synthetic.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const assert=require('node:assert/strict');
+const runtime=require('../../sentinel/correlation/runtime-metadata.cjs');
+const engine=require('../../sentinel/correlation/correlation-engine.cjs');
+
+const shaOld='1111111111111111111111111111111111111111';
+const shaNew='2222222222222222222222222222222222222222';
+const shaOther='3333333333333333333333333333333333333333';
+const req='123e4567-e89b-42d3-a456-426614174000';
+const trace='0123456789abcdef0123456789abcdef';
+
+const envMeta=runtime.fromEnv({
+  RAILWAY_GIT_COMMIT_SHA:shaNew,
+  RAILWAY_DEPLOYMENT_ID:'dep-new',
+  RAILWAY_ENVIRONMENT_NAME:'production',
+  RAILWAY_SERVICE_NAME:'ascenda-os',
+  RAILWAY_REPLICA_ID:'replica-1',
+  RAILWAY_GIT_AUTHOR:'SHOULD_NOT_APPEAR',
+  RAILWAY_GIT_COMMIT_MESSAGE:'FREE TEXT MUST NOT APPEAR'
+},{request_id:req,trace_id:trace,observed_at:'2026-08-16T23:30:00Z'});
+assert.equal(envMeta.commit_sha,shaNew);
+assert.equal(envMeta.release,`ascenda-os@${shaNew}`);
+assert.equal(envMeta.deployment_id,'dep-new');
+assert.equal(envMeta.environment,'production');
+assert.equal(envMeta.request_id,req);
+assert.equal(envMeta.trace_id,trace);
+assert.ok(!Object.prototype.hasOwnProperty.call(envMeta,'RAILWAY_GIT_AUTHOR'));
+assert.ok(!JSON.stringify(envMeta).includes('SHOULD_NOT_APPEAR'));
+assert.ok(!JSON.stringify(envMeta).includes('FREE TEXT'));
+
+const deployments=[
+  {deployment_id:'dep-old',commit_sha:shaOld,environment:'production',service_name:'ascenda-os',started_at:'2026-08-16T21:00:00Z',status:'SUCCESS',health_state:'HEALTHY'},
+  {deployment_id:'dep-new',commit_sha:shaNew,environment:'production',service_name:'ascenda-os',started_at:'2026-08-16T23:00:00Z',status:'SUCCESS',health_state:'DEGRADED'},
+  {deployment_id:'dep-other',commit_sha:shaOther,environment:'zero-cost',service_name:'ascenda-os',started_at:'2026-08-16T22:55:00Z',status:'SUCCESS',health_state:'HEALTHY'}
+];
+const changes=[
+  {commit_sha:shaOld,pull_request:205,merged_at:'2026-08-16T21:00:00Z'},
+  {commit_sha:shaNew,pull_request:206,merged_at:'2026-08-16T22:55:00Z'}
+];
+
+const exact=engine.correlate({
+  signal:{observed_at:'2026-08-16T23:30:00Z',environment:'production',service_name:'ascenda-os',release:`ascenda-os@${shaNew}`,commit_sha:shaNew,deployment_id:'dep-new',request_id:req,trace_id:trace},
+  deployments,changes
+});
+assert.equal(exact.confidence,'EXACT');
+assert.equal(exact.commit_sha,shaNew);
+assert.equal(exact.deployment_id,'dep-new');
+assert.equal(exact.github_change.pull_request,206);
+assert.equal(exact.suspect_change.causality,'NOT_ESTABLISHED');
+assert.equal(exact.rollback.status,'EXACT_TARGET');
+assert.equal(exact.rollback.target.commit_sha,shaOld);
+assert.equal(exact.rollback.target.deployment_id,'dep-old');
+assert.equal(exact.rollback.action_authorized,false);
+assert.equal(exact.automatic_action_authorized,false);
+
+const releaseOnly=engine.correlate({
+  signal:{observed_at:'2026-08-16T23:20:00Z',environment:'production',service_name:'ascenda-os',release:`ascenda-os@${shaNew}`,request_id:req,trace_id:trace},
+  deployments,changes
+});
+assert.equal(releaseOnly.confidence,'STRONG');
+assert.equal(releaseOnly.deployment_id,'dep-new');
+assert.equal(releaseOnly.commit_sha,shaNew);
+
+const temporal=engine.correlate({
+  signal:{observed_at:'2026-08-16T23:10:00Z',environment:'production',service_name:'ascenda-os',request_id:req,trace_id:trace},
+  deployments,changes,regression_window_minutes:30
+});
+assert.equal(temporal.confidence,'WEAK');
+assert.equal(temporal.suspect_change.basis,'TEMPORAL_CANDIDATE');
+assert.equal(temporal.suspect_change.causality,'NOT_ESTABLISHED');
+
+const contradiction=engine.correlate({
+  signal:{observed_at:'2026-08-16T23:30:00Z',environment:'production',service_name:'ascenda-os',release:`ascenda-os@${shaOld}`,commit_sha:shaNew,deployment_id:'dep-new'},
+  deployments,changes
+});
+assert.equal(contradiction.confidence,'UNKNOWN');
+assert.equal(contradiction.correlation_reason,'CONTRADICTORY_RELEASE_AND_COMMIT');
+assert.equal(contradiction.suspect_change,null);
+assert.equal(contradiction.rollback.status,'UNKNOWN');
+
+const noPrior=engine.correlate({
+  signal:{observed_at:'2026-08-16T21:10:00Z',environment:'production',service_name:'ascenda-os',commit_sha:shaOld,deployment_id:'dep-old'},
+  deployments,changes
+});
+assert.equal(noPrior.confidence,'EXACT');
+assert.equal(noPrior.rollback.status,'UNKNOWN');
+assert.equal(noPrior.rollback.reason,'NO_PRIOR_KNOWN_GOOD_DEPLOYMENT');
+
+const wrongEnv=engine.correlate({
+  signal:{observed_at:'2026-08-16T23:30:00Z',environment:'production',service_name:'ascenda-os',commit_sha:shaOther,deployment_id:'dep-other'},
+  deployments,changes
+});
+assert.equal(wrongEnv.confidence,'UNKNOWN');
+
+assert.throws(()=>engine.correlate({signal:{observed_at:'2026-08-16T23:30:00Z',environment:'production',service_name:'ascenda-os',patient_name:'NO'}}),/F7_SIGNAL_UNAPPROVED_KEY/);
+assert.throws(()=>engine.correlate({signal:{observed_at:'invalid',environment:'production',service_name:'ascenda-os'}}),/F7_SIGNAL_OBSERVED_AT_INVALID/);
+
+console.log(JSON.stringify({
+  ok:true,
+  certificate:'SENTINEL_F7_CORRELATION_SYNTHETIC_PASS',
+  exact_sha_environment:true,
+  exact_deployment:true,
+  request_trace_passthrough:true,
+  temporal_candidate_is_inference:true,
+  causality_never_asserted:true,
+  rollback_exact_known_good:true,
+  rollback_never_guessed:true,
+  contradiction_unknown:true,
+  free_text_not_ingested:true,
+  production_mutation:false
+}));

--- a/docs/control/SENTINEL_CONTROL_MASTER.md
+++ b/docs/control/SENTINEL_CONTROL_MASTER.md
@@ -251,8 +251,8 @@ El roadmap operativo detallado está en `docs/control/SENTINEL_ROADMAP_V1.md`.
 
 ## 16. Checkpoint actual
 
-- F1–F5: `100_COMPLETE` y fusionadas a `main`.
-- F6: `100_COMPLETE` candidate; PR #206 requiere exact-head PASS, merge y post-merge PASS para que el cierre sea autoritativo.
-- F6 baseline: motor aggregate-only con invariantes Call Center, Sales, WhatsApp y Email; Zero-PHI/PII; sin persistencia ni notificaciones.
-- F7: siguiente fase canónica tras cierre autoritativo F6 — `Release, Deploy & Correlation Layer`.
-- Certificados terminales: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md` y `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`.
+- F1–F6: `100_COMPLETE` y fusionadas a `main` con post-merge CI.
+- F7: `100_COMPLETE` candidate; PR #207 requiere terminal exact-head PASS, merge y post-merge PASS para que el cierre sea autoritativo.
+- F7 baseline: correlation envelope vendor-neutral con release/SHA/deployment/request/trace, confidence `EXACT/STRONG/WEAK/UNKNOWN`, temporal candidate sin causalidad asumida y rollback target known-good sin ejecución.
+- F8: siguiente fase canónica tras cierre autoritativo F7 — `Sentinel Incident Engine (SEN-*)`.
+- Certificados terminales: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.

--- a/docs/control/SENTINEL_F7_CORRELATION_PLAN_20260816.md
+++ b/docs/control/SENTINEL_F7_CORRELATION_PLAN_20260816.md
@@ -1,0 +1,158 @@
+# Sentinel F7 — Release, Deploy & Correlation Layer
+
+**Estado:** EN CURSO  
+**Fecha:** 2026-08-16 (America/Lima)  
+**Baseline:** `main@c1a857fc515397ad9b9b9b6dcbadc6e53df30341`  
+**Branch:** `feature/sentinel-f7-correlation`  
+**Riesgo:** MEDIUM. Baseline F7 es read-only y no activa cambios runtime.
+
+## 1. Objetivo
+
+Responder de manera demostrable:
+
+- qué SHA/release estaba asociado a una señal;
+- qué deployment y ambiente corresponden;
+- qué `request_id` / `trace_id` permiten seguir evidencia técnica;
+- qué cambio GitHub coincide exactamente o aparece solo como candidato temporal;
+- cuál es el último deployment previo **conocido como sano** que podría servir de rollback target;
+- cuándo la evidencia es insuficiente y el resultado debe ser `UNKNOWN`.
+
+F7 no afirma causalidad y no ejecuta rollback.
+
+## 2. Recovery técnico
+
+### F3 — Telemetry
+
+Ya existe:
+
+- `service.version` obligatorio;
+- `deployment.environment.name` obligatorio;
+- `request_id` UUID v4;
+- W3C Trace Context;
+- `trace_id` de 32 hex;
+- propagación portable y sanitizada.
+
+### F4 — Sentry
+
+Ya existe:
+
+- release `ascenda-os@<commit_sha>`;
+- fuente principal `RAILWAY_GIT_COMMIT_SHA`;
+- environment normalizado;
+- Sentry permanece sensor, no fuente canónica de correlación.
+
+### Railway
+
+Railway documenta como system environment variables disponibles en builds/deployments:
+
+- `RAILWAY_GIT_COMMIT_SHA`;
+- `RAILWAY_DEPLOYMENT_ID`;
+- `RAILWAY_ENVIRONMENT_NAME`;
+- `RAILWAY_SERVICE_NAME`;
+- `RAILWAY_REPLICA_ID`.
+
+F7 usa solo IDs técnicos. No captura `RAILWAY_GIT_AUTHOR` ni `RAILWAY_GIT_COMMIT_MESSAGE` porque son free text innecesario para correlación.
+
+Railway API no es requisito de F7. Si en fases futuras se añade un conector/API, será una fuente adicional y no una dependencia estructural.
+
+## 3. Correlation Envelope
+
+Campos baseline:
+
+- `system=ascenda-os`;
+- `environment`;
+- `service_name`;
+- `release`;
+- `commit_sha`;
+- `deployment_id`;
+- `replica_id`;
+- `request_id`;
+- `trace_id`;
+- `observed_at`;
+- `source`.
+
+No incluye bodies, mensajes, datos de usuario, author/commit message ni secretos.
+
+## 4. Confidence model
+
+### EXACT
+
+`deployment_id` explícito y `commit_sha` coinciden con el deployment del mismo ambiente/servicio.
+
+### STRONG
+
+El SHA/release exacto coincide con un deployment del mismo ambiente/servicio, aunque la señal no traiga `deployment_id`.
+
+### WEAK
+
+Solo existe proximidad temporal dentro de la regression window. Puede mostrarse como **candidate**, nunca como causa.
+
+### UNKNOWN
+
+Falta evidencia, hay contradicción o el scope no coincide.
+
+## 5. Regla de causalidad
+
+Sentinel F7 nunca escribe:
+
+`deployment X caused incident Y`
+
+Solo puede representar:
+
+- exact correlated deployment;
+- suspect change candidate;
+- deployment in regression window;
+- causality `NOT_ESTABLISHED`.
+
+## 6. Rollback target
+
+F7 puede **determinar** un target; no puede ejecutarlo.
+
+Target exacto = deployment más reciente anterior al deployment sospechoso que cumpla simultáneamente:
+
+- mismo environment;
+- mismo service;
+- `status=SUCCESS`;
+- `health_state=HEALTHY`;
+- SHA válido;
+- fecha anterior al deployment sospechoso.
+
+Si no existe evidencia suficiente: `UNKNOWN`.
+
+La ejecución de rollback pertenece a F12 y requiere sus gates/autorización.
+
+## 7. Gates
+
+| Gate | Criterio |
+|---|---|
+| F7-G01 Recovery | F3/F4/Railway metadata contracts auditados |
+| F7-G02 Privacy | solo IDs técnicos/enums/timestamps; free text y secretos fuera |
+| F7-G03 Runtime extractor | fake Railway env produce SHA/release/deployment/env sin free text |
+| F7-G04 Exact correlation | incidente sintético identifica SHA + environment + deployment exactos |
+| F7-G05 Request/trace | UUID/trace_id válidos pasan sin payload |
+| F7-G06 GitHub change | commit exacto puede mapear a PR metadata sanitizada |
+| F7-G07 Temporal inference | candidate temporal se marca WEAK y `causality=NOT_ESTABLISHED` |
+| F7-G08 Contradiction | release/SHA contradictorios producen UNKNOWN |
+| F7-G09 Rollback | target previo known-good se determina; ausencia produce UNKNOWN |
+| F7-G10 Cross-platform | Windows FAST + Linux Zero-Cost PASS |
+| F7-G11 Scope | sin app runtime mutation, Railway API/token, DB DDL ni secretos |
+| F7-G12 Closure | exact-head PASS + certificado + merge + post-merge PASS + Notion |
+
+## 8. Artefactos
+
+- `sentinel/correlation/f7-contract.json`
+- `sentinel/correlation/runtime-metadata.cjs`
+- `sentinel/correlation/correlation-engine.cjs`
+- `ci/sentinel/phase7_correlation_contract.js`
+- `ci/sentinel/phase7_correlation_synthetic.js`
+- `.github/workflows/sentinel-phase7-correlation.yml`
+
+## 9. Próximo tramo
+
+1. ejecutar CI cross-platform;
+2. corregir cualquier contradicción del motor;
+3. abrir PR;
+4. revisar diff exacto y exact-head CI;
+5. generar certificado terminal;
+6. merge y post-merge;
+7. Notion F7 `Cerrada / 100%` y F8 como única siguiente.

--- a/docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md
+++ b/docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md
@@ -1,0 +1,167 @@
+# Sentinel F7 — Final Certificate
+
+**Phase:** F7 — Release, Deploy & Correlation Layer  
+**Status:** `100_COMPLETE` candidate pending terminal exact-head merge gate  
+**Date:** 2026-08-16 (America/Lima)  
+**Baseline:** `main@c1a857fc515397ad9b9b6dcbadc6e53df30341`  
+**Implementation mode:** read-only / provider-neutral  
+
+## Scope certified
+
+F7 establishes a correlation layer that can identify the technical version context of a Sentinel signal without asserting unsupported causality.
+
+The baseline correlates:
+
+- release;
+- git commit SHA;
+- Railway deployment ID;
+- Railway environment/service/replica technical metadata;
+- F3 `request_id` and `trace_id`;
+- sanitized GitHub commit→PR metadata supplied to the engine;
+- regression-window deployment candidates;
+- latest prior known-good rollback target.
+
+No Railway API/token is required and F7 does not modify production runtime.
+
+## Upstream evidence
+
+### F3
+
+The telemetry contract already provides:
+
+- `service.version`;
+- `deployment.environment.name`;
+- UUID-v4 `request_id`;
+- W3C Trace Context;
+- 32-hex `trace_id`.
+
+### F4
+
+The Sentry contract already provides release format:
+
+`ascenda-os@<commit_sha>`
+
+using `RAILWAY_GIT_COMMIT_SHA` as the primary Railway Git source.
+
+### Railway
+
+Railway's current Variables Reference was verified on 2026-08-16. The F7 allowed technical system variables are:
+
+- `RAILWAY_GIT_COMMIT_SHA`;
+- `RAILWAY_DEPLOYMENT_ID`;
+- `RAILWAY_ENVIRONMENT_NAME`;
+- `RAILWAY_SERVICE_NAME`;
+- `RAILWAY_REPLICA_ID`.
+
+Human-authored `RAILWAY_GIT_AUTHOR` and `RAILWAY_GIT_COMMIT_MESSAGE` are deliberately not captured.
+
+## Correlation confidence
+
+| Level | Meaning |
+|---|---|
+| EXACT | deployment ID and commit SHA agree in the same environment/service |
+| STRONG | exact SHA/release maps to same-scope deployment; deployment ID absent in the signal |
+| WEAK | only time proximity inside the regression window identifies a candidate |
+| UNKNOWN | evidence missing, ambiguous, out-of-scope, or contradictory |
+
+## Causality boundary
+
+A deployment correlated to an incident is **not automatically its cause**.
+
+F7 emits:
+
+`causality = NOT_ESTABLISHED`
+
+Temporal-only matches are explicitly marked:
+
+`basis = TEMPORAL_CANDIDATE`
+
+This prevents Sentinel from presenting sequence as proof of causation.
+
+## Rollback target policy
+
+F7 may determine a rollback target only when evidence identifies the latest deployment that is:
+
+- prior to the suspect deployment;
+- same environment;
+- same service;
+- `status=SUCCESS`;
+- `health_state=HEALTHY`;
+- backed by a valid commit SHA.
+
+If no such deployment exists, target = `UNKNOWN`.
+
+`action_authorized=false` is permanent in F7. Rollback execution belongs to F12.
+
+## Synthetic gate evidence
+
+The F7 fixture proves:
+
+1. fake Railway system env → exact release/SHA/deployment/environment metadata;
+2. author/commit-message free text is not ingested;
+3. exact signal → `EXACT` correlation;
+4. release-only signal → `STRONG` correlation;
+5. temporal-only signal → `WEAK`, candidate only, causality not established;
+6. contradictory explicit SHA vs release SHA → `UNKNOWN`;
+7. request/trace IDs survive as technical identifiers only;
+8. same-scope exact change can map to a sanitized PR number;
+9. rollback target selects the latest prior known-good deployment;
+10. absent prior known-good evidence → rollback `UNKNOWN`;
+11. mismatched environment cannot be correlated as exact;
+12. unapproved signal keys are rejected.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| F7-G01 Recovery F3/F4/Railway | PASS |
+| F7-G02 Privacy/free-text exclusion | PASS |
+| F7-G03 Safe runtime extractor | PASS |
+| F7-G04 Exact SHA/environment/deployment | PASS |
+| F7-G05 Request/trace passthrough | PASS |
+| F7-G06 GitHub change correlation | PASS |
+| F7-G07 Temporal inference labeling | PASS |
+| F7-G08 Contradiction → UNKNOWN | PASS |
+| F7-G09 Rollback target / never guess | PASS |
+| F7-G10 Cross-platform CI | PASS |
+| F7-G11 Scope/read-only | PASS |
+| F7-G12 Closure | PENDING terminal exact-head PASS → merge → post-merge PASS → Notion |
+
+## CI evidence before terminal docs
+
+Implementation head:
+
+`3c944bab0e022c181e34315b8bd074223502f745`
+
+- push `Sentinel F7 Release Deploy Correlation Certificate` #2: SUCCESS;
+- PR #207 `Sentinel F7 Release Deploy Correlation Certificate` #3: SUCCESS;
+- PR #207 `Ascenda CI` #2032: SUCCESS;
+- Windows FAST contract/synthetic: SUCCESS;
+- Linux `ascenda-zero-cost-v2` disposable Node: SUCCESS.
+
+## Scope audit
+
+Pre-terminal diff:
+
+- 7 added files;
+- Sentinel correlation code/contract;
+- Sentinel CI fixtures/workflow;
+- Sentinel control documentation;
+- no `app/` changes;
+- no database migrations;
+- no Railway variable changes;
+- no provider credentials;
+- no production writes.
+
+## Final decision
+
+F7 is functionally ready for `100_COMPLETE`.
+
+The authoritative closure requires:
+
+1. terminal certificate/roadmap/control head exact checks remain green;
+2. PR #207 merge;
+3. post-merge Sentinel F7 and Ascenda CI PASS on `main`;
+4. Notion updated last.
+
+After that, **F8 — Sentinel Incident Engine (`SEN-*`)** becomes the only next phase.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -363,9 +363,11 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 - Fase 3: `CERRADA / 100_COMPLETE`.
 - Fase 4: `CERRADA / 100_COMPLETE / 18/18 PASS`.
 - Fase 5: `CERRADA / 100_COMPLETE` — hybrid availability: UptimeRobot Free cloud + Uptime Kuma/CREACTIVE local, G01–G12 PASS.
-- Fase 6: `CERRADA / 100_COMPLETE` — 4 invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; cierre se vuelve autoritativo al fusionar PR #206 tras exact-head PASS.
-- Fase 7: `SIGUIENTE — Release, Deploy & Correlation Layer`.
-- Fases 8–13: `PENDIENTE`.
+- Fase 6: `CERRADA / 100_COMPLETE` — 4 invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; PR #206 fusionado y post-merge certificado.
+- Fase 7: `CERRADA / 100_COMPLETE` — release/SHA/deployment/request/trace correlation, confidence EXACT/STRONG/WEAK/UNKNOWN, causalidad no asumida y rollback target known-good sin ejecución; cierre se vuelve autoritativo al fusionar PR #207 tras exact-head PASS.
+- Fase 8: `SIGUIENTE — Sentinel Incident Engine (SEN-*)`.
+- Fases 9–13: `PENDIENTE`.
 - Certificado F5: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`.
 - Certificado F6: `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`.
-- F6 no crea incidentes persistentes ni notificaciones: esas responsabilidades permanecen asignadas a F8 y F9.
+- Certificado F7: `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.
+- F7 no ejecuta rollback ni persiste incidentes; rollback/remediation pertenece a F12 y persistencia `SEN-*` comienza en F8.

--- a/sentinel/correlation/correlation-engine.cjs
+++ b/sentinel/correlation/correlation-engine.cjs
@@ -1,0 +1,147 @@
+'use strict';
+
+const meta=require('./runtime-metadata.cjs');
+const {UNKNOWN}=meta;
+
+const CONFIDENCE=Object.freeze({EXACT:'EXACT',STRONG:'STRONG',WEAK:'WEAK',UNKNOWN:'UNKNOWN'});
+const SAFE_STATES=new Set(['SUCCESS','FAILED','CRASHED','REMOVED','UNKNOWN']);
+const SAFE_HEALTH=new Set(['HEALTHY','DEGRADED','INCIDENT','CRITICAL','UNKNOWN']);
+const ALLOWED_SIGNAL_KEYS=new Set(['observed_at','environment','service_name','release','commit_sha','deployment_id','replica_id','request_id','trace_id']);
+const ALLOWED_DEPLOY_KEYS=new Set(['deployment_id','commit_sha','environment','service_name','started_at','status','health_state']);
+const ALLOWED_CHANGE_KEYS=new Set(['commit_sha','pull_request','merged_at']);
+
+function iso(value){
+  if(typeof value!=='string'||Number.isNaN(Date.parse(value)))return null;
+  return new Date(value).toISOString();
+}
+function safeTechnical(value){
+  const v=String(value||'').trim();
+  return v&&/^[A-Za-z0-9._:@/-]{1,160}$/.test(v)?v:UNKNOWN;
+}
+function ensureOnly(obj,allowed,label){
+  if(!obj||typeof obj!=='object'||Array.isArray(obj))throw new Error(`${label}_OBJECT_REQUIRED`);
+  for(const key of Object.keys(obj))if(!allowed.has(key))throw new Error(`${label}_UNAPPROVED_KEY:${key}`);
+}
+function normalizeSignal(signal={}){
+  ensureOnly(signal,ALLOWED_SIGNAL_KEYS,'F7_SIGNAL');
+  const releaseParsed=meta.parseRelease(signal.release);
+  const explicitSha=meta.normalizeSha(signal.commit_sha);
+  const releaseSha=releaseParsed?releaseParsed.commit_sha:UNKNOWN;
+  let commit=explicitSha!==UNKNOWN?explicitSha:releaseSha;
+  let contradiction=false;
+  if(explicitSha!==UNKNOWN&&releaseSha!==UNKNOWN&&explicitSha!==releaseSha){commit=UNKNOWN;contradiction=true;}
+  const observed=iso(signal.observed_at);
+  if(!observed)throw new Error('F7_SIGNAL_OBSERVED_AT_INVALID');
+  return {
+    system:'ascenda-os',
+    environment:meta.normalizeEnvironment(signal.environment),
+    service_name:meta.safeId(signal.service_name),
+    release:releaseParsed?releaseParsed.release:(commit!==UNKNOWN?`ascenda-os@${commit}`:'ascenda-os@unknown'),
+    commit_sha:commit,
+    deployment_id:meta.safeId(signal.deployment_id),
+    replica_id:meta.safeId(signal.replica_id),
+    request_id:meta.normalizeRequestId(signal.request_id),
+    trace_id:meta.normalizeTraceId(signal.trace_id),
+    observed_at:observed,
+    contradiction
+  };
+}
+function normalizeDeployment(input){
+  ensureOnly(input,ALLOWED_DEPLOY_KEYS,'F7_DEPLOYMENT');
+  const started=iso(input.started_at);
+  if(!started)throw new Error('F7_DEPLOYMENT_STARTED_AT_INVALID');
+  const state=String(input.status||'UNKNOWN').toUpperCase();
+  const health=String(input.health_state||'UNKNOWN').toUpperCase();
+  return {
+    deployment_id:meta.safeId(input.deployment_id),
+    commit_sha:meta.normalizeSha(input.commit_sha),
+    environment:meta.normalizeEnvironment(input.environment),
+    service_name:meta.safeId(input.service_name),
+    started_at:started,
+    status:SAFE_STATES.has(state)?state:'UNKNOWN',
+    health_state:SAFE_HEALTH.has(health)?health:'UNKNOWN'
+  };
+}
+function normalizeChange(input){
+  ensureOnly(input,ALLOWED_CHANGE_KEYS,'F7_CHANGE');
+  const pr=Number.isInteger(input.pull_request)&&input.pull_request>0?input.pull_request:null;
+  return {commit_sha:meta.normalizeSha(input.commit_sha),pull_request:pr,merged_at:iso(input.merged_at)};
+}
+function sameScope(a,b){
+  return a.environment!==UNKNOWN&&b.environment===a.environment&&a.service_name!==UNKNOWN&&b.service_name===a.service_name;
+}
+function findDeployment(signal,deployments,windowMinutes=60){
+  if(signal.contradiction)return {deployment:null,confidence:CONFIDENCE.UNKNOWN,reason:'CONTRADICTORY_RELEASE_AND_COMMIT'};
+  const rows=deployments.map(normalizeDeployment).filter(d=>sameScope(signal,d));
+  if(signal.deployment_id!==UNKNOWN){
+    const matches=rows.filter(d=>d.deployment_id===signal.deployment_id);
+    if(matches.length!==1)return {deployment:null,confidence:CONFIDENCE.UNKNOWN,reason:matches.length?'AMBIGUOUS_DEPLOYMENT_ID':'DEPLOYMENT_ID_NOT_FOUND'};
+    const d=matches[0];
+    if(signal.commit_sha!==UNKNOWN&&d.commit_sha!==UNKNOWN&&d.commit_sha!==signal.commit_sha)return {deployment:null,confidence:CONFIDENCE.UNKNOWN,reason:'DEPLOYMENT_COMMIT_CONTRADICTION'};
+    return {deployment:d,confidence:signal.commit_sha!==UNKNOWN&&d.commit_sha===signal.commit_sha?CONFIDENCE.EXACT:CONFIDENCE.STRONG,reason:'DEPLOYMENT_ID_MATCH'};
+  }
+  if(signal.commit_sha!==UNKNOWN){
+    const matches=rows.filter(d=>d.commit_sha===signal.commit_sha).sort((a,b)=>Date.parse(b.started_at)-Date.parse(a.started_at));
+    if(matches.length)return {deployment:matches[0],confidence:CONFIDENCE.STRONG,reason:'COMMIT_SHA_MATCH'};
+  }
+  const observedMs=Date.parse(signal.observed_at);
+  const maxAge=Math.max(1,Number(windowMinutes)||60)*60000;
+  const candidates=rows.filter(d=>Date.parse(d.started_at)<=observedMs&&observedMs-Date.parse(d.started_at)<=maxAge).sort((a,b)=>Date.parse(b.started_at)-Date.parse(a.started_at));
+  if(candidates.length)return {deployment:candidates[0],confidence:CONFIDENCE.WEAK,reason:'TEMPORAL_REGRESSION_WINDOW'};
+  return {deployment:null,confidence:CONFIDENCE.UNKNOWN,reason:'NO_CORRELATED_DEPLOYMENT'};
+}
+function findChange(commitSha,changes=[]){
+  if(commitSha===UNKNOWN)return null;
+  const rows=changes.map(normalizeChange).filter(c=>c.commit_sha===commitSha);
+  if(rows.length!==1)return null;
+  return rows[0];
+}
+function chooseRollbackTarget(suspect,deployments=[]){
+  if(!suspect||suspect.started_at==null)return {status:'UNKNOWN',reason:'SUSPECT_DEPLOYMENT_UNKNOWN',target:null,action_authorized:false};
+  const rows=deployments.map(normalizeDeployment)
+    .filter(d=>d.environment===suspect.environment&&d.service_name===suspect.service_name)
+    .filter(d=>Date.parse(d.started_at)<Date.parse(suspect.started_at))
+    .filter(d=>d.status==='SUCCESS'&&d.health_state==='HEALTHY'&&d.commit_sha!==UNKNOWN)
+    .sort((a,b)=>Date.parse(b.started_at)-Date.parse(a.started_at));
+  if(!rows.length)return {status:'UNKNOWN',reason:'NO_PRIOR_KNOWN_GOOD_DEPLOYMENT',target:null,action_authorized:false};
+  const target=rows[0];
+  return {status:'EXACT_TARGET',reason:'LATEST_PRIOR_KNOWN_GOOD',target:{deployment_id:target.deployment_id,commit_sha:target.commit_sha,environment:target.environment,service_name:target.service_name,started_at:target.started_at},action_authorized:false};
+}
+function correlate(input={}){
+  const signal=normalizeSignal(input.signal||{});
+  const deployments=Array.isArray(input.deployments)?input.deployments:[];
+  const changes=Array.isArray(input.changes)?input.changes:[];
+  const match=findDeployment(signal,deployments,input.regression_window_minutes||60);
+  const deployment=match.deployment;
+  const effectiveCommit=deployment&&deployment.commit_sha!==UNKNOWN?deployment.commit_sha:signal.commit_sha;
+  const change=findChange(effectiveCommit,changes);
+  const rollback=chooseRollbackTarget(deployment,deployments);
+  const temporal=match.confidence===CONFIDENCE.WEAK;
+  return {
+    ok:true,
+    schema_version:'sentinel-correlation-result/v1',
+    observed_at:signal.observed_at,
+    environment:signal.environment,
+    service_name:signal.service_name,
+    release:signal.release,
+    commit_sha:effectiveCommit,
+    deployment_id:deployment?deployment.deployment_id:signal.deployment_id,
+    request_id:signal.request_id,
+    trace_id:signal.trace_id,
+    confidence:match.confidence,
+    correlation_reason:match.reason,
+    deployment:deployment||null,
+    github_change:change,
+    suspect_change:deployment?{
+      commit_sha:effectiveCommit,
+      deployment_id:deployment.deployment_id,
+      pull_request:change?change.pull_request:null,
+      basis:temporal?'TEMPORAL_CANDIDATE':'EXACT_OR_STRONG_CORRELATION',
+      causality:'NOT_ESTABLISHED'
+    }:null,
+    rollback,
+    automatic_action_authorized:false
+  };
+}
+
+module.exports={CONFIDENCE,normalizeSignal,normalizeDeployment,normalizeChange,findDeployment,findChange,chooseRollbackTarget,correlate};

--- a/sentinel/correlation/f7-contract.json
+++ b/sentinel/correlation/f7-contract.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "sentinel-correlation/v1",
+  "phase": "F7",
+  "baseline_main": "c1a857fc515397ad9b9b6dcbadc6e53df30341",
+  "purpose": "Correlate Sentinel signals with exact release, commit, deployment, request and trace metadata without asserting unproven causality.",
+  "design": {
+    "vendor_neutral": true,
+    "read_only": true,
+    "zero_phi_pii": true,
+    "railway_api_required": false,
+    "github_write_required": false,
+    "production_runtime_activation_in_f7": false,
+    "automatic_rollback": false
+  },
+  "upstream_contracts": {
+    "f3_telemetry": {
+      "path": "sentinel/telemetry/contract-v1.json",
+      "correlation_fields": ["service.version", "deployment.environment.name", "request_id", "trace_id"]
+    },
+    "f4_sentry": {
+      "path": "sentinel/sentry/f4-contract.json",
+      "release_format": "ascenda-os@<commit_sha>",
+      "release_variable": "RAILWAY_GIT_COMMIT_SHA"
+    },
+    "f6_business_health": {
+      "path": "sentinel/business-health/f6-contract.json",
+      "signal_fields": ["domain", "component", "capability", "invariant_id", "state", "observed_at"]
+    }
+  },
+  "railway_system_metadata": {
+    "verified_on": "2026-08-16",
+    "documentation": "Railway Variables Reference",
+    "allowed_variables": [
+      "RAILWAY_GIT_COMMIT_SHA",
+      "RAILWAY_DEPLOYMENT_ID",
+      "RAILWAY_ENVIRONMENT_NAME",
+      "RAILWAY_SERVICE_NAME",
+      "RAILWAY_REPLICA_ID"
+    ],
+    "forbidden_variables": [
+      "RAILWAY_GIT_AUTHOR",
+      "RAILWAY_GIT_COMMIT_MESSAGE"
+    ],
+    "reason_for_forbidden": "Human-authored free text is unnecessary for correlation and can contain sensitive or irrelevant data."
+  },
+  "correlation_envelope": {
+    "schema_version": "sentinel-correlation-envelope/v1",
+    "fields": [
+      "system",
+      "environment",
+      "service_name",
+      "release",
+      "commit_sha",
+      "deployment_id",
+      "replica_id",
+      "request_id",
+      "trace_id",
+      "observed_at",
+      "source"
+    ],
+    "system": "ascenda-os",
+    "unknown_marker": "UNKNOWN"
+  },
+  "confidence": {
+    "EXACT": "Explicit deployment_id and commit_sha agree with a deployment record in the same environment/service.",
+    "STRONG": "Exact commit_sha/release maps to a deployment in the same environment/service, but deployment_id was absent.",
+    "WEAK": "Only temporal proximity identifies a candidate deployment; this is an inference, not identity or causality.",
+    "UNKNOWN": "Evidence is insufficient or contradictory."
+  },
+  "regression_window": {
+    "default_minutes": 60,
+    "temporal_candidate_allowed": true,
+    "temporal_candidate_is_causality": false,
+    "wording": "suspect change candidate / deployment in regression window"
+  },
+  "rollback_policy": {
+    "selection": "latest prior known-good deployment in same environment and service",
+    "known_good_requires": ["status=SUCCESS", "health_state=HEALTHY", "valid commit_sha", "started_at before suspect deployment"],
+    "if_missing": "UNKNOWN",
+    "never_guess": true,
+    "action_authorized": false,
+    "execution_owned_by_phase": "F12"
+  },
+  "privacy": {
+    "allowed_value_classes": ["technical-id", "enum", "timestamp"],
+    "free_text_forbidden": true,
+    "request_body_forbidden": true,
+    "message_content_forbidden": true,
+    "patient_contact_identifiers_forbidden": true,
+    "auth_material_forbidden": true
+  },
+  "gates": {
+    "exact_sha_environment": true,
+    "request_trace_passthrough": true,
+    "deployment_match": true,
+    "temporal_inference_labeled": true,
+    "rollback_target_without_guessing": true,
+    "contradiction_returns_unknown": true,
+    "cross_platform_ci": true
+  }
+}

--- a/sentinel/correlation/runtime-metadata.cjs
+++ b/sentinel/correlation/runtime-metadata.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+const SHA_RE=/^[0-9a-f]{7,40}$/i;
+const SAFE_ID_RE=/^[A-Za-z0-9._:-]{1,160}$/;
+const UUID_V4_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TRACE_ID_RE=/^[0-9a-f]{32}$/i;
+const UNKNOWN='UNKNOWN';
+
+function safeId(value){
+  const v=String(value||'').trim();
+  return v&&SAFE_ID_RE.test(v)?v:UNKNOWN;
+}
+function normalizeEnvironment(value){
+  const v=String(value||'').trim().toLowerCase();
+  if(v==='production')return 'production';
+  if(['zero-cost','zero_cost','staging','test'].includes(v))return 'zero-cost';
+  if(v==='development')return 'development';
+  return UNKNOWN;
+}
+function normalizeSha(value){
+  const v=String(value||'').trim().toLowerCase();
+  return SHA_RE.test(v)?v:UNKNOWN;
+}
+function parseRelease(value){
+  const v=String(value||'').trim();
+  const m=/^ascenda-os@([0-9a-f]{7,40})$/i.exec(v);
+  return m?{release:`ascenda-os@${m[1].toLowerCase()}`,commit_sha:m[1].toLowerCase()}:null;
+}
+function normalizeRequestId(value){
+  const v=String(value||'').trim().toLowerCase();
+  return UUID_V4_RE.test(v)?v:UNKNOWN;
+}
+function normalizeTraceId(value){
+  const v=String(value||'').trim().toLowerCase();
+  return TRACE_ID_RE.test(v)&&!/^0+$/.test(v)?v:UNKNOWN;
+}
+function fromEnv(env=process.env,context={}){
+  const commit=normalizeSha(env.RAILWAY_GIT_COMMIT_SHA||env.GITHUB_SHA);
+  const release=commit!==UNKNOWN?`ascenda-os@${commit}`:'ascenda-os@unknown';
+  const hasRailway=Boolean(String(env.RAILWAY_DEPLOYMENT_ID||env.RAILWAY_SERVICE_NAME||env.RAILWAY_ENVIRONMENT_NAME||'').trim());
+  return {
+    schema_version:'sentinel-correlation-envelope/v1',
+    system:'ascenda-os',
+    environment:normalizeEnvironment(env.RAILWAY_ENVIRONMENT_NAME||env.SENTRY_ENVIRONMENT),
+    service_name:safeId(env.RAILWAY_SERVICE_NAME||context.service_name),
+    release,
+    commit_sha:commit,
+    deployment_id:safeId(env.RAILWAY_DEPLOYMENT_ID),
+    replica_id:safeId(env.RAILWAY_REPLICA_ID),
+    request_id:normalizeRequestId(context.request_id),
+    trace_id:normalizeTraceId(context.trace_id),
+    observed_at:new Date(context.observed_at||Date.now()).toISOString(),
+    source:hasRailway?'railway-system-env':'process-env'
+  };
+}
+
+module.exports={UNKNOWN,SHA_RE,SAFE_ID_RE,UUID_V4_RE,TRACE_ID_RE,safeId,normalizeEnvironment,normalizeSha,parseRelease,normalizeRequestId,normalizeTraceId,fromEnv};


### PR DESCRIPTION
## Sentinel F7 — Release, Deploy & Correlation Layer

Adds a portable read-only correlation layer that links Sentinel signals to release/SHA, Railway deployment metadata, request/trace context, GitHub change metadata and a prior known-good rollback target.

### Key properties
- consumes Railway-provided technical system metadata without Railway API/token;
- maps F4 release `ascenda-os@<commit_sha>` and F3 request/trace contracts;
- confidence model EXACT / STRONG / WEAK / UNKNOWN;
- temporal proximity is explicitly an inference, never causality;
- contradictory release/SHA evidence returns UNKNOWN;
- rollback target is only the latest prior same-scope SUCCESS + HEALTHY deployment with valid SHA;
- rollback execution is forbidden in F7 and remains owned by F12;
- no human-authored commit messages/authors ingested;
- Zero-PHI/PII and no runtime activation in F7.

### Terminal exact-head evidence
Final head: `e7cd8945fa826e5a942a666809138213f2505244`.

- Sentinel F7 Release Deploy Correlation Certificate #8: SUCCESS;
- Ascenda CI #2035: SUCCESS;
- Sentinel F6 regression #18: SUCCESS;
- Sentinel F5 regression #77: SUCCESS.

### Scope
Final PR contains Sentinel correlation code/contract/tests/workflow plus control docs/certificate only. No `app/` modification, no DB migration, no Railway variable change, no provider credentials and no production mutation.

Certificate: `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.