### PR TITLE
fix(sentinel): align F8 migration history with Supabase live

### DIFF
--- a/ci/sentinel/phase8_incident_engine_contract.js
+++ b/ci/sentinel/phase8_incident_engine_contract.js
@@ -45,7 +45,7 @@ ok(f8.persistence_target.initial_engine_repository==='in-memory reference adapte
 ok(f8.persistence_target.fixture_uses_production_persistence===false,'F8_FIXTURE_MUST_NOT_USE_PRODUCTION');
 ok(f8.persistence_target.live_incidents_in_notion===false,'F8_NOTION_RUNTIME_STORE_FORBIDDEN');
 ok(f8.persistence_target.production_status==='certified','F8_PRODUCTION_PERSISTENCE_NOT_CERTIFIED');
-ok(f8.persistence_target.production_migration_version==='20260817000919','F8_PRODUCTION_MIGRATION_VERSION_DRIFT');
+ok(f8.persistence_target.production_migration_version==='20260817000618','F8_PRODUCTION_MIGRATION_VERSION_DRIFT');
 ok(f8.persistence_target.production_canary_incident==='SEN-2026-0001'&&f8.persistence_target.production_canary_final_status==='RESOLVED','F8_PRODUCTION_CANARY_DRIFT');
 ok(f8.gates.production_persistence_requires_separate_gate===true,'F8_PRODUCTION_PERSISTENCE_GATE_MISSING');
 ok(f8.gates.zero_cost_persistence_certified===true&&f8.gates.production_persistence_certified===true,'F8_PERSISTENCE_CERTIFICATION_DRIFT');

--- a/docs/control/SENTINEL_CONTROL_MASTER.md
+++ b/docs/control/SENTINEL_CONTROL_MASTER.md
@@ -255,10 +255,11 @@ El roadmap operativo detallado está en `docs/control/SENTINEL_ROADMAP_V1.md`.
 ## 16. Checkpoint actual
 
 - F1–F7: `CERRADA / 100_COMPLETE` y fusionadas a `main` con post-merge CI.
-- F8: `COMPLETE CANDIDATE / G12+G13 PASS`; producción ya contiene la migración versionada `20260817000919 sentinel_f8_incident_engine` y el canary sintético `SEN-2026-0001` terminó `RESOLVED`.
+- F8: `COMPLETE CANDIDATE / G12+G13 PASS`; producción contiene la migración `sentinel_f8_incident_engine` con versión de historial live `20260817000618`; el archivo fuente es `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`; el canary `SEN-2026-0001` terminó `RESOLVED`.
 - F8 G12: run `31980704736` PASS en Windows/Linux/PostgreSQL local; Ascenda CI `31980704753` PASS.
 - F8 security boundary: 4 tablas con RLS, sin políticas directas, RPCs operativas `service_role`-only, SECURITY DEFINER con search_path fijo y cero columnas sensibles.
-- F8 terminal pendiente: exact-head CI de documentación final → PR #208 ready → merge exact head → post-merge main → Notion last.
+- F8 PR #208 fue fusionado a `main@a30de31de1f659f4d367f63dab9ff5db8ebab5ac`; una verificación read-only posterior detectó y está corrigiendo únicamente el identificador documental de migration-history para igualarlo a Supabase live.
+- F8 terminal pendiente: hotfix de paridad documental → exact-head CI → merge → final post-merge → Notion last.
 - F9: única fase `SIGUIENTE` después del cierre autoritativo F8 — `Alert Routing, Telegram & Noise Control`.
 - Certificados terminales: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
 - Los advisories globales Supabase no relacionados con `aos_sentinel_*` se mantienen fuera del scope F8 y deben tratarse como backlog técnico separado.

--- a/docs/control/SENTINEL_F8_CHECKPOINT_20260816.md
+++ b/docs/control/SENTINEL_F8_CHECKPOINT_20260816.md
@@ -1,11 +1,13 @@
 # Sentinel F8 — Terminal Checkpoint
 
 **Fecha:** 2026-08-16/17 (America/Lima)  
-**Estado técnico:** `F8 COMPLETE CANDIDATE — TERMINAL REPO SYNC PENDING`  
-**PR:** `#208 DRAFT`  
+**Estado técnico:** `F8 COMPLETE CANDIDATE — MIGRATION-HISTORY PARITY HOTFIX`  
+**PR funcional:** `#208 MERGED`  
 **Producción:** `F8 PERSISTENCE APPLIED + CANARY CERTIFIED`  
 **Functional certified head:** `d9f84652b1818a6a61e9d9e8dbfbdb85a4ede041`  
-**Production migration:** `20260817000919 sentinel_f8_incident_engine`  
+**F8 merge main:** `a30de31de1f659f4d367f63dab9ff5db8ebab5ac`  
+**Production migration history:** `20260817000618 sentinel_f8_incident_engine`  
+**Repository migration file:** `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`  
 **Production canary:** `SEN-2026-0001 / RESOLVED`  
 
 ## Completed before F8
@@ -75,7 +77,8 @@ Production read-only preflight:
 Production apply:
 
 - migration applied once through Supabase migration tooling;
-- migration history version `20260817000919`;
+- live migration history version `20260817000618`;
+- migration name `sentinel_f8_incident_engine`;
 - no unrelated production object changed by F8.
 
 Post-DDL security verification:
@@ -118,20 +121,19 @@ Post-DDL security/performance advisors were reviewed.
 - Fresh Sentinel indexes may be reported as unused immediately after creation; retain until sufficient operational evidence exists.
 - Existing non-Sentinel database advisories are separate backlog items and are not modified under F8 scope.
 
-## Current terminal gate
+## Runtime parity correction
 
-`F8-G14 — Repository / Control Synchronization`
+A post-merge read-only migration-history verification detected that the production migration tooling recorded version `20260817000618`, while terminal documentation initially contained `20260817000919`. The database objects and applied SQL were correct; only the documentary migration-history identifier was stale. This hotfix aligns the machine-readable contract and control evidence with the live Supabase source of truth before F8 closure.
+
+## Current terminal gate
 
 Remaining before authoritative `CERRADA / 100_COMPLETE`:
 
-1. commit final certificate + roadmap/control state;
-2. exact-head F8 workflow PASS;
-3. exact-head Ascenda CI/regressions PASS;
-4. mark PR #208 ready;
-5. merge exact green head to `main`;
-6. post-merge verification on `main`;
-7. update Notion last;
-8. promote F9 as the sole active next phase.
+1. migration-history parity hotfix exact-head CI;
+2. merge hotfix to `main`;
+3. final post-merge verification;
+4. update Notion last;
+5. promote F9 as the sole active next phase.
 
 ## Hard boundary
 

--- a/docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md
+++ b/docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md
@@ -6,7 +6,7 @@
 **PR:** `#208`  
 **Certified functional head before terminal docs:** `d9f84652b1818a6a61e9d9e8dbfbdb85a4ede041`  
 **Production Supabase project:** `ituyqwstonmhnfshnaqz`  
-**Production migration version:** `20260817000919` — `sentinel_f8_incident_engine`  
+**Production migration version:** `20260817000618` — `sentinel_f8_incident_engine`  
 **Synthetic production canary:** `SEN-2026-0001` — final state `RESOLVED`  
 
 ## Result
@@ -64,9 +64,11 @@ These changes reduce false-red CI without weakening any F8 database gate.
 
 The owner explicitly authorized the full controlled F8 production gate after G12 certification.
 
-Production migration was applied once through Supabase migration tooling and recorded as:
+Production migration was applied once through Supabase migration tooling and recorded by the live migration history as:
 
-`20260817000919 sentinel_f8_incident_engine`
+`20260817000618 sentinel_f8_incident_engine`
+
+The repository migration filename remains `20260816233500_sentinel_f8_incident_engine.sql`; Supabase's production migration-history version is the authoritative runtime identifier above.
 
 No production rollback/reapply cycle was performed. Rollback/reapply was already proven in isolated G12; production rollback remains contingency-only.
 

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -365,7 +365,7 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 - Fase 5: `CERRADA / 100_COMPLETE` — hybrid availability: UptimeRobot Free cloud + Uptime Kuma/CREACTIVE local; G01–G12 PASS.
 - Fase 6: `CERRADA / 100_COMPLETE` — 4 invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; PR #206 fusionado y post-merge certificado.
 - Fase 7: `CERRADA / 100_COMPLETE` — PR #207 fusionado; correlation envelope vendor-neutral con release/SHA/deployment/request/trace, confidence `EXACT/STRONG/WEAK/UNKNOWN`, causalidad no asumida y rollback target known-good sin ejecución.
-- Fase 8: `COMPLETE CANDIDATE / G12+G13 PASS` — Incident Engine y persistencia productiva aplicados; migración `20260817000919 sentinel_f8_incident_engine`; canary `SEN-2026-0001` final `RESOLVED`; pendiente únicamente terminal exact-head merge/post-merge/Notion para cierre autoritativo.
+- Fase 8: `COMPLETE CANDIDATE / G12+G13 PASS / PARITY HOTFIX` — Incident Engine y persistencia productiva aplicados; Supabase live registra `20260817000618 sentinel_f8_incident_engine`; archivo fuente `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`; canary `SEN-2026-0001` final `RESOLVED`; PR #208 ya fusionado a `main@a30de31de1f659f4d367f63dab9ff5db8ebab5ac`; pendiente únicamente hotfix documental de paridad → exact-head/post-merge → Notion.
 - Fase 9: `SIGUIENTE — Alert Routing, Telegram & Noise Control` después del cierre autoritativo F8.
 - Fases 10–13: `PENDIENTE`.
 - Certificado F5: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`.

--- a/sentinel/incidents/f8-contract.json
+++ b/sentinel/incidents/f8-contract.json
@@ -117,7 +117,7 @@
     "fixture_uses_production_persistence": false,
     "live_incidents_in_notion": false,
     "production_status": "certified",
-    "production_migration_version": "20260817000919",
+    "production_migration_version": "20260817000618",
     "production_migration_name": "sentinel_f8_incident_engine",
     "production_canary_incident": "SEN-2026-0001",
     "production_canary_final_status": "RESOLVED"


### PR DESCRIPTION
## Sentinel F8 migration-history parity hotfix

Read-only post-merge verification against Supabase live found one documentary mismatch: production migration history records `20260817000618 sentinel_f8_incident_engine`, while six canonical GitHub references contained `20260817000919`.

### Scope
- no SQL/DDL changes;
- no Supabase mutation;
- no runtime/app changes;
- no secrets;
- only machine-readable/control evidence alignment.

### Corrected sources
- `sentinel/incidents/f8-contract.json`
- `ci/sentinel/phase8_incident_engine_contract.js`
- `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`
- `docs/control/SENTINEL_F8_CHECKPOINT_20260816.md`
- `docs/control/SENTINEL_CONTROL_MASTER.md`
- `docs/control/SENTINEL_ROADMAP_V1.md`

### Source of truth
Supabase `list_migrations` currently reports `20260817000618 sentinel_f8_incident_engine`. The repository migration filename remains `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`; these identifiers serve different purposes and are now explicitly distinguished.

Merge only after exact-head Sentinel F8 + Ascenda CI/regression gates pass. After merge, verify `main` again, then update Notion last and activate F9.