### PR TITLE
S15.1 — Auth-bound notification boundary

### DIFF
--- a/.github/workflows/s15-unified-notifications.yml
+++ b/.github/workflows/s15-unified-notifications.yml
@@ -4,15 +4,18 @@ on:
     paths:
       - 'app/server-f17.js'
       - 'app/push-notifications-s14.js'
+      - 'app/public/phase2-service-worker.js'
       - 'app/public/notification-push-s14.js'
       - 'app/public/notification-center-s15.js'
       - 'app/public/icons/channel-*.svg'
       - 'supabase/migrations/20260817224500_s15_unified_notification_events.sql'
       - 'supabase/migrations/20260817224600_s15_topbar_notification_bridge.sql'
       - 'supabase/migrations/20260817224700_s15_legacy_notification_bridge.sql'
+      - 'supabase/migrations/20260817235500_s15_notification_auth_boundary.sql'
       - 'supabase/rollback/20260817224500_s15_unified_notification_events_rollback.sql'
       - 'supabase/rollback/20260817224600_s15_topbar_notification_bridge_rollback.sql'
       - 'supabase/rollback/20260817224700_s15_legacy_notification_bridge_rollback.sql'
+      - 'supabase/rollback/20260817235500_s15_notification_auth_boundary_rollback.sql'
       - 'ci/s15/**'
       - '.github/workflows/s15-unified-notifications.yml'
   push:
@@ -20,12 +23,14 @@ on:
     paths:
       - 'app/server-f17.js'
       - 'app/push-notifications-s14.js'
+      - 'app/public/phase2-service-worker.js'
       - 'app/public/notification-push-s14.js'
       - 'app/public/notification-center-s15.js'
       - 'app/public/icons/channel-*.svg'
       - 'supabase/migrations/20260817224500_s15_unified_notification_events.sql'
       - 'supabase/migrations/20260817224600_s15_topbar_notification_bridge.sql'
       - 'supabase/migrations/20260817224700_s15_legacy_notification_bridge.sql'
+      - 'supabase/migrations/20260817235500_s15_notification_auth_boundary.sql'
       - 'ci/s15/**'
       - '.github/workflows/s15-unified-notifications.yml'
   workflow_dispatch:
@@ -74,3 +79,6 @@ jobs:
       - name: S15 legacy producer bridge contract
         shell: powershell
         run: node ci/s15/legacy_bridge_contract.js
+      - name: S15.1 actor-bound notification authorization contract
+        shell: powershell
+        run: node ci/s15/auth_boundary_contract.js

--- a/app/public/notification-center-s15.js
+++ b/app/public/notification-center-s15.js
@@ -1,4 +1,4 @@
-// ASCENDA S15 — unified in-app notification center.
+// ASCENDA S15.1 — unified in-app notification center with actor-bound F17 reads.
 (function(){
 'use strict';
 if(window.__AOS_NOTIFICATION_CENTER_S15)return;
@@ -33,19 +33,17 @@ function toast(payload){
   setTimeout(function(){if(!d.isConnected)return;d.style.opacity='0';d.style.transform='translateY(-10px)';setTimeout(function(){try{d.remove();}catch(_){}},250);},6500);
 }
 
-function currentUser(){
-  try{var s=JSON.parse(localStorage.getItem('aos_session')||'{}');return String(s.nombre||'').toUpperCase();}catch(_){}
-  try{return String(window.AOS&&AOS.ctx&&AOS.ctx.nombre||'').toUpperCase();}catch(_){return'';}
-}
-function sbRpc(name,payload){
-  var SB='https://ituyqwstonmhnfshnaqz.supabase.co',SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXNlIiwicmVmIjoiaXR1eXF3c3Rvbm1obmZzaG5hcXoiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc3NDc0NDIxOCwiZXhwIjoyMDkwMzIwMjE4fQ.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
-  return fetch(SB+'/rest/v1/rpc/'+name,{method:'POST',headers:{apikey:SK,Authorization:'Bearer '+SK,'Content-Type':'application/json'},body:JSON.stringify(payload||{}),cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP_'+r.status);return r.json();});
+function token(){try{return String(sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'').trim();}catch(_){return '';}}
+function api(path,opts){
+  opts=opts||{};var t=token();if(t.length<32)return Promise.reject(new Error('AOS_APP_SESSION_MISSING'));
+  var h=new Headers(opts.headers||{});h.set('Accept','application/json');h.set('X-AOS-App-Token',t);if(opts.body!=null&&!h.has('Content-Type'))h.set('Content-Type','application/json');
+  return fetch(path,{method:opts.method||'GET',headers:h,body:opts.body==null?undefined:(typeof opts.body==='string'?opts.body:JSON.stringify(opts.body)),cache:'no-store',credentials:'same-origin'}).then(function(r){return r.text().then(function(txt){var d={};try{d=txt?JSON.parse(txt):{};}catch(_){d={};}if(!r.ok||d.ok===false){var e=new Error(d.error||('HTTP_'+r.status));e.status=r.status;throw e;}return d;});});
 }
 function cardIcon(n){return meta(n&&n.channel).emoji;}
 function applyAdminLoadPatch(){
   if(typeof window.lNo!=='function'||window.lNo.__aosS15)return;
   var fallback=window.lNo;
-  var fn=function(){return sbRpc('aos_admin_notificaciones_v1',{p_limit:50}).then(function(d){if(window.D){D.no=d&&d.rows||[];if(D.rpTab==='n'&&typeof window.rNo==='function')window.rNo();}return d;}).catch(function(){try{return fallback();}catch(_){return null;}});};
+  var fn=function(){return api('/api/notifications/inbox?limit=50').then(function(d){if(window.D){D.no=d&&d.rows||[];if(D.rpTab==='n'&&typeof window.rNo==='function')window.rNo();}return d;}).catch(function(){try{return fallback();}catch(_){return null;}});};
   fn.__aosS15=true;fn.__aosFallback=fallback;window.lNo=fn;
   if(document.getElementById('zNL'))setTimeout(function(){try{fn();}catch(_){}},0);
 }
@@ -78,8 +76,8 @@ function applyReadPatch(){
   fn.__aosS15=true;fn.__aosFallback=fallback;window.aRN=fn;
 }
 function readAndOpen(id,route,entityId){
-  var u=currentUser();if(!id){go(route,entityId);return;}
-  sbRpc('aos_marcar_notif_leida',{p_notif_id:id,p_usuario:u}).catch(function(){}).finally(function(){try{if(typeof window.aLoad==='function')window.aLoad();}catch(_){}go(route,entityId);});
+  if(!id){go(route,entityId);return;}
+  api('/api/notifications/read',{method:'POST',body:{id:id}}).catch(function(){}).finally(function(){try{if(typeof window.aLoad==='function')window.aLoad();}catch(_){}go(route,entityId);});
 }
 function patchPanels(){applyAdminLoadPatch();applyAdvisorRenderPatch();applyAdminRenderPatch();applyReadPatch();}
 

--- a/app/public/notification-push-s14.js
+++ b/app/public/notification-push-s14.js
@@ -1,4 +1,4 @@
-// ASCENDA S14/S15 — generic PWA Web Push subscription client + unified notification center loader.
+// ASCENDA S14/S15.1 — generic PWA Web Push subscription client + actor-bound notification center loader.
 (function(){
 'use strict';
 if(window.__AOS_PUSH_S14)return;
@@ -17,7 +17,7 @@ function ensureSubscription(){if(S.busy||!S.enabled)return Promise.resolve(statu
 function enable(){S.enabled=true;try{localStorage.setItem('aos_push_enabled','1');}catch(_){}if(!supported())return Promise.resolve(status());if(Notification.permission==='granted')return ensureSubscription();if(Notification.permission==='default')return Notification.requestPermission().then(function(p){return p==='granted'?ensureSubscription():status();});return Promise.resolve(status());}
 function disable(){S.enabled=false;try{localStorage.setItem('aos_push_enabled','0');}catch(_){}if(!supported())return Promise.resolve(status());return navigator.serviceWorker.ready.then(function(reg){return reg.pushManager.getSubscription();}).then(function(sub){if(!sub)return status();var endpoint=sub.endpoint;return api('/api/push/unsubscribe',{method:'POST',body:{endpoint:endpoint}}).catch(function(){}).then(function(){return sub.unsubscribe();}).then(function(){return status();});}).catch(function(){return status();});}
 function status(){return {version:S.version,supported:supported(),enabled:S.enabled,permission:typeof Notification==='undefined'?'unsupported':Notification.permission,busy:S.busy,last:S.last};}
-function loadCenter(){if(window.__AOS_NOTIFICATION_CENTER_S15||document.querySelector('script[data-aos-notification-center]'))return;var s=document.createElement('script');s.src='/notification-center-s15.js?v=20260817-s15-p01';s.async=true;s.dataset.aosNotificationCenter='1';document.head.appendChild(s);}
+function loadCenter(){if(window.__AOS_NOTIFICATION_CENTER_S15||document.querySelector('script[data-aos-notification-center]'))return;var s=document.createElement('script');s.src='/notification-center-s15.js?v=20260817-s15-auth-p02';s.async=true;s.dataset.aosNotificationCenter='1';document.head.appendChild(s);}
 function bindPermissionGesture(){document.addEventListener('click',function(e){if(!S.enabled||!supported()||Notification.permission!=='default')return;var node=e.target&&e.target.closest?e.target.closest('#nav-admin-whatsapp,#nav-whatsapp-agent,#nav-advisor-coord,#nav-admin-coord,#nav-admin-chats,#nav-advisor-sales,#nav-admin-sales,#nav-advisor-commissions,#nav-admin-commissions,#nav-advisor-agenda,#nav-advisor-citas,#nav-admin-agenda'):null;if(node)enable().catch(function(){});},{capture:true});}
 function boot(){loadCenter();bindPermissionGesture();if(S.enabled&&supported()&&Notification.permission==='granted')setTimeout(function(){ensureSubscription();},1200);}
 

--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -1,4 +1,4 @@
-// ASCENDA OS Phase 2/F4/F9/WA-S14 — controlled-write + revenue + Sentinel + generic Web Push bridge.
+// ASCENDA OS Phase 2/F4/F9/WA-S14/S15.1 — controlled-write + revenue + Sentinel + actor-bound notification bridge.
 'use strict';
 self.addEventListener('install',function(){self.skipWaiting();});
 self.addEventListener('activate',function(e){e.waitUntil(self.clients.claim());});
@@ -48,6 +48,13 @@ function isMissing(r){return r.status===404||r.status===400;}
 function parseMatch(u){var out={};u.searchParams.forEach(function(v,k){if(k==='select'||k==='order'||k==='limit'||k==='offset')return;if(String(v).indexOf('eq.')!==0)throw new Error('FILTER_NOT_ALLOWED');out[k]=String(v).slice(3);});return out;}
 async function requestJson(req){try{return await req.clone().json();}catch(e){return {};}}
 async function rpcFrom(req,name,payload){var u=new URL(req.url);var target=u.origin+'/rest/v1/rpc/'+name;var h=new Headers(req.headers);h.set('Content-Type','application/json');return fetch(target,{method:'POST',headers:h,body:JSON.stringify(payload),credentials:req.credentials,mode:req.mode==='navigate'?'cors':req.mode,cache:'no-store'});}
+async function notificationApi(path,method,body){
+  var t=String(await getToken()).trim();if(t.length<32)return json({ok:false,error:'NOTIFICATION_APP_SESSION_REQUIRED'},401);
+  var h=new Headers({'Accept':'application/json','X-AOS-App-Token':t});
+  var opts={method:method||'GET',headers:h,cache:'no-store',credentials:'same-origin'};
+  if(body!==undefined){h.set('Content-Type','application/json');opts.body=JSON.stringify(body);}
+  try{return await fetch(self.location.origin+path,opts);}catch(_){return json({ok:false,error:'NOTIFICATION_BRIDGE_UNAVAILABLE'},503);}
+}
 
 async function injectF4(req){
   var r=await fetch(req,{cache:'no-store'});if(!r.ok)return r;
@@ -72,7 +79,7 @@ async function injectF4(req){
     tags+='<script src="/wa-human-alerts.js?v=20260817-wa-alerts-s14-p01"></script>';
   }
   if(html.indexOf('/notification-push-s14.js')<0){
-    tags+='<script src="/notification-push-s14.js?v=20260817-push-s14-p01"></script>';
+    tags+='<script src="/notification-push-s14.js?v=20260817-push-s15-auth-p02"></script>';
   }
   if(html.indexOf('/sentinel-inapp-notifications.js')<0){
     tags+='<script src="/sentinel-inapp-notifications.js?v=20260816-f9-inapp-v1"></script>';
@@ -116,12 +123,20 @@ self.addEventListener('fetch',function(event){
     event.respondWith(Response.redirect(u.origin+'/app.html#admin-whatsapp',302));return;
   }
   // Same-origin governed APIs use the already-controlled Phase 2 token cache.
-  if(u.origin===self.location.origin&&(u.pathname.indexOf('/api/wa3/')===0||u.pathname.indexOf('/api/wa/')===0||u.pathname.indexOf('/api/push/')===0)){
+  if(u.origin===self.location.origin&&(u.pathname.indexOf('/api/wa3/')===0||u.pathname.indexOf('/api/wa/')===0||u.pathname.indexOf('/api/push/')===0||u.pathname.indexOf('/api/notifications/')===0)){
     event.respondWith(injectSameOriginAppToken(req));return;
   }
   if(u.hostname.indexOf('supabase.co')<0)return;
 
   var rm=u.pathname.match(/\/rest\/v1\/rpc\/([^/]+)$/);
+  // Existing app-shell bell still calls these legacy RPC names. Keep its UI contract,
+  // but bind identity to the verified application token through F17 instead of trusting p_id_asesor.
+  if(rm&&rm[1]==='aos_list_notificaciones'){
+    event.respondWith(notificationApi('/api/notifications/inbox?limit=30','GET'));return;
+  }
+  if(rm&&rm[1]==='aos_mark_notif_read'){
+    event.respondWith((async function(){var p=await requestJson(req);return notificationApi('/api/notifications/read','POST',{id:p.p_id});})());return;
+  }
   if(rm&&IDENTITY[rm[1]]){
     event.respondWith((async function(){var p=await requestJson(req);p.p_token=await getToken();if(rm[1]==='aos_admin_cambiar_password'&&!p.p_usuario_id){return json({ok:false,error:'LEGACY_IDENTITY_FLOW_RETIRED'},403);}if(rm[1]==='aos_cambiar_password')p={p_token:p.p_token,p_password_actual:p.p_password_actual,p_password_nuevo:p.p_password_nuevo};var r=await rpcFrom(req,IDENTITY[rm[1]],p);if(isMissing(r))return fetch(req);return r;})());return;
   }

--- a/app/server-f17.js
+++ b/app/server-f17.js
@@ -40,7 +40,7 @@ function requestSupabase(name, payload, service) {
     if (!key) return reject(new Error(service ? 'SUPABASE_SERVICE_ROLE_NOT_CONFIGURED' : 'SUPABASE_ANON_KEY_NOT_CONFIGURED'))
     let url; try { url = new URL(SB_URL) } catch (e) { return reject(e) }
     const body = JSON.stringify(payload || {})
-    const headers = { apikey: key, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), 'User-Agent': 'AscendaOS-F17/1.3' }
+    const headers = { apikey: key, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), 'User-Agent': 'AscendaOS-F17/1.4' }
     if (!/^sb_(?:secret|publishable)_/i.test(key)) headers.Authorization = 'Bearer ' + key
     const req = https.request({ hostname: url.hostname, port: url.port || 443, path: '/rest/v1/rpc/' + encodeURIComponent(name), method: 'POST', headers: headers, timeout: 12000 }, function(res) {
       let raw = ''
@@ -115,6 +115,35 @@ function proxyBuffered(req, raw, callback) {
   })
   q.on('error', function(e) { callback(e) })
   q.write(raw); q.end()
+}
+
+async function handleNotificationInbox(req, res, url) {
+  const actor = await verifyApp(req.headers['x-aos-app-token'], false)
+  if (!actor.ok) return writeJson(res, actor.status || 403, { ok: false, error: 'NOTIFICATION_APP_SESSION_REQUIRED' })
+  const limit = Math.max(1, Math.min(100, Number(url.searchParams.get('limit') || 50)))
+  try {
+    const out = await serviceRpc('aos_notification_inbox_actor_v1', { p_payload: { actor_id: actor.actor_id, limit: limit } })
+    return writeJson(res, 200, out || { ok: true, unreadNotifs: 0, unreadMsgs: 0, items: [], rows: [] })
+  } catch (e) {
+    console.error('[S15.1] notification inbox', e.message)
+    return writeJson(res, 503, { ok: false, error: 'NOTIFICATION_INBOX_UNAVAILABLE' })
+  }
+}
+
+async function handleNotificationRead(req, res) {
+  let raw; try { raw = await readRaw(req, 16 * 1024) } catch (e) { return writeJson(res, e.status || 400, { ok: false, error: e.message }) }
+  const body = parseJson(raw.toString('utf8'))
+  if (!body || !UUID_RE.test(String(body.id || ''))) return writeJson(res, 400, { ok: false, error: 'NOTIFICATION_ID_REQUIRED' })
+  const actor = await verifyApp(req.headers['x-aos-app-token'], false)
+  if (!actor.ok) return writeJson(res, actor.status || 403, { ok: false, error: 'NOTIFICATION_APP_SESSION_REQUIRED' })
+  try {
+    const out = await serviceRpc('aos_notification_mark_read_actor_v1', { p_payload: { actor_id: actor.actor_id, notification_id: body.id } })
+    if (!out || out.ok !== true) return writeJson(res, 403, out || { ok: false, error: 'NOTIFICATION_READ_REJECTED' })
+    return writeJson(res, 200, out)
+  } catch (e) {
+    console.error('[S15.1] notification read', e.message)
+    return writeJson(res, 503, { ok: false, error: 'NOTIFICATION_READ_UNAVAILABLE' })
+  }
 }
 
 async function handlePushConfig(req, res) {
@@ -205,6 +234,9 @@ async function handleGovernedWebhook(req, res) {
 
 const server = http.createServer(async function(req, res) {
   let url; try { url = new URL(req.url, 'http://localhost') } catch (_) { return writeJson(res, 400, { ok: false, error: 'INVALID_URL' }) }
+  if (url.pathname === '/api/notifications/health' && req.method === 'GET') return writeJson(res, 200, { ok: true, version: 'S15.1', auth: 'actor-bound' })
+  if (url.pathname === '/api/notifications/inbox' && req.method === 'GET') return handleNotificationInbox(req, res, url)
+  if (url.pathname === '/api/notifications/read' && req.method === 'POST') return handleNotificationRead(req, res)
   if (url.pathname === '/api/push/config' && req.method === 'GET') return handlePushConfig(req, res)
   if (url.pathname === '/api/push/subscribe' && req.method === 'POST') return handlePushSubscribe(req, res)
   if (url.pathname === '/api/push/unsubscribe' && req.method === 'POST') return handlePushUnsubscribe(req, res)
@@ -222,9 +254,9 @@ function start() {
   child = spawn(process.execPath, ['server-f5.js'], { cwd: __dirname, env: Object.assign({}, process.env, { PORT: String(INNER_PORT) }), stdio: ['ignore', 'inherit', 'inherit'] })
   child.on('exit', function(code) { process.exit(code == null ? 1 : code) })
   server.listen(EXTERNAL_PORT, '0.0.0.0', function() {
-    console.log('[F17] listening', { external: EXTERNAL_PORT, inner: INNER_PORT, gatewayConfigured: gateway.configured(), whatsappGoverned: true, pushVersion: 'AOS_PUSH_V1', notificationEvents: 'S15' })
+    console.log('[F17] listening', { external: EXTERNAL_PORT, inner: INNER_PORT, gatewayConfigured: gateway.configured(), whatsappGoverned: true, pushVersion: 'AOS_PUSH_V1', notificationEvents: 'S15.1' })
     push.ensureVapid().then(function() { console.log('[S14] VAPID ready'); startNotificationPump() }).catch(function(e) { console.error('[S14] VAPID deferred', e.message); startNotificationPump() })
   })
 }
 if (require.main === module) start()
-module.exports = { verifyApp: verifyApp, gateway: gateway, f17wa: f17wa, push: push, server: server, start: start, runNotificationPump: runNotificationPump }
+module.exports = { verifyApp: verifyApp, gateway: gateway, f17wa: f17wa, push: push, server: server, start: start, runNotificationPump: runNotificationPump, handleNotificationInbox: handleNotificationInbox, handleNotificationRead: handleNotificationRead }

--- a/ci/s15/auth_boundary_contract.js
+++ b/ci/s15/auth_boundary_contract.js
@@ -1,0 +1,53 @@
+'use strict'
+const fs=require('fs'),path=require('path')
+const root=path.resolve(__dirname,'../..')
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260817235500_s15_notification_auth_boundary.sql'),'utf8')
+const rollback=fs.readFileSync(path.join(root,'supabase/rollback/20260817235500_s15_notification_auth_boundary_rollback.sql'),'utf8')
+const server=fs.readFileSync(path.join(root,'app/server-f17.js'),'utf8')
+const sw=fs.readFileSync(path.join(root,'app/public/phase2-service-worker.js'),'utf8')
+const center=fs.readFileSync(path.join(root,'app/public/notification-center-s15.js'),'utf8')
+const pushClient=fs.readFileSync(path.join(root,'app/public/notification-push-s14.js'),'utf8')
+function ok(v,m){if(!v){console.error('S15.1 AUTH CONTRACT FAIL:',m);process.exit(1)}}
+
+ok(migration.includes('create or replace function public.aos_notification_inbox_actor_v1'),'actor inbox RPC missing')
+ok(migration.includes('create or replace function public.aos_notification_mark_read_actor_v1'),'actor mark-read RPC missing')
+ok(migration.includes("begin uid:=(p_payload->>'actor_id')::uuid"),'actor inbox must bind to UUID supplied by trusted server')
+ok(migration.includes("x.para_user_id=uid")||migration.includes('n.para_user_id=uid'),'actor visibility must include canonical user UUID')
+ok(migration.includes('NOTIFICATION_NOT_VISIBLE_TO_ACTOR'),'mark-read must enforce recipient visibility')
+for(const sig of [
+  'public.aos_notification_inbox_actor_v1(jsonb)',
+  'public.aos_notification_mark_read_actor_v1(jsonb)',
+  'public.aos_list_notificaciones(text,date)',
+  'public.aos_mark_notif_read(uuid)',
+  'public.aos_admin_notificaciones_v1(integer)',
+  'public.aos_mis_notificaciones_v1(text,integer)'
+]) ok(migration.includes('revoke all on function '+sig+' from public,anon,authenticated'),'public/anon revoke missing: '+sig)
+ok(migration.includes('grant execute on function public.aos_notification_inbox_actor_v1(jsonb) to service_role'),'actor inbox must be service-role only')
+ok(migration.includes('grant execute on function public.aos_notification_mark_read_actor_v1(jsonb) to service_role'),'actor read must be service-role only')
+
+ok(server.includes("url.pathname === '/api/notifications/inbox'"),'F17 notification inbox endpoint missing')
+ok(server.includes("url.pathname === '/api/notifications/read'"),'F17 notification read endpoint missing')
+ok(server.includes("url.pathname === '/api/notifications/health'"),'F17 deploy health endpoint missing')
+ok(server.includes("verifyApp(req.headers['x-aos-app-token'], false)"),'F17 notification endpoints must verify application token')
+ok(server.includes("actor_id: actor.actor_id"),'F17 must derive notification identity from verified actor')
+ok(server.includes("serviceRpc('aos_notification_inbox_actor_v1'"),'F17 actor inbox service call missing')
+ok(server.includes("serviceRpc('aos_notification_mark_read_actor_v1'"),'F17 actor read service call missing')
+
+ok(sw.includes("u.pathname.indexOf('/api/notifications/')===0"),'service worker token bridge must cover notification APIs')
+ok(sw.includes("rm[1]==='aos_list_notificaciones'"),'topbar legacy list RPC interception missing')
+ok(sw.includes("notificationApi('/api/notifications/inbox?limit=30','GET')"),'topbar list must route to actor-bound F17')
+ok(sw.includes("rm[1]==='aos_mark_notif_read'"),'topbar legacy mark-read interception missing')
+ok(sw.includes("notificationApi('/api/notifications/read','POST',{id:p.p_id})"),'topbar read must route to actor-bound F17')
+
+ok(center.includes("api('/api/notifications/inbox?limit=50')"),'unified center must use same-origin actor inbox')
+ok(center.includes("api('/api/notifications/read',{method:'POST',body:{id:id}})"),'unified center must use actor-bound mark-read endpoint')
+ok(!center.includes('supabase.co'),'unified center must not directly call Supabase')
+ok(!center.includes('eyJhbGciOi'),'unified center must not embed anon JWT')
+ok(!center.includes('aos_admin_notificaciones_v1'),'new admin center must not trust direct legacy reader')
+ok(pushClient.includes('/notification-center-s15.js?v=20260817-s15-auth-p02'),'auth-hardened notification center cache version missing')
+ok(sw.includes('/notification-push-s14.js?v=20260817-push-s15-auth-p02'),'service-worker client cache version missing')
+
+ok(rollback.includes('drop function if exists public.aos_notification_inbox_actor_v1(jsonb)'),'actor inbox rollback missing')
+ok(rollback.includes('grant execute on function public.aos_list_notificaciones(text,date) to anon,authenticated,service_role'),'compatibility rollback grant missing')
+
+console.log('S15.1 actor-bound notification authorization contract PASS')

--- a/ci/s15/contract.js
+++ b/ci/s15/contract.js
@@ -42,10 +42,10 @@ ok(server.includes('setInterval(function() { runNotificationPump()'), 'notificat
 ok(server.includes("console.error('[S15] notification pump fail-open'"),'notification pump must be fail-open')
 ok(server.includes('stopNotificationPump(); server.close'),'pump shutdown cleanup missing')
 
-ok(client.includes("'/notification-center-s15.js?v=20260817-s15-p01'"),'global notification center loader missing')
+ok(client.includes("'/notification-center-s15.js?v=20260817-s15-p01'")||client.includes("'/notification-center-s15.js?v=20260817-s15-auth-p02'"),'global notification center loader missing')
 ok(client.includes('#nav-advisor-sales')&&client.includes('#nav-admin-agenda'),'notification opt-in gesture must cover non-WhatsApp modules')
 ok(center.includes("d.type==='AOS_PUSH_EVENT'"),'open-app generic push listener missing')
-ok(center.includes("sbRpc('aos_admin_notificaciones_v1'"),'admin notification filter patch missing')
+ok(center.includes("sbRpc('aos_admin_notificaciones_v1'")||center.includes("api('/api/notifications/inbox?limit=50')"),'admin notification filter patch missing')
 ok(center.includes('AOS_NOTIFICATION_CENTER.readAndOpen'),'notification read+route UX missing')
 for(const ch of ['WHATSAPP','SALES','COMMISSION','AGENDA','CHAT','TASKS','SENTINEL','SYSTEM'])ok(center.includes(ch+':{')||center.includes(ch+"':{"),'channel visual distinction missing: '+ch)
 

--- a/supabase/migrations/20260817235500_s15_notification_auth_boundary.sql
+++ b/supabase/migrations/20260817235500_s15_notification_auth_boundary.sql
@@ -1,0 +1,161 @@
+-- ASCENDA S15.1 — notification authorization boundary.
+-- Browser identity parameters are no longer trusted for the new S15 notification readers.
+
+create or replace function public.aos_notification_inbox_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  uid uuid;
+  uname text;
+  is_admin boolean:=false;
+  lim integer:=least(100,greatest(1,coalesce((p_payload->>'limit')::integer,50)));
+  rows jsonb;
+  unread_notifs integer:=0;
+  unread_msgs integer:=0;
+begin
+  begin uid:=(p_payload->>'actor_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTOR_ID'); end;
+  select nombre,(upper(coalesce(rol,''))='ADMIN' or coalesce(nivel_jerarquia,999)=1)
+    into uname,is_admin
+    from public.aos_usuarios
+   where id=uid and activo=true;
+  if uname is null then return jsonb_build_object('ok',false,'error','ACTIVE_ACTOR_REQUIRED'); end if;
+
+  select coalesce(jsonb_agg(jsonb_build_object(
+    'id',x.id,
+    'titulo',x.titulo,
+    'contenido',x.contenido,
+    'cuerpo',x.contenido,
+    'tipo',x.tipo,
+    'prioridad',x.prioridad,
+    'channel',x.channel,
+    'event_type',x.event_type,
+    'route',x.route,
+    'entity_id',x.entity_id,
+    'icon',x.icon,
+    'created_at',x.created_at,
+    'fecha',to_char(x.created_at at time zone 'America/Lima','YYYY-MM-DD'),
+    'hora',to_char(x.created_at at time zone 'America/Lima','HH24:MI:SS'),
+    'leido',(x.leido_por ? uname),
+    'tsLeido',case when x.leido_por ? uname then x.created_at else null end
+  ) order by x.created_at desc),'[]'::jsonb)
+  into rows
+  from (
+    select n.*
+      from public.aos_notificaciones n
+     where n.in_app_enabled=true
+       and (n.expira_at is null or n.expira_at>now())
+       and (
+         n.para_user_id=uid
+         or (n.para_user_id is null and n.para is null)
+         or (n.para_user_id is null and upper(coalesce(n.para,''))=upper(uname))
+         or (n.para_user_id is null and upper(coalesce(n.para,''))='ADMIN' and is_admin)
+       )
+     order by n.created_at desc
+     limit lim
+  ) x;
+
+  select count(*) into unread_notifs
+    from public.aos_notificaciones n
+   where n.in_app_enabled=true
+     and (n.expira_at is null or n.expira_at>now())
+     and not (n.leido_por ? uname)
+     and (
+       n.para_user_id=uid
+       or (n.para_user_id is null and n.para is null)
+       or (n.para_user_id is null and upper(coalesce(n.para,''))=upper(uname))
+       or (n.para_user_id is null and upper(coalesce(n.para,''))='ADMIN' and is_admin)
+     );
+
+  select count(*) into unread_msgs
+    from public.aos_mensajes m
+    join public.aos_canales c on c.id=m.canal
+   where coalesce(m.eliminado,false)=false
+     and upper(trim(coalesce(m.de,'')))<>upper(uname)
+     and coalesce(c.participantes,'[]'::jsonb) ? uname
+     and not (coalesce(m.leido_por,'[]'::jsonb) ? uname);
+
+  return jsonb_build_object(
+    'ok',true,
+    'actor_id',uid,
+    'actor_name',uname,
+    'is_admin',is_admin,
+    'unreadNotifs',coalesce(unread_notifs,0),
+    'unreadMsgs',coalesce(unread_msgs,0),
+    'items',coalesce(rows,'[]'::jsonb),
+    'rows',coalesce(rows,'[]'::jsonb)
+  );
+end;
+$$;
+
+create or replace function public.aos_notification_mark_read_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  uid uuid;
+  nid uuid;
+  uname text;
+  is_admin boolean:=false;
+  allowed boolean:=false;
+  n integer:=0;
+begin
+  begin
+    uid:=(p_payload->>'actor_id')::uuid;
+    nid:=(p_payload->>'notification_id')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_IDS');
+  end;
+
+  select nombre,(upper(coalesce(rol,''))='ADMIN' or coalesce(nivel_jerarquia,999)=1)
+    into uname,is_admin
+    from public.aos_usuarios
+   where id=uid and activo=true;
+  if uname is null then return jsonb_build_object('ok',false,'error','ACTIVE_ACTOR_REQUIRED'); end if;
+
+  select exists(
+    select 1 from public.aos_notificaciones x
+     where x.id=nid
+       and x.in_app_enabled=true
+       and (x.expira_at is null or x.expira_at>now())
+       and (
+         x.para_user_id=uid
+         or (x.para_user_id is null and x.para is null)
+         or (x.para_user_id is null and upper(coalesce(x.para,''))=upper(uname))
+         or (x.para_user_id is null and upper(coalesce(x.para,''))='ADMIN' and is_admin)
+       )
+  ) into allowed;
+  if not allowed then return jsonb_build_object('ok',false,'error','NOTIFICATION_NOT_VISIBLE_TO_ACTOR'); end if;
+
+  update public.aos_notificaciones
+     set leido_por=case when coalesce(leido_por,'[]'::jsonb) ? uname then coalesce(leido_por,'[]'::jsonb) else coalesce(leido_por,'[]'::jsonb)||to_jsonb(uname) end,
+         updated_at=now()
+   where id=nid;
+  get diagnostics n=row_count;
+  return jsonb_build_object('ok',n=1,'id',nid,'actor_id',uid);
+end;
+$$;
+
+-- New actor-bound functions are server-only.
+revoke all on function public.aos_notification_inbox_actor_v1(jsonb) from public,anon,authenticated;
+revoke all on function public.aos_notification_mark_read_actor_v1(jsonb) from public,anon,authenticated;
+grant execute on function public.aos_notification_inbox_actor_v1(jsonb) to service_role;
+grant execute on function public.aos_notification_mark_read_actor_v1(jsonb) to service_role;
+
+-- Retire public execution on S15 readers introduced for UI compatibility.
+-- F17 + the service worker now form the authorization bridge.
+revoke all on function public.aos_list_notificaciones(text,date) from public,anon,authenticated;
+revoke all on function public.aos_mark_notif_read(uuid) from public,anon,authenticated;
+revoke all on function public.aos_admin_notificaciones_v1(integer) from public,anon,authenticated;
+revoke all on function public.aos_mis_notificaciones_v1(text,integer) from public,anon,authenticated;
+grant execute on function public.aos_list_notificaciones(text,date) to service_role;
+grant execute on function public.aos_mark_notif_read(uuid) to service_role;
+grant execute on function public.aos_admin_notificaciones_v1(integer) to service_role;
+grant execute on function public.aos_mis_notificaciones_v1(text,integer) to service_role;
+
+comment on function public.aos_notification_inbox_actor_v1(jsonb) is 'S15.1 server-only notification inbox bound to verified ASCENDA actor UUID.';
+comment on function public.aos_notification_mark_read_actor_v1(jsonb) is 'S15.1 server-only read marker enforcing notification visibility for verified actor.';

--- a/supabase/rollback/20260817235500_s15_notification_auth_boundary_rollback.sql
+++ b/supabase/rollback/20260817235500_s15_notification_auth_boundary_rollback.sql
@@ -1,0 +1,9 @@
+-- ASCENDA S15.1 rollback — restore the pre-hardening compatibility grants.
+
+drop function if exists public.aos_notification_inbox_actor_v1(jsonb);
+drop function if exists public.aos_notification_mark_read_actor_v1(jsonb);
+
+grant execute on function public.aos_list_notificaciones(text,date) to anon,authenticated,service_role;
+grant execute on function public.aos_mark_notif_read(uuid) to anon,authenticated,service_role;
+grant execute on function public.aos_admin_notificaciones_v1(integer) to anon,authenticated,service_role;
+grant execute on function public.aos_mis_notificaciones_v1(text,integer) to anon,authenticated,service_role;


### PR DESCRIPTION
Hardens the S15 notification plane without changing notification behavior.

Scope:
- actor-bound inbox and mark-read RPCs keyed by verified ASCENDA user UUID;
- F17 authenticated notification endpoints using X-AOS-App-Token;
- existing app-shell bell compatibility RPCs are intercepted by the service worker and routed to F17;
- unified notification center no longer embeds/calls Supabase anon directly;
- service worker token bridge extended to /api/notifications/*;
- prepares revocation of anon/authenticated execute on new S15 reader RPCs;
- rollback and CI authorization contract included.

Deployment safety: the database revocation migration must be applied only after this runtime is confirmed live in Railway, so stale clients do not lose their notification bell during rollout.