### PR TITLE
CIA-F17 V22 — CURRENT closeout for replay + allowlisted canary

### DIFF
--- a/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260817_V22.md
+++ b/docs/control/commercial-intelligence/PHASE_17_IMPACT_REPORT_20260817_V22.md
@@ -1,0 +1,71 @@
+# CIA V3 F17 — V22 CURRENT Closeout Impact Report
+
+Date: 2026-08-17 America/Lima
+Exact baseline: `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab`
+Workstream: `CIA-F17`
+
+## Control handoff
+
+CURRENT explicitly hands the single mutable HIGH/CRITICAL workstream to CIA-F17/F18. Revenue, WhatsApp and KronIA remain paused; Sentinel remains regression-only. V22 therefore becomes the isolated CIA-F17 closeout vehicle.
+
+## Authoritative preflight
+
+Production Supabase: `ituyqwstonmhnfshnaqz`.
+
+F16→F17 is certified:
+- `aos_cia_email_f17_readiness_v1()` exists;
+- `status=READY_F17_EMAIL_CERTIFIED`;
+- `ready_for_f17=true`;
+- all seven F16 release gates true;
+- `illegal_send_states=0`;
+- browser direct table access false for `anon` and `authenticated`;
+- GitHub #104 closed/completed.
+
+F17→F18 remains fail-closed:
+- `status=IN_PROGRESS_MULTICHANNEL_GOVERNANCE`;
+- `ready_for_f18=false`;
+- true gates: `contracts_active`, `whatsapp_bridge_validated`, `outbound_policy_validated`, `rollback_verified`;
+- false gates: `webhook_replay_validated`, `canary_passed`;
+- `illegal_send_states=0`;
+- browser direct table access false for `anon` and `authenticated`;
+- GitHub #173 closed/completed.
+
+## Runtime baseline
+
+PR #265 is merged and the effective production chain includes F17:
+`Phase S → F17 → F5 → WA4 → WA3 → WA2 → F4`.
+
+Existing live traversal evidence is necessary but is not sufficient to certify replay or canary. PR #261 is stale historical evidence and must not be merged wholesale.
+
+## Scope
+
+1. Revalidate F17 runtime-chain/provider-neutral contracts against this exact CURRENT.
+2. Prove a genuinely Meta-signed WhatsApp webhook traverses production F17.
+3. Prove replay/idempotency with zero duplicate side effects.
+4. Run exactly one owner-authorized allowlist canary only when fresh authorization and an owner-controlled recipient exist.
+5. Re-read production readiness and require both remaining gates true.
+6. Prove rollback/recovery and zero-residue.
+7. Require exact-head CI and post-deploy smoke before merge/closure.
+8. Reconcile only the F17-owned slice of #238 without re-running historical production DDL or falsifying migration history.
+
+## Architectural invariants
+
+- One canonical Audience Engine and one canonical identity/contact truth.
+- No duplicated audience/customer/lead/patient truth per channel.
+- Provider/backend remains interchangeable transport infrastructure.
+- Channel facts link to canonical identity/audience/activation/attribution.
+- Consent, suppression and opt-out fail closed.
+- Signed/replay-safe webhooks and idempotency are mandatory.
+- Secrets remain server-side/environment-only.
+- No PII/PHI, phone numbers, message bodies, tokens or secrets in CI/issues/logs.
+
+## Safety boundaries
+
+- No broad-send, SMS/provider activation, paid fallback or provider spend expansion.
+- No production mutation merely to make a gate green.
+- No real canary without fresh owner authorization.
+- No F18 implementation until production returns `READY_F18_MULTICHANNEL_CERTIFIED` with `ready_for_f18=true` and closeout evidence is clean.
+
+## Rollback
+
+Every additive closeout change must have a versioned rollback/recovery path and post-rollback proof of zero duplicate side effects and zero residue. Any failed preflight, exact-head gate or authorization check leaves V22 draft/fail-closed.


### PR DESCRIPTION
Fresh CIA-F17 closeout vehicle from exact CURRENT `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab` after the global lock was explicitly handed to CIA-F17/F18.

Starts governance-first with the V22 Impact Report only. No runtime/schema/provider mutation yet.

Production remains authoritative: F16 is `READY_F17_EMAIL_CERTIFIED / ready_for_f17=true`; F17 is `IN_PROGRESS_MULTICHANNEL_GOVERNANCE / ready_for_f18=false` with only `webhook_replay_validated` and `canary_passed` false.

Hard invariants: one canonical Audience Engine/identity truth; no per-channel audience/customer/lead/patient truth; no PII/PHI/message/phone/token/secret logging; no broad-send, paid fallback or provider spend; no real canary without fresh owner authorization.

Do not mark ready/merge/close F17 until exact-head gates are clean and production returns `READY_F18_MULTICHANNEL_CERTIFIED` with `ready_for_f18=true`.