### PR TITLE
Sync current main into S15.2

### DIFF
--- a/docs/control/SENTINEL_CONTROL_MASTER.md
+++ b/docs/control/SENTINEL_CONTROL_MASTER.md
@@ -1,11 +1,13 @@
 # Sentinel — Control Maestro
 
-**Estado:** CURRENT / CANONICAL / DESIGN BASELINE  
+**Estado:** `CERRADA / 100_COMPLETE / CANONICAL BASELINE V1`  
 **Fecha:** 2026-08-16/17 (America/Lima)  
 **Repositorio:** `CESARJAUREGUITORRES/ascenda-os`  
 **Workstream:** `SENTINEL`  
 **Rama fundacional:** `docs/sentinel-control-v1`  
-**Ámbito:** observabilidad, detección, correlación, triage, incidentes y respuesta segura para ASCENDA OS.
+**Ámbito:** observabilidad, detección, correlación, triage, incidentes y respuesta segura para ASCENDA OS.  
+**Roadmap terminal:** `docs/control/SENTINEL_ROADMAP_V1.md`  
+**Certificado F13:** `docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md`
 
 ---
 
@@ -22,7 +24,7 @@ Sentinel observa; los dominios funcionales continúan gobernando sus propios dat
 3. **Vendor-neutral by design.** Sentinel no depende estructuralmente de Sentry. OpenTelemetry y contratos propios de Sentinel definen la capa portable.
 4. **Cost-bounded observability.** Ningún sensor puede generar gasto cloud adicional sin gate económico y autorización expresa según `ASCENDA_ZERO_COST_VALIDATION_STANDARD.md`.
 5. **Fail-closed para automatización.** La detección puede ser automática; la mutación de producción nunca lo será por defecto.
-6. **No false-green.** Si Sentinel no puede observar una capacidad debe devolver `UNKNOWN`, no `HEALTHY`.
+6. **No false-green.** Si Sentinel no puede observar una capacidad devuelve `UNKNOWN`, no `HEALTHY`.
 7. **No duplicar fuentes de verdad.** Sentinel guarda evidencia operacional y metadatos de incidentes, no copias de datos clínicos/comerciales.
 8. **Toda remediación sigue branch → CI → staging/fixture → PR → canary → autorización → producción cuando corresponda.**
 
@@ -30,34 +32,35 @@ Sentinel observa; los dominios funcionales continúan gobernando sus propios dat
 
 ### 3.1 Por qué no Sentry-only
 
-Sentry es excelente para excepciones, stack traces, issues agrupados, tracing, releases y debugging, pero no detecta por sí solo todos los fallos funcionales. Un endpoint puede responder HTTP 200 y, aun así, devolver cero leads, una cola vacía o una regla de negocio rota.
+Sentry es un sensor de alto valor para excepciones, stack traces, issues agrupados, tracing, releases y debugging, pero no detecta por sí solo todos los fallos funcionales. Un endpoint puede responder HTTP 200 y, aun así, devolver cero leads, una cola vacía o una regla de negocio rota.
 
-Además, el plan Developer es suficiente para una primera capa humana de debugging, pero Sentinel no debe diseñar su panel o incident engine dependiendo de una API/feature que pueda requerir un plan superior.
+Sentinel no diseña su panel ni su Incident Engine dependiendo de una API/feature propietaria concreta.
 
 ### 3.2 Por qué no open-source-only desde el día 1
 
-Es técnicamente viable reemplazar Sentry por una combinación self-hosted, pero añade infraestructura, mantenimiento, backups, upgrades y otra superficie de fallo antes de que exista necesidad real. El objetivo inicial es obtener alta señal con costo marginal mínimo.
+Es técnicamente viable reemplazar Sentry por una combinación self-hosted, pero añade infraestructura, mantenimiento, backups, upgrades y otra superficie de fallo. La baseline prioriza alta señal con costo marginal mínimo y mantiene una ruta portable.
 
 ### 3.3 Estrategia adoptada
 
 - **Sentry Cloud Developer:** sensor especializado de errores/traces de alto valor; no es la base de datos de Sentinel.
 - **OpenTelemetry:** contrato portable de telemetría y futura capa de routing/filter/redaction/sampling.
-- **UptimeRobot Free:** cobertura cloud continua del endpoint público `/health` para disponibilidad externa sin costo incremental.
-- **Uptime Kuma:** observador local/intermitente en CREACTIVE con persistencia, autoarranque Docker y reconciliación de coverage gaps.
+- **UptimeRobot Free:** cobertura cloud continua del endpoint público `/health` sin costo incremental.
+- **Uptime Kuma:** observador local/intermitente en CREACTIVE con persistencia, autoarranque Docker y coverage gaps explícitos.
 - **Sentinel Core:** topología, reglas de negocio, estados, incidentes `SEN-*`, severidad, evidencias y correlación.
-- **Supabase:** persistencia mínima versionada de estado/incidentes Sentinel; F8 estableció la primera capa productiva protegida y F9 añadió estado durable de alertas/noise control.
-- **GitHub:** código, releases, commits, PR, CI y evidencia reproducible.
-- **Railway:** runtime/deploy actual; se correlaciona, no se reemplaza.
-- **Telegram:** canal owner para incidentes relevantes; nunca se usa como fuente canónica.
-- **GlitchTip:** ruta de portabilidad/self-hosting compatible con SDK Sentry si en el futuro costo, control o residencia de datos lo justifican.
+- **Supabase:** persistencia mínima versionada de incidentes/alertas; F8/F9/F13 usan boundaries gobernados.
+- **GitHub + self-hosted CI:** código, releases, commits, PR, diagnóstico, candidate remediation y evidencia reproducible.
+- **Railway:** runtime/deploy actual; se correlaciona y observa, no se reemplaza.
+- **ASCENDA in-app:** canal owner/admin canónico para alertas Sentinel, con dedup/noise-control y read receipts separados de delivery.
+- **Telegram `F9-T`:** transporte externo opcional y `DEFERRED / NON-BLOCKING`; no es dependencia estructural ni gate de la baseline.
+- **GlitchTip u otro backend compatible:** ruta futura de portabilidad/self-hosting si costo, control o residencia de datos lo justifican.
 
 ## 4. Modelo de observación
 
 Sentinel combina cuatro tipos de señal:
 
-1. **Technical Errors** — excepciones, crashes, stack traces, rejects y fallos runtime.
-2. **Availability** — HTTP/TCP/health checks y disponibilidad externa.
-3. **Business Health** — invariantes funcionales, freshness, cardinalidades esperadas, colas, sincronizaciones y contratos operativos.
+1. **Technical Errors** — excepciones, crashes, rejects y fallos runtime.
+2. **Availability** — HTTP/health checks y disponibilidad externa.
+3. **Business Health** — invariantes funcionales, freshness, cardinalidades, colas, sincronizaciones y contratos operativos.
 4. **Dependencies** — Supabase, Railway, Meta/WhatsApp, Resend/email, IA/providers y otras integraciones.
 
 Ninguna señal individual puede declarar salud global por sí sola.
@@ -72,7 +75,7 @@ Ninguna señal individual puede declarar salud global por sí sola.
 
 ## 6. Taxonomía mínima obligatoria
 
-Toda señal/incident debe poder correlacionarse, cuando aplique, con:
+Toda señal/incidente debe poder correlacionarse, cuando aplique, con:
 
 - `system=ascenda-os`
 - `environment`
@@ -89,7 +92,7 @@ Toda señal/incident debe poder correlacionarse, cuando aplique, con:
 - `incident_id`
 - `sede` solo si puede representarse sin PII/PHI y aporta diagnóstico
 
-No se usarán identificadores de pacientes/personas como tags de observabilidad.
+No se usan identificadores de pacientes/personas como tags de observabilidad.
 
 ## 7. Incident ID
 
@@ -97,11 +100,11 @@ Formato canónico:
 
 `SEN-YYYY-NNNN`
 
-F8 certificó generación transaccional anual, replay idempotente, convergencia explícita por fingerprint, escalamiento de severidad, lifecycle y reopen del mismo ID dentro de la ventana gobernada.
+F8 certificó generación transaccional anual, replay idempotente, convergencia por fingerprint, escalamiento de severidad, lifecycle y reopen del mismo ID dentro de la ventana gobernada.
 
-Un incidente puede relacionar múltiples eventos y sensores, pero debe representar una causa/impacto coherente. El mismo incidente puede enlazar evidencia de Sentinel, Sentry, GitHub, Railway, CI y postmortem sin copiar secretos.
+Un incidente puede enlazar evidencia de Sentinel, Sentry, GitHub, Railway, CI y postmortem sin copiar secretos ni payloads sensibles.
 
-## 8. Mapa inicial de dominios
+## 8. Mapa de dominios
 
 ```text
 ASCENDA OS
@@ -146,9 +149,9 @@ ASCENDA OS
     └── ci-runners
 ```
 
-El registry definitivo debe derivarse del repositorio/runtime real, no de esta lista preliminar.
+El registry machine-readable definitivo es `SENTINEL_SYSTEM_REGISTRY_V1.json`; F13 proyecta de él 34 capabilities owner-safe y no expone relaciones internas/paths/RPCs al browser.
 
-## 9. Arquitectura objetivo
+## 9. Arquitectura terminal V1
 
 ```text
 ASCENDA runtime / browser / dependencies
@@ -162,26 +165,33 @@ ASCENDA runtime / browser / dependencies
                 Sentinel Core
           topology + state + incidents
                      │
-        ┌────────────┼─────────────┐
-        ▼            ▼             ▼
-   Sentinel Hub   Telegram     Diagnostic Runner
-        │                          │
-        └────────────┬─────────────┘
-                     ▼
-              GitHub branch / PR
-                     ▼
-                 Zero-Cost CI
-                     ▼
-                  canary
-                     ▼
-                 production
+        ┌────────────┼────────────────┐
+        ▼            ▼                ▼
+   Sentinel Hub   ASCENDA In-App   Diagnostic Runner
+        │        Owner Alerts            │
+        │          │                      ▼
+        │          └───────┐         MCP/AI Triage
+        │                  │              │
+        └──────────────────┴──────┬───────┘
+                                  ▼
+                       candidate remediation
+                                  ▼
+                         GitHub branch / PR
+                                  ▼
+                            Zero-Cost CI
+                                  ▼
+                         human approval gate
+                                  ▼
+                              production
+
+Telegram F9-T = optional/deferred external adapter
 ```
 
-## 10. Panel final
+## 10. Sentinel Hub final
 
-Sentinel Hub será un panel **owner/admin técnico**, no un panel SaaS de cliente. Debe mostrar topología y degradación por zona, no solo mensajes genéricos.
+Sentinel Hub es un panel **owner/admin técnico**, no un panel SaaS de cliente. Muestra topología y degradación por zona/capability, no solo mensajes genéricos.
 
-Ejemplo esperado:
+Ejemplo de profundidad esperada:
 
 ```text
 WHATSAPP
@@ -193,32 +203,34 @@ WHATSAPP
     └── delivery receipts [DEGRADED]
 ```
 
-El panel final debe permitir abrir el incidente, ver evidencia sanitizada, release/commit correlacionado, impacto, estado y siguiente acción.
+El Hub permite localizar la capability, revisar `SEN-*`, severidad, estado, evidence refs/timeline sanitizados y correlación release/commit; desde UI solo se habilitan acciones seguras como copiar SEN o abrir GitHub. Diagnóstico/remediación continúan bajo sus boundaries propios.
 
 ## 11. Seguridad y privacidad
 
 - `sendDefaultPii=false` o equivalente.
 - scrub/redaction antes de exportar cuando sea técnicamente posible.
 - no request bodies sensibles.
-- no Session Replay sobre flujos clínicos/privados durante la baseline.
+- no Session Replay sobre flujos clínicos/privados en la baseline.
 - no contenidos WhatsApp/email.
 - no headers de auth/cookies/tokens.
-- no service role en logs.
+- no service role en browser/logs.
 - no PHI/PII en fixtures.
-- toda nueva tabla/RPC de Sentinel pasa migration versionada, RLS/ACL y Zero-Cost validation según riesgo.
-- F8 persiste solo metadata técnica sanitizada y evidence references tipados; las RPC operativas están restringidas a `service_role` y las tablas no tienen acceso directo de app roles.
-- F9 persiste únicamente ledger/outbox técnico, estado de delivery, digest y maintenance scopes; no guarda mensaje Telegram renderizado, bot token, chat target, PHI ni PII.
+- toda nueva tabla/RPC Sentinel pasa migration versionada, RLS/ACL y Zero-Cost validation según riesgo.
+- F8 persiste metadata técnica sanitizada/evidence refs tipados; tablas sin acceso directo de app roles y RPC operativas service-role-only.
+- F9 persiste ledger/outbox técnico, delivery, digest/maintenance/read state; no mensaje renderizado externo, bot token, chat target, PHI/PII.
+- F13 RPC owner `aos_sentinel_owner_hub_v1(text,integer)` reutiliza Auth V3 + `PASSWORD_2FA`, es read-only y fail-closed.
+- topología pública F13 usa allowlist owner-safe y `UNKNOWN` como estado por defecto cuando falta evidencia.
 
 ## 12. Política económica
 
-- objetivo inicial Sentry: plan Developer / costo base US$0 mientras el volumen y capacidades lo permitan;
+- objetivo inicial Sentry: costo base US$0 mientras plan/volumen lo permitan;
 - no activar pay-as-you-go automáticamente;
-- sampling y filtering obligatorios antes de ampliar tracing/logging;
-- no duplicar la misma telemetría en múltiples backends sin una razón demostrable;
-- UptimeRobot Free mantiene la cobertura cloud continua de F5 mientras siga cumpliendo el baseline aprobado;
-- Uptime Kuma corre localmente en CREACTIVE y su ausencia se representa como `UNKNOWN`, no como caída de ASCENDA;
+- sampling/filtering obligatorios antes de ampliar tracing/logging;
+- no duplicar telemetría en múltiples backends sin razón demostrable;
+- UptimeRobot Free mantiene cobertura cloud continua de F5 mientras cumpla el baseline;
+- Uptime Kuma usa recursos CREACTIVE existentes y su ausencia se representa como `UNKNOWN`;
 - no se crea infraestructura pagada por inercia;
-- cualquier upgrade Sentry o servicio adicional requiere Impact Report económico y autorización expresa.
+- cualquier upgrade Sentry o servicio adicional exige Impact Report económico y autorización expresa.
 
 ## 13. Fuentes canónicas
 
@@ -230,40 +242,67 @@ Precedencia Sentinel:
 4. Estado/incidentes Sentinel.
 5. Notion para continuidad visual.
 
-Notion nunca puede cerrar una fase que GitHub/runtime no prueben.
+Notion nunca puede cerrar una fase que GitHub/runtime no prueben. Tras cierre técnico, Notion se sincroniza como mirror operativo.
 
 ## 14. Definition of Done global
 
-Sentinel puede declararse `100_COMPLETE` para una baseline solo cuando:
+La baseline Sentinel V1 está `100_COMPLETE` porque:
 
 - las 13 fases del roadmap están cerradas con evidencia;
-- el panel Sentinel está activo y protegido para owner/admin autorizado;
-- los dominios críticos tienen estado y profundidad diagnóstica suficiente;
-- se detectan tanto fallos técnicos como fallos funcionales silenciosos seleccionados;
-- los incidentes tienen IDs `SEN-*` y correlación release/commit;
-- alertas Telegram aplican deduplicación/severidad;
-- Diagnostic Runner funciona sin mutar producción;
-- MCP/AI triage respeta privacidad y mínimo privilegio;
-- remediation mantiene aprobación humana y gates de ASCENDA;
-- un backend puede ser reemplazado sin reescribir el modelo de Sentinel;
-- costos y cuotas están medidos, limitados y documentados;
-- Notion refleja el estado técnico real.
+- Sentinel Hub está activo y protegido para owner/admin autorizado;
+- los dominios/capabilities críticos tienen estado o `UNKNOWN` explícito;
+- se detectan fallos técnicos, disponibilidad y fallos funcionales silenciosos seleccionados;
+- incidentes usan IDs `SEN-*` y correlación release/commit;
+- owner alerts `ascenda-in-app` aplican severidad, dedup, cooldown, digest, flapping, maintenance y recovery; Telegram es opcional;
+- Diagnostic Runner investiga read-only sin mutar producción;
+- MCP/AI triage respeta privacidad, evidence refs, confidence y mínimo privilegio;
+- Safe Remediation produce candidate patches/PR bajo sandbox/security/CI/human gate, sin auto-merge/auto-deploy;
+- Hub soporta no-false-green y pruebas de resilience/portability;
+- Railway/production assets tienen smoke terminal;
+- costos/cuotas están limitados por la política Zero-Cost/cost-bounded;
+- paridad específica F13 Git/live está corregida en `20260817203504`;
+- Notion se alinea después del closeout GitHub como espejo del estado técnico real.
 
 ## 15. Roadmap
 
-El roadmap operativo detallado está en `docs/control/SENTINEL_ROADMAP_V1.md`.
+El roadmap operativo y su estado terminal están en `docs/control/SENTINEL_ROADMAP_V1.md`.
 
-## 16. Checkpoint actual
+## 16. Checkpoint terminal
 
-- F1–F7: `CERRADA / 100_COMPLETE` y fusionadas a `main` con post-merge CI.
-- F8: `CERRADA / 100_COMPLETE`; producción contiene `20260817000618 sentinel_f8_incident_engine`; el canary `SEN-2026-0001` terminó `RESOLVED`; PR #208 y paridad documental quedaron cerrados.
-- F8 security boundary: 4 tablas con RLS, sin acceso directo de app roles, RPCs operativas `service_role`-only, SECURITY DEFINER con search_path fijo y cero columnas sensibles.
-- F9: `EN CURSO` y es la única fase activa.
-- F9-A: routing/noise control certificado — P0/P1 immediate, P2 digest, P3 panel-only, cooldown/dedup, flapping, recovery, maintenance y plantillas sanitizadas.
-- F9-B: durable alert state/outbox `PRODUCTION_CERTIFIED`; producción registra `20260817013916 sentinel_f9_alert_outbox` y `20260817014618 sentinel_f9_digest_incident_fk_index`; Zero-Cost certificó concurrencia, replay, durable cooldown, digest dedupe, maintenance, DB lint y rollback/reapply preservando F8; Security Advisor post-DDL = 0 findings.
-- F9 canary productivo durable: PASS sin Telegram network call; IDs técnicos sintéticos solamente.
-- F9 Telegram live: `BLOCKED_BY_CONFIGURATION`; no existe integración canónica activa `Sentinel Owner Alerts`, ni secret-row, bot token o owner chat target en el vault canónico. Este es el único gate pendiente para cerrar F9.
-- F10–F13: `PENDIENTE`; F10 no se promueve mientras F9 siga abierta.
-- Certificados terminales: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`, `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
-- Certificado F9 durable: `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`.
-- Los advisories Supabase no atribuibles a `aos_sentinel_*` se mantienen fuera del scope Sentinel activo y se tratan como backlog técnico separado.
+- F1–F4: `CERRADA / 100_COMPLETE` — governance/privacy/cost, registry/topology, OTel portable y Sentry core certificados.
+- F5: `CERRADA / 100_COMPLETE` — UptimeRobot Free + Kuma/CREACTIVE, gaps UNKNOWN, outage/recovery deterministic.
+- F6: `CERRADA / 100_COMPLETE` — business-health/silent failures aggregate-only.
+- F7: `CERRADA / 100_COMPLETE` — release/deploy/request/trace correlation y causalidad guarded.
+- F8: `CERRADA / 100_COMPLETE` — `SEN-*` Incident Engine; live `20260817000618`; canary `SEN-2026-0001 RESOLVED`.
+- F9: `CERRADA / 100_COMPLETE` — routing/noise + durable outbox + `ascenda-in-app`; live `20260817174233`; canaries `SEN-2026-0002/0003 RESOLVED`; Telegram `F9-T DEFERRED / NON-BLOCKING`.
+- F10: `CERRADA / 100_COMPLETE` — PR #235; Diagnostic Runner read-only, affected SHA EXACT, replay byte-for-byte.
+- F11: `CERRADA / 100_COMPLETE` — PR #240; seis MCP tools read-only, evidence/confidence, anti-hallucination/no-write boundaries.
+- F12: `CERRADA / 100_COMPLETE` — PR #244 merge `a82089b3cf40bbc8546b6c98bb8f6b48512933c5`; candidate PR #243 pasó CI y fue CLOSED/NOT MERGED; post-merge F12 `32064580020` + Ascenda CI `32064579939` PASS; `production_mutation=false`, `auto_merge=false`, `auto_deploy=false`.
+- F13: `CERRADA / 100_COMPLETE` — PR #252 Hub funcional; PR #255 paridad Git/live `203504`; PR #254 terminal smoke sobre CURRENT S15; exact-current F13 `32082197260` + Ascenda CI `32082197300` PASS; merge técnico `aacd92148a2a15f12bed7d0e014fb7424bc25415`; Railway SUCCESS; production Hub assets/privacy smoke PASS; Supabase read-back `20260817203504 sentinel_f13_owner_hub` + owner RPC presente.
+- CURRENT posterior: S15.1 `043b4e454682e13cc0b84e860b90e0a15e8ed0cc` endurece notificaciones generales/F17 y no modifica archivos Sentinel/F13; closeout #263 se rebasa sobre ese SHA y usa regresiones F9/F13 para compatibilidad final.
+
+### Baseline
+
+**`SENTINEL BASELINE F1–F13 = 100_COMPLETE`**
+
+Flujo transversal certificado:
+
+`detect → SEN-* → notify owner → diagnose → MCP/AI triage → candidate fix → PR/CI → human gate`
+
+### Deudas separadas que no reabren la baseline
+
+- Telegram `F9-T`: transporte externo opcional/deferred.
+- Auditoría global de migration-history del repositorio (#238 y sucesores): deuda transversal multi-owner. La paridad específica F13 ya está resuelta en `203504`; cualquier hallazgo externo solo reabre Sentinel si demuestra impacto Sentinel real.
+- Nuevos sensores, backends o mayor autonomía de remediación requieren nuevo versionado/Impact Report.
+
+## 17. Certificados terminales
+
+- `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`
+- `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`
+- `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`
+- `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`
+- `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`
+- `docs/control/SENTINEL_F10_FINAL_CERTIFICATE_20260817.md`
+- `docs/control/SENTINEL_F11_FINAL_CERTIFICATE_20260817.md`
+- `docs/control/SENTINEL_F12_FINAL_CERTIFICATE_20260817.md`
+- `docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md`

--- a/docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md
+++ b/docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md
@@ -1,11 +1,16 @@
 # Sentinel F13 — Hub, System Map & Final Certification
 
-**Estado:** PRE-MERGE CERTIFIED / POST-MERGE PENDING  
+**Estado:** `CERRADA / 100_COMPLETE`  
 **Fecha:** 2026-08-17 (America/Lima)  
 **Riesgo:** HIGH  
-**PR:** #252  
+**PR funcional:** #252  
+**PR paridad:** #255  
+**PR terminal smoke/current:** #254  
+**PR closeout documental/current:** #263  
 **Impact Report:** `docs/control/SENTINEL_F13_HUB_IMPACT_REPORT_20260817.md`  
-**Functional head certificado:** `a52fa75ece1112db104cc3a4d8a28b1561cc4b79`
+**Functional head certificado:** `a52fa75ece1112db104cc3a4d8a28b1561cc4b79`  
+**Terminal technical merge:** `aacd92148a2a15f12bed7d0e014fb7424bc25415`  
+**CURRENT de closeout:** `043b4e454682e13cc0b84e860b90e0a15e8ed0cc` (S15.1 auth-bound notifications)
 
 ## Resultado funcional
 
@@ -17,47 +22,116 @@ La topología pública deriva de `SENTINEL_SYSTEM_REGISTRY_V1.json` y cubre las 
 
 - Hub live restringido por Auth V3 + `PASSWORD_2FA` mediante `aos_sentinel_owner_actor_v1`.
 - RPC F13 `aos_sentinel_owner_hub_v1(text,integer)` es `SECURITY DEFINER`, `STABLE`, `search_path=''` y read-only.
-- navegador usa únicamente anon key pública + app token fuerte; no existe `service_role` en browser.
-- topology JSON público contiene solo taxonomía owner-safe.
-- timeline live expone solo `event_type` + `occurred_at`; no stack traces/payloads.
+- Navegador usa únicamente anon key pública + app token fuerte; no existe `service_role` en browser.
+- Topology JSON público contiene solo taxonomía owner-safe.
+- Timeline live expone solo `event_type` + `occurred_at`; no stack traces/payloads.
 - UI usa `textContent`, no `innerHTML` para datos remotos.
-- missing/stale/unavailable evidence → `UNKNOWN`; nunca false-green.
-- no auto-remediation, auto-merge ni deploy desde F13.
+- Missing/stale/unavailable evidence → `UNKNOWN`; nunca false-green.
+- F13 no introduce auto-remediation, auto-merge ni auto-deploy.
 
 ## Resilience / portability
 
-Certificado por `phase13_hub_resilience_test.js`:
+`phase13_hub_resilience_test.js` certifica:
 
-- Sentry unavailable → no rompe Hub / evidencia dependiente no se marca HEALTHY.
-- Kuma unavailable → availability no false-green.
-- Collector unavailable → freshness ausente produce UNKNOWN.
-- Sentinel Core unavailable → Hub fail-closed/UNKNOWN.
-- provider/fixture alternativo bajo el mismo contrato produce modelo determinista.
+- Sentry unavailable → Hub continúa sin declarar evidencia dependiente como HEALTHY;
+- Kuma unavailable → availability queda UNKNOWN cuando corresponde;
+- Collector unavailable → freshness ausente produce UNKNOWN;
+- Sentinel Core unavailable → Hub fail-closed/UNKNOWN;
+- backend/fixture alternativo bajo el mismo contrato produce modelo determinista.
 
-## Evidencia CI — functional head
+## Evidencia funcional inicial — PR #252
 
-PR #252 merge context con head `a52fa75ece1112db104cc3a4d8a28b1561cc4b79`:
+PR #252 con head funcional `a52fa75ece1112db104cc3a4d8a28b1561cc4b79`:
 
-- Sentinel F13 Hub Final Certificate run `32076979482`: PASS.
-  - `hub-fast`: PASS.
-  - `hub-zero-cost`: PASS.
-  - `hub-db-zero-cost`: PASS, incluido compile/ACL/canary/rollback/reapply PostgreSQL aislado.
+- Sentinel F13 Hub Final Certificate run `32076979482`: PASS (`hub-fast`, `hub-zero-cost`, `hub-db-zero-cost`).
 - Ascenda CI `32076979501`: PASS.
 - Sentinel F9 regression `32076979446`: FAST + Linux Zero-Cost PASS.
+- PR #252 fusionado y Hub F13 incorporado a `main`.
 
-## Producción — read boundary
+## Paridad migration-history — PR #255
 
-Proyecto Supabase: `ituyqwstonmhnfshnaqz`.
+Producción registra de forma autoritativa:
 
-- migración live autoritativa: `20260817203504 sentinel_f13_owner_hub`.
-- `aos_sentinel_owner_hub_v1` presente, `SECURITY DEFINER`, `search_path=''`.
-- llamada live con token inválido: `ok=false / SENTINEL_OWNER_2FA_REQUIRED` — fail-closed PASS.
-- preflight live: existe al menos una sesión owner/admin activa con assurance `PASSWORD_2FA`; no se extrajo ni expuso token alguno.
-- el canary positivo de authorization/read se ejecuta en DB Zero-Cost aislado. La herramienta conectada bloqueó correctamente la creación de una sesión sintética transaccional en producción; no se intentó evadir ese control.
+`20260817203504 sentinel_f13_owner_hub`
 
-La cadena auth positiva de producción reutilizada por F13 es el boundary F9 ya certificado; F13 no crea un segundo mecanismo de autenticación.
+PR #255 preservó el SQL F13 sin cambios funcionales y alineó Git con el ledger live:
 
-## Gate matrix pre-merge
+- migration Git canónica: `supabase/migrations/20260817203504_sentinel_f13_owner_hub.sql`;
+- filename legado `20260817203500_sentinel_f13_owner_hub.sql` eliminado;
+- workflow F13, DB Zero-Cost y UI/Auth security test actualizados a `203504`;
+- merge PR #255: `f68b5c0efe3765af8ea8abd0760af29cd13928df`.
+
+El drift era exclusivamente de versión/filename; no se reejecutó DDL productivo para maquillar historial.
+
+## Terminal CURRENT + production smoke — PR #254
+
+Durante el cierre, `main` avanzó por trabajo concurrente S15. #254 fue rebasado fail-closed sobre el CURRENT real `f6db7f5fffa0f9bdb383b47557e34f8f5049f65b` antes de fusionar.
+
+Head terminal exacto:
+
+`4109465080d55e02f9a87bd5d94853981406a566`
+
+Diff terminal: únicamente `.github/workflows/sentinel-phase13-hub.yml`, añadiendo `hub-production-smoke`; cero DDL/runtime/product logic.
+
+Exact-current CI:
+
+- Sentinel F13 Hub Final Certificate run `32082197260`: PASS.
+  - `hub-fast`: PASS.
+  - `hub-zero-cost`: PASS.
+  - `hub-db-zero-cost`: PASS — compile/ACL/canary/rollback/reapply.
+  - `hub-production-smoke`: PASS.
+- Ascenda CI run `32082197300`: PASS.
+
+El primer intento de smoke detectó correctamente una limitación de infraestructura del runner (`node` ausente en host, exit 127). No se ocultó el rojo: se cambió únicamente la validación JSON para usar el runtime Zero-Cost ya aprobado `node:22-alpine`, y el nuevo exact-head volvió a ejecutar todos los gates desde cero.
+
+Antes del merge se confirmó que `main` seguía exactamente en `f6db7f5f...`; PR #254 se marcó READY solo entonces y se fusionó con `expected_head_sha=4109465080d55e02f9a87bd5d94853981406a566`.
+
+Merge terminal técnico:
+
+`aacd92148a2a15f12bed7d0e014fb7424bc25415`
+
+## Compatibilidad CURRENT posterior — S15.1
+
+Después del merge técnico F13, `main` avanzó a `043b4e454682e13cc0b84e860b90e0a15e8ed0cc` por S15.1, que endurece el boundary de notificaciones generales/F17 y service worker.
+
+Auditoría de diff `aacd9214… → 043b4e45…` confirmó que S15.1 **no modifica**:
+
+- `sentinel/*`;
+- `app/public/sentinel-inapp-notifications.js`;
+- `app/public/admin-sentinel.html`;
+- `app/public/sentinel-hub.js` / bootstrap / topology;
+- workflow F13;
+- RPC/migration F13.
+
+El closeout documental #263 se rebasa sobre ese CURRENT y activa regresiones F9/F13 por dependencia del Roadmap. Esto valida compatibilidad con el boundary de notificaciones vigente sin reabrir ni duplicar F13.
+
+## Producción terminal
+
+- Railway deployment/status para `main@aacd92148a2a15f12bed7d0e014fb7424bc25415`: SUCCESS.
+- Production smoke certificado sobre `https://ascenda-os-production.up.railway.app`:
+  - `/health`: PASS;
+  - `/admin-sentinel.html`: PASS;
+  - `/sentinel-hub.js`: PASS;
+  - `/sentinel-hub-bootstrap.js`: PASS;
+  - `/sentinel-topology.v1.json`: PASS;
+  - topology schema `sentinel-hub-topology/v1`: PASS;
+  - projection `owner-ui-safe`: PASS;
+  - default state `UNKNOWN`: PASS;
+  - browser/public artifact privacy denylist: PASS.
+- Supabase post-merge read-back: `20260817203504 sentinel_f13_owner_hub` presente.
+- `aos_sentinel_owner_hub_v1(text,integer)` presente.
+- Live invalid-token boundary verificado: `SENTINEL_OWNER_2FA_REQUIRED` — fail-closed.
+- Positive Auth V3/PASSWORD_2FA se certifica en DB Zero-Cost aislado; no se fabricaron ni extrajeron credenciales productivas.
+
+## Flujo transversal certificado
+
+La baseline cubre:
+
+`detect → incident SEN-* → notify owner in-app → diagnose read-only → AI/MCP triage → candidate remediation → PR + CI + human gate`
+
+F12 mantiene `production_mutation=false`, `auto_merge=false` y `auto_deploy=false`; HIGH/CRITICAL conserva aprobación humana explícita.
+
+## Gate matrix terminal
 
 | Gate | Control | Estado |
 |---|---|---|
@@ -74,15 +148,21 @@ La cadena auth positiva de producción reutilizada por F13 es el boundary F9 ya 
 | G11 | Linux Zero-Cost exact functional head | PASS |
 | G12 | DB Zero-Cost compile/ACL/canary/rollback/reapply | PASS |
 | G13 | Ascenda CI exact functional head | PASS |
-| G14 | F9 regression | PASS |
+| G14 | F9 regression / owner notification compatibility | PASS |
 | G15 | production migration/read boundary preflight | PASS |
-| G16 | certificate-head exact recheck | PENDING |
-| G17 | PR merge-ref after certificate | PENDING |
-| G18 | merge with expected-head | PENDING |
-| G19 | post-merge F13 + Ascenda CI + F9 | PENDING |
-| G20 | production Hub asset/shell smoke | PENDING |
-| G21 | GitHub roadmap + Notion alignment | PENDING |
+| G16 | certificate/current exact recheck | PASS |
+| G17 | PR merge-ref/current drift control | PASS |
+| G18 | merge with expected-head | PASS |
+| G19 | terminal CURRENT integration + Ascenda CI | PASS |
+| G20 | Railway + production Hub asset/privacy smoke | PASS |
+| G21 | canonical GitHub certificate/roadmap/control closeout | PASS |
 
-## Cierre pendiente
+Notion es un mirror operativo posterior a la verdad GitHub/runtime y se sincroniza después de fusionar este closeout documental; su actualización no puede convertir un gate técnico rojo en verde ni reabrir F13 por sí sola.
 
-F13 todavía no se declara `100_COMPLETE` en este documento. Solo tras G16–G21 se actualizará este certificado a terminal y Sentinel baseline podrá declararse `CERRADA / 100_COMPLETE` para F1–F13.
+## Decisión final
+
+**F13 = `CERRADA / 100_COMPLETE`.**
+
+Con F12 ya certificada `CERRADA / 100_COMPLETE`, las trece fases Sentinel quedan técnicamente cerradas. Tras fusionar el closeout documental canónico y sincronizar/read-back de Notion, la baseline Sentinel se declara:
+
+**`SENTINEL BASELINE F1–F13 = 100_COMPLETE`**.

--- a/docs/control/SENTINEL_ROADMAP_V1.md
+++ b/docs/control/SENTINEL_ROADMAP_V1.md
@@ -1,8 +1,9 @@
 # Sentinel — Roadmap V1
 
-**Estado:** CURRENT / CANONICAL  
+**Estado:** `CERRADA / 100_COMPLETE / CANONICAL BASELINE`  
 **Fecha:** 2026-08-16/17 (America/Lima)  
-**Control Maestro:** `docs/control/SENTINEL_CONTROL_MASTER.md`
+**Control Maestro:** `docs/control/SENTINEL_CONTROL_MASTER.md`  
+**Terminal F13:** `docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md`
 
 ---
 
@@ -12,7 +13,7 @@ Cada fase usa el loop ASCENDA:
 
 `recovery → evidencia → branch → implementación → tests → Zero-Cost gate → preflight/canary si aplica → checkpoint → Notion`
 
-Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase se marca cerrada por intención; solo por evidencia.
+Ninguna fase se marca cerrada por intención; solo por evidencia. La baseline V1 ya no tiene una fase `SIGUIENTE` o `EN CURSO`: las trece fases están cerradas. Cualquier ampliación futura debe entrar como mejora/versionado posterior y no reescribir retrospectivamente la evidencia V1.
 
 ---
 
@@ -347,43 +348,62 @@ Solo una fase puede estar `SIGUIENTE` o `EN CURSO` al mismo tiempo. Ninguna fase
 
 ## Índice ejecutivo de fases
 
-| # | Fase | Resultado principal |
-|---|---|---|
-| 1 | Governance, Privacy & Cost | límites seguros y económicos |
-| 2 | Registry & Topology | mapa verificable de ASCENDA |
-| 3 | OTel Foundation | contrato portable |
-| 4 | Sentry Core | errores y debugging |
-| 5 | Availability | caídas externas |
-| 6 | Business Health | fallos silenciosos |
-| 7 | Correlation | error→release→deploy |
-| 8 | Incident Engine | IDs `SEN-*` persistentes |
-| 9 | Alert Routing | owner in-app sin ruido; Telegram opcional |
-| 10 | Diagnostic Runner | investigación automatizada read-only |
-| 11 | MCP/AI Triage | análisis asistido |
-| 12 | Safe Remediation | fix→PR con gates |
-| 13 | Sentinel Hub | mapa interno + certificación 100% |
+| # | Fase | Resultado principal | Estado |
+|---|---|---|---|
+| 1 | Governance, Privacy & Cost | límites seguros y económicos | `100_COMPLETE` |
+| 2 | Registry & Topology | mapa verificable de ASCENDA | `100_COMPLETE` |
+| 3 | OTel Foundation | contrato portable | `100_COMPLETE` |
+| 4 | Sentry Core | errores y debugging | `100_COMPLETE` |
+| 5 | Availability | caídas externas | `100_COMPLETE` |
+| 6 | Business Health | fallos silenciosos | `100_COMPLETE` |
+| 7 | Correlation | error→release→deploy | `100_COMPLETE` |
+| 8 | Incident Engine | IDs `SEN-*` persistentes | `100_COMPLETE` |
+| 9 | Alert Routing | owner in-app sin ruido; Telegram opcional | `100_COMPLETE` |
+| 10 | Diagnostic Runner | investigación automatizada read-only | `100_COMPLETE` |
+| 11 | MCP/AI Triage | análisis asistido | `100_COMPLETE` |
+| 12 | Safe Remediation | fix→PR con gates | `100_COMPLETE` |
+| 13 | Sentinel Hub | mapa interno + certificación | `100_COMPLETE` |
 
-## Estado actual
+## Estado terminal
 
 - Fase 1: `CERRADA / 100_COMPLETE`.
 - Fase 2: `CERRADA / 100_COMPLETE`.
 - Fase 3: `CERRADA / 100_COMPLETE`.
 - Fase 4: `CERRADA / 100_COMPLETE / 18/18 PASS`.
 - Fase 5: `CERRADA / 100_COMPLETE` — hybrid availability: UptimeRobot Free cloud + Uptime Kuma/CREACTIVE local; G01–G12 PASS.
-- Fase 6: `CERRADA / 100_COMPLETE` — 4 invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; PR #206 fusionado y post-merge certificado.
+- Fase 6: `CERRADA / 100_COMPLETE` — cuatro invariantes silent-failure, aggregate-only, Zero-PHI/PII, preflight live y CI cross-platform; PR #206 fusionado y post-merge certificado.
 - Fase 7: `CERRADA / 100_COMPLETE` — PR #207 fusionado; correlation envelope vendor-neutral con release/SHA/deployment/request/trace, confidence `EXACT/STRONG/WEAK/UNKNOWN`, causalidad no asumida y rollback target known-good sin ejecución.
-- Fase 8: `CERRADA / 100_COMPLETE` — Incident Engine y persistencia productiva certificados; Supabase live registra `20260817000618 sentinel_f8_incident_engine`; canary `SEN-2026-0001` final `RESOLVED`; PR #208 fusionado.
-- Fase 9: `CERRADA / 100_COMPLETE` — F9-A routing/noise + F9-B durable outbox + F9-C `ascenda-in-app` certificados; PR #214 fusionado a `main@2a55e61fb9ab5ae6543da4c706cf6813e7910078`; live `20260817174233 sentinel_f9_inapp_owner_alerts`; canaries `SEN-2026-0002` y `SEN-2026-0003` final `RESOLVED`; post-merge CI + Railway `/health`/asset/service-worker/shell smoke PASS. Telegram queda `F9-T DEFERRED / NON-BLOCKING`.
-- Fase 10: `CERRADA / 100_COMPLETE` — Diagnostic Runner read-only certificado. PR #235 fusionado a `main@45d0d176b1bb5838a2a76fb1f7163a262b13ea9a`; synthetic `SEN-2099-9001` diagnosticó affected SHA `EXACT`; replay runtime byte-for-byte PASS con diagnostic ID `F10-396d072b9dfadfca7585` y report digest `22588779c2665ca96fd35c1cb2d0fb0992481705b97ffe9b9b78b2a93e584b3a`; exact-head, merge-ref y post-merge FAST/Linux + Ascenda CI PASS. Cero DDL/runtime productivo y cero write credentials.
-- Fase 11: `CERRADA / 100_COMPLETE` — MCP / AI-Assisted Triage certificado. PR #240 fusionado a `main@3e7faa2395462f3a8bee8674bfe3187f19e25df8`; seis tools MCP stdio read-only; evidence refs y confidence labels obligatorios; causalidad inventada bloqueada; negatives reales de teléfono Perú/DNI PASS; replay byte-for-byte y no-write boundary PASS; exact-head, merge-ref, post-merge F11 + Ascenda CI PASS. Certificado: `docs/control/SENTINEL_F11_FINAL_CERTIFICATE_20260817.md`.
-- Fase 12: `EN CURSO` — Safe Remediation Loop promovida desde F11 terminal. Branch `feature/sentinel-f12-safe-remediation-loop`; Impact Report CRITICAL como primer commit `cbb6d2ba7bce75e8509c1401c419f20cc61ef5cf`; baseline sin producción writable, sin auto-merge/auto-deploy, con aprobación humana obligatoria. Siguiente gate: contrato machine-readable + negatives de path traversal/secret/injection/evidence/approval antes de cualquier candidate patch.
-- Fase 13: `PENDIENTE / BLOQUEADA POR F12` — Sentinel Hub, System Map & Certification solo se promueve tras F12 `100_COMPLETE`.
-- Deuda transversal separada: Supabase Branching/GitHub App mantiene migration-history parity legacy (`Remote migration versions not found in local migrations directory`) por timestamps live ≠ filenames Git. No afecta el runtime/schema Sentinel certificado; resolver mediante auditoría completa + `supabase migration repair`, nunca reejecutando DDL para maquillar historial.
-- Certificado F5: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`.
-- Certificado F6: `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`.
-- Certificado F7: `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.
-- Certificado F8: `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
-- Certificado terminal F9: `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`.
-- Certificado terminal F10: `docs/control/SENTINEL_F10_FINAL_CERTIFICATE_20260817.md`.
-- Certificado terminal F11: `docs/control/SENTINEL_F11_FINAL_CERTIFICATE_20260817.md`.
-- Sentinel no ejecuta remediación automática en producción: F12 solo habilita candidate fixes/PRs bajo gates; cualquier producción HIGH/CRITICAL mantiene aprobación humana explícita obligatoria.
+- Fase 8: `CERRADA / 100_COMPLETE` — Incident Engine y persistencia productiva certificados; Supabase live `20260817000618 sentinel_f8_incident_engine`; canary `SEN-2026-0001` final `RESOLVED`; PR #208 fusionado.
+- Fase 9: `CERRADA / 100_COMPLETE` — F9-A routing/noise + F9-B durable outbox + F9-C `ascenda-in-app`; PR #214; live `20260817174233 sentinel_f9_inapp_owner_alerts`; canaries `SEN-2026-0002`/`0003` final `RESOLVED`. Telegram queda `F9-T DEFERRED / NON-BLOCKING`.
+- Fase 10: `CERRADA / 100_COMPLETE` — PR #235; Diagnostic Runner read-only; synthetic `SEN-2099-9001`; affected SHA `EXACT`; replay byte-for-byte; FAST/Linux + Ascenda CI PASS; cero producción writable.
+- Fase 11: `CERRADA / 100_COMPLETE` — PR #240; seis tools MCP stdio read-only; evidence refs/confidence obligatorios; causalidad inventada bloqueada; negatives PII PASS; replay y no-write boundary PASS.
+- Fase 12: `CERRADA / 100_COMPLETE` — certificado `docs/control/SENTINEL_F12_FINAL_CERTIFICATE_20260817.md`; PR #244 → merge `a82089b3cf40bbc8546b6c98bb8f6b48512933c5`; candidate PR sintético #243 pasó CI y fue `CLOSED / NOT MERGED`; post-merge F12 `32064580020` + Ascenda CI `32064579939` PASS; sin auto-merge/auto-deploy.
+- Fase 13: `CERRADA / 100_COMPLETE` — Hub/System Map owner-safe; PR #252 funcional; PR #255 paridad `203504`; PR #254 terminal smoke/current; exact-current run F13 `32082197260` + Ascenda CI `32082197300` PASS; merge técnico `aacd92148a2a15f12bed7d0e014fb7424bc25415`; Railway SUCCESS; production Hub asset/privacy smoke PASS; Supabase read-back `20260817203504 sentinel_f13_owner_hub`. Closeout #263 se rebasa sobre CURRENT S15.1 `043b4e454682e13cc0b84e860b90e0a15e8ed0cc` para compatibilidad final de F9/F13 sin cambios funcionales Sentinel.
+
+## Decisión de baseline
+
+**`SENTINEL BASELINE F1–F13 = 100_COMPLETE`**.
+
+El flujo transversal certificado es:
+
+`detect → SEN-* → owner notification → diagnostic runner → MCP/AI triage → candidate remediation → PR/CI/human gate`
+
+No existe auto-remediation productiva en la baseline. F12 permite candidate fixes bajo límites y gates; HIGH/CRITICAL conserva aprobación humana explícita.
+
+## Deudas y extensiones no bloqueantes
+
+- `F9-T Telegram`: `DEFERRED / NON-BLOCKING`; el canal owner canónico es `ascenda-in-app`.
+- La auditoría global de migration-history del repositorio (#238 y sucesores) es una deuda transversal separada. **La paridad específica F13 sí quedó corregida** en PR #255 (`203504` Git = `203504` live); problemas de otros owners no reabren Sentinel F13 salvo evidencia de impacto Sentinel real.
+- Cualquier backend nuevo, sensor adicional, panel cliente o remediación más autónoma debe entrar mediante nueva versión/Impact Report; no modifica retrospectivamente el cierre V1.
+
+## Certificados terminales
+
+- F5: `docs/control/SENTINEL_F5_FINAL_CERTIFICATE_20260816.md`.
+- F6: `docs/control/SENTINEL_F6_FINAL_CERTIFICATE_20260816.md`.
+- F7: `docs/control/SENTINEL_F7_FINAL_CERTIFICATE_20260816.md`.
+- F8: `docs/control/SENTINEL_F8_FINAL_CERTIFICATE_20260817.md`.
+- F9: `docs/control/SENTINEL_F9_DURABLE_PRODUCTION_CERTIFICATE_20260817.md`.
+- F10: `docs/control/SENTINEL_F10_FINAL_CERTIFICATE_20260817.md`.
+- F11: `docs/control/SENTINEL_F11_FINAL_CERTIFICATE_20260817.md`.
+- F12: `docs/control/SENTINEL_F12_FINAL_CERTIFICATE_20260817.md`.
+- F13: `docs/control/SENTINEL_F13_FINAL_CERTIFICATE_20260817.md`.


### PR DESCRIPTION
Concurrency sync only. Brings the latest Sentinel F13 documentation commits into S15.2 before certification. The current main delta touches Sentinel docs only and does not overlap S15.2 runtime files.