### PR TITLE
feat(sentinel): F9 durable alert outbox and restart-safe noise control

### DIFF
--- a/.github/workflows/sentinel-phase9-alert-routing.yml
+++ b/.github/workflows/sentinel-phase9-alert-routing.yml
@@ -6,11 +6,14 @@ on:
     paths: &f9_paths
       - 'sentinel/alerts/**'
       - 'ci/sentinel/phase9_alert_routing_*.js'
+      - 'ci/sentinel/phase9_alert_outbox_zero_cost.*'
+      - 'supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql'
+      - 'supabase/rollbacks/20260817010000_sentinel_f9_alert_outbox_rollback.sql'
       - 'docs/control/SENTINEL_F9_*.md'
       - 'docs/control/SENTINEL_ROADMAP_V1.md'
       - '.github/workflows/sentinel-phase9-alert-routing.yml'
   push:
-    branches: ['feature/sentinel-f9-alert-routing','main']
+    branches: ['feature/sentinel-f9-alert-routing','feature/sentinel-f9-durable-alert-state','main']
     paths: *f9_paths
 
 permissions:
@@ -91,3 +94,27 @@ jobs:
             -w /work \
             node:22-alpine \
             sh -lc 'node --version && node --check sentinel/alerts/memory-alert-state.cjs && node --check sentinel/alerts/alert-router.cjs && node --check sentinel/alerts/alert-dispatcher.cjs && node --check sentinel/alerts/fake-transport.cjs && node --check sentinel/alerts/telegram-transport.cjs && node --check sentinel/alerts/supabase-telegram-config-provider.cjs && node ci/sentinel/phase9_alert_routing_contract.js && node ci/sentinel/phase9_alert_routing_synthetic.js && node ci/sentinel/phase9_alert_routing_telegram_adapter.js && node ci/sentinel/phase9_alert_routing_secret_provider.js'
+
+  outbox-zero-cost:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 25
+    env:
+      SUPABASE_CLI_VERSION: '2.72.8'
+      NODE_CLI_IMAGE: 'node:22-bookworm-slim'
+      PSQL_IMAGE: 'postgres:17-alpine'
+      WORKSPACE_FIX_IMAGE: 'alpine:3.20'
+    steps:
+      - name: Repair container-owned workspace before checkout
+        run: |
+          set -euo pipefail
+          docker version >/dev/null
+          docker run --rm -v "$GITHUB_WORKSPACE:/work" "$WORKSPACE_FIX_IMAGE" sh -lc "rm -rf /work/ci/zero-cost-staging/supabase/.branches; chown -R $(id -u):$(id -g) /work 2>/dev/null || true"
+      - uses: actions/checkout@v4
+      - name: Enforce isolated Zero-Cost runner
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          docker version >/dev/null
+          bash -n ci/sentinel/phase9_alert_outbox_zero_cost.sh
+      - name: F9 durable outbox PostgreSQL certificate
+        run: bash ci/sentinel/phase9_alert_outbox_zero_cost.sh

--- a/ci/sentinel/phase9_alert_outbox_zero_cost.sh
+++ b/ci/sentinel/phase9_alert_outbox_zero_cost.sh
@@ -9,6 +9,8 @@ WORKSPACE_FIX_IMAGE="${WORKSPACE_FIX_IMAGE:-alpine:3.20}"
 F8_MIGRATION="supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql"
 F9_MIGRATION="supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql"
 F9_ROLLBACK="supabase/rollbacks/20260817010000_sentinel_f9_alert_outbox_rollback.sql"
+F9_PERF_MIGRATION="supabase/migrations/20260817015500_sentinel_f9_digest_incident_fk_index.sql"
+F9_PERF_ROLLBACK="supabase/rollbacks/20260817015500_sentinel_f9_digest_incident_fk_index_rollback.sql"
 FIXTURE="ci/sentinel/phase9_alert_outbox_zero_cost.sql"
 DOCKER_BIN="$(command -v docker)"
 PROJECT_DIR="$GITHUB_WORKSPACE/ci/zero-cost-staging"
@@ -17,10 +19,10 @@ HOST_UID="$(id -u)"
 HOST_GID="$(id -g)"
 DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
-for f in "$F8_MIGRATION" "$F9_MIGRATION" "$F9_ROLLBACK" "$FIXTURE"; do test -f "$GITHUB_WORKSPACE/$f"; done
+for f in "$F8_MIGRATION" "$F9_MIGRATION" "$F9_ROLLBACK" "$F9_PERF_MIGRATION" "$F9_PERF_ROLLBACK" "$FIXTURE"; do test -f "$GITHUB_WORKSPACE/$f"; done
 docker version >/dev/null
 python3 --version >/dev/null
-! grep -Eq '(SUPABASE_SERVICE_ROLE_KEY|Bearer [A-Za-z0-9._-]{20,}|sb_secret_|sk-proj-)' "$GITHUB_WORKSPACE/$F9_MIGRATION" "$GITHUB_WORKSPACE/$F9_ROLLBACK" "$GITHUB_WORKSPACE/$FIXTURE"
+! grep -Eq '(SUPABASE_SERVICE_ROLE_KEY|Bearer [A-Za-z0-9._-]{20,}|sb_secret_|sk-proj-)' "$GITHUB_WORKSPACE/$F9_MIGRATION" "$GITHUB_WORKSPACE/$F9_ROLLBACK" "$GITHUB_WORKSPACE/$F9_PERF_MIGRATION" "$GITHUB_WORKSPACE/$F9_PERF_ROLLBACK" "$GITHUB_WORKSPACE/$FIXTURE"
 
 supa(){
   docker run --rm --network host \
@@ -52,7 +54,10 @@ psql_cmd(){ docker run --rm --network host "$PSQL_IMAGE" psql "$DB_URL" -v ON_ER
 psql_cmd -Atqc "select current_database()" | grep -qx postgres
 psql_file "$F8_MIGRATION" >/dev/null
 psql_file "$F9_MIGRATION" >/dev/null
+psql_file "$F9_PERF_MIGRATION" >/dev/null
+psql_cmd -Atqc "select count(*) from pg_indexes where schemaname='public' and tablename='aos_sentinel_alert_digest_items_v1' and indexname='aos_sentinel_alert_digest_items_v1_incident_idx'" | grep -qx 1
 echo 'SENTINEL_F9_LOCAL_MIGRATION=PASS'
+echo 'SENTINEL_F9_DIGEST_FK_INDEX=PASS'
 psql_file "$FIXTURE"
 
 # Same attempt in two concurrent transactions must produce exactly one ledger row.
@@ -69,11 +74,19 @@ supa "db lint --local --level warning" >/tmp/f9-db-lint.txt
 ! grep -Eqi '(security definer.*mutable search_path|aos_sentinel_alert_.*rls.*disabled)' /tmp/f9-db-lint.txt
 echo 'SENTINEL_F9_DB_LINT=PASS'
 
+# Hotfix rollback/reapply must be reversible without touching F9 tables.
+psql_file "$F9_PERF_ROLLBACK" >/dev/null
+psql_cmd -Atqc "select count(*) from pg_indexes where schemaname='public' and indexname='aos_sentinel_alert_digest_items_v1_incident_idx'" | grep -qx 0
+psql_file "$F9_PERF_MIGRATION" >/dev/null
+psql_cmd -Atqc "select count(*) from pg_indexes where schemaname='public' and indexname='aos_sentinel_alert_digest_items_v1_incident_idx'" | grep -qx 1
+echo 'SENTINEL_F9_PERF_ROLLBACK_REAPPLY=PASS'
+
 # Rollback F9 only; F8 must remain intact. Then reapply and replay fixtures.
 psql_file "$F9_ROLLBACK" >/dev/null
 psql_cmd -Atqc "select case when to_regclass('public.aos_sentinel_alert_dispatches_v1') is null then 'gone' else 'present' end" | grep -qx gone
 psql_cmd -Atqc "select case when to_regclass('public.aos_sentinel_incidents_v1') is not null then 'f8-present' else 'f8-missing' end" | grep -qx f8-present
 psql_file "$F9_MIGRATION" >/dev/null
+psql_file "$F9_PERF_MIGRATION" >/dev/null
 psql_file "$FIXTURE" >/dev/null
 echo 'SENTINEL_F9_ROLLBACK_REAPPLY=PASS'
 echo 'SENTINEL_F9_ALERT_OUTBOX_ZERO_COST=PASS'

--- a/ci/sentinel/phase9_alert_outbox_zero_cost.sh
+++ b/ci/sentinel/phase9_alert_outbox_zero_cost.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE required}"
+SUPABASE_CLI_VERSION="${SUPABASE_CLI_VERSION:-2.72.8}"
+NODE_CLI_IMAGE="${NODE_CLI_IMAGE:-node:22-bookworm-slim}"
+PSQL_IMAGE="${PSQL_IMAGE:-postgres:17-alpine}"
+WORKSPACE_FIX_IMAGE="${WORKSPACE_FIX_IMAGE:-alpine:3.20}"
+F8_MIGRATION="supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql"
+F9_MIGRATION="supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql"
+F9_ROLLBACK="supabase/rollbacks/20260817010000_sentinel_f9_alert_outbox_rollback.sql"
+FIXTURE="ci/sentinel/phase9_alert_outbox_zero_cost.sql"
+DOCKER_BIN="$(command -v docker)"
+PROJECT_DIR="$GITHUB_WORKSPACE/ci/zero-cost-staging"
+NPM_CACHE="sentinel-f9-npm-cache"
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+
+for f in "$F8_MIGRATION" "$F9_MIGRATION" "$F9_ROLLBACK" "$FIXTURE"; do test -f "$GITHUB_WORKSPACE/$f"; done
+docker version >/dev/null
+python3 --version >/dev/null
+! grep -Eq '(SUPABASE_SERVICE_ROLE_KEY|Bearer [A-Za-z0-9._-]{20,}|sb_secret_|sk-proj-)' "$GITHUB_WORKSPACE/$F9_MIGRATION" "$GITHUB_WORKSPACE/$F9_ROLLBACK" "$GITHUB_WORKSPACE/$FIXTURE"
+
+supa(){
+  docker run --rm --network host \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$DOCKER_BIN:/usr/local/bin/docker:ro" \
+    -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+    -v "$NPM_CACHE:/root/.npm" \
+    -w "$PROJECT_DIR" \
+    "$NODE_CLI_IMAGE" sh -lc "npx --yes supabase@${SUPABASE_CLI_VERSION} $*"
+}
+repair(){
+  docker run --rm -v "$GITHUB_WORKSPACE:/work" "$WORKSPACE_FIX_IMAGE" \
+    sh -lc "rm -rf /work/ci/zero-cost-staging/supabase/.branches; chown -R ${HOST_UID}:${HOST_GID} /work 2>/dev/null || true" >/dev/null 2>&1 || true
+}
+cleanup(){
+  supa "stop --no-backup >/dev/null 2>&1 || true" >/dev/null 2>&1 || true
+  docker volume rm -f "$NPM_CACHE" >/dev/null 2>&1 || true
+  rm -f /tmp/f9-concurrent-a.txt /tmp/f9-concurrent-b.txt /tmp/f9-db-lint.txt
+  repair
+}
+trap cleanup EXIT
+repair
+supa "stop --no-backup >/dev/null 2>&1 || true" >/dev/null
+supa "db start >/dev/null"
+
+psql_file(){ docker run --rm --network host -v "$GITHUB_WORKSPACE:/work:ro" "$PSQL_IMAGE" psql "$DB_URL" -v ON_ERROR_STOP=1 -f "/work/$1"; }
+psql_cmd(){ docker run --rm --network host "$PSQL_IMAGE" psql "$DB_URL" -v ON_ERROR_STOP=1 "$@"; }
+
+psql_cmd -Atqc "select current_database()" | grep -qx postgres
+psql_file "$F8_MIGRATION" >/dev/null
+psql_file "$F9_MIGRATION" >/dev/null
+echo 'SENTINEL_F9_LOCAL_MIGRATION=PASS'
+psql_file "$FIXTURE"
+
+# Same attempt in two concurrent transactions must produce exactly one ledger row.
+SQL="select public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object('attempt_key','f9-concurrent-attempt','decision_key','SEN-2026-0001:INCIDENT:P0:OPEN','incident_id','SEN-2026-0001','action','IMMEDIATE','severity','P0','status','OPEN','environment','zero-cost','domain','SENTINEL','decided_at','2026-08-17T00:50:00Z','cooldown_seconds',60));"
+psql_cmd -Atqc "$SQL" >/tmp/f9-concurrent-a.txt & A=$!
+psql_cmd -Atqc "$SQL" >/tmp/f9-concurrent-b.txt & B=$!
+wait "$A"; wait "$B"
+psql_cmd -Atqc "select count(*) from public.aos_sentinel_alert_dispatches_v1 where attempt_key='f9-concurrent-attempt'" | grep -qx 1
+echo 'SENTINEL_F9_CONCURRENT_ATTEMPT=PASS'
+
+# Fixed search_path / lint.
+psql_cmd -Atqc "select count(*) from pg_proc p join pg_namespace n on n.oid=p.pronamespace where n.nspname='public' and p.proname like 'aos_sentinel_alert_%_v1' and p.prosecdef and coalesce(array_to_string(p.proconfig,','),'') like '%search_path=%'" | grep -Eq '^[4-9][0-9]*$'
+supa "db lint --local --level warning" >/tmp/f9-db-lint.txt
+! grep -Eqi '(security definer.*mutable search_path|aos_sentinel_alert_.*rls.*disabled)' /tmp/f9-db-lint.txt
+echo 'SENTINEL_F9_DB_LINT=PASS'
+
+# Rollback F9 only; F8 must remain intact. Then reapply and replay fixtures.
+psql_file "$F9_ROLLBACK" >/dev/null
+psql_cmd -Atqc "select case when to_regclass('public.aos_sentinel_alert_dispatches_v1') is null then 'gone' else 'present' end" | grep -qx gone
+psql_cmd -Atqc "select case when to_regclass('public.aos_sentinel_incidents_v1') is not null then 'f8-present' else 'f8-missing' end" | grep -qx f8-present
+psql_file "$F9_MIGRATION" >/dev/null
+psql_file "$FIXTURE" >/dev/null
+echo 'SENTINEL_F9_ROLLBACK_REAPPLY=PASS'
+echo 'SENTINEL_F9_ALERT_OUTBOX_ZERO_COST=PASS'

--- a/ci/sentinel/phase9_alert_outbox_zero_cost.sql
+++ b/ci/sentinel/phase9_alert_outbox_zero_cost.sql
@@ -1,0 +1,89 @@
+\set ON_ERROR_STOP on
+
+-- Seed one synthetic F8 incident through the certified F8 API.
+select public.aos_sentinel_ingest_signal_v1(jsonb_build_object(
+  'event_id','f9-zc-incident-001','signal_class','ERROR','environment','zero-cost','domain','SENTINEL','component','alert-router','capability','durable-outbox','failure_family','synthetic-canary','signal_fingerprint','error:sentinel:f9-outbox','incident_fingerprint','zero-cost:sentinel:alert-router:durable-outbox:synthetic-canary','severity','P1','observed_at','2026-08-17T00:00:00Z'
+));
+
+-- RLS, ACL and SECURITY DEFINER contract.
+do $$
+begin
+  if (select count(*) from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid=c.relnamespace where n.nspname='public' and c.relname in ('aos_sentinel_alert_dispatches_v1','aos_sentinel_alert_digest_items_v1','aos_sentinel_maintenance_windows_v1') and c.relrowsecurity) <> 3 then raise exception 'F9_ZC_RLS'; end if;
+  if exists(select 1 from pg_catalog.pg_proc p join pg_catalog.pg_namespace n on n.oid=p.pronamespace where n.nspname='public' and p.proname in ('aos_sentinel_alert_reserve_dispatch_v1','aos_sentinel_alert_mark_delivery_v1','aos_sentinel_alert_queue_digest_v1','aos_sentinel_alert_recent_dispatches_v1','aos_sentinel_active_maintenance_windows_v1') and (not p.prosecdef or coalesce(array_to_string(p.proconfig,','),'') not like '%search_path=%')) then raise exception 'F9_ZC_RPC_SECURITY'; end if;
+  if has_function_privilege('anon','public.aos_sentinel_alert_reserve_dispatch_v1(jsonb)','EXECUTE') then raise exception 'F9_ZC_ANON_EXECUTE'; end if;
+  if has_function_privilege('authenticated','public.aos_sentinel_alert_reserve_dispatch_v1(jsonb)','EXECUTE') then raise exception 'F9_ZC_AUTH_EXECUTE'; end if;
+  if not has_function_privilege('service_role','public.aos_sentinel_alert_reserve_dispatch_v1(jsonb)','EXECUTE') then raise exception 'F9_ZC_SERVICE_EXECUTE'; end if;
+  if has_table_privilege('anon','public.aos_sentinel_alert_dispatches_v1','SELECT') or has_table_privilege('authenticated','public.aos_sentinel_alert_dispatches_v1','SELECT') then raise exception 'F9_ZC_DIRECT_TABLE_ACCESS'; end if;
+end $$;
+
+-- First reservation and exact-attempt replay.
+do $$
+declare a jsonb; b jsonb; id bigint;
+begin
+  a:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-attempt-a','decision_key','SEN-2026-0001:INCIDENT:P1:OPEN','incident_id','SEN-2026-0001','action','IMMEDIATE','severity','P1','status','OPEN','environment','zero-cost','domain','SENTINEL','component','alert-router','capability','durable-outbox','failure_family','synthetic-canary','signal_count',1,'reopened_count',0,'decided_at','2026-08-17T00:01:00Z','cooldown_seconds',300
+  ));
+  if a->>'result'<>'RESERVED' then raise exception 'F9_ZC_FIRST_RESERVE'; end if;
+  id:=(a->>'dispatch_id')::bigint;
+  b:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-attempt-a','decision_key','SEN-2026-0001:INCIDENT:P1:OPEN','incident_id','SEN-2026-0001','action','IMMEDIATE','severity','P1','status','OPEN','environment','zero-cost','domain','SENTINEL','component','alert-router','capability','durable-outbox','failure_family','synthetic-canary','signal_count',1,'reopened_count',0,'decided_at','2026-08-17T00:01:00Z','cooldown_seconds',300
+  ));
+  if b->>'result'<>'REPLAY' or (b->>'dispatch_id')::bigint<>id then raise exception 'F9_ZC_ATTEMPT_REPLAY'; end if;
+  perform public.aos_sentinel_alert_mark_delivery_v1(id,'DELIVERED','fake-1001',null,'2026-08-17T00:01:05Z');
+end $$;
+
+-- Cooldown survives process restart because it is in PostgreSQL.
+do $$
+declare x jsonb;
+begin
+  x:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-attempt-b','decision_key','SEN-2026-0001:INCIDENT:P1:OPEN','incident_id','SEN-2026-0001','action','IMMEDIATE','severity','P1','status','OPEN','environment','zero-cost','domain','SENTINEL','decided_at','2026-08-17T00:03:00Z','cooldown_seconds',300
+  ));
+  if x->>'result'<>'SUPPRESSED_COOLDOWN' then raise exception 'F9_ZC_COOLDOWN_NOT_DURABLE'; end if;
+  x:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-attempt-c','decision_key','SEN-2026-0001:INCIDENT:P1:OPEN','incident_id','SEN-2026-0001','action','IMMEDIATE','severity','P1','status','OPEN','environment','zero-cost','domain','SENTINEL','decided_at','2026-08-17T00:07:00Z','cooldown_seconds',300
+  ));
+  if x->>'result'<>'RESERVED' then raise exception 'F9_ZC_POST_COOLDOWN_RESERVE'; end if;
+end $$;
+
+-- Two distinct resolve transitions use distinct durable decision keys and both may reserve.
+do $$
+declare a jsonb; b jsonb;
+begin
+  a:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-recovery-a','decision_key','SEN-2026-0001:RECOVERY:P1:RESOLVED:2026-08-17T00:10:00.000Z','incident_id','SEN-2026-0001','action','RECOVERY','severity','P1','status','RESOLVED','environment','zero-cost','domain','SENTINEL','decided_at','2026-08-17T00:10:00Z','cooldown_seconds',0
+  ));
+  b:=public.aos_sentinel_alert_reserve_dispatch_v1(jsonb_build_object(
+    'attempt_key','f9-recovery-b','decision_key','SEN-2026-0001:RECOVERY:P1:RESOLVED:2026-08-17T00:20:00.000Z','incident_id','SEN-2026-0001','action','RECOVERY','severity','P1','status','RESOLVED','environment','zero-cost','domain','SENTINEL','decided_at','2026-08-17T00:20:00Z','cooldown_seconds',0
+  ));
+  if a->>'result'<>'RESERVED' or b->>'result'<>'RESERVED' then raise exception 'F9_ZC_SECOND_RECOVERY_BLOCKED'; end if;
+end $$;
+
+-- Durable P2 digest item is idempotent.
+do $$
+declare a jsonb; b jsonb;
+begin
+  a:=public.aos_sentinel_alert_queue_digest_v1(jsonb_build_object('digest_key','zero-cost:SENTINEL:1770000000000','incident_id','SEN-2026-0001','environment','zero-cost','domain','SENTINEL','bucket_start','2026-08-17T00:30:00Z','bucket_end','2026-08-17T00:45:00Z','queued_at','2026-08-17T00:31:00Z'));
+  b:=public.aos_sentinel_alert_queue_digest_v1(jsonb_build_object('digest_key','zero-cost:SENTINEL:1770000000000','incident_id','SEN-2026-0001','environment','zero-cost','domain','SENTINEL','bucket_start','2026-08-17T00:30:00Z','bucket_end','2026-08-17T00:45:00Z','queued_at','2026-08-17T00:31:00Z'));
+  if (a->>'inserted')::boolean is not true or (b->>'inserted')::boolean is not false then raise exception 'F9_ZC_DIGEST_IDEMPOTENCY'; end if;
+end $$;
+
+-- Maintenance data contains only technical taxonomy and controlled reason code.
+insert into public.aos_sentinel_maintenance_windows_v1(environment,domain,component,capability,reason_code,starts_at,ends_at)
+values('zero-cost','SENTINEL','alert-router','durable-outbox','synthetic-maintenance','2026-08-17T00:00:00Z','2026-08-17T01:00:00Z');
+do $$
+declare x jsonb;
+begin
+  x:=public.aos_sentinel_active_maintenance_windows_v1('2026-08-17T00:40:00Z');
+  if pg_catalog.jsonb_array_length(x)<>1 or x->0->>'reason_code'<>'synthetic-maintenance' then raise exception 'F9_ZC_MAINTENANCE_READ'; end if;
+end $$;
+
+-- No message/payload/credential/contact columns.
+do $$
+begin
+  if exists(select 1 from information_schema.columns where table_schema='public' and table_name in ('aos_sentinel_alert_dispatches_v1','aos_sentinel_alert_digest_items_v1','aos_sentinel_maintenance_windows_v1') and lower(column_name) ~ '(message|mensaje|body|payload|token|secret|cookie|authorization|phone|telefono|dni|email|patient|paciente|nombre|recipient|wa_id)') then raise exception 'F9_ZC_SENSITIVE_COLUMN'; end if;
+  if (select count(*) from public.aos_sentinel_alert_digest_items_v1 where digest_key='zero-cost:SENTINEL:1770000000000')<>1 then raise exception 'F9_ZC_DIGEST_COUNT'; end if;
+  if (select count(*) from public.aos_sentinel_alert_dispatches_v1 where decision_key='SEN-2026-0001:INCIDENT:P1:OPEN')<>2 then raise exception 'F9_ZC_DISPATCH_COUNT'; end if;
+end $$;
+
+select 'SENTINEL_F9_ALERT_OUTBOX_FIXTURE=PASS' as certificate;

--- a/ci/sentinel/phase9_alert_routing_synthetic.js
+++ b/ci/sentinel/phase9_alert_routing_synthetic.js
@@ -34,7 +34,6 @@ function incident(id,severity,status='OPEN',overrides={}){
 }
 
 (async()=>{
-  // P1 immediate + delivery ack + cooldown dedup.
   let d=router.route(incident('SEN-2026-1001','P1'));
   assert.equal(d.action,'IMMEDIATE');
   let ack=await dispatcher.dispatch(d);
@@ -44,38 +43,46 @@ function incident(id,severity,status='OPEN',overrides={}){
   d=router.route(incident('SEN-2026-1001','P1'));
   assert.equal(d.action,'SUPPRESSED_COOLDOWN');
 
-  // Recovery is emitted once after a prior notifiable route.
+  // Recovery is emitted once per distinct resolve transition.
   setNow('2026-08-16T18:57:00-05:00');
   d=router.route(incident('SEN-2026-1001','P1','RESOLVED'));
   assert.equal(d.action,'RECOVERY');
+  const firstRecoveryKey=d.dedup_key;
   ack=await dispatcher.dispatch(d);
   assert.equal(ack.delivered,true);
   d=router.route(incident('SEN-2026-1001','P1','RESOLVED'));
   assert.equal(d.action,'SUPPRESSED_COOLDOWN');
 
-  // P3 never pages owner.
+  // Reopen + later resolve must emit a second recovery with a different durable key.
+  setNow('2026-08-16T19:00:00-05:00');
+  d=router.route(incident('SEN-2026-1001','P1','OPEN',{reopened_count:1}));
+  assert.equal(d.action,'IMMEDIATE');
+  await dispatcher.dispatch(d);
+  setNow('2026-08-16T19:01:00-05:00');
+  d=router.route(incident('SEN-2026-1001','P1','RESOLVED',{reopened_count:1}));
+  assert.equal(d.action,'RECOVERY');
+  assert.notEqual(d.dedup_key,firstRecoveryKey);
+  assert.equal((await dispatcher.dispatch(d)).status,'DELIVERED');
+
   d=router.route(incident('SEN-2026-1002','P3'));
   assert.equal(d.action,'PANEL_ONLY');
   assert.equal((await dispatcher.dispatch(d)).delivered,false);
 
-  // Maintenance suppresses P1 but never P0.
   const mw=[{starts_at:'2026-08-16T18:50:00-05:00',ends_at:'2026-08-16T19:30:00-05:00',environment:'production',domain:'WHATSAPP',component:'human-outbound'}];
   d=router.route(incident('SEN-2026-1003','P1'),{maintenance_windows:mw});
   assert.equal(d.action,'SUPPRESSED_MAINTENANCE');
   d=router.route(incident('SEN-2026-1004','P0'),{maintenance_windows:mw});
   assert.equal(d.action,'IMMEDIATE');
 
-  // Transport unavailable must not be claimed as delivered and must not start cooldown.
   const unavailable=new FakeTransport({isAvailable:false,clock});
   const unavailableDispatcher=new AlertDispatcher({router,transport:unavailable});
   d=router.route(incident('SEN-2026-1005','P1'));
   assert.equal((await unavailableDispatcher.dispatch(d)).status,'UNAVAILABLE');
-  setNow('2026-08-16T18:58:00-05:00');
+  setNow('2026-08-16T19:02:00-05:00');
   d=router.route(incident('SEN-2026-1005','P1'));
   assert.equal(d.action,'IMMEDIATE');
 
-  // P2 incidents are grouped into a single digest bucket.
-  setNow('2026-08-16T19:00:00-05:00');
+  setNow('2026-08-16T19:05:00-05:00');
   const p2a=router.route(incident('SEN-2026-2001','P2','OPEN',{domain:'EMAIL',component:'resend-gateway',capability:'send-and-webhook-progression'}));
   const p2b=router.route(incident('SEN-2026-2002','P2','OPEN',{domain:'EMAIL',component:'resend-gateway',capability:'send-and-webhook-progression'}));
   assert.equal(p2a.action,'DIGEST_QUEUED');
@@ -89,7 +96,6 @@ function incident(id,severity,status='OPEN',overrides={}){
   assert.deepEqual(digests[0].incident_ids,['SEN-2026-2001','SEN-2026-2002']);
   assert.equal((await dispatcher.dispatch(digests[0])).status,'DELIVERED');
 
-  // Severity escalation P2 -> P1 bypasses grouping/cooldown and becomes immediate.
   setNow('2026-08-16T19:17:00-05:00');
   d=router.route(incident('SEN-2026-3001','P2'));
   assert.equal(d.action,'DIGEST_QUEUED');
@@ -97,7 +103,6 @@ function incident(id,severity,status='OPEN',overrides={}){
   d=router.route(incident('SEN-2026-3001','P1'));
   assert.equal(d.action,'IMMEDIATE');
 
-  // Four status changes in 10 minutes emit one flapping summary, then suppress noise.
   setNow('2026-08-16T19:20:00-05:00');
   router.route(incident('SEN-2026-4001','P1','OPEN'));
   setNow('2026-08-16T19:21:00-05:00');
@@ -109,20 +114,18 @@ function incident(id,severity,status='OPEN',overrides={}){
   setNow('2026-08-16T19:24:00-05:00');
   d=router.route(incident('SEN-2026-4001','P1','INVESTIGATING'));
   assert.equal(d.action,'FLAPPING_SUMMARY');
+  assert.match(d.dedup_key,/^SEN-2026-4001:FLAPPING:/);
   assert.equal((await dispatcher.dispatch(d)).status,'DELIVERED');
   setNow('2026-08-16T19:25:00-05:00');
   d=router.route(incident('SEN-2026-4001','P1','MITIGATED'));
   assert.equal(d.action,'SUPPRESSED_FLAPPING');
 
-  // P0 bypasses an active flapping suppression window.
   setNow('2026-08-16T19:26:00-05:00');
   d=router.route(incident('SEN-2026-4001','P0','INVESTIGATING'));
   assert.equal(d.action,'IMMEDIATE');
 
-  // Sensitive caller-provided keys are rejected before rendering.
   assert.throws(()=>router.route({...incident('SEN-2026-9001','P1'),patient_name:'synthetic'}),/F9_SENSITIVE_INPUT_KEY/);
 
-  // Renderer contains only governed technical fields.
   const rendered=renderTelegramEnvelope(router.route(incident('SEN-2026-9002','P1')));
   assert.match(rendered.text,/SEN-2026-9002/);
   assert.doesNotMatch(rendered.text,/(patient|paciente|telefono|phone|dni|email|token|authorization|cookie|password)\s*:/i);
@@ -132,7 +135,8 @@ function incident(id,severity,status='OPEN',overrides={}){
     certificate:'SENTINEL_F9_ALERT_ROUTING_SYNTHETIC_PASS',
     p1_immediate:true,
     cooldown_dedup:true,
-    recovery_once:true,
+    recovery_once_per_resolve_transition:true,
+    second_recovery_after_reopen:true,
     p3_panel_only:true,
     maintenance_suppression:true,
     p0_maintenance_bypass:true,
@@ -140,6 +144,7 @@ function incident(id,severity,status='OPEN',overrides={}){
     p2_grouped_digest:true,
     severity_escalation_immediate:true,
     flapping_summary_then_suppression:true,
+    flapping_summary_has_durable_key:true,
     p0_flapping_bypass:true,
     sensitive_key_rejection:true,
     sanitized_template:true,

--- a/docs/control/SENTINEL_CONTROL_MASTER.md
+++ b/docs/control/SENTINEL_CONTROL_MASTER.md
@@ -45,7 +45,7 @@ Es técnicamente viable reemplazar Sentry por una combinación self-hosted, pero
 - **UptimeRobot Free:** cobertura cloud continua del endpoint público `/health` para disponibilidad externa sin costo incremental.
 - **Uptime Kuma:** observador local/intermitente en CREACTIVE con persistencia, autoarranque Docker y reconciliación de coverage gaps.
 - **Sentinel Core:** topología, reglas de negocio, estados, incidentes `SEN-*`, severidad, evidencias y correlación.
-- **Supabase:** persistencia mínima versionada de estado/incidentes Sentinel; F8 estableció la primera capa productiva protegida.
+- **Supabase:** persistencia mínima versionada de estado/incidentes Sentinel; F8 estableció la primera capa productiva protegida y F9 añadió estado durable de alertas/noise control.
 - **GitHub:** código, releases, commits, PR, CI y evidencia reproducible.
 - **Railway:** runtime/deploy actual; se correlaciona, no se reemplaza.
 - **Telegram:** canal owner para incidentes relevantes; nunca se usa como fuente canónica.
@@ -207,6 +207,7 @@ El panel final debe permitir abrir el incidente, ver evidencia sanitizada, relea
 - no PHI/PII en fixtures.
 - toda nueva tabla/RPC de Sentinel pasa migration versionada, RLS/ACL y Zero-Cost validation según riesgo.
 - F8 persiste solo metadata técnica sanitizada y evidence references tipados; las RPC operativas están restringidas a `service_role` y las tablas no tienen acceso directo de app roles.
+- F9 persiste únicamente ledger/outbox técnico, estado de delivery, digest y maintenance scopes; no guarda mensaje Telegram renderizado, bot token, chat target, PHI ni PII.
 
 ## 12. Política económica
 
@@ -255,11 +256,14 @@ El roadmap operativo detallado está en `docs/control/SENTINEL_ROADMAP_V1.md`.
 ## 16. Checkpoint actual
 
 - F1–F7: `CERRADA / 100_COMPLETE` y fusionadas a `main` con post-merge CI.
-- F8: `COMPLETE CANDIDATE / G12+G13 PASS`; producción contiene la migración `sentinel_f8_incident_engine` con versión de historial live `20260817000618`; el archivo fuente es `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`; el canary `SEN-2026-0001` terminó `RESOLVED`.
-- F8 G12: run `31980704736` PASS en Windows/Linux/PostgreSQL local; Ascenda CI `31980704753` PASS.
-- F8 security boundary: 4 tablas con RLS, sin políticas directas, RPCs operativas `service_role`-only, SECURITY DEFINER con search_path fijo y cero columnas sensibles.
-- F8 PR #208 fue fusionado a `main@a30de31de1f659f4d367f63dab9ff5db8ebab5ac`; una verificación read-only posterior detectó y está corrigiendo únicamente el identificador documental de migration-history para igualarlo a Supabase live.
-- F8 terminal pendiente: hotfix de paridad documental → exact-head CI → merge → final post-merge → Notion last.
-- F9: única fase `SIGUIENTE` después del cierre autoritativo F8 — `Alert Routing, Telegram & Noise Control`.
+- F8: `CERRADA / 100_COMPLETE`; producción contiene `20260817000618 sentinel_f8_incident_engine`; el canary `SEN-2026-0001` terminó `RESOLVED`; PR #208 y paridad documental quedaron cerrados.
+- F8 security boundary: 4 tablas con RLS, sin acceso directo de app roles, RPCs operativas `service_role`-only, SECURITY DEFINER con search_path fijo y cero columnas sensibles.
+- F9: `EN CURSO` y es la única fase activa.
+- F9-A: routing/noise control certificado — P0/P1 immediate, P2 digest, P3 panel-only, cooldown/dedup, flapping, recovery, maintenance y plantillas sanitizadas.
+- F9-B: durable alert state/outbox `PRODUCTION_CERTIFIED`; producción registra `20260817013916 sentinel_f9_alert_outbox` y `20260817014618 sentinel_f9_digest_incident_fk_index`; Zero-Cost certificó concurrencia, replay, durable cooldown, digest dedupe, maintenance, DB lint y rollback/reapply preservando F8; Security Advisor post-DDL = 0 findings.
+- F9 canary productivo durable: PASS sin Telegram network call; IDs técnicos sintéticos solamente.
+- F9 Telegram live: `BLOCKED_BY_CONFIGURATION`; no existe integración canónica activa `Sentinel Owner Alerts`, ni secret-row, bot token o owner chat target en el vault canónico. Este es el único gate pendiente para cerrar F9.
+- F10–F13: `PENDIENTE`; F10 no se promueve mientras F9 siga abierta.
 - Certificados terminales: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
-- Los advisories globales Supabase no relacionados con `aos_sentinel_*` se mantienen fuera del scope F8 y deben tratarse como backlog técnico separado.
+- Certificado F9 durable: `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`.
+- Los advisories Supabase no atribuibles a `aos_sentinel_*` se mantienen fuera del scope Sentinel activo y se tratan como backlog técnico separado.

--- a/docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md
+++ b/docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md
@@ -1,0 +1,141 @@
+# Sentinel F9 — Durable Alert State / Outbox — Production Certificate
+
+**Fecha:** 2026-08-17 (America/Lima)  
+**Workstream:** Sentinel / F9 — Alert Routing, Telegram & Noise Control  
+**PR:** #212  
+**Base productiva al iniciar:** `a72a68c600dbacf04b778380d343f345bd5c71fc`  
+**Estado de este bloque:** `F9-B DURABLE STATE = PRODUCTION_CERTIFIED`  
+**Estado F9 global:** `EN CURSO — único gate pendiente: Telegram live configuration + real sanitized canary`
+
+## 1. Alcance certificado
+
+Este certificado cubre únicamente la capa durable de alertas y control de ruido:
+
+- delivery ledger / outbox restart-safe;
+- delivery ACK state;
+- replay idempotente por `attempt_key`;
+- cooldown durable por `decision_key` después de ACK;
+- P2 digest queue durable;
+- maintenance windows técnicas;
+- concurrencia serializada con advisory locks;
+- recovery / flapping keys deterministas;
+- RLS + service_role-only RPC boundary;
+- rollback/reapply;
+- performance hotfix de FK digest→incident.
+
+No declara que Telegram live esté activo.
+
+## 2. Zero-Cost exact-head
+
+Head funcional certificado antes del cierre documental:
+
+`372d01e9b12774cb032e668b73da137fdfd8c168`
+
+Workflow `Sentinel F9 Alert Routing Certificate`, run `31985875030`:
+
+- `routing-fast` — PASS;
+- `routing-linux` — PASS;
+- `outbox-zero-cost` — PASS.
+
+El job PostgreSQL aislado certificó:
+
+`migration → RLS/ACL → replay → concurrent same-attempt → durable cooldown → digest dedupe → maintenance read → DB lint → performance-index rollback/reapply → F9 rollback/reapply → F8 preserved`
+
+## 3. Producción Supabase
+
+Proyecto: `ituyqwstonmhnfshnaqz`.
+
+Historial live autoritativo:
+
+- `20260817000618 sentinel_f8_incident_engine`;
+- `20260817013916 sentinel_f9_alert_outbox`;
+- `20260817014618 sentinel_f9_digest_incident_fk_index`.
+
+Archivos fuente versionados:
+
+- `supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql`;
+- `supabase/migrations/20260817015500_sentinel_f9_digest_incident_fk_index.sql`;
+- rollbacks correspondientes en `supabase/rollbacks/`.
+
+## 4. Post-DDL security certificate
+
+Live verification:
+
+- 3/3 tablas F9 con RLS habilitado;
+- 5/5 RPCs F9 `SECURITY DEFINER`;
+- 5/5 con `search_path` fijo;
+- `anon` EXECUTE = false;
+- `authenticated` EXECUTE = false;
+- `service_role` EXECUTE = true;
+- acceso directo a tablas revocado;
+- F8 preservado;
+- sensitive-column scan F9 = `[]`;
+- Supabase Security Advisor post-DDL = `0 lints`.
+
+## 5. Canary durable productivo
+
+Canary técnico, sin Telegram network call y sin PHI/PII:
+
+`SENTINEL_F9_DURABLE_PRODUCTION_CANARY=PASS`
+
+Validó:
+
+- reserve → `RESERVED`;
+- delivery ACK → `DELIVERED`;
+- mismo attempt → `REPLAY`;
+- mismo decision dentro cooldown → `SUPPRESSED_COOLDOWN`;
+- nuevo attempt después cooldown → `RESERVED`;
+- digest insert + duplicate dedupe;
+- maintenance window read;
+- limpieza de digest/maintenance synthetic residue.
+
+Residuo de auditoría permitido: 2 dispatch rows sintéticos técnicos; no contienen mensaje renderizado, token, chat target, PHI ni PII.
+
+## 6. Performance advisor
+
+El advisor post-DDL detectó una FK F9 sin índice de cobertura:
+
+`aos_sentinel_alert_digest_items_v1.incident_id`
+
+Se corrigió con migración aditiva:
+
+`20260817014618 sentinel_f9_digest_incident_fk_index`
+
+El índice se valida y su rollback/reapply está incluido en Zero-Cost. Los avisos de `unused_index` inmediatamente después del despliegue no se interpretan como regresión y no justifican eliminar índices nuevos. Los demás avisos del advisor pertenecen a tablas/workstreams previos y quedan fuera de este certificado.
+
+Referencia de remediación Supabase para foreign keys sin índice: https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys
+
+## 7. Telegram live gate
+
+Preflight live, sin leer valores secretos:
+
+- canonical integration name: `Sentinel Owner Alerts`;
+- matching integrations: `0`;
+- active integrations: `0`;
+- secret rows: `0`;
+- bot token present: `false`;
+- owner chat target present: `false`.
+
+Por tanto:
+
+`F9_TELEGRAM_LIVE = BLOCKED_BY_CONFIGURATION`
+
+Esto no es un fallo del router/outbox. Es ausencia de configuración humana/origen externo. Sentinel no inventará ni copiará credenciales de otros canales.
+
+## 8. Boundary
+
+Hasta que exista la integración canónica:
+
+- no se envía Telegram real;
+- no se registra ACK real de Telegram;
+- F9 no se marca `100_COMPLETE`;
+- F10 no se promueve como fase siguiente autoritativa.
+
+Una vez configurados bot + owner chat en el vault existente, el gate restante será:
+
+`provider preflight → one sanitized synthetic Telegram alert → provider ACK → durable DELIVERED → one recovery → noise/replay verification → F9 final certificate`.
+
+## 9. Resultado
+
+**F9-B durable persistence, RLS/ACL, concurrency, noise state, rollback and production canary: PASS.**  
+**F9 global: EN CURSO, pendiente exclusivamente Telegram live.**

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -365,11 +365,12 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 - Fase 5: `CERRADA / 100_COMPLETE` — hybrid availability: UptimeRobot Free cloud + Uptime Kuma/CREACTIVE local; G01–G12 PASS.
 - Fase 6: `CERRADA / 100_COMPLETE` — 4 invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; PR #206 fusionado y post-merge certificado.
 - Fase 7: `CERRADA / 100_COMPLETE` — PR #207 fusionado; correlation envelope vendor-neutral con release/SHA/deployment/request/trace, confidence `EXACT/STRONG/WEAK/UNKNOWN`, causalidad no asumida y rollback target known-good sin ejecución.
-- Fase 8: `COMPLETE CANDIDATE / G12+G13 PASS / PARITY HOTFIX` — Incident Engine y persistencia productiva aplicados; Supabase live registra `20260817000618 sentinel_f8_incident_engine`; archivo fuente `supabase/migrations/20260816233500_sentinel_f8_incident_engine.sql`; canary `SEN-2026-0001` final `RESOLVED`; PR #208 ya fusionado a `main@a30de31de1f659f4d367f63dab9ff5db8ebab5ac`; pendiente únicamente hotfix documental de paridad → exact-head/post-merge → Notion.
-- Fase 9: `SIGUIENTE — Alert Routing, Telegram & Noise Control` después del cierre autoritativo F8.
-- Fases 10–13: `PENDIENTE`.
+- Fase 8: `CERRADA / 100_COMPLETE` — Incident Engine y persistencia productiva certificados; Supabase live registra `20260817000618 sentinel_f8_incident_engine`; canary `SEN-2026-0001` final `RESOLVED`; PR #208 fusionado y paridad documental cerrada.
+- Fase 9: `EN CURSO` — F9-A routing/noise control certificado; F9-B durable outbox productivo y certificado con migraciones live `20260817013916 sentinel_f9_alert_outbox` y `20260817014618 sentinel_f9_digest_incident_fk_index`; RLS/ACL, concurrencia, cooldown durable, digest, maintenance, DB lint, rollback/reapply y canary productivo PASS. Único gate pendiente: crear/configurar de forma segura la integración canónica Telegram `Sentinel Owner Alerts` y ejecutar canary real sanitizado + provider ACK + recovery/noise verification. No existe actualmente bot token/chat target en el vault canónico.
+- Fases 10–13: `PENDIENTE`; F10 no se promueve mientras F9 siga abierta.
 - Certificado F5: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`.
 - Certificado F6: `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`.
 - Certificado F7: `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.
 - Certificado F8: `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
-- F8 no envía alertas ni ejecuta remediación; alerting comienza en F9 y rollback/remediation automática pertenece a F12.
+- Certificado durable F9: `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`.
+- Sentinel no ejecuta remediación automática: diagnóstico pertenece a F10/F11 y rollback/remediation segura a F12.

--- a/sentinel/alerts/alert-router.cjs
+++ b/sentinel/alerts/alert-router.cjs
@@ -117,7 +117,8 @@ class AlertRouter {
         next.flap_summary_until=next.flap_until;
         next.had_notifiable_route=true;
         this.state.saveIncident(safe.incident_id,next);
-        return this._decision('FLAPPING_SUMMARY',safe,now,{channel:'telegram-owner',reason:'STATUS_FLAPPING',cooldown_seconds:900});
+        const key=`${safe.incident_id}:FLAPPING:${next.flap_until}`;
+        return this._decision('FLAPPING_SUMMARY',safe,now,{channel:'telegram-owner',reason:'STATUS_FLAPPING',cooldown_seconds:900,dedup_key:key});
       }
       this.state.saveIncident(safe.incident_id,next);
       return this._decision('SUPPRESSED_FLAPPING',safe,now,{channel:null,reason:'FLAPPING_WINDOW'});
@@ -188,7 +189,10 @@ class AlertRouter {
     this.state.recordDispatch(decision.dedup_key,iso(at,'DELIVERY'));
   }
 
-  _dedupKey(safe,kind){return `${safe.incident_id}:${kind}:${safe.severity}:${safe.status}`;}
+  _dedupKey(safe,kind){
+    if(kind==='RECOVERY')return `${safe.incident_id}:RECOVERY:${safe.severity}:${safe.status}:${safe.observed_at}`;
+    return `${safe.incident_id}:${kind}:${safe.severity}:${safe.status}`;
+  }
   _decision(action,safe,now,extra){return {action,notification_kind:action,...safe,routed_at:now,...extra};}
 }
 

--- a/sentinel/alerts/f9-persistence-contract.json
+++ b/sentinel/alerts/f9-persistence-contract.json
@@ -24,7 +24,7 @@
     "states":["RESERVED","DELIVERED","FAILED","UNAVAILABLE","RETRY_LATER"],
     "actions":["IMMEDIATE","RECOVERY","FLAPPING_SUMMARY","DIGEST"],
     "delivery_truth":"DELIVERED only after transport ACK",
-    "provider_message_id":"technical identifier only"
+    "provider_ack_id":"technical acknowledgement identifier only; never rendered content"
   },
   "digest":{
     "unique_item":"digest_key + incident_id",

--- a/sentinel/alerts/f9-persistence-contract.json
+++ b/sentinel/alerts/f9-persistence-contract.json
@@ -1,0 +1,50 @@
+{
+  "schema_version":"sentinel-alert-persistence/v1",
+  "phase":"F9-B",
+  "baseline_main":"a72a68c600dbacf04b778380d343f345bd5c71fc",
+  "purpose":"Persist notification reservations, delivery acknowledgements, P2 digest queue and technical maintenance windows so F9 noise control survives process restarts without storing rendered messages or secrets.",
+  "tables":[
+    "aos_sentinel_alert_dispatches_v1",
+    "aos_sentinel_alert_digest_items_v1",
+    "aos_sentinel_maintenance_windows_v1"
+  ],
+  "security":{
+    "rls_all_tables":true,
+    "direct_app_role_access":false,
+    "operational_rpcs_service_role_only":true,
+    "security_definer_fixed_search_path":true,
+    "rendered_message_storage":false,
+    "secret_storage":false,
+    "phi_pii_storage":false
+  },
+  "dispatch":{
+    "attempt_key_unique":true,
+    "decision_key_reusable_after_cooldown":true,
+    "decision_key_lock":"pg_advisory_xact_lock",
+    "states":["RESERVED","DELIVERED","FAILED","UNAVAILABLE","RETRY_LATER"],
+    "actions":["IMMEDIATE","RECOVERY","FLAPPING_SUMMARY","DIGEST"],
+    "delivery_truth":"DELIVERED only after transport ACK",
+    "provider_message_id":"technical identifier only"
+  },
+  "digest":{
+    "unique_item":"digest_key + incident_id",
+    "states":["QUEUED","CLAIMED","SENT"],
+    "rendered_text_stored":false
+  },
+  "maintenance":{
+    "technical_scope_only":["environment","domain","component","capability"],
+    "reason_code_slug_only":true,
+    "p0_policy_enforced_by_router":true
+  },
+  "gates":{
+    "exact_attempt_replay_idempotent":true,
+    "concurrent_attempt_reservation_idempotent":true,
+    "cooldown_survives_restart":true,
+    "new_attempt_after_cooldown_allowed":true,
+    "second_recovery_after_reopen_allowed":true,
+    "digest_queue_deduplicated":true,
+    "rls_acl_certified":true,
+    "rollback_reapply_certified":true,
+    "production_apply_requires_zero_cost_pass":true
+  }
+}

--- a/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
+++ b/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
@@ -31,6 +31,7 @@ create table public.aos_sentinel_alert_dispatches_v1 (
   delivered_at timestamptz,
   updated_at timestamptz not null default now(),
   check ((action='DIGEST' and incident_id is null and digest_key is not null) or (action<>'DIGEST' and incident_id is not null and digest_key is null)),
+  check (digest_key is null or (digest_key ~ '^[A-Za-z0-9._:@/-]{1,240}$' and digest_key !~ '[?#]' and digest_key !~ '\.\.')),
   check (component is null or component ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
   check (capability is null or capability ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
   check (failure_family is null or failure_family ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
@@ -40,13 +41,9 @@ create table public.aos_sentinel_alert_dispatches_v1 (
   check (provider_message_id is null or provider_message_id ~ '^[A-Za-z0-9._:@/-]{1,200}$'),
   check ((delivery_state='DELIVERED' and delivered_at is not null) or delivery_state<>'DELIVERED')
 );
-
-create index aos_sentinel_alert_dispatches_v1_decision_idx
-  on public.aos_sentinel_alert_dispatches_v1(decision_key, delivered_at desc nulls last, decided_at desc);
-create index aos_sentinel_alert_dispatches_v1_incident_idx
-  on public.aos_sentinel_alert_dispatches_v1(incident_id, decided_at desc) where incident_id is not null;
-create index aos_sentinel_alert_dispatches_v1_state_idx
-  on public.aos_sentinel_alert_dispatches_v1(delivery_state, updated_at);
+create index aos_sentinel_alert_dispatches_v1_decision_idx on public.aos_sentinel_alert_dispatches_v1(decision_key,delivered_at desc nulls last,decided_at desc);
+create index aos_sentinel_alert_dispatches_v1_incident_idx on public.aos_sentinel_alert_dispatches_v1(incident_id,decided_at desc) where incident_id is not null;
+create index aos_sentinel_alert_dispatches_v1_state_idx on public.aos_sentinel_alert_dispatches_v1(delivery_state,updated_at);
 
 create table public.aos_sentinel_alert_digest_items_v1 (
   digest_key text not null check (digest_key ~ '^[A-Za-z0-9._:@/-]{1,240}$' and digest_key !~ '[?#]' and digest_key !~ '\.\.'),
@@ -63,8 +60,7 @@ create table public.aos_sentinel_alert_digest_items_v1 (
   check (bucket_end > bucket_start),
   check ((state='CLAIMED' and claim_expires_at is not null) or state<>'CLAIMED')
 );
-create index aos_sentinel_alert_digest_items_v1_due_idx
-  on public.aos_sentinel_alert_digest_items_v1(state,bucket_end,claim_expires_at);
+create index aos_sentinel_alert_digest_items_v1_due_idx on public.aos_sentinel_alert_digest_items_v1(state,bucket_end,claim_expires_at);
 
 create table public.aos_sentinel_maintenance_windows_v1 (
   window_id bigint generated always as identity primary key,
@@ -79,8 +75,7 @@ create table public.aos_sentinel_maintenance_windows_v1 (
   created_at timestamptz not null default now(),
   check (ends_at > starts_at)
 );
-create index aos_sentinel_maintenance_windows_v1_active_idx
-  on public.aos_sentinel_maintenance_windows_v1(enabled,starts_at,ends_at);
+create index aos_sentinel_maintenance_windows_v1_active_idx on public.aos_sentinel_maintenance_windows_v1(enabled,starts_at,ends_at);
 
 alter table public.aos_sentinel_alert_dispatches_v1 enable row level security;
 alter table public.aos_sentinel_alert_digest_items_v1 enable row level security;
@@ -108,8 +103,9 @@ begin
   v_env:=pg_catalog.lower(p_request->>'environment'); v_domain:=pg_catalog.upper(p_request->>'domain');
   v_component:=nullif(pg_catalog.lower(coalesce(p_request->>'component','')),''); v_capability:=nullif(pg_catalog.lower(coalesce(p_request->>'capability','')),'');
   v_failure:=nullif(pg_catalog.lower(coalesce(p_request->>'failure_family','')),''); v_release:=nullif(p_request->>'release',''); v_commit:=nullif(p_request->>'commit_sha',''); v_deploy:=nullif(p_request->>'deployment_id','');
-  v_signal_count:=coalesce((p_request->>'signal_count')::bigint,0); v_reopened:=coalesce((p_request->>'reopened_count')::integer,0); v_cooldown:=coalesce((p_request->>'cooldown_seconds')::integer,0);
-  begin v_decided:=(p_request->>'decided_at')::timestamptz; exception when others then raise exception 'F9_DISPATCH_INVALID_TIMESTAMP'; end;
+  begin
+    v_signal_count:=coalesce((p_request->>'signal_count')::bigint,0); v_reopened:=coalesce((p_request->>'reopened_count')::integer,0); v_cooldown:=coalesce((p_request->>'cooldown_seconds')::integer,0); v_decided:=(p_request->>'decided_at')::timestamptz;
+  exception when others then raise exception 'F9_DISPATCH_NUMERIC_OR_TIMESTAMP_INVALID'; end;
 
   if v_attempt is null or v_attempt !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_attempt ~ '[?#]' or v_attempt ~ '\.\.' then raise exception 'F9_ATTEMPT_KEY_INVALID'; end if;
   if v_decision is null or v_decision !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_decision ~ '[?#]' or v_decision ~ '\.\.' then raise exception 'F9_DECISION_KEY_INVALID'; end if;
@@ -118,6 +114,7 @@ begin
   if v_env !~ '^[a-z0-9][a-z0-9._:-]{0,63}$' or v_domain !~ '^[A-Z][A-Z0-9_]{0,63}$' then raise exception 'F9_SCOPE_INVALID'; end if;
   if v_cooldown<0 or v_cooldown>86400 or v_signal_count<0 or v_reopened<0 then raise exception 'F9_COUNTER_OR_COOLDOWN_INVALID'; end if;
   if (v_action='DIGEST' and (v_incident is not null or v_digest is null)) or (v_action<>'DIGEST' and (v_incident is null or v_digest is not null)) then raise exception 'F9_DISPATCH_TARGET_INVALID'; end if;
+  if v_digest is not null and (v_digest !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_digest ~ '[?#]' or v_digest ~ '\.\.') then raise exception 'F9_DIGEST_KEY_INVALID'; end if;
 
   perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('sentinel:f9:attempt:'||v_attempt,0));
   select dispatch_id into v_existing from public.aos_sentinel_alert_dispatches_v1 where attempt_key=v_attempt;
@@ -126,16 +123,12 @@ begin
   perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('sentinel:f9:decision:'||v_decision,0));
   if v_cooldown>0 then
     select max(delivered_at) into v_last from public.aos_sentinel_alert_dispatches_v1 where decision_key=v_decision and delivery_state='DELIVERED';
-    if v_last is not null and v_decided < v_last + pg_catalog.make_interval(secs=>v_cooldown) then
-      return pg_catalog.jsonb_build_object('ok',true,'result','SUPPRESSED_COOLDOWN','last_delivered_at',v_last);
-    end if;
+    if v_last is not null and v_decided < v_last + pg_catalog.make_interval(secs=>v_cooldown) then return pg_catalog.jsonb_build_object('ok',true,'result','SUPPRESSED_COOLDOWN','last_delivered_at',v_last); end if;
   end if;
 
-  insert into public.aos_sentinel_alert_dispatches_v1(
-    attempt_key,decision_key,incident_id,digest_key,action,severity,status,channel,environment,domain,component,capability,failure_family,release,commit_sha,deployment_id,signal_count,reopened_count,decided_at,cooldown_seconds
-  ) values(
-    v_attempt,v_decision,v_incident,v_digest,v_action,v_severity,v_status,'telegram-owner',v_env,v_domain,v_component,v_capability,v_failure,v_release,v_commit,v_deploy,v_signal_count,v_reopened,v_decided,v_cooldown
-  ) returning dispatch_id into v_id;
+  insert into public.aos_sentinel_alert_dispatches_v1(attempt_key,decision_key,incident_id,digest_key,action,severity,status,channel,environment,domain,component,capability,failure_family,release,commit_sha,deployment_id,signal_count,reopened_count,decided_at,cooldown_seconds)
+  values(v_attempt,v_decision,v_incident,v_digest,v_action,v_severity,v_status,'telegram-owner',v_env,v_domain,v_component,v_capability,v_failure,v_release,v_commit,v_deploy,v_signal_count,v_reopened,v_decided,v_cooldown)
+  returning dispatch_id into v_id;
   return pg_catalog.jsonb_build_object('ok',true,'result','RESERVED','dispatch_id',v_id);
 end;
 $$;
@@ -165,20 +158,21 @@ language plpgsql
 security definer
 set search_path=''
 as $$
-declare v_key text; v_incident text; v_env text; v_domain text; v_start timestamptz; v_end timestamptz; v_queued timestamptz; v_inserted boolean;
+declare v_key text; v_incident text; v_env text; v_domain text; v_start timestamptz; v_end timestamptz; v_queued timestamptz; v_count bigint; k text;
 begin
   if p_item is null or pg_catalog.jsonb_typeof(p_item)<>'object' then raise exception 'F9_DIGEST_OBJECT_REQUIRED'; end if;
+  for k in select pg_catalog.jsonb_object_keys(p_item) loop
+    if k not in ('digest_key','incident_id','environment','domain','bucket_start','bucket_end','queued_at') then raise exception 'F9_DIGEST_UNAPPROVED_KEY:%',k; end if;
+  end loop;
   if not (p_item ?& array['digest_key','incident_id','environment','domain','bucket_start','bucket_end','queued_at']) then raise exception 'F9_DIGEST_REQUIRED_FIELD_MISSING'; end if;
-  if exists(select 1 from pg_catalog.jsonb_object_keys(p_item) k where k not in ('digest_key','incident_id','environment','domain','bucket_start','bucket_end','queued_at')) then raise exception 'F9_DIGEST_UNAPPROVED_KEY'; end if;
   v_key:=p_item->>'digest_key'; v_incident:=p_item->>'incident_id'; v_env:=pg_catalog.lower(p_item->>'environment'); v_domain:=pg_catalog.upper(p_item->>'domain');
   begin v_start:=(p_item->>'bucket_start')::timestamptz; v_end:=(p_item->>'bucket_end')::timestamptz; v_queued:=(p_item->>'queued_at')::timestamptz; exception when others then raise exception 'F9_DIGEST_INVALID_TIMESTAMP'; end;
   if v_key !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_key ~ '[?#]' or v_key ~ '\.\.' then raise exception 'F9_DIGEST_KEY_INVALID'; end if;
   if v_incident !~ '^SEN-[0-9]{4}-[0-9]{4,}$' or v_env !~ '^[a-z0-9][a-z0-9._:-]{0,63}$' or v_domain !~ '^[A-Z][A-Z0-9_]{0,63}$' or v_end<=v_start then raise exception 'F9_DIGEST_SCOPE_INVALID'; end if;
   insert into public.aos_sentinel_alert_digest_items_v1(digest_key,incident_id,environment,domain,bucket_start,bucket_end,queued_at)
-  values(v_key,v_incident,v_env,v_domain,v_start,v_end,v_queued)
-  on conflict(digest_key,incident_id) do nothing;
-  get diagnostics v_inserted = row_count;
-  return pg_catalog.jsonb_build_object('ok',true,'inserted',v_inserted,'digest_key',v_key,'incident_id',v_incident);
+  values(v_key,v_incident,v_env,v_domain,v_start,v_end,v_queued) on conflict(digest_key,incident_id) do nothing;
+  get diagnostics v_count = row_count;
+  return pg_catalog.jsonb_build_object('ok',true,'inserted',(v_count=1),'digest_key',v_key,'incident_id',v_incident);
 end;
 $$;
 
@@ -189,10 +183,7 @@ stable
 security definer
 set search_path=''
 as $$
-  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
-    'dispatch_id',d.dispatch_id,'attempt_key',d.attempt_key,'decision_key',d.decision_key,'action',d.action,'severity',d.severity,'status',d.status,
-    'decided_at',d.decided_at,'cooldown_seconds',d.cooldown_seconds,'delivery_state',d.delivery_state,'delivered_at',d.delivered_at,'retry_after_seconds',d.retry_after_seconds
-  ) order by d.dispatch_id),'[]'::jsonb)
+  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object('dispatch_id',d.dispatch_id,'attempt_key',d.attempt_key,'decision_key',d.decision_key,'action',d.action,'severity',d.severity,'status',d.status,'decided_at',d.decided_at,'cooldown_seconds',d.cooldown_seconds,'delivery_state',d.delivery_state,'delivered_at',d.delivered_at,'retry_after_seconds',d.retry_after_seconds) order by d.dispatch_id),'[]'::jsonb)
   from public.aos_sentinel_alert_dispatches_v1 d where d.incident_id=p_incident_id;
 $$;
 
@@ -203,11 +194,8 @@ stable
 security definer
 set search_path=''
 as $$
-  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
-    'window_id',w.window_id,'environment',w.environment,'domain',w.domain,'component',w.component,'capability',w.capability,'reason_code',w.reason_code,'starts_at',w.starts_at,'ends_at',w.ends_at
-  ) order by w.window_id),'[]'::jsonb)
-  from public.aos_sentinel_maintenance_windows_v1 w
-  where w.enabled and coalesce(p_at,pg_catalog.clock_timestamp()) between w.starts_at and w.ends_at;
+  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object('window_id',w.window_id,'environment',w.environment,'domain',w.domain,'component',w.component,'capability',w.capability,'reason_code',w.reason_code,'starts_at',w.starts_at,'ends_at',w.ends_at) order by w.window_id),'[]'::jsonb)
+  from public.aos_sentinel_maintenance_windows_v1 w where w.enabled and coalesce(p_at,pg_catalog.clock_timestamp()) between w.starts_at and w.ends_at;
 $$;
 
 revoke all on table public.aos_sentinel_alert_dispatches_v1 from PUBLIC,anon,authenticated,service_role;

--- a/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
+++ b/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
@@ -26,7 +26,7 @@ create table public.aos_sentinel_alert_dispatches_v1 (
   decided_at timestamptz not null,
   cooldown_seconds integer not null default 0 check (cooldown_seconds between 0 and 86400),
   delivery_state text not null default 'RESERVED' check (delivery_state in ('RESERVED','DELIVERED','FAILED','UNAVAILABLE','RETRY_LATER')),
-  provider_message_id text,
+  provider_ack_id text,
   retry_after_seconds integer check (retry_after_seconds is null or retry_after_seconds between 1 and 86400),
   delivered_at timestamptz,
   updated_at timestamptz not null default now(),
@@ -38,7 +38,7 @@ create table public.aos_sentinel_alert_dispatches_v1 (
   check (release is null or release='ascenda-os@unknown' or release ~ '^ascenda-os@[0-9a-f]{7,40}$'),
   check (commit_sha is null or commit_sha ~ '^[0-9a-f]{7,40}$'),
   check (deployment_id is null or (deployment_id ~ '^[A-Za-z0-9._:@/-]{1,200}$' and deployment_id !~ '[?#]' and deployment_id !~ '\.\.')),
-  check (provider_message_id is null or provider_message_id ~ '^[A-Za-z0-9._:@/-]{1,200}$'),
+  check (provider_ack_id is null or provider_ack_id ~ '^[A-Za-z0-9._:@/-]{1,200}$'),
   check ((delivery_state='DELIVERED' and delivered_at is not null) or delivery_state<>'DELIVERED')
 );
 create index aos_sentinel_alert_dispatches_v1_decision_idx on public.aos_sentinel_alert_dispatches_v1(decision_key,delivered_at desc nulls last,decided_at desc);
@@ -133,7 +133,7 @@ begin
 end;
 $$;
 
-create or replace function public.aos_sentinel_alert_mark_delivery_v1(p_dispatch_id bigint,p_state text,p_provider_message_id text default null,p_retry_after_seconds integer default null,p_at timestamptz default null)
+create or replace function public.aos_sentinel_alert_mark_delivery_v1(p_dispatch_id bigint,p_state text,p_provider_ack_id text default null,p_retry_after_seconds integer default null,p_at timestamptz default null)
 returns jsonb
 language plpgsql
 security definer
@@ -142,12 +142,12 @@ as $$
 declare v_state text:=pg_catalog.upper(coalesce(p_state,'')); v_at timestamptz:=coalesce(p_at,pg_catalog.clock_timestamp()); v public.aos_sentinel_alert_dispatches_v1%rowtype;
 begin
   if v_state not in ('DELIVERED','FAILED','UNAVAILABLE','RETRY_LATER') then raise exception 'F9_DELIVERY_STATE_INVALID'; end if;
-  if p_provider_message_id is not null and (p_provider_message_id !~ '^[A-Za-z0-9._:@/-]{1,200}$' or p_provider_message_id ~ '[?#]' or p_provider_message_id ~ '\.\.') then raise exception 'F9_PROVIDER_MESSAGE_ID_INVALID'; end if;
+  if p_provider_ack_id is not null and (p_provider_ack_id !~ '^[A-Za-z0-9._:@/-]{1,200}$' or p_provider_ack_id ~ '[?#]' or p_provider_ack_id ~ '\.\.') then raise exception 'F9_PROVIDER_ACK_ID_INVALID'; end if;
   if p_retry_after_seconds is not null and (p_retry_after_seconds<1 or p_retry_after_seconds>86400) then raise exception 'F9_RETRY_AFTER_INVALID'; end if;
   select * into v from public.aos_sentinel_alert_dispatches_v1 where dispatch_id=p_dispatch_id for update;
   if not found then raise exception 'F9_DISPATCH_NOT_FOUND'; end if;
   if v.delivery_state='DELIVERED' then return pg_catalog.jsonb_build_object('ok',true,'replay',true,'dispatch_id',v.dispatch_id,'state',v.delivery_state); end if;
-  update public.aos_sentinel_alert_dispatches_v1 set delivery_state=v_state,provider_message_id=case when v_state='DELIVERED' then p_provider_message_id else null end,retry_after_seconds=case when v_state='RETRY_LATER' then p_retry_after_seconds else null end,delivered_at=case when v_state='DELIVERED' then v_at else null end,updated_at=v_at where dispatch_id=p_dispatch_id returning * into v;
+  update public.aos_sentinel_alert_dispatches_v1 set delivery_state=v_state,provider_ack_id=case when v_state='DELIVERED' then p_provider_ack_id else null end,retry_after_seconds=case when v_state='RETRY_LATER' then p_retry_after_seconds else null end,delivered_at=case when v_state='DELIVERED' then v_at else null end,updated_at=v_at where dispatch_id=p_dispatch_id returning * into v;
   return pg_catalog.jsonb_build_object('ok',true,'replay',false,'dispatch_id',v.dispatch_id,'state',v.delivery_state,'delivered_at',v.delivered_at,'retry_after_seconds',v.retry_after_seconds);
 end;
 $$;

--- a/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
+++ b/supabase/migrations/20260817010000_sentinel_f9_alert_outbox.sql
@@ -1,0 +1,231 @@
+-- Sentinel F9 durable alert state / outbox
+-- Zero-PHI/PII. No rendered Telegram message, token, chat target or arbitrary payload is stored.
+
+begin;
+
+create table public.aos_sentinel_alert_dispatches_v1 (
+  dispatch_id bigint generated always as identity primary key,
+  attempt_key text not null unique check (attempt_key ~ '^[A-Za-z0-9._:@/-]{1,240}$' and attempt_key !~ '[?#]' and attempt_key !~ '\.\.'),
+  decision_key text not null check (decision_key ~ '^[A-Za-z0-9._:@/-]{1,240}$' and decision_key !~ '[?#]' and decision_key !~ '\.\.'),
+  incident_id text references public.aos_sentinel_incidents_v1(incident_id) on delete cascade,
+  digest_key text,
+  action text not null check (action in ('IMMEDIATE','RECOVERY','FLAPPING_SUMMARY','DIGEST')),
+  severity text not null check (severity in ('P0','P1','P2')),
+  status text not null check (status in ('OPEN','ACK','INVESTIGATING','MITIGATED','RESOLVED')),
+  channel text not null check (channel='telegram-owner'),
+  environment text not null check (environment ~ '^[a-z0-9][a-z0-9._:-]{0,63}$'),
+  domain text not null check (domain ~ '^[A-Z][A-Z0-9_]{0,63}$'),
+  component text,
+  capability text,
+  failure_family text,
+  release text,
+  commit_sha text,
+  deployment_id text,
+  signal_count bigint not null default 0 check (signal_count >= 0),
+  reopened_count integer not null default 0 check (reopened_count >= 0),
+  decided_at timestamptz not null,
+  cooldown_seconds integer not null default 0 check (cooldown_seconds between 0 and 86400),
+  delivery_state text not null default 'RESERVED' check (delivery_state in ('RESERVED','DELIVERED','FAILED','UNAVAILABLE','RETRY_LATER')),
+  provider_message_id text,
+  retry_after_seconds integer check (retry_after_seconds is null or retry_after_seconds between 1 and 86400),
+  delivered_at timestamptz,
+  updated_at timestamptz not null default now(),
+  check ((action='DIGEST' and incident_id is null and digest_key is not null) or (action<>'DIGEST' and incident_id is not null and digest_key is null)),
+  check (component is null or component ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
+  check (capability is null or capability ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
+  check (failure_family is null or failure_family ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
+  check (release is null or release='ascenda-os@unknown' or release ~ '^ascenda-os@[0-9a-f]{7,40}$'),
+  check (commit_sha is null or commit_sha ~ '^[0-9a-f]{7,40}$'),
+  check (deployment_id is null or (deployment_id ~ '^[A-Za-z0-9._:@/-]{1,200}$' and deployment_id !~ '[?#]' and deployment_id !~ '\.\.')),
+  check (provider_message_id is null or provider_message_id ~ '^[A-Za-z0-9._:@/-]{1,200}$'),
+  check ((delivery_state='DELIVERED' and delivered_at is not null) or delivery_state<>'DELIVERED')
+);
+
+create index aos_sentinel_alert_dispatches_v1_decision_idx
+  on public.aos_sentinel_alert_dispatches_v1(decision_key, delivered_at desc nulls last, decided_at desc);
+create index aos_sentinel_alert_dispatches_v1_incident_idx
+  on public.aos_sentinel_alert_dispatches_v1(incident_id, decided_at desc) where incident_id is not null;
+create index aos_sentinel_alert_dispatches_v1_state_idx
+  on public.aos_sentinel_alert_dispatches_v1(delivery_state, updated_at);
+
+create table public.aos_sentinel_alert_digest_items_v1 (
+  digest_key text not null check (digest_key ~ '^[A-Za-z0-9._:@/-]{1,240}$' and digest_key !~ '[?#]' and digest_key !~ '\.\.'),
+  incident_id text not null references public.aos_sentinel_incidents_v1(incident_id) on delete cascade,
+  environment text not null check (environment ~ '^[a-z0-9][a-z0-9._:-]{0,63}$'),
+  domain text not null check (domain ~ '^[A-Z][A-Z0-9_]{0,63}$'),
+  bucket_start timestamptz not null,
+  bucket_end timestamptz not null,
+  queued_at timestamptz not null,
+  state text not null default 'QUEUED' check (state in ('QUEUED','CLAIMED','SENT')),
+  claim_expires_at timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key(digest_key,incident_id),
+  check (bucket_end > bucket_start),
+  check ((state='CLAIMED' and claim_expires_at is not null) or state<>'CLAIMED')
+);
+create index aos_sentinel_alert_digest_items_v1_due_idx
+  on public.aos_sentinel_alert_digest_items_v1(state,bucket_end,claim_expires_at);
+
+create table public.aos_sentinel_maintenance_windows_v1 (
+  window_id bigint generated always as identity primary key,
+  environment text check (environment is null or environment ~ '^[a-z0-9][a-z0-9._:-]{0,63}$'),
+  domain text check (domain is null or domain ~ '^[A-Z][A-Z0-9_]{0,63}$'),
+  component text check (component is null or component ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
+  capability text check (capability is null or capability ~ '^[a-z0-9][a-z0-9._:-]{0,199}$'),
+  reason_code text not null check (reason_code ~ '^[a-z0-9][a-z0-9._:-]{0,99}$'),
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  check (ends_at > starts_at)
+);
+create index aos_sentinel_maintenance_windows_v1_active_idx
+  on public.aos_sentinel_maintenance_windows_v1(enabled,starts_at,ends_at);
+
+alter table public.aos_sentinel_alert_dispatches_v1 enable row level security;
+alter table public.aos_sentinel_alert_digest_items_v1 enable row level security;
+alter table public.aos_sentinel_maintenance_windows_v1 enable row level security;
+
+create or replace function public.aos_sentinel_alert_reserve_dispatch_v1(p_request jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_attempt text; v_decision text; v_incident text; v_digest text; v_action text; v_severity text; v_status text;
+  v_env text; v_domain text; v_component text; v_capability text; v_failure text; v_release text; v_commit text; v_deploy text;
+  v_signal_count bigint; v_reopened integer; v_decided timestamptz; v_cooldown integer; v_existing bigint; v_last timestamptz; v_id bigint; k text;
+begin
+  if p_request is null or pg_catalog.jsonb_typeof(p_request)<>'object' then raise exception 'F9_DISPATCH_OBJECT_REQUIRED'; end if;
+  for k in select pg_catalog.jsonb_object_keys(p_request) loop
+    if k not in ('attempt_key','decision_key','incident_id','digest_key','action','severity','status','environment','domain','component','capability','failure_family','release','commit_sha','deployment_id','signal_count','reopened_count','decided_at','cooldown_seconds') then raise exception 'F9_DISPATCH_UNAPPROVED_KEY:%',k; end if;
+  end loop;
+  if not (p_request ?& array['attempt_key','decision_key','action','severity','status','environment','domain','decided_at','cooldown_seconds']) then raise exception 'F9_DISPATCH_REQUIRED_FIELD_MISSING'; end if;
+
+  v_attempt:=p_request->>'attempt_key'; v_decision:=p_request->>'decision_key'; v_incident:=nullif(p_request->>'incident_id',''); v_digest:=nullif(p_request->>'digest_key','');
+  v_action:=pg_catalog.upper(p_request->>'action'); v_severity:=pg_catalog.upper(p_request->>'severity'); v_status:=pg_catalog.upper(p_request->>'status');
+  v_env:=pg_catalog.lower(p_request->>'environment'); v_domain:=pg_catalog.upper(p_request->>'domain');
+  v_component:=nullif(pg_catalog.lower(coalesce(p_request->>'component','')),''); v_capability:=nullif(pg_catalog.lower(coalesce(p_request->>'capability','')),'');
+  v_failure:=nullif(pg_catalog.lower(coalesce(p_request->>'failure_family','')),''); v_release:=nullif(p_request->>'release',''); v_commit:=nullif(p_request->>'commit_sha',''); v_deploy:=nullif(p_request->>'deployment_id','');
+  v_signal_count:=coalesce((p_request->>'signal_count')::bigint,0); v_reopened:=coalesce((p_request->>'reopened_count')::integer,0); v_cooldown:=coalesce((p_request->>'cooldown_seconds')::integer,0);
+  begin v_decided:=(p_request->>'decided_at')::timestamptz; exception when others then raise exception 'F9_DISPATCH_INVALID_TIMESTAMP'; end;
+
+  if v_attempt is null or v_attempt !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_attempt ~ '[?#]' or v_attempt ~ '\.\.' then raise exception 'F9_ATTEMPT_KEY_INVALID'; end if;
+  if v_decision is null or v_decision !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_decision ~ '[?#]' or v_decision ~ '\.\.' then raise exception 'F9_DECISION_KEY_INVALID'; end if;
+  if v_action not in ('IMMEDIATE','RECOVERY','FLAPPING_SUMMARY','DIGEST') then raise exception 'F9_ACTION_INVALID'; end if;
+  if v_severity not in ('P0','P1','P2') or v_status not in ('OPEN','ACK','INVESTIGATING','MITIGATED','RESOLVED') then raise exception 'F9_DISPATCH_STATE_INVALID'; end if;
+  if v_env !~ '^[a-z0-9][a-z0-9._:-]{0,63}$' or v_domain !~ '^[A-Z][A-Z0-9_]{0,63}$' then raise exception 'F9_SCOPE_INVALID'; end if;
+  if v_cooldown<0 or v_cooldown>86400 or v_signal_count<0 or v_reopened<0 then raise exception 'F9_COUNTER_OR_COOLDOWN_INVALID'; end if;
+  if (v_action='DIGEST' and (v_incident is not null or v_digest is null)) or (v_action<>'DIGEST' and (v_incident is null or v_digest is not null)) then raise exception 'F9_DISPATCH_TARGET_INVALID'; end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('sentinel:f9:attempt:'||v_attempt,0));
+  select dispatch_id into v_existing from public.aos_sentinel_alert_dispatches_v1 where attempt_key=v_attempt;
+  if v_existing is not null then return pg_catalog.jsonb_build_object('ok',true,'result','REPLAY','dispatch_id',v_existing); end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('sentinel:f9:decision:'||v_decision,0));
+  if v_cooldown>0 then
+    select max(delivered_at) into v_last from public.aos_sentinel_alert_dispatches_v1 where decision_key=v_decision and delivery_state='DELIVERED';
+    if v_last is not null and v_decided < v_last + pg_catalog.make_interval(secs=>v_cooldown) then
+      return pg_catalog.jsonb_build_object('ok',true,'result','SUPPRESSED_COOLDOWN','last_delivered_at',v_last);
+    end if;
+  end if;
+
+  insert into public.aos_sentinel_alert_dispatches_v1(
+    attempt_key,decision_key,incident_id,digest_key,action,severity,status,channel,environment,domain,component,capability,failure_family,release,commit_sha,deployment_id,signal_count,reopened_count,decided_at,cooldown_seconds
+  ) values(
+    v_attempt,v_decision,v_incident,v_digest,v_action,v_severity,v_status,'telegram-owner',v_env,v_domain,v_component,v_capability,v_failure,v_release,v_commit,v_deploy,v_signal_count,v_reopened,v_decided,v_cooldown
+  ) returning dispatch_id into v_id;
+  return pg_catalog.jsonb_build_object('ok',true,'result','RESERVED','dispatch_id',v_id);
+end;
+$$;
+
+create or replace function public.aos_sentinel_alert_mark_delivery_v1(p_dispatch_id bigint,p_state text,p_provider_message_id text default null,p_retry_after_seconds integer default null,p_at timestamptz default null)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_state text:=pg_catalog.upper(coalesce(p_state,'')); v_at timestamptz:=coalesce(p_at,pg_catalog.clock_timestamp()); v public.aos_sentinel_alert_dispatches_v1%rowtype;
+begin
+  if v_state not in ('DELIVERED','FAILED','UNAVAILABLE','RETRY_LATER') then raise exception 'F9_DELIVERY_STATE_INVALID'; end if;
+  if p_provider_message_id is not null and (p_provider_message_id !~ '^[A-Za-z0-9._:@/-]{1,200}$' or p_provider_message_id ~ '[?#]' or p_provider_message_id ~ '\.\.') then raise exception 'F9_PROVIDER_MESSAGE_ID_INVALID'; end if;
+  if p_retry_after_seconds is not null and (p_retry_after_seconds<1 or p_retry_after_seconds>86400) then raise exception 'F9_RETRY_AFTER_INVALID'; end if;
+  select * into v from public.aos_sentinel_alert_dispatches_v1 where dispatch_id=p_dispatch_id for update;
+  if not found then raise exception 'F9_DISPATCH_NOT_FOUND'; end if;
+  if v.delivery_state='DELIVERED' then return pg_catalog.jsonb_build_object('ok',true,'replay',true,'dispatch_id',v.dispatch_id,'state',v.delivery_state); end if;
+  update public.aos_sentinel_alert_dispatches_v1 set delivery_state=v_state,provider_message_id=case when v_state='DELIVERED' then p_provider_message_id else null end,retry_after_seconds=case when v_state='RETRY_LATER' then p_retry_after_seconds else null end,delivered_at=case when v_state='DELIVERED' then v_at else null end,updated_at=v_at where dispatch_id=p_dispatch_id returning * into v;
+  return pg_catalog.jsonb_build_object('ok',true,'replay',false,'dispatch_id',v.dispatch_id,'state',v.delivery_state,'delivered_at',v.delivered_at,'retry_after_seconds',v.retry_after_seconds);
+end;
+$$;
+
+create or replace function public.aos_sentinel_alert_queue_digest_v1(p_item jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_key text; v_incident text; v_env text; v_domain text; v_start timestamptz; v_end timestamptz; v_queued timestamptz; v_inserted boolean;
+begin
+  if p_item is null or pg_catalog.jsonb_typeof(p_item)<>'object' then raise exception 'F9_DIGEST_OBJECT_REQUIRED'; end if;
+  if not (p_item ?& array['digest_key','incident_id','environment','domain','bucket_start','bucket_end','queued_at']) then raise exception 'F9_DIGEST_REQUIRED_FIELD_MISSING'; end if;
+  if exists(select 1 from pg_catalog.jsonb_object_keys(p_item) k where k not in ('digest_key','incident_id','environment','domain','bucket_start','bucket_end','queued_at')) then raise exception 'F9_DIGEST_UNAPPROVED_KEY'; end if;
+  v_key:=p_item->>'digest_key'; v_incident:=p_item->>'incident_id'; v_env:=pg_catalog.lower(p_item->>'environment'); v_domain:=pg_catalog.upper(p_item->>'domain');
+  begin v_start:=(p_item->>'bucket_start')::timestamptz; v_end:=(p_item->>'bucket_end')::timestamptz; v_queued:=(p_item->>'queued_at')::timestamptz; exception when others then raise exception 'F9_DIGEST_INVALID_TIMESTAMP'; end;
+  if v_key !~ '^[A-Za-z0-9._:@/-]{1,240}$' or v_key ~ '[?#]' or v_key ~ '\.\.' then raise exception 'F9_DIGEST_KEY_INVALID'; end if;
+  if v_incident !~ '^SEN-[0-9]{4}-[0-9]{4,}$' or v_env !~ '^[a-z0-9][a-z0-9._:-]{0,63}$' or v_domain !~ '^[A-Z][A-Z0-9_]{0,63}$' or v_end<=v_start then raise exception 'F9_DIGEST_SCOPE_INVALID'; end if;
+  insert into public.aos_sentinel_alert_digest_items_v1(digest_key,incident_id,environment,domain,bucket_start,bucket_end,queued_at)
+  values(v_key,v_incident,v_env,v_domain,v_start,v_end,v_queued)
+  on conflict(digest_key,incident_id) do nothing;
+  get diagnostics v_inserted = row_count;
+  return pg_catalog.jsonb_build_object('ok',true,'inserted',v_inserted,'digest_key',v_key,'incident_id',v_incident);
+end;
+$$;
+
+create or replace function public.aos_sentinel_alert_recent_dispatches_v1(p_incident_id text)
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+    'dispatch_id',d.dispatch_id,'attempt_key',d.attempt_key,'decision_key',d.decision_key,'action',d.action,'severity',d.severity,'status',d.status,
+    'decided_at',d.decided_at,'cooldown_seconds',d.cooldown_seconds,'delivery_state',d.delivery_state,'delivered_at',d.delivered_at,'retry_after_seconds',d.retry_after_seconds
+  ) order by d.dispatch_id),'[]'::jsonb)
+  from public.aos_sentinel_alert_dispatches_v1 d where d.incident_id=p_incident_id;
+$$;
+
+create or replace function public.aos_sentinel_active_maintenance_windows_v1(p_at timestamptz default null)
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select coalesce(pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+    'window_id',w.window_id,'environment',w.environment,'domain',w.domain,'component',w.component,'capability',w.capability,'reason_code',w.reason_code,'starts_at',w.starts_at,'ends_at',w.ends_at
+  ) order by w.window_id),'[]'::jsonb)
+  from public.aos_sentinel_maintenance_windows_v1 w
+  where w.enabled and coalesce(p_at,pg_catalog.clock_timestamp()) between w.starts_at and w.ends_at;
+$$;
+
+revoke all on table public.aos_sentinel_alert_dispatches_v1 from PUBLIC,anon,authenticated,service_role;
+revoke all on table public.aos_sentinel_alert_digest_items_v1 from PUBLIC,anon,authenticated,service_role;
+revoke all on table public.aos_sentinel_maintenance_windows_v1 from PUBLIC,anon,authenticated,service_role;
+revoke all on function public.aos_sentinel_alert_reserve_dispatch_v1(jsonb) from PUBLIC,anon,authenticated;
+revoke all on function public.aos_sentinel_alert_mark_delivery_v1(bigint,text,text,integer,timestamptz) from PUBLIC,anon,authenticated;
+revoke all on function public.aos_sentinel_alert_queue_digest_v1(jsonb) from PUBLIC,anon,authenticated;
+revoke all on function public.aos_sentinel_alert_recent_dispatches_v1(text) from PUBLIC,anon,authenticated;
+revoke all on function public.aos_sentinel_active_maintenance_windows_v1(timestamptz) from PUBLIC,anon,authenticated;
+grant execute on function public.aos_sentinel_alert_reserve_dispatch_v1(jsonb) to service_role;
+grant execute on function public.aos_sentinel_alert_mark_delivery_v1(bigint,text,text,integer,timestamptz) to service_role;
+grant execute on function public.aos_sentinel_alert_queue_digest_v1(jsonb) to service_role;
+grant execute on function public.aos_sentinel_alert_recent_dispatches_v1(text) to service_role;
+grant execute on function public.aos_sentinel_active_maintenance_windows_v1(timestamptz) to service_role;
+
+comment on table public.aos_sentinel_alert_dispatches_v1 is 'Sentinel F9 technical delivery ledger only; no rendered messages, credentials, PHI or PII.';
+comment on table public.aos_sentinel_alert_digest_items_v1 is 'Sentinel F9 P2 digest queue storing technical incident IDs only.';
+comment on table public.aos_sentinel_maintenance_windows_v1 is 'Sentinel F9 technical maintenance scopes; reason_code is controlled slug, not free text.';
+
+commit;

--- a/supabase/migrations/20260817015500_sentinel_f9_digest_incident_fk_index.sql
+++ b/supabase/migrations/20260817015500_sentinel_f9_digest_incident_fk_index.sql
@@ -1,0 +1,9 @@
+-- Sentinel F9 performance hotfix: cover digest incident foreign key.
+-- Additive, no data rewrite, no PHI/PII.
+
+begin;
+
+create index if not exists aos_sentinel_alert_digest_items_v1_incident_idx
+  on public.aos_sentinel_alert_digest_items_v1(incident_id);
+
+commit;

--- a/supabase/rollbacks/20260817010000_sentinel_f9_alert_outbox_rollback.sql
+++ b/supabase/rollbacks/20260817010000_sentinel_f9_alert_outbox_rollback.sql
@@ -1,0 +1,12 @@
+begin;
+
+drop function if exists public.aos_sentinel_active_maintenance_windows_v1(timestamptz);
+drop function if exists public.aos_sentinel_alert_recent_dispatches_v1(text);
+drop function if exists public.aos_sentinel_alert_queue_digest_v1(jsonb);
+drop function if exists public.aos_sentinel_alert_mark_delivery_v1(bigint,text,text,integer,timestamptz);
+drop function if exists public.aos_sentinel_alert_reserve_dispatch_v1(jsonb);
+drop table if exists public.aos_sentinel_maintenance_windows_v1;
+drop table if exists public.aos_sentinel_alert_digest_items_v1;
+drop table if exists public.aos_sentinel_alert_dispatches_v1;
+
+commit;

--- a/supabase/rollbacks/20260817015500_sentinel_f9_digest_incident_fk_index_rollback.sql
+++ b/supabase/rollbacks/20260817015500_sentinel_f9_digest_incident_fk_index_rollback.sql
@@ -1,0 +1,7 @@
+-- Rollback for Sentinel F9 digest incident FK performance hotfix.
+
+begin;
+
+drop index if exists public.aos_sentinel_alert_digest_items_v1_incident_idx;
+
+commit;


### PR DESCRIPTION
## Sentinel F9-B — Durable Alert State / Outbox

**PRODUCTION-CERTIFIED DURABLE STATE. F9 GLOBAL REMAINS OPEN ONLY FOR TELEGRAM LIVE CONFIGURATION.**

### Certified
- routing Windows FAST: PASS;
- routing Linux Zero-Cost: PASS;
- durable PostgreSQL outbox: PASS;
- exact-attempt replay and concurrent reservation: PASS;
- ACK-based durable cooldown: PASS;
- P2 digest dedupe: PASS;
- maintenance-window persistence: PASS;
- RLS/ACL/fixed search_path: PASS;
- DB lint: PASS;
- F9 rollback/reapply with F8 preserved: PASS;
- production durable synthetic canary: PASS;
- Supabase Security Advisor: 0 findings;
- performance finding caused by F9 corrected with covering FK index and Zero-Cost rollback/reapply: PASS.

### Production migration history
- `20260817013916 sentinel_f9_alert_outbox`
- `20260817014618 sentinel_f9_digest_incident_fk_index`

### Privacy/security
No rendered Telegram content, bot token, chat target, PHI, PII or arbitrary payload is stored in the F9 durable tables. Operational RPCs are service_role-only and direct table access is revoked.

### Telegram live gate
Read-only live preflight found:
- canonical integration `Sentinel Owner Alerts`: 0;
- active canonical integrations: 0;
- secret rows: 0;
- bot token present: false;
- owner chat target present: false.

Therefore live Telegram delivery is intentionally NOT enabled. This is now the sole remaining F9 global gate and requires externally-originated bot/chat configuration; credentials must not be pasted into GitHub or chat.

### Certificate
`docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`

PR may merge once its terminal exact-head checks are green. Merging this PR does not activate Telegram live delivery.