### PR TITLE
F17 — final legacy WhatsApp ACL closure

### DIFF
--- a/supabase/migrations/20260817170500_f17_legacy_whatsapp_acl_final.sql
+++ b/supabase/migrations/20260817170500_f17_legacy_whatsapp_acl_final.sql
@@ -1,0 +1,17 @@
+-- F17 final legacy WhatsApp ACL closure.
+-- Preconditions: governed server gateway deployed and browser template consumer cut over.
+-- Server-side service_role access remains intact; browser roles are fail-closed.
+
+alter table public.aos_plantillas_whatsapp enable row level security;
+alter table public.aos_plantillas_whatsapp force row level security;
+alter table public.aos_whatsapp_mensajes enable row level security;
+alter table public.aos_whatsapp_mensajes force row level security;
+
+revoke all on table public.aos_plantillas_whatsapp from anon, authenticated;
+revoke all on table public.aos_whatsapp_mensajes from anon, authenticated;
+
+grant select, insert, update, delete on table public.aos_plantillas_whatsapp to service_role;
+grant select, insert, update, delete on table public.aos_whatsapp_mensajes to service_role;
+
+comment on table public.aos_plantillas_whatsapp is 'F17 legacy WhatsApp templates: server-authoritative service_role access only; browser direct access retired 2026-08-17.';
+comment on table public.aos_whatsapp_mensajes is 'F17 legacy WhatsApp messages: server-authoritative service_role access only; browser direct access retired 2026-08-17.';

--- a/supabase/rollback/20260817170500_f17_legacy_whatsapp_acl_final_rollback.sql
+++ b/supabase/rollback/20260817170500_f17_legacy_whatsapp_acl_final_rollback.sql
@@ -1,0 +1,10 @@
+-- Emergency rollback for 20260817170500_f17_legacy_whatsapp_acl_final.sql.
+-- Use only if post-cutover compatibility smoke fails.
+
+grant select on table public.aos_plantillas_whatsapp to anon, authenticated;
+grant select on table public.aos_whatsapp_mensajes to anon, authenticated;
+
+alter table public.aos_plantillas_whatsapp no force row level security;
+alter table public.aos_plantillas_whatsapp disable row level security;
+alter table public.aos_whatsapp_mensajes no force row level security;
+alter table public.aos_whatsapp_mensajes disable row level security;


### PR DESCRIPTION
Final closure for #173 after governed runtime smoke PASS and browser consumer cutover. Scope: one forward migration + explicit emergency rollback. Enables RLS+FORCE on `aos_plantillas_whatsapp` and `aos_whatsapp_mensajes`, revokes all direct `anon/authenticated` privileges, preserves service_role CRUD. No provider send, no message mutation, no identity changes. Post-apply checks: browser SELECT=false, RLS+FORCE=true, service_role intact, F17 runtime fail-closed route still healthy. Tracks #173.