### PR TITLE
feat(sentinel): F10 deterministic diagnostic runner

### DIFF
--- a/.github/workflows/sentinel-phase10-diagnostic-runner.yml
+++ b/.github/workflows/sentinel-phase10-diagnostic-runner.yml
@@ -40,6 +40,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Diff hygiene
         shell: powershell
         run: git diff --check
@@ -56,6 +58,7 @@ jobs:
     timeout-minutes: 20
     env:
       WORKSPACE_FIX_IMAGE: alpine:3.20
+      NODE_CLI_IMAGE: node:22-bookworm
     steps:
       - name: Repair container-owned workspace before checkout
         run: |
@@ -64,6 +67,8 @@ jobs:
           docker run --rm -v "$GITHUB_WORKSPACE:/work" "$WORKSPACE_FIX_IMAGE" sh -lc "rm -rf /work/ci/zero-cost-staging/supabase/.branches; chown -R $(id -u):$(id -g) /work 2>/dev/null || true"
       - name: Checkout F10 tooling
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Resolve and validate affected SHA
         id: prep
         env:
@@ -85,6 +90,11 @@ jobs:
         with:
           ref: ${{ steps.prep.outputs.target_sha }}
           path: affected
+          persist-credentials: false
+      - name: Verify disposable diagnostic runtime
+        run: |
+          set -euo pipefail
+          docker run --rm "$NODE_CLI_IMAGE" bash -lc 'node --version && git --version'
       - name: Prepare synthetic CI health evidence
         if: github.event_name != 'workflow_dispatch'
         run: |
@@ -107,17 +117,18 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            args=(--target-sha "$TARGET_SHA" --repo affected --out .f10-report)
+            printf '%s' "$F10_REQUEST_JSON" > .f10-request.json
+            args=(--request .f10-request.json --target-sha "$TARGET_SHA" --repo affected --out .f10-report)
             if [[ -f .f10-health.json ]]; then args+=(--health .f10-health.json); fi
-            node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}"
           else
-            node sentinel/diagnostics/diagnostic-runner.cjs \
-              --request ci/sentinel/phase10_synthetic_request.json \
-              --target-sha "$TARGET_SHA" \
-              --repo affected \
-              --health .f10-health.json \
-              --out .f10-report
+            args=(--request ci/sentinel/phase10_synthetic_request.json --target-sha "$TARGET_SHA" --repo affected --health .f10-health.json --out .f10-report)
           fi
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            "$NODE_CLI_IMAGE" \
+            node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}"
+          rm -f .f10-request.json
       - name: Verify report and digest
         run: |
           set -euo pipefail

--- a/.github/workflows/sentinel-phase10-diagnostic-runner.yml
+++ b/.github/workflows/sentinel-phase10-diagnostic-runner.yml
@@ -117,7 +117,7 @@ jobs:
           if [[ $code -ne 0 ]]; then
             printf '%s\n' '{"ok":false,"service":"ascenda-phase-s","child_alive":false,"inner_ready":false}' > .f10-health.json
           fi
-      - name: Execute deterministic diagnostic
+      - name: Execute deterministic diagnostic and exact replay
         env:
           F10_REQUEST_JSON: ${{ inputs.request_json }}
           TARGET_SHA: ${{ steps.prep.outputs.target_sha }}
@@ -125,19 +125,27 @@ jobs:
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             printf '%s' "$F10_REQUEST_JSON" > .f10-request.json
-            args=(--request .f10-request.json --target-sha "$TARGET_SHA" --repo affected --out .f10-report)
+            args=(--request .f10-request.json --target-sha "$TARGET_SHA" --repo affected)
             if [[ -f .f10-health.json ]]; then args+=(--health .f10-health.json); fi
           else
-            args=(--request ci/sentinel/phase10_synthetic_request.json --target-sha "$TARGET_SHA" --repo affected --health .f10-health.json --out .f10-report)
+            args=(--request ci/sentinel/phase10_synthetic_request.json --target-sha "$TARGET_SHA" --repo affected --health .f10-health.json)
           fi
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/tmp \
-            -v "$GITHUB_WORKSPACE:/work" \
-            -w /work \
-            "$F10_RUNTIME_IMAGE" \
-            node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}"
-          rm -f .f10-request.json
+          run_diag() {
+            local out="$1"
+            docker run --rm \
+              --user "$(id -u):$(id -g)" \
+              -e HOME=/tmp \
+              -v "$GITHUB_WORKSPACE:/work" \
+              -w /work \
+              "$F10_RUNTIME_IMAGE" \
+              node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}" --out "$out"
+          }
+          run_diag .f10-report
+          run_diag .f10-replay
+          cmp -s .f10-report/diagnostic-report.json .f10-replay/diagnostic-report.json
+          cmp -s .f10-report/diagnostic-report.md .f10-replay/diagnostic-report.md
+          echo "SENTINEL_F10_RUNTIME_REPLAY=PASS"
+          rm -rf .f10-replay .f10-request.json
       - name: Verify report and digest
         run: |
           set -euo pipefail

--- a/.github/workflows/sentinel-phase10-diagnostic-runner.yml
+++ b/.github/workflows/sentinel-phase10-diagnostic-runner.yml
@@ -1,0 +1,136 @@
+name: Sentinel F10 Diagnostic Runner Certificate
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact affected commit SHA (40 lowercase hex)
+        required: true
+        type: string
+      request_json:
+        description: Sanitized sentinel-diagnostic-request/v1 JSON
+        required: true
+        type: string
+      live_health:
+        description: Include read-only production /health evidence
+        required: true
+        default: true
+        type: boolean
+  push:
+    branches: ['feature/sentinel-f10-diagnostic-runner','main']
+    paths: &f10_paths
+      - 'sentinel/diagnostics/**'
+      - 'ci/sentinel/phase10_*'
+      - 'docs/control/SENTINEL_F10_*'
+      - '.github/workflows/sentinel-phase10-diagnostic-runner.yml'
+  pull_request:
+    branches: [main]
+    paths: *f10_paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sentinel-f10-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-fast:
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Diff hygiene
+        shell: powershell
+        run: git diff --check
+      - name: F10 syntax and contract
+        shell: powershell
+        run: |
+          node --check sentinel/diagnostics/diagnostic-runner.cjs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node ci/sentinel/phase10_diagnostic_contract.js
+
+  diagnostic-zero-cost:
+    needs: contract-fast
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 20
+    env:
+      WORKSPACE_FIX_IMAGE: alpine:3.20
+    steps:
+      - name: Repair container-owned workspace before checkout
+        run: |
+          set -euo pipefail
+          docker version >/dev/null
+          docker run --rm -v "$GITHUB_WORKSPACE:/work" "$WORKSPACE_FIX_IMAGE" sh -lc "rm -rf /work/ci/zero-cost-staging/supabase/.branches; chown -R $(id -u):$(id -g) /work 2>/dev/null || true"
+      - name: Checkout F10 tooling
+        uses: actions/checkout@v4
+      - name: Resolve and validate affected SHA
+        id: prep
+        env:
+          INPUT_TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            target="${INPUT_TARGET_SHA,,}"
+          else
+            target="${GITHUB_SHA,,}"
+          fi
+          if [[ ! "$target" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "F10_TARGET_SHA_INVALID" >&2
+            exit 1
+          fi
+          echo "target_sha=$target" >> "$GITHUB_OUTPUT"
+      - name: Checkout exact affected SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.prep.outputs.target_sha }}
+          path: affected
+      - name: Prepare synthetic CI health evidence
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          printf '%s\n' '{"ok":true,"service":"synthetic-ci","child_alive":true,"inner_ready":true}' > .f10-health.json
+      - name: Collect optional read-only live health evidence
+        if: github.event_name == 'workflow_dispatch' && inputs.live_health == true
+        run: |
+          set +e
+          curl --fail --silent --show-error --max-time 10 --retry 1 \
+            https://ascenda-os-production.up.railway.app/health > .f10-health.json
+          code=$?
+          set -e
+          if [[ $code -ne 0 ]]; then
+            printf '%s\n' '{"ok":false,"service":"ascenda-phase-s","child_alive":false,"inner_ready":false}' > .f10-health.json
+          fi
+      - name: Execute deterministic diagnostic
+        env:
+          F10_REQUEST_JSON: ${{ inputs.request_json }}
+          TARGET_SHA: ${{ steps.prep.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            args=(--target-sha "$TARGET_SHA" --repo affected --out .f10-report)
+            if [[ -f .f10-health.json ]]; then args+=(--health .f10-health.json); fi
+            node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}"
+          else
+            node sentinel/diagnostics/diagnostic-runner.cjs \
+              --request ci/sentinel/phase10_synthetic_request.json \
+              --target-sha "$TARGET_SHA" \
+              --repo affected \
+              --health .f10-health.json \
+              --out .f10-report
+          fi
+      - name: Verify report and digest
+        run: |
+          set -euo pipefail
+          test -s .f10-report/diagnostic-report.json
+          test -s .f10-report/diagnostic-report.md
+          sha256sum .f10-report/diagnostic-report.json .f10-report/diagnostic-report.md | tee .f10-report/sha256.txt
+          cat .f10-report/diagnostic-report.md >> "$GITHUB_STEP_SUMMARY"
+          echo "SENTINEL_F10_ZERO_COST_DIAGNOSTIC=PASS"
+      - name: Upload controlled diagnostic report
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sentinel-f10-${{ steps.prep.outputs.target_sha }}
+          path: .f10-report
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/sentinel-phase10-diagnostic-runner.yml
+++ b/.github/workflows/sentinel-phase10-diagnostic-runner.yml
@@ -58,7 +58,8 @@ jobs:
     timeout-minutes: 20
     env:
       WORKSPACE_FIX_IMAGE: alpine:3.20
-      NODE_CLI_IMAGE: node:22-bookworm
+      NODE_BASE_IMAGE: node:22-bookworm-slim
+      F10_RUNTIME_IMAGE: ascenda-f10-nodegit:22-bookworm-slim-v1
     steps:
       - name: Repair container-owned workspace before checkout
         run: |
@@ -91,10 +92,16 @@ jobs:
           ref: ${{ steps.prep.outputs.target_sha }}
           path: affected
           persist-credentials: false
-      - name: Verify disposable diagnostic runtime
+      - name: Prepare minimal disposable diagnostic runtime
         run: |
           set -euo pipefail
-          docker run --rm "$NODE_CLI_IMAGE" bash -lc 'node --version && git --version'
+          docker image inspect "$F10_RUNTIME_IMAGE" >/dev/null 2>&1 || docker build --pull=false -t "$F10_RUNTIME_IMAGE" - <<EOF
+          FROM $NODE_BASE_IMAGE
+          RUN apt-get update -qq \
+            && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends git ca-certificates >/dev/null \
+            && rm -rf /var/lib/apt/lists/*
+          EOF
+          docker run --rm "$F10_RUNTIME_IMAGE" sh -lc 'node --version && git --version'
       - name: Prepare synthetic CI health evidence
         if: github.event_name != 'workflow_dispatch'
         run: |
@@ -126,7 +133,7 @@ jobs:
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/work" \
             -w /work \
-            "$NODE_CLI_IMAGE" \
+            "$F10_RUNTIME_IMAGE" \
             node sentinel/diagnostics/diagnostic-runner.cjs "${args[@]}"
           rm -f .f10-request.json
       - name: Verify report and digest

--- a/.github/workflows/sentinel-phase10-diagnostic-runner.yml
+++ b/.github/workflows/sentinel-phase10-diagnostic-runner.yml
@@ -131,6 +131,8 @@ jobs:
             args=(--request ci/sentinel/phase10_synthetic_request.json --target-sha "$TARGET_SHA" --repo affected --health .f10-health.json --out .f10-report)
           fi
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
             -v "$GITHUB_WORKSPACE:/work" \
             -w /work \
             "$F10_RUNTIME_IMAGE" \

--- a/ci/sentinel/phase10_diagnostic_contract.js
+++ b/ci/sentinel/phase10_diagnostic_contract.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const path=require('node:path');
+const cp=require('node:child_process');
+const ROOT=path.resolve(__dirname,'../..');
+const {runDiagnostic,normalizeRequest}=require('../../sentinel/diagnostics/diagnostic-runner.cjs');
+
+function fixture(){return JSON.parse(fs.readFileSync(path.join(ROOT,'ci/sentinel/phase10_synthetic_request.json'),'utf8'));}
+function head(){return cp.execFileSync('git',['rev-parse','HEAD'],{cwd:ROOT,encoding:'utf8'}).trim().toLowerCase();}
+
+const sha=head();
+const base={...fixture(),commit_sha:sha,release:`ascenda-os@${sha}`};
+const health={ok:true,service:'synthetic-ci',child_alive:true,inner_ready:true};
+
+const first=runDiagnostic(base,{toolingRoot:ROOT,repoRoot:ROOT,health});
+const second=runDiagnostic(base,{toolingRoot:ROOT,repoRoot:ROOT,health});
+assert.deepEqual(first.report,second.report,'same input must produce same report');
+assert.equal(first.digest,second.digest,'same input must produce same digest');
+assert.match(first.report.diagnostic_id,/^F10-[0-9a-f]{20}$/);
+assert.equal(first.report.affected_sha_state,'EXACT');
+assert.equal(first.report.plan.invariant_id,'whatsapp.outbound_receipt_stall');
+assert.equal(first.report.safety.read_only,true);
+assert.equal(first.report.safety.production_mutation,false);
+assert.ok(first.report.evidence.some(e=>e.kind==='CONTRACT_TEST'&&e.result.code==='INVARIANT_MATCH'));
+assert.ok(first.report.evidence.some(e=>e.kind==='RELEASE_CORRELATION'&&e.result.code==='AFFECTED_SHA_CHECKED_OUT'));
+assert.ok(first.report.evidence.some(e=>e.kind==='HEALTH_CHECK'&&e.result.code==='HEALTH_OK'));
+assert.ok(first.report.hypotheses.every(h=>h.causality_confirmed===false));
+assert.doesNotMatch(first.markdown,/(authorization|cookie|password|service_role|apikey|secret)\s*[:=]/i);
+
+assert.throws(()=>runDiagnostic({...base,patient_name:'synthetic'},{toolingRoot:ROOT,repoRoot:ROOT}),/F10_SENSITIVE_INPUT_KEY/);
+assert.throws(()=>runDiagnostic({...base,commit_sha:'abc'},{toolingRoot:ROOT,repoRoot:ROOT}),/F10_COMMIT_SHA_INVALID/);
+assert.throws(()=>runDiagnostic({...base,unexpected:'x'},{toolingRoot:ROOT,repoRoot:ROOT}),/F10_REQUEST_UNAPPROVED_KEY/);
+assert.throws(()=>runDiagnostic({...base,evidence_refs:[{kind:'ci-run',id:'bad?query=1'}]},{toolingRoot:ROOT,repoRoot:ROOT}),/F10_EVIDENCE_REF_ID/);
+assert.throws(()=>normalizeRequest({...base,diagnostic_revision:0},{toolingRoot:ROOT}),/F10_DIAGNOSTIC_REVISION_INVALID/);
+
+const noSha=fixture();
+const noShaReport=runDiagnostic(noSha,{toolingRoot:ROOT,repoRoot:ROOT}).report;
+assert.equal(noShaReport.affected_sha_state,'UNKNOWN');
+assert.ok(noShaReport.evidence.some(e=>e.kind==='MISSING_EVIDENCE'&&e.result.code==='AFFECTED_SHA_UNKNOWN'));
+
+const unknown={...base,domain:'MYSTERY',component:'unknown-component',capability:'unknown-capability'};
+const unknownReport=runDiagnostic(unknown,{toolingRoot:ROOT,repoRoot:ROOT}).report;
+assert.equal(unknownReport.plan.invariant_id,null);
+assert.ok(unknownReport.evidence.some(e=>e.kind==='MISSING_EVIDENCE'&&e.result.code==='NO_EXACT_INVARIANT'));
+assert.equal(unknownReport.hypotheses[0].confidence,'UNKNOWN');
+assert.equal(unknownReport.hypotheses[0].causality_confirmed,false);
+
+const workflow=fs.readFileSync(path.join(ROOT,'.github/workflows/sentinel-phase10-diagnostic-runner.yml'),'utf8');
+assert.match(workflow,/workflow_dispatch:/);
+assert.match(workflow,/permissions:\s*\n\s*contents:\s*read/);
+assert.match(workflow,/ascenda-zero-cost-v2/);
+assert.match(workflow,/timeout-minutes:/);
+assert.match(workflow,/concurrency:/);
+assert.doesNotMatch(workflow,/contents:\s*write|pull-requests:\s*write|deployments:\s*write|actions:\s*write/i);
+assert.doesNotMatch(workflow,/SUPABASE_(?:DB|SERVICE|ACCESS)|RAILWAY_TOKEN|SERVICE_ROLE|git\s+push|supabase\s+db\s+push/i);
+
+const runner=fs.readFileSync(path.join(ROOT,'sentinel/diagnostics/diagnostic-runner.cjs'),'utf8');
+assert.doesNotMatch(runner,/execute_sql|\/rest\/v1|supabase\s+db\s+push|railway\s+up|git['"]?,\s*\[['"]push/i);
+
+console.log(JSON.stringify({
+  ok:true,
+  certificate:'SENTINEL_F10_DIAGNOSTIC_CONTRACT_PASS',
+  deterministic_replay:true,
+  exact_sha_checkout:true,
+  f6_domain_contract:true,
+  f7_release_correlation:true,
+  f8_incident_contract:true,
+  sensitive_key_rejection:true,
+  invalid_sha_rejection:true,
+  unknown_evidence_explicit:true,
+  causality_not_assumed:true,
+  read_only_workflow:true,
+  no_production_write_path:true,
+  report_digest:first.digest
+}));

--- a/ci/sentinel/phase10_synthetic_request.json
+++ b/ci/sentinel/phase10_synthetic_request.json
@@ -1,0 +1,18 @@
+{
+  "incident_id": "SEN-2099-9001",
+  "diagnostic_revision": 1,
+  "severity": "P1",
+  "status": "OPEN",
+  "environment": "production",
+  "domain": "WHATSAPP",
+  "component": "human-outbound",
+  "capability": "provider-status-progression",
+  "failure_family": "synthetic-diagnostic",
+  "observed_at": "2026-08-17T18:15:00Z",
+  "signal_count": 2,
+  "reopened_count": 0,
+  "deployment_id": "dep-f10-synthetic",
+  "evidence_refs": [
+    {"kind": "ci-run", "id": "f10-synthetic"}
+  ]
+}

--- a/docs/control/SENTINEL_F10_DIAGNOSTIC_RUNNER_IMPACT_REPORT_20260817.md
+++ b/docs/control/SENTINEL_F10_DIAGNOSTIC_RUNNER_IMPACT_REPORT_20260817.md
@@ -1,0 +1,38 @@
+# Sentinel F10 — Diagnostic Runner — Impact Report
+
+**Estado:** PRE-IMPLEMENTATION / REQUIRED FIRST ARTIFACT  
+**Fecha:** 2026-08-17 America/Lima  
+**Riesgo:** HIGH  
+**Fuente previa auditable:** GitHub Issue #233
+
+## Objetivo
+Diagnosticar incidentes `SEN-*` de forma reproducible en self-hosted CI usando solo metadata/evidencia sanitizada y sin mutar producción.
+
+## Anti-scope
+F10 no escribe producción, no modifica incidentes, no fusiona/despliega, no ejecuta rollback, no crea fixes automáticos y no usa PHI/PII/messages/secrets. AI/MCP pertenece a F11 y remediation a F12.
+
+## Baseline
+`SEN-* → sanitized diagnostic request → workflow_dispatch controlado → self-hosted runner → affected-SHA checkout → contracts/fixtures + recent-diff + safe health evidence → JSON/Markdown diagnostic report`
+
+Permisos baseline: `contents: read`; sin PR/deploy/actions write ni credenciales cloud de escritura.
+
+## Data contract
+Allowlist: incident_id, severity, status, environment, domain, component, capability, failure_family, signal_count, reopened_count, release, commit_sha, deployment_id, typed evidence refs y timestamps técnicos.
+
+Denylist: patient/paciente, DNI, phone/telefono, email address, message/body/payload, authorization, cookie, token, password, secret y datos clínicos.
+
+Evidence kinds: `CONTRACT_TEST`, `SYNTHETIC_REPRO`, `RECENT_DIFF`, `HEALTH_CHECK`, `RELEASE_CORRELATION`, `DEPENDENCY_STATUS`, `MISSING_EVIDENCE`.
+
+Hipótesis: confidence `SUPPORTED / PLAUSIBLE / WEAK / UNKNOWN`; `causality_confirmed=false` por defecto. Proximidad temporal no prueba causalidad.
+
+## Zero-Cost gates
+G01 contract/denylist → G02 planner → G03 synthetic fixture → G04 affected-SHA checkout → G05 read-only permissions → G06 no-production-write scan → G07 domain tests → G08 recent diff → G09 timeout/concurrency/idempotency → G10 sanitized report → G11 Linux Zero-Cost → G12 negatives → G13 disable/remove preserves F1–F9 → G14 synthetic end-to-end → G15 certificate + Notion.
+
+## Exit gate
+F10 solo puede quedar `100_COMPLETE` cuando un `SEN-*` sintético genera diagnóstico reproducible, SHA exacto o `UNKNOWN`, reporte sanitizado, replay determinista, timeout/negatives PASS, no existe ruta de escritura productiva, rollback lógico preserva F1–F9 y exact-head/post-merge CI quedan verdes.
+
+## Rollback
+Deshabilitar/remover workflow + artifacts. Baseline sin DDL productivo. Persistencia futura requiere Impact Report adicional antes de migration.
+
+## Deuda separada
+Supabase migration-history parity sigue como deuda transversal; resolver mediante auditoría completa + `migration repair`, nunca reejecutando DDL dentro de F10.

--- a/docs/control/SENTINEL_F10_FINAL_CERTIFICATE_20260817.md
+++ b/docs/control/SENTINEL_F10_FINAL_CERTIFICATE_20260817.md
@@ -1,0 +1,88 @@
+# Sentinel F10 — Diagnostic Runner — Final Certificate
+
+**Estado:** PRE-MERGE CERTIFIED / G01–G14 PASS  
+**Fecha:** 2026-08-17 America/Lima  
+**PR:** #235  
+**Impact Report:** Issue #233 + `docs/control/SENTINEL_F10_DIAGNOSTIC_RUNNER_IMPACT_REPORT_20260817.md`  
+**Functional head certificado antes de este commit:** `9a59163d40bd1e5ed68f4f891fae6bea738f0ecd`
+
+## Alcance
+F10 automatiza diagnóstico reproducible de incidentes `SEN-*` mediante self-hosted CI y evidencia sanitizada. Es estrictamente read-only.
+
+No escribe producción, no modifica incidentes, no fusiona/despliega, no ejecuta rollback productivo, no crea fixes y no usa AI/MCP. F11 posee AI triage; F12 remediation.
+
+## Arquitectura certificada
+`SEN-* → sanitized request → controlled workflow → self-hosted runner → exact affected-SHA checkout separado → F6/F7/F8 contracts + recent filenames + health evidence → deterministic JSON/Markdown report`
+
+Seguridad:
+- workflow GitHub `contents: read` únicamente;
+- `persist-credentials:false` en checkouts;
+- cero credenciales Supabase/Railway write;
+- tooling F10 se ejecuta desde la branch certificada, nunca desde el checkout afectado;
+- affected SHA debe ser 40-hex o queda `UNKNOWN`;
+- sensitive keys se rechazan recursivamente;
+- evidence refs heredan allowlist F8;
+- message/body/payload/secrets prohibidos;
+- causality siempre `false` en F10 baseline.
+
+## G01–G12 — PASS
+- G01 contract/denylist — PASS.
+- G02 planner determinista — PASS.
+- G03 synthetic fixture `SEN-2099-9001` — PASS.
+- G04 exact affected-SHA checkout — PASS.
+- G05 read-only permissions — PASS.
+- G06 no-production-write static scan — PASS.
+- G07 F6 domain contract evidence — PASS.
+- G08 recent diff filenames-only — PASS.
+- G09 timeout/concurrency/idempotency — PASS.
+- G10 JSON/Markdown sanitized report — PASS.
+- G11 Linux Zero-Cost on `ASCENDA-ZERO-COST-V2 / CREACTIVE` — PASS.
+- G12 negatives: sensitive input, invalid SHA, unapproved key, query-string evidence ref, revision 0, unknown/missing evidence — PASS.
+
+## G09/G14 runtime replay evidence
+Branch run `32055149504` on functional head `9a59163d40bd1e5ed68f4f891fae6bea738f0ecd`:
+
+- `contract-fast` — SUCCESS;
+- `diagnostic-zero-cost` — SUCCESS;
+- target SHA checkout — EXACT;
+- synthetic incident — `SEN-2099-9001`;
+- first diagnostic id — `F10-396d072b9dfadfca7585`;
+- first report digest — `22588779c2665ca96fd35c1cb2d0fb0992481705b97ffe9b9b78b2a93e584b3a`;
+- immediate replay diagnostic id — identical;
+- immediate replay report digest — identical;
+- byte-for-byte JSON/Markdown compare — PASS;
+- marker `SENTINEL_F10_RUNTIME_REPLAY=PASS`;
+- marker `SENTINEL_F10_ZERO_COST_DIAGNOSTIC=PASS`.
+
+This is the controlled synthetic end-to-end G14 baseline. `workflow_dispatch` remains available for owner-triggered diagnostics after merge; no public webhook or automatic production trigger is enabled.
+
+## G13 rollback/isolation — PASS
+Diff against current main contains only:
+- `.github/workflows/sentinel-phase10-diagnostic-runner.yml`;
+- `sentinel/diagnostics/f10-contract.json`;
+- `sentinel/diagnostics/diagnostic-runner.cjs`;
+- `ci/sentinel/phase10_diagnostic_contract.js`;
+- `ci/sentinel/phase10_synthetic_request.json`;
+- F10 governance/certificate docs.
+
+No migration, DB/RPC, Railway runtime, application server or production frontend file is changed. Logical rollback is removal/disable of the F10 workflow/tooling and therefore leaves F1–F9 intact.
+
+## Infrastructure defects resolved during certification
+1. Linux host had no global Node: fixed by disposable container; host unchanged.
+2. Full Node image pull was too heavy: replaced by cached `node:22-bookworm-slim` derived image with only Git/CA certs.
+3. Container root ownership caused report hash failure and Git safe-directory `UNKNOWN`: fixed by running the diagnostic container with host UID/GID + `HOME=/tmp`.
+
+All fixes preserve read-only scope.
+
+## PR merge-ref compatibility
+PR run `32055154914` against the current merge candidate passed both FAST and Linux diagnostic jobs, including exact replay. This validates F10 combined with concurrent `main` changes rather than branch-only behavior.
+
+## G15 terminal sequence
+F10 is not marked `100_COMPLETE` until:
+1. final certificate commit exact-head F10 + Ascenda CI PASS;
+2. PR #235 ready and merged;
+3. post-merge F10 + Ascenda CI PASS on `main`;
+4. GitHub roadmap + Notion set F10 `CERRADA / 100_COMPLETE`;
+5. F11 promoted.
+
+No production DDL or runtime deployment is required for F10 baseline.

--- a/sentinel/diagnostics/diagnostic-runner.cjs
+++ b/sentinel/diagnostics/diagnostic-runner.cjs
@@ -1,0 +1,250 @@
+'use strict';
+
+const fs=require('node:fs');
+const path=require('node:path');
+const crypto=require('node:crypto');
+const cp=require('node:child_process');
+
+const HERE=__dirname;
+const CONTRACT=JSON.parse(fs.readFileSync(path.join(HERE,'f10-contract.json'),'utf8'));
+const REQUIRED=new Set(CONTRACT.request.required_fields);
+const OPTIONAL=new Set(CONTRACT.request.optional_fields);
+const ALLOWED=new Set([...REQUIRED,...OPTIONAL]);
+const FORBIDDEN=CONTRACT.forbidden_key_fragments.map(v=>String(v).toLowerCase());
+const SEVERITIES=new Set(['P0','P1','P2','P3']);
+const STATUSES=new Set(['OPEN','ACK','INVESTIGATING','MITIGATED','RESOLVED']);
+const CONFIDENCE=new Set(CONTRACT.evidence.confidence);
+const TECH=/^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,239}$/;
+const SEGMENT=/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const DOMAIN=/^[A-Z][A-Z0-9_]{0,63}$/;
+const SHA=/^[0-9a-f]{40}$/;
+
+function isObject(v){return !!v&&typeof v==='object'&&!Array.isArray(v);}
+function stable(v){
+  if(Array.isArray(v))return `[${v.map(stable).join(',')}]`;
+  if(isObject(v))return `{${Object.keys(v).sort().map(k=>`${JSON.stringify(k)}:${stable(v[k])}`).join(',')}}`;
+  return JSON.stringify(v);
+}
+function digest(v){return crypto.createHash('sha256').update(stable(v)).digest('hex');}
+function fail(code,detail=''){const e=new Error(detail?`${code}:${detail}`:code);e.code=code;throw e;}
+function normalizedKey(k){return String(k).toLowerCase().replace(/[^a-z0-9_]/g,'');}
+function scanSensitiveKeys(v){
+  if(Array.isArray(v)){v.forEach(scanSensitiveKeys);return;}
+  if(!isObject(v))return;
+  for(const [k,val] of Object.entries(v)){
+    const nk=normalizedKey(k);
+    if(FORBIDDEN.some(f=>nk.includes(f)))fail('F10_SENSITIVE_INPUT_KEY',k);
+    scanSensitiveKeys(val);
+  }
+}
+function technical(v,code,max=240){
+  const s=String(v??'').trim();
+  if(!s||s.length>max||!TECH.test(s)||s.includes('..')||s.includes('?')||s.includes('#'))fail(code);
+  return s;
+}
+function segment(v,code){const s=String(v??'').trim();if(!s||!SEGMENT.test(s))fail(code);return s;}
+function nonNegativeInt(v,code){const n=Number(v);if(!Number.isSafeInteger(n)||n<0)fail(code);return n;}
+function loadJson(root,rel){return JSON.parse(fs.readFileSync(path.join(root,rel),'utf8'));}
+function loadUpstream(toolingRoot){
+  return {
+    f6:loadJson(toolingRoot,CONTRACT.upstream_contracts.f6_business_health),
+    f7:loadJson(toolingRoot,CONTRACT.upstream_contracts.f7_correlation),
+    f8:loadJson(toolingRoot,CONTRACT.upstream_contracts.f8_incidents)
+  };
+}
+function validateEvidenceRefs(refs,f8){
+  if(refs===undefined)return [];
+  if(!Array.isArray(refs)||refs.length>20)fail('F10_EVIDENCE_REFS_INVALID');
+  const allowedKinds=new Set(f8.evidence_reference.allowed_kinds);
+  return refs.map((ref,idx)=>{
+    if(!isObject(ref)||Object.keys(ref).sort().join(',')!=='id,kind')fail('F10_EVIDENCE_REF_SHAPE',String(idx));
+    const kind=String(ref.kind||'');
+    if(!allowedKinds.has(kind))fail('F10_EVIDENCE_REF_KIND',kind);
+    const id=technical(ref.id,'F10_EVIDENCE_REF_ID');
+    return {kind,id};
+  });
+}
+function normalizeRequest(input,{toolingRoot=path.resolve(HERE,'../..')}={}){
+  if(!isObject(input))fail('F10_REQUEST_OBJECT_REQUIRED');
+  scanSensitiveKeys(input);
+  for(const k of Object.keys(input))if(!ALLOWED.has(k))fail('F10_REQUEST_UNAPPROVED_KEY',k);
+  for(const k of REQUIRED)if(!(k in input))fail('F10_REQUEST_REQUIRED_FIELD',k);
+  const upstream=loadUpstream(toolingRoot);
+  const out={};
+  out.incident_id=String(input.incident_id||'').toUpperCase();
+  if(!(new RegExp(CONTRACT.request.incident_id_pattern)).test(out.incident_id))fail('F10_INCIDENT_ID_INVALID');
+  out.diagnostic_revision=nonNegativeInt(input.diagnostic_revision,'F10_DIAGNOSTIC_REVISION_INVALID');
+  if(out.diagnostic_revision<CONTRACT.request.diagnostic_revision_min)fail('F10_DIAGNOSTIC_REVISION_INVALID');
+  out.severity=String(input.severity||'').toUpperCase();if(!SEVERITIES.has(out.severity))fail('F10_SEVERITY_INVALID');
+  out.status=String(input.status||'').toUpperCase();if(!STATUSES.has(out.status))fail('F10_STATUS_INVALID');
+  out.environment=segment(String(input.environment||'').toLowerCase(),'F10_ENVIRONMENT_INVALID');
+  out.domain=String(input.domain||'').toUpperCase();if(!DOMAIN.test(out.domain))fail('F10_DOMAIN_INVALID');
+  out.component=segment(String(input.component||'').toLowerCase(),'F10_COMPONENT_INVALID');
+  out.capability=segment(String(input.capability||'').toLowerCase(),'F10_CAPABILITY_INVALID');
+  out.failure_family=segment(String(input.failure_family||'').toLowerCase(),'F10_FAILURE_FAMILY_INVALID');
+  out.observed_at=String(input.observed_at||'');if(!Number.isFinite(Date.parse(out.observed_at)))fail('F10_OBSERVED_AT_INVALID');
+  if(input.signal_count!==undefined)out.signal_count=nonNegativeInt(input.signal_count,'F10_SIGNAL_COUNT_INVALID');
+  if(input.reopened_count!==undefined)out.reopened_count=nonNegativeInt(input.reopened_count,'F10_REOPENED_COUNT_INVALID');
+  if(input.commit_sha!==undefined){out.commit_sha=String(input.commit_sha).toLowerCase();if(!SHA.test(out.commit_sha))fail('F10_COMMIT_SHA_INVALID');}
+  if(input.release!==undefined)out.release=technical(input.release,'F10_RELEASE_INVALID',160);
+  if(input.deployment_id!==undefined)out.deployment_id=technical(input.deployment_id,'F10_DEPLOYMENT_ID_INVALID',160);
+  if(input.evidence_refs!==undefined)out.evidence_refs=validateEvidenceRefs(input.evidence_refs,upstream.f8);
+  return {request:out,upstream};
+}
+function git(repo,args){return cp.execFileSync('git',args,{cwd:repo,encoding:'utf8',stdio:['ignore','pipe','pipe'],timeout:8000}).trim();}
+function tryGit(repo,args){try{return {ok:true,value:git(repo,args)};}catch{return {ok:false,value:''};}}
+function domainKey(domain){return domain.toLowerCase();}
+function buildPlan(request,f6){
+  const invariant=(f6.invariants||[]).find(x=>x.domain===request.domain&&x.component===request.component&&x.capability===request.capability)||null;
+  const source=(f6.source_contracts||{})[domainKey(request.domain)]||null;
+  const runtimeFiles=source&&Array.isArray(source.runtime_files)?[...source.runtime_files].sort():[];
+  return {
+    domain:request.domain,
+    component:request.component,
+    capability:request.capability,
+    invariant_id:invariant?invariant.id:null,
+    runtime_files:runtimeFiles,
+    steps:['VALIDATE_REQUEST','VERIFY_CORRELATION','VERIFY_DOMAIN_CONTRACT','INSPECT_AFFECTED_SHA','INSPECT_RECENT_DIFF','ASSESS_HEALTH','FORM_HYPOTHESES','RENDER_REPORT']
+  };
+}
+function addEvidence(list,kind,source,result,confidence,ref){
+  if(!CONTRACT.evidence.allowed_kinds.includes(kind)||!CONFIDENCE.has(confidence))fail('F10_INTERNAL_EVIDENCE_INVALID');
+  const e={id:`E${String(list.length+1).padStart(3,'0')}`,kind,source,result,confidence};
+  if(ref)e.ref=ref;
+  list.push(e);return e.id;
+}
+function sanitizeHealth(health){
+  if(!isObject(health))return null;
+  const out={};
+  for(const k of ['ok','service','child_alive','inner_ready'])if(k in health){
+    if(k==='service')out.service=segment(health.service,'F10_HEALTH_SERVICE_INVALID');
+    else out[k]=health[k]===true;
+  }
+  return out;
+}
+function collectRepo(request,repoRoot,evidence){
+  if(!request.commit_sha){
+    addEvidence(evidence,'MISSING_EVIDENCE','git',{code:'AFFECTED_SHA_UNKNOWN'},'UNKNOWN');
+    return {shaState:'UNKNOWN',files:[]};
+  }
+  const exists=tryGit(repoRoot,['cat-file','-e',`${request.commit_sha}^{commit}`]);
+  if(!exists.ok){
+    addEvidence(evidence,'MISSING_EVIDENCE','git',{code:'AFFECTED_SHA_NOT_PRESENT'},'UNKNOWN');
+    return {shaState:'UNKNOWN',files:[]};
+  }
+  const head=tryGit(repoRoot,['rev-parse','HEAD']);
+  const exact=head.ok&&head.value.toLowerCase()===request.commit_sha;
+  addEvidence(evidence,'RELEASE_CORRELATION','git',{code:exact?'AFFECTED_SHA_CHECKED_OUT':'AFFECTED_SHA_PRESENT',commit_sha:request.commit_sha},exact?'SUPPORTED':'PLAUSIBLE',`github-commit:${request.commit_sha}`);
+  const changed=tryGit(repoRoot,['show','--format=','--name-only',request.commit_sha,'--']);
+  const files=changed.ok?[...new Set(changed.value.split(/\r?\n/).map(s=>s.trim()).filter(Boolean))].sort().slice(0,80):[];
+  addEvidence(evidence,'RECENT_DIFF','git',{code:'AFFECTED_COMMIT_FILES',file_count:files.length,files},changed.ok?'SUPPORTED':'UNKNOWN');
+  return {shaState:exact?'EXACT':'PRESENT',files};
+}
+function correlationEvidence(request,evidence){
+  if(!request.commit_sha){addEvidence(evidence,'MISSING_EVIDENCE','f7-correlation',{code:'COMMIT_SHA_UNKNOWN'},'UNKNOWN');return;}
+  if(request.release===`ascenda-os@${request.commit_sha}`){
+    addEvidence(evidence,'RELEASE_CORRELATION','f7-correlation',{code:'RELEASE_SHA_AGREE',release:request.release,commit_sha:request.commit_sha},'SUPPORTED');
+  }else if(request.release){
+    addEvidence(evidence,'RELEASE_CORRELATION','f7-correlation',{code:'RELEASE_SHA_CONTRADICT',release:request.release,commit_sha:request.commit_sha},'UNKNOWN');
+  }else{
+    addEvidence(evidence,'MISSING_EVIDENCE','f7-correlation',{code:'RELEASE_UNKNOWN',commit_sha:request.commit_sha},'UNKNOWN');
+  }
+}
+function domainEvidence(plan,evidence){
+  if(plan.invariant_id)addEvidence(evidence,'CONTRACT_TEST','f6-business-health',{code:'INVARIANT_MATCH',invariant_id:plan.invariant_id},'SUPPORTED',`contract:${plan.invariant_id}`);
+  else addEvidence(evidence,'MISSING_EVIDENCE','f6-business-health',{code:'NO_EXACT_INVARIANT',domain:plan.domain,component:plan.component,capability:plan.capability},'UNKNOWN');
+}
+function buildHypotheses(request,plan,repo,health,evidence){
+  const out=[];
+  const recent=evidence.find(e=>e.kind==='RECENT_DIFF');
+  const files=recent&&recent.result&&Array.isArray(recent.result.files)?recent.result.files:[];
+  const matches=plan.runtime_files.filter(p=>files.includes(p));
+  if(matches.length){
+    out.push({id:'H001',statement_code:'RECENT_DOMAIN_RUNTIME_CHANGE_CANDIDATE',supporting_evidence:[recent.id],contradicting_evidence:[],confidence:'PLAUSIBLE',causality_confirmed:false,matched_paths:matches});
+  }
+  if(health&&health.ok===false){
+    const h=evidence.find(e=>e.kind==='HEALTH_CHECK');
+    out.push({id:`H${String(out.length+1).padStart(3,'0')}`,statement_code:'OUTER_RUNTIME_HEALTH_DEGRADED_CANDIDATE',supporting_evidence:h?[h.id]:[],contradicting_evidence:[],confidence:'PLAUSIBLE',causality_confirmed:false});
+  }
+  if(!out.length){
+    const refs=evidence.filter(e=>e.confidence==='SUPPORTED').map(e=>e.id).slice(0,3);
+    out.push({id:'H001',statement_code:'ROOT_CAUSE_NOT_ESTABLISHED',supporting_evidence:refs,contradicting_evidence:[],confidence:'UNKNOWN',causality_confirmed:false});
+  }
+  return out;
+}
+function assertReportInvariant(report){
+  for(const h of report.hypotheses){
+    if(h.causality_confirmed!==false)fail('F10_CAUSALITY_MUST_REMAIN_UNCONFIRMED');
+    if(!CONFIDENCE.has(h.confidence))fail('F10_HYPOTHESIS_CONFIDENCE_INVALID');
+  }
+  const serialized=JSON.stringify(report);
+  if(/(?:authorization|cookie|password|service_role|apikey|secret)["'=:\s]/i.test(serialized))fail('F10_REPORT_SENSITIVE_OUTPUT');
+}
+function renderMarkdown(report){
+  const lines=[
+    `# Sentinel Diagnostic ${report.incident.incident_id}`,
+    '',
+    `- Diagnostic ID: \`${report.diagnostic_id}\``,
+    `- Revision: ${report.incident.diagnostic_revision}`,
+    `- Severity / status: \`${report.incident.severity}\` / \`${report.incident.status}\``,
+    `- Scope: \`${report.incident.domain}/${report.incident.component}/${report.incident.capability}\``,
+    `- Affected SHA state: \`${report.affected_sha_state}\``,
+    '',
+    '## Evidence'
+  ];
+  for(const e of report.evidence)lines.push(`- **${e.id} ${e.kind}** [${e.confidence}] \`${e.source}\` — \`${e.result.code}\``);
+  lines.push('','## Hypotheses');
+  for(const h of report.hypotheses)lines.push(`- **${h.id}** [${h.confidence}] \`${h.statement_code}\` — causality_confirmed=false`);
+  lines.push('','## Safety','- Read-only diagnostic baseline.','- No production mutation or remediation was executed.','');
+  return lines.join('\n');
+}
+function runDiagnostic(input,{toolingRoot=path.resolve(HERE,'../..'),repoRoot=toolingRoot,health=null}={}){
+  const {request,upstream}=normalizeRequest(input,{toolingRoot});
+  const plan=buildPlan(request,upstream.f6);
+  const evidence=[];
+  addEvidence(evidence,'CONTRACT_TEST','f8-incidents',{code:'SEN_REQUEST_VALIDATED',incident_id:request.incident_id},'SUPPORTED');
+  correlationEvidence(request,evidence);
+  domainEvidence(plan,evidence);
+  const repo=collectRepo(request,repoRoot,evidence);
+  const safeHealth=sanitizeHealth(health);
+  if(safeHealth)addEvidence(evidence,'HEALTH_CHECK','ascenda-health',{code:safeHealth.ok?'HEALTH_OK':'HEALTH_NOT_OK',...safeHealth},safeHealth.ok?'SUPPORTED':'WEAK');
+  else addEvidence(evidence,'MISSING_EVIDENCE','ascenda-health',{code:'HEALTH_NOT_PROVIDED'},'UNKNOWN');
+  const report={
+    schema_version:'sentinel-diagnostic-report/v1',
+    diagnostic_id:`F10-${digest(request).slice(0,20)}`,
+    generated_at:request.observed_at,
+    incident:request,
+    affected_sha_state:repo.shaState,
+    plan,
+    evidence,
+    hypotheses:buildHypotheses(request,plan,repo,safeHealth,evidence),
+    safety:{read_only:true,production_mutation:false,automatic_remediation:false,ai_triage:false}
+  };
+  assertReportInvariant(report);
+  return {report,markdown:renderMarkdown(report),digest:digest(report)};
+}
+function parseArgs(argv){const out={};for(let i=0;i<argv.length;i++){const a=argv[i];if(a.startsWith('--'))out[a.slice(2)]=argv[++i];}return out;}
+if(require.main===module){
+  try{
+    const args=parseArgs(process.argv.slice(2));
+    const toolingRoot=path.resolve(args.tooling||path.resolve(HERE,'../..'));
+    const repoRoot=path.resolve(args.repo||toolingRoot);
+    let input;
+    if(args.request)input=JSON.parse(fs.readFileSync(path.resolve(args.request),'utf8'));
+    else if(process.env.F10_REQUEST_JSON)input=JSON.parse(process.env.F10_REQUEST_JSON);
+    else fail('F10_REQUEST_SOURCE_REQUIRED');
+    if(args['target-sha']){
+      const target=String(args['target-sha']).toLowerCase();if(!SHA.test(target))fail('F10_COMMIT_SHA_INVALID');
+      if(input.commit_sha&&String(input.commit_sha).toLowerCase()!==target)fail('F10_TARGET_SHA_MISMATCH');
+      input={...input,commit_sha:target};
+    }
+    let health=null;if(args.health)health=JSON.parse(fs.readFileSync(path.resolve(args.health),'utf8'));
+    const result=runDiagnostic(input,{toolingRoot,repoRoot,health});
+    const outDir=path.resolve(args.out||'.f10-report');fs.mkdirSync(outDir,{recursive:true});
+    fs.writeFileSync(path.join(outDir,'diagnostic-report.json'),JSON.stringify(result.report,null,2)+'\n');
+    fs.writeFileSync(path.join(outDir,'diagnostic-report.md'),result.markdown);
+    console.log(JSON.stringify({ok:true,certificate:'SENTINEL_F10_DIAGNOSTIC_PASS',diagnostic_id:result.report.diagnostic_id,report_digest:result.digest,affected_sha_state:result.report.affected_sha_state,hypothesis_confidence:result.report.hypotheses.map(h=>h.confidence)}));
+  }catch(err){console.error(err&&err.stack?err.stack:String(err));process.exit(1);}
+}
+
+module.exports={normalizeRequest,buildPlan,runDiagnostic,renderMarkdown,digest};

--- a/sentinel/diagnostics/f10-contract.json
+++ b/sentinel/diagnostics/f10-contract.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "sentinel-diagnostic/v1",
+  "phase": "F10",
+  "purpose": "Produce deterministic, privacy-safe diagnostic evidence for SEN-* incidents without any production mutation path.",
+  "design": {
+    "read_only": true,
+    "zero_phi_pii": true,
+    "production_database_access": false,
+    "production_write_credentials": false,
+    "automatic_fix": false,
+    "automatic_deploy": false,
+    "automatic_rollback": false,
+    "ai_triage": false
+  },
+  "trigger": {"baseline":"workflow_dispatch","public_webhook":false,"automatic_production_trigger":false},
+  "request": {
+    "schema": "sentinel-diagnostic-request/v1",
+    "required_fields": ["incident_id","diagnostic_revision","severity","status","environment","domain","component","capability","failure_family","observed_at"],
+    "optional_fields": ["signal_count","reopened_count","release","commit_sha","deployment_id","evidence_refs"],
+    "incident_id_pattern": "^SEN-[0-9]{4}-[0-9]{4,}$",
+    "commit_sha_pattern": "^[0-9a-f]{40}$",
+    "diagnostic_revision_min": 1,
+    "free_text_payload_forbidden": true
+  },
+  "forbidden_key_fragments": ["patient","paciente","dni","phone","telefono","numero_limpio","email","recipient","destinatario","message","mensaje","body","payload","prompt","authorization","cookie","token","apikey","service_role","secret","password","clinical","clinico","diagnostico_medico"],
+  "evidence": {
+    "allowed_kinds": ["CONTRACT_TEST","SYNTHETIC_REPRO","RECENT_DIFF","HEALTH_CHECK","RELEASE_CORRELATION","DEPENDENCY_STATUS","MISSING_EVIDENCE"],
+    "confidence": ["SUPPORTED","PLAUSIBLE","WEAK","UNKNOWN"],
+    "raw_payload_forbidden": true,
+    "query_strings_forbidden": true,
+    "credentials_forbidden": true
+  },
+  "hypothesis": {"confidence":["SUPPORTED","PLAUSIBLE","WEAK","UNKNOWN"],"causality_confirmed_default":false,"temporal_proximity_is_causality":false},
+  "upstream_contracts": {
+    "f6_business_health": "sentinel/business-health/f6-contract.json",
+    "f7_correlation": "sentinel/correlation/f7-contract.json",
+    "f8_incidents": "sentinel/incidents/f8-contract.json"
+  },
+  "permissions": {"github_contents":"read","pull_requests_write":false,"deployments_write":false,"actions_write":false,"supabase_write":false,"railway_write":false},
+  "gates": {
+    "request_allowlist":true,"sensitive_key_rejection":true,"affected_sha_exact_or_unknown":true,"deterministic_planner":true,"domain_contract_evidence":true,"recent_diff_filenames_only":true,"sanitized_report":true,"deterministic_replay":true,"timeout_and_concurrency":true,"no_production_write_path":true,"rollback_is_workflow_removal":true
+  }
+}


### PR DESCRIPTION
## Sentinel F10 — Diagnostic Runner

**DRAFT / DO NOT MERGE until G01–G15 + exact-head + controlled workflow_dispatch end-to-end are green.**

### Governance
- F1–F9 are `100_COMPLETE`.
- Pre-code Impact Report frozen first in Issue #233 and materialized in `docs/control/SENTINEL_F10_DIAGNOSTIC_RUNNER_IMPACT_REPORT_20260817.md`.
- F10 is HIGH risk but intentionally read-only.

### Anti-scope
F10 does not write production DB/RPC state, modify incidents, merge/deploy, rollback production, generate fixes, or perform AI/MCP triage. F11 owns AI triage; F12 owns remediation.

### Architecture
`SEN-* → sanitized request → controlled GitHub workflow → self-hosted runner → exact affected-SHA checkout → F6/F7/F8 contracts + synthetic evidence + recent filenames + optional read-only /health → deterministic JSON/Markdown diagnostic report`

### Security
- workflow permissions: `contents: read` only;
- checkouts use `persist-credentials:false`;
- no Supabase/Railway write credential is loaded;
- affected commit is checked out into separate `affected/` tree and is not used as the tooling source;
- exact 40-hex SHA required when supplied;
- sensitive input keys rejected recursively;
- evidence refs inherit F8 typed allowlist;
- free payload/message/body/secrets forbidden;
- temporal deploy proximity never confirms causality;
- every hypothesis keeps `causality_confirmed=false` in F10 baseline.

### Determinism / evidence
- stable request hash gives stable diagnostic ID;
- same input produces identical report/digest in contract tests;
- missing/unavailable evidence becomes explicit `UNKNOWN`;
- F6 exact invariant match is used when available;
- F7 release/SHA correlation is evidence, not causal proof;
- git recent-diff evidence contains filenames only, not commit-message text.

### Zero-Cost status
Current head: `b6fed14cd6edc088e798a9088cee42b44cc705c0`.

- FAST contract/syntax gate: PASS on previous implementation head and re-running on current head.
- First Linux attempt reached exact affected-SHA checkout successfully but host lacked global `node` (`exit 127`). This was an infrastructure/runtime assumption, not a diagnostic defect.
- Fix: F10 now executes Node/Git inside disposable `node:22-bookworm`; CREACTIVE host remains unmodified.
- canonical Linux rerun is currently pending/running.

### Remaining gates
G01 contract/denylist → G02 planner → G03 synthetic fixture → G04 exact SHA → G05 read-only permissions → G06 no-write scan → G07 domain contracts → G08 recent diff → G09 timeout/concurrency/idempotency → G10 sanitized reports → G11 Linux Zero-Cost → G12 negatives → G13 logical rollback preserves F1–F9 → G14 controlled synthetic workflow_dispatch → G15 final certificate/Notion/post-merge.

No production DDL is part of the F10 baseline.