### PR TITLE
F17 v2 — move WhatsApp template consumer behind governed gateway

### DIFF
--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -573,7 +573,7 @@ function openWaCC(){
   var headers = {'apikey':_sk,'Authorization':'Bearer '+_sk};
 
   Promise.all([
-    fetch(_sb+'/rest/v1/aos_plantillas_whatsapp?activo=eq.true&order=orden',{headers:headers}).then(function(r){return r.json()}),
+    fetch('/api/f17/whatsapp/templates',{headers:{'X-ASCENDA-Session':((window.AOS_getToken?window.AOS_getToken():'')||'')},cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('WHATSAPP_TEMPLATE_GATEWAY_'+r.status);return r.json();}).then(function(d){return d&&d.ok&&Array.isArray(d.templates)?d.templates:[];}),
     fetch(_sb+'/rest/v1/aos_info_tratamientos?activo=eq.true',{headers:headers}).then(function(r){return r.json()})
   ]).then(function(results) {
     var plantillasDB = results[0] || [];


### PR DESCRIPTION
Exact current-main base `cc30a7e8aad89939850f06f5b619221cb8c86ee1`. One-file release: `app/public/calls.js` only. Current-main source blob exactly matches the materializer-certified base (`b9b21aff...`). The only change replaces browser direct SELECT from `aos_plantillas_whatsapp` with authenticated `/api/f17/whatsapp/templates` using `X-ASCENDA-Session` and `no-store`; the treatments fetch and UI fallback remain unchanged. Production gateway smoke is PASS (`/health=200`, unauthenticated template route=401). No ACL/RLS/provider/spend mutation. Tracks #173.