### PR TITLE
F17 — move WhatsApp template consumer behind governed gateway

### DIFF
--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -573,7 +573,7 @@ function openWaCC(){
   var headers = {'apikey':_sk,'Authorization':'Bearer '+_sk};
 
   Promise.all([
-    fetch(_sb+'/rest/v1/aos_plantillas_whatsapp?activo=eq.true&order=orden',{headers:headers}).then(function(r){return r.json()}),
+    fetch('/api/f17/whatsapp/templates',{headers:{'X-ASCENDA-Session':((window.AOS_getToken?window.AOS_getToken():'')||'')},cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('WHATSAPP_TEMPLATE_GATEWAY_'+r.status);return r.json();}).then(function(d){return d&&d.ok&&Array.isArray(d.templates)?d.templates:[];}),
     fetch(_sb+'/rest/v1/aos_info_tratamientos?activo=eq.true',{headers:headers}).then(function(r){return r.json()})
   ]).then(function(results) {
     var plantillasDB = results[0] || [];


### PR DESCRIPTION
Superseded before merge because main advanced to `cc30a7e8aad89939850f06f5b619221cb8c86ee1`. Fresh verification shows current-main `app/public/calls.js` still has the exact original blob `b9b21aff4d403a38ab7d47739744cfd05cbc6412`, so no functional drift exists. No production mutation occurred from this PR. A v2 release is recreated directly from current main with the same previously materializer-certified consumer blob.