### PR TITLE
PHASE S S5 — native WA3 bootstrap prelude

### DIFF
--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -37,6 +37,21 @@ async function injectF4(req){
   return new Response(html,{status:r.status,statusText:r.statusText,headers:h});
 }
 
+async function injectEmbeddedWa(req){
+  var r=await fetch(req,{cache:'no-store'});if(!r.ok)return r;
+  var type=(r.headers.get('content-type')||'').toLowerCase();if(type.indexOf('text/html')<0)return r;
+  var html=await r.text();
+  if(html.indexOf('/wa-native-bootstrap-prelude.js')<0){
+    var tag='<script src="/wa-native-bootstrap-prelude.js?v=20260817-s5-p01"></script>\n';
+    var marker='<script>\n(function(){\'use strict\';';
+    if(html.indexOf(marker)>=0)html=html.replace(marker,tag+marker);
+    else if(html.indexOf('</head>')>=0)html=html.replace('</head>',tag+'</head>');
+    else html=tag+html;
+  }
+  var h=new Headers(r.headers);h.set('Cache-Control','no-store, no-cache, must-revalidate');h.delete('content-length');
+  return new Response(html,{status:r.status,statusText:r.statusText,headers:h});
+}
+
 async function injectSameOriginAppToken(req){
   var h=new Headers(req.headers),t=String(await getToken()).trim();
   if(t.length>=32)h.set('X-AOS-App-Token',t);
@@ -47,6 +62,9 @@ self.addEventListener('fetch',function(event){
   var req=event.request,u;
   try{u=new URL(req.url);}catch(e){return;}
   if(u.origin===self.location.origin&&req.method==='GET'&&(u.pathname==='/app'||u.pathname==='/app.html')){event.respondWith(injectF4(req));return;}
+  if(u.origin===self.location.origin&&req.method==='GET'&&req.mode==='navigate'&&u.pathname==='/admin-whatsapp.html'&&u.searchParams.get('embedded')==='1'){
+    event.respondWith(injectEmbeddedWa(req));return;
+  }
   // A direct WA-3 page is now a compatibility entrypoint. Normal navigation is
   // returned to the canonical ASCENDA shell; the embedded iframe bypasses this.
   if(u.origin===self.location.origin&&req.method==='GET'&&req.mode==='navigate'&&u.pathname==='/admin-whatsapp.html'&&u.searchParams.get('embedded')!=='1'){

--- a/app/public/wa-native-bootstrap-prelude.js
+++ b/app/public/wa-native-bootstrap-prelude.js
@@ -1,0 +1,30 @@
+// ASCENDA Conversations — PHASE S S5 native bootstrap prelude.
+// Runs before WA-3 inline app code inside the same-origin embedded Hub.
+(function(){
+'use strict';
+var RETRYABLE={403:1,502:1,503:1,504:1};
+try{
+  if(window.parent&&window.parent!==window){
+    var p=window.parent.sessionStorage;
+    var t=p.getItem('aos_app_token')||p.getItem('aos_si_token')||'';
+    if(String(t).trim().length>=32)sessionStorage.setItem('aos_app_token',String(t).trim());
+  }
+}catch(e){console.warn('[WA-S5] parent token sync skipped',e);}
+
+var baseFetch=window.fetch.bind(window);
+window.fetch=function(input,init){
+  var url='';
+  try{url=typeof input==='string'?input:String(input&&input.url||'');}catch(_){url='';}
+  if(url.indexOf('/api/wa3/bootstrap')<0)return baseFetch(input,init);
+  var attempt=0;
+  function run(){
+    attempt++;
+    return baseFetch(input,init).then(function(r){
+      if(r.ok||!RETRYABLE[r.status]||attempt>=5)return r;
+      var wait=Math.min(1200,200*attempt);
+      return new Promise(function(resolve){setTimeout(resolve,wait);}).then(run);
+    });
+  }
+  return run();
+};
+})();


### PR DESCRIPTION
Fixes the persistent read-only recovery state observed after valid 2FA login. The embedded WhatsApp page now receives a prelude before its inline WA-3 app boots. The prelude synchronizes the strong ASCENDA token from the same-origin parent and retries only /api/wa3/bootstrap on transient 403/502/503/504 responses. No send, ownership, canary, idempotency, routing or AI gate is bypassed. Recovery remains the final safety net.