### PR TITLE
CONTROL — Lock ASCENDA to WhatsApp/Notifications closeout

### DIFF
--- a/docs/MEMORY_CURRENT.md
+++ b/docs/MEMORY_CURRENT.md
@@ -1,9 +1,8 @@
 # ASCENDA OS — MEMORY CURRENT
 
-**CURRENT control baseline:** `main@addd14f2a57f06ec54b5ace10e042f4d8b69a85a`  
-**Runtime inherited:** S15.3 / `ce7ca6ee1326646f22e9f70ef51eb25e7f9d4189`  
-**Railway at handoff:** SUCCESS  
-**ACTIVE WORKSTREAM:** `CIA-F17/F18-CLOSEOUT`
+**Captured from control baseline:** `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab`  
+**Runtime:** S15.3; S15.4 DB recovery live, client release pending exact-current merge  
+**ACTIVE WORKSTREAM:** `WA-NOTIFICATIONS-CLOSEOUT`
 
 ## Authority
 
@@ -13,57 +12,51 @@ Read in order:
 2. `SECURITY.md`
 3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`
-5. selected project CURRENT control / phase
-6. exact GitHub + live Supabase/Railway
-7. `aos_memory`
-8. Notion
+5. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`
+6. WhatsApp Revenue Hub CURRENT control + notification closeout docs
+7. exact GitHub + live Supabase/Railway
+8. `aos_memory`
+9. Notion
 
-Historical `docs/MEMORY.md`, `docs/adn/AGENTS.md`, chat summaries and `aos_codigo_fuente` do not override CURRENT.
+Historical docs/chat checkpoints never override CURRENT.
 
 ## Runtime
 
 `server-phase-s-f17.js → server-phase-s.js → server-f17.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → lower/core`
 
-S15.3 fixes buffered HTTP framing for signed/governed WhatsApp traffic through F17.
+S15.3 fixed Phase S → F17 buffered request framing without bypassing downstream WA4/WA3/WA2/F4.
 
-## Active project — CIA
+## Active WA / Notifications state
 
-- CIA-F0..F16 closed.
-- CIA-F17 live 4/6.
-- true: contracts, WhatsApp bridge, outbound policy, rollback.
-- false: signed webhook replay/idempotency, real allowlisted canary.
-- `ready_for_f18=false`.
-- handoff live evidence: governed inbound=1, governed send requests/events=0, WA message facts=12.
-- PR #261 = evidence-only; do not merge as-is.
-- CIA-F18 remains blocked until F17 is 6/6 and ready=true.
+- WA0/WA2/WA3 previously closed; WA1 and WA4 require closeout revalidation against CURRENT before final percentage/certificate.
+- `PRUEBA 6 S15.3` persisted as real inbound and updated the HUMAN_ACTIVE CESAR-owned conversation, proving the inbound regression was repaired.
+- the same canary created a Web Push attempt that returned provider `WEB_PUSH_410`.
+- stale CESAR PWA subscription is terminal/inactive; it must not be blindly reactivated.
+- production migration `20260818013809_s15_4_push_retired_subscription_recovery` is live and returns `reset_required=true` for the retired endpoint while preserving service-role-only execution.
+- S15.4 client must unsubscribe the terminal PushSubscription and register a fresh provider endpoint.
+- final legacy notification ACL cutover remains withheld until a real closed-PWA Push reaches `DELIVERED` and the notification click/deep-link is proven.
+- Meta outbound remains separately blocked by `TOKEN_INVALID_OR_EXPIRED`; fix only after inbound + Push certification, using a long-lived System User token in Railway and never exposing the token in source/chat.
 
 ## Paused programs
 
-### Sentinel
-SEN-F1..F13 100_COMPLETE; regression-only. PR #271 paused maintenance.
-
-### Revenue
-REV-F1..F4 closed. REV-F5 paused: 1000/15498 staged, 3950 clusters, 0 members, 0 previews, 7675 patients. No canonical mutation.
-
-### WhatsApp
-WA0/WA2/WA3 closed; WA1=98%, WA4=70%, WA5–WA8 pending. Project execution paused while CIA owns the lock.
-
-### KronIA
-K0 closed; K1–K8 pending. PR #94/#175 closed evidence-only. Fresh K1 starts from then-CURRENT and reuses CIA-F15 canonical registry/policy artifacts.
-
-### Migration governance
-#238 is owner-scoped history parity. #250 is reproducible pre-history baseline. Neither is an independent concurrent feature workstream.
+- CIA: F0–F16 closed; CIA-F17 4/6; F18 blocked. Read-only while WA owns lock.
+- Revenue: F1–F4 closed; F5/F6/F7 paused.
+- Sentinel: F1–F13 closed/regression-only.
+- KronIA: K0 closed; K1–K8 paused.
+- #238/#250: maintenance lanes only; no independent concurrent mutation.
 
 ## Lock sequence
 
-`CIA-F17/F18 → Revenue F5/F7 → WhatsApp WA1/WA8 → #250 baseline → KronIA K1/K8 → final cross-program certification`
+There is **no automatic next project**. Finish `WA-NOTIFICATIONS-CLOSEOUT`, reconcile GitHub/runtime/Supabase/aos_memory/Notion, then obtain/record the next explicit owner-approved lock.
 
-## Institutional rules
+## Institutional learning
 
-- one HIGH/CRITICAL mutable workstream globally;
-- Zero-Cost DB runner reserved to that workstream;
-- exact CURRENT revalidation before every merge/certification;
-- runtime activation != phase completion;
-- sibling-project PASS is input evidence only;
-- Notion updated last;
-- old green CI never certifies a stale branch.
+- one global HIGH/CRITICAL mutable workstream;
+- shared runners do not imply shared project state;
+- exact-current revalidation is mandatory after every unrelated `main` advance;
+- wrapper topology tests must include wire-level HTTP framing, not syntax/topology only;
+- provider Push 404/410 is terminal endpoint evidence;
+- a Push subscription row does not certify delivery—real provider `DELIVERED` evidence is required;
+- runtime activation does not equal phase completion;
+- old green CI cannot certify a stale branch;
+- GitHub/runtime/live DB are technical authority; Notion is continuity and is updated last.

--- a/docs/adn/AGENTS_CURRENT.md
+++ b/docs/adn/AGENTS_CURRENT.md
@@ -1,85 +1,89 @@
 # ASCENDA OS — AGENTS CURRENT OVERLAY
 
-**Captured:** 2026-08-17 20:03 America/Lima  
-**Applies to:** every CURRENT ASCENDA agent/chat.
+**Applies to:** every CURRENT ASCENDA agent/chat  
+**ACTIVE WORKSTREAM:** `WA-NOTIFICATIONS-CLOSEOUT`
 
-This overlay supersedes operational assumptions in historical `docs/adn/AGENTS.md` while preserving that file as provenance/domain knowledge.
+This overlay supersedes operational assumptions in historical `docs/adn/AGENTS.md` and earlier CURRENT snapshots while preserving them as provenance.
 
 ## Mandatory bootstrap
 
 Before any write:
 
 1. root `AGENTS.md` + `SECURITY.md`;
-2. `ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`;
-3. `ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
-4. exact `main` and runtime chain;
-5. live Supabase for the selected project;
-6. one selected project's Control Maestro/active checkpoint;
-7. old PR/branch classification.
+2. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`;
+3. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
+4. `docs/MEMORY_CURRENT.md`;
+5. exact `main` and runtime chain;
+6. live Supabase for WhatsApp/Push/Notifications;
+7. WhatsApp Revenue Hub CURRENT Control Maestro + S15.3/S15.4 evidence;
+8. current WA branch/PR/checks.
 
-If workstream ownership is ambiguous, stop writes and reconcile read-only.
+If ownership is ambiguous, stop writes and reconcile read-only. The current owner directive is unambiguous: WhatsApp/Notifications closes first.
 
-## A-01 Portfolio Controller
+## Portfolio Controller
 
-Declares `WORKSTREAM_ID`, enforces one global HIGH/CRITICAL mutable workstream, and owns handoff. It prevents project/phase-name collisions such as bare `F17`.
+Declare `WORKSTREAM_ID=WA-NOTIFICATIONS-CLOSEOUT`. Enforce one global HIGH/CRITICAL mutable workstream. CIA, Revenue, KronIA and migration-governance mutation are paused; Sentinel is regression-only.
 
-## A-02 Runtime Architect
+## Runtime Architect
 
-Reads `app/railway.json`, `app/package.json` and actual wrappers before modifying runtime.
-
-Captured CURRENT chain:
+Captured chain:
 
 `Phase S F17 → Phase S → F17 → F5 → WA4 → WA3 → WA2 → F4 → lower/core`.
 
-Never assumes `server.js` is the outer entrypoint from historical docs.
+S15.3 repaired buffered HTTP framing. Any wrapper/runtime change must preserve exact chain and wire-level framing invariants.
 
-## A-03 Supabase/Data Architect
+## Supabase/Data Architect
 
-Owns migration/RPC/RLS/ACL impact. Keeps #238 parity separate from #250 pre-history baseline. Never rewrites history or replays production DDL merely to satisfy CI. Preserves F5 provenance/human review.
+Current production evidence includes S15.4 migration `20260818013809_s15_4_push_retired_subscription_recovery`. Do not replay it cosmetically. Verify its exact content/ACL and keep retired provider endpoints inactive.
 
-## A-04 Security Guardian
+Final legacy notification ACL cutover remains pending until closed-PWA Push certification.
 
-Uses root `SECURITY.md`. HIGH/CRITICAL requires exact-current security/negative-auth/rollback evidence; secrets stay environment/vault only.
+## Security Guardian
 
-## A-05 CI/Runner Governor
+Use root `SECURITY.md`. Provider tokens remain environment/vault only. Meta outbound token repair is a later WA gate and the token must never be committed, printed or pasted into chat.
 
-- Zero-Cost DB runner belongs to the ACTIVE workstream during DB gates.
-- No unrelated materializers compete for shared workspace/ports.
-- `queued/pending` is capacity wait, not product failure.
-- FAST may run isolated same-workstream syntax/UI/regressions, never replace DB/security gates.
-- Certification names workstream + phase + exact SHA.
+## CI/Runner Governor
 
-## A-06 Project Historian / Memory Manager
+- shared runners are capacity, not authority;
+- exact commit/diff + deployment SHA + live DB are authority;
+- DB runner belongs to WA when DB/security gates are required;
+- FAST may run isolated WA/runtime regressions;
+- another workstream PASS is regression evidence only;
+- any unrelated `main` advance requires diff/revalidation before WA merge/certification.
 
-At each pause/closure:
+## Historian / Memory Manager
 
-1. update GitHub CURRENT docs;
-2. update `aos_memory` current keys;
-3. update project phase/Control Maestro in Notion;
-4. mark superseded evidence explicitly;
-5. record the next input contract.
+At each material incident or closeout:
 
-Never treats `aos_codigo_fuente` as CURRENT production authority.
+1. freeze GitHub evidence;
+2. record production ledger/runtime evidence;
+3. update CURRENT GitHub docs;
+4. update `aos_memory` after the release baseline is known;
+5. update Notion last;
+6. mark superseded PRs/branches clearly.
 
-## A-07 Release Certifier
+Current lessons to preserve: Phase S/F17 invalid dual HTTP framing caused lost inbound; Web Push 410 is a terminal provider endpoint; server retirement alone is insufficient unless browser PushManager state is reset; subscription presence alone does not certify delivery.
 
-Distinguishes `ZERO-COST CERTIFIED`, `CANARY CERTIFIED`, `PRODUCTION CERTIFIED`, and `100_COMPLETE`. A sibling project's PASS is only input evidence.
+## Release Certifier
 
-## Current state
+Do not declare WA/Notifications 100_COMPLETE until:
 
-- Sentinel: closed/regression-only.
-- CIA: F17/F18 remaining; first feature workstream after realignment.
-- Revenue: F5–F7 paused.
-- WhatsApp: WA1/WA4/WA5–WA8 paused; phase state must serialize.
-- KronIA: K1–K8 paused; stale K1 branches evidence-only.
+- S15.4 exact-current CI and Railway deploy pass;
+- fresh PWA subscription is active and stale endpoint remains inactive;
+- closed-PWA real inbound generates Push `DELIVERED`;
+- Windows notification and click/deep-link are proven;
+- duplicate/noise behavior is clean;
+- legacy notification ACL cutover is applied/audited;
+- Meta outbound token/canary is repaired separately;
+- final WA1/WA2/WA3/WA4/Phase S/S13/S14/S15 regressions pass;
+- GitHub/runtime/Supabase/aos_memory/Notion are reconciled.
 
-## Anti-confusion examples
+## Current portfolio state
 
-Do not:
+- WhatsApp/Notifications: **ACTIVE**.
+- CIA: F17 4/6, F18 blocked; **PAUSED/READ-ONLY**.
+- Revenue: F5–F7 **PAUSED**.
+- Sentinel: F1–F13 **CLOSED / REGRESSION-ONLY**.
+- KronIA: K1–K8 **PAUSED**.
 
-- run Revenue F5 recovery while certifying CIA-F17;
-- materialize K1 Auth/secrets while the F17 runtime baseline is moving;
-- interpret Sentinel regression jobs as Sentinel development;
-- treat WA transport completion as CIA readiness or CIA readiness as WA closure;
-- use `SKIPPED`, another workstream's PASS, or historical green CI as the current phase gate;
-- continue from a chat summary without rereading CURRENT GitHub/Supabase.
+No next workstream is automatically assigned after WA; wait for explicit owner handoff.

--- a/docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md
+++ b/docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md
@@ -1,8 +1,8 @@
 # ASCENDA OS — AGENT BOOTSTRAP CURRENT
 
-**Control baseline:** `main@addd14f2a57f06ec54b5ace10e042f4d8b69a85a`  
-**Runtime:** S15.3  
-**ACTIVE WORKSTREAM:** `CIA-F17/F18-CLOSEOUT`
+**Captured from baseline:** `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab`  
+**Runtime:** S15.3 + S15.4 Push recovery closeout  
+**ACTIVE WORKSTREAM:** `WA-NOTIFICATIONS-CLOSEOUT`
 
 ## Mandatory bootstrap
 
@@ -11,50 +11,45 @@
 3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`
 5. `docs/MEMORY_CURRENT.md`
-6. CIA CURRENT Control Maestro + CIA-F17 checkpoint only
-7. exact `main`, Railway runtime and F17 Supabase readiness
-8. relevant branch/PR/checks
+6. WhatsApp Revenue Hub Control Maestro + S15.3/S15.4 closeout evidence
+7. exact `main`, Railway runtime/deploy and live Supabase WA/Push state
+8. relevant WA branch/PR/checks only
 
-Do not resume Revenue, WhatsApp, KronIA, Sentinel maintenance, #238 or #250 as a competing mutable workstream while CIA owns the lock.
+Do not resume CIA, Revenue, KronIA, migration-governance mutation or Sentinel maintenance as a competing workstream while WA owns the lock.
 
 ## Runtime
 
 `server-phase-s-f17.js → server-phase-s.js → server-f17.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → lower/core`
 
-S15.3 fixed buffered HTTP framing for F17 webhook/governed traffic.
+S15.3 fixed invalid Phase S → F17 buffered HTTP framing. Do not bypass F17 or downstream WA wrappers.
 
-## CIA-F17 entry contract
+## WA closeout entry contract
 
-At portfolio handoff:
+Verified production evidence:
 
-- contracts=true
-- WhatsApp bridge=true
-- outbound policy=true
-- rollback=true
-- webhook replay=false
-- canary=false
-- ready_for_f18=false
-- illegal send states=0
-- governed inbound facts=1
-- governed send requests/events=0
-- WA messages=12
+- real inbound after S15.3 persists again;
+- `PRUEBA 6 S15.3` produced canonical `message.received` and updated `zi vital`;
+- conversation remains `HUMAN_ACTIVE`, owner CESAR;
+- Push dispatch executed and returned provider 410;
+- retired PWA endpoint is inactive with one recorded failure;
+- S15.4 production DB recovery migration is live and service-role-only;
+- old legacy notification RPC ACL remains intentionally uncut.
 
-Do not turn this into 5/6 by inference. The remaining gates need explicit signed replay/idempotency and real allowlisted canary evidence.
+## Next actions
 
-PR #261 is evidence-only and must not merge as-is. Start remaining F17 work from CURRENT.
-
-## CIA-F17 next actions
-
-1. freeze exact CURRENT and live readiness;
-2. inventory only unresolved F17 history/parity/runtime scope;
-3. run isolated F17 DB/replay/security/rollback gates;
-4. validate authentic signed Meta webhook + replay/idempotency;
-5. execute only owner-approved allowlisted canary, broad send OFF;
-6. reconcile ledgers/outcomes and rollback;
-7. require F17 6/6 and `ready_for_f18=true`;
-8. then execute CIA-F18 under the same CIA lock;
-9. close CIA, update memory/Notion, and hand lock to Revenue.
+1. freeze exact CURRENT before each merge;
+2. integrate S15.4 client recovery from exact CURRENT;
+3. pass S14/S15/Ascenda CI on the exact candidate;
+4. verify exact Railway deploy;
+5. reopen installed PWA and require a new active Push subscription while stale endpoint stays inactive;
+6. close PWA completely and run a new real inbound canary;
+7. require WA persistence + Push `DELIVERED` + Windows notification + deep-link;
+8. verify no visible-app duplicate storm;
+9. execute final legacy notification ACL cutover only after the physical Push gate;
+10. repair Meta outbound token separately with a long-lived System User token in Railway, then controlled outbound canary;
+11. revalidate WA1/WA2/WA3/WA4/Phase S/S13/S14/S15 before any 100_COMPLETE claim;
+12. update GitHub current docs, `aos_memory`, then Notion and wait for explicit next owner lock.
 
 ## Certification rule
 
-No percentage, runtime merge, sibling PASS, skipped check or old CI certifies CIA-F17. Use exact-head CURRENT, live readiness, security, rollback/recovery and required real canary evidence.
+No percentage, runtime merge, sibling PASS, queued/skipped job or historical green CI certifies WA/Notifications. Require exact-head evidence, live state, security boundary, rollback/recovery, real physical canaries and final cross-source reconciliation.

--- a/docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md
+++ b/docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md
@@ -1,79 +1,69 @@
 # ASCENDA OS — PROJECT PORTFOLIO CURRENT
 
-**CURRENT control baseline:** `main@addd14f2a57f06ec54b5ace10e042f4d8b69a85a`  
+**Captured from control baseline:** `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab`  
 **Runtime inherited:** S15.3 / `ce7ca6ee1326646f22e9f70ef51eb25e7f9d4189`  
-**ACTIVE PORTFOLIO OWNER:** `CIA-F17/F18-CLOSEOUT`
+**ACTIVE PORTFOLIO OWNER:** `WA-NOTIFICATIONS-CLOSEOUT`
+
+## Owner override
+
+The current owner instruction is to finish and certify the WhatsApp Revenue Hub + Notifications recovery before another HIGH/CRITICAL project continues. This supersedes the earlier CIA-first handoff encoded in the previous CURRENT control layer.
 
 ## Runtime
 
-Railway outer command:
+Railway outer command remains the S15.3 chain beginning at `server-phase-s-f17.js`.
 
-`NODE_OPTIONS=--require ./sentinel-sentry-init.cjs node server-phase-s-f17.js`
-
-Chain:
+Effective chain:
 
 `Phase S F17 → Phase S → F17 → F5 → WA4 → WA3 → WA2 → F4 → lower/core`
 
-S15.3 fixed buffered HTTP framing while preserving the topology.
-
 ## Program map
 
-| Program | Closed | Remaining | Portfolio state |
+| Program | Closed / validated input | Remaining | Portfolio state |
 |---|---|---|---|
-| Sentinel | SEN-F1..F13 | only deferred/maintenance findings | **FROZEN / REGRESSION-ONLY** |
-| CIA | CIA-F0..F16 | CIA-F17 4/6; CIA-F18 pending | **ACTIVE** |
-| Revenue | REV-F1..F4 | REV-F5/F6/F7 | **PAUSED** |
-| WhatsApp | WA0/WA2/WA3 | WA1=98; WA4=70; WA5–WA8 | **PAUSED** |
-| KronIA | K0 | K1–K8 | **PAUSED / REBUILD FROM CURRENT** |
-| Migration governance | safe owner slices | #238 owner parity; #250 baseline | **MAINTENANCE LANE** |
+| WhatsApp + Notifications | WA0/WA2/WA3 historical closure; S15.3 inbound recovery proven; S15.4 DB recovery live | fresh Push endpoint, closed-PWA DELIVERED/click, legacy ACL cutover, Meta outbound token/canary, WA closeout revalidation | **ACTIVE** |
+| CIA | CIA-F0..F16 closed | CIA-F17 4/6; CIA-F18 blocked | **PAUSED / READ-ONLY** |
+| Revenue | REV-F1..F4 closed | REV-F5/F6/F7 | **PAUSED** |
+| Sentinel | SEN-F1..F13 closed | regression-only/deferred maintenance | **FROZEN / REGRESSION-ONLY** |
+| KronIA | K0 closed | K1–K8 | **PAUSED / REBUILD FROM THEN-CURRENT** |
+| Migration governance | safe owner slices | #238 owner parity; #250 baseline | **MAINTENANCE ONLY** |
 
-## CIA active entry state
+## WhatsApp / Notifications live state
 
-Live at handoff:
+S15.3 physical canary `PRUEBA 6 S15.3` proved real inbound traversal and canonical persistence. The same canary exposed a provider-terminal Push subscription (`WEB_PUSH_410`).
 
-- contracts=true
-- WhatsApp bridge=true
-- outbound policy=true
-- rollback=true
-- webhook replay=false
-- canary=false
-- ready_for_f18=false
-- illegal send states=0
-- governed inbound=1
-- governed send requests/events=0
-- WA messages=12
+Production Supabase now contains `20260818013809_s15_4_push_retired_subscription_recovery`, which prevents an inactive provider-terminal endpoint from being silently reactivated with identical keys and requests a browser-side reset. The stale CESAR endpoint remains inactive.
 
-Runtime traversal has improved after S15.3, but F17 is still exactly 4/6 until explicit replay/idempotency and allowlisted canary evidence exists.
+The legacy notification ACL cutover is deliberately pending until a new real closed-PWA canary reaches Push `DELIVERED` and native notification click/deep-link is proven.
 
-PR #261 is evidence-only; remaining work starts from CURRENT.
+Meta outbound `TOKEN_INVALID_OR_EXPIRED` is a separate known blocker and must be solved after inbound + Push certification with a long-lived System User token in Railway; no provider secret enters GitHub/chat.
 
 ## Paused inputs
 
+### CIA
+CIA-F17 remains exactly 4/6: contracts/WhatsApp bridge/outbound policy/rollback true; signed replay/idempotency and real allowlisted CIA canary not yet certified. No CIA mutation while WA owns the lock.
+
 ### Revenue
-1000/15498 staged, 3950 clusters, 0 members, 0 previews, 7675 canonical patients at control handoff. No concurrent ingest/rebuild/apply and no canonical mutation.
-
-### WhatsApp
-WA1 and WA4 are no longer simultaneously active. When WhatsApp receives the lock, WA1 is revalidated/closed first, then WA4 is rebaselined.
-
-CIA may use the same Meta transport for its own explicitly scoped F17 canary; that evidence does not automatically close WA1/WA4.
+REV-F5 and later remain paused. No concurrent historical ingest/rebuild/apply or canonical patient mutation.
 
 ### KronIA
-K0 closed; K1–K8 pending. PR #94/#175 closed as superseded. New K1 starts from then-CURRENT and reuses CIA-F15 canonical registry/policy.
+K1–K8 remain paused. Stale K1 branches/PRs are evidence only and must rebuild from future CURRENT.
 
 ### Sentinel
-F1–F13 100_COMPLETE; PR #271 is paused maintenance evidence. Sentinel regressions may be checked, but program scope is not reopened by default.
+SEN-F1..F13 remains closed. Run only regressions required as sensors for the WA release unless a real Sentinel regression is demonstrated.
 
-## Sequential closeout
+## Closeout requirement
 
-1. **CIA-F17/F18 — ACTIVE**
-2. Revenue F5/F7
-3. WhatsApp WA1/WA8
-4. #250 reproducible baseline once feature schemas stabilize
-5. KronIA K1/K8
-6. final cross-program certification
+Before WA releases the lock:
 
-#238 is resolved only as an owner-scoped dependency of the active project; it is not a parallel schema-history rewrite project.
+1. exact main/runtime and S15.4 merge/deploy captured;
+2. fresh active Push subscription verified while terminal endpoint remains inactive;
+3. closed-PWA inbound produces Push `DELIVERED` and native Windows notification;
+4. notification click/deep-link verified;
+5. duplicate/noise behavior verified;
+6. final legacy notification ACL cutover applied and audited;
+7. Meta outbound credential/canary resolved and controlled;
+8. WA1/WA2/WA3/WA4/Phase S/S13/S14/S15 regressions re-run;
+9. no unresolved HIGH/CRITICAL issue remains inside declared closeout scope;
+10. GitHub CURRENT docs + `aos_memory` + Notion reconciled.
 
-## Handoff requirement
-
-Before CIA releases the lock to Revenue: exact main/runtime, live readiness, PR classification, CI/canary/rollback evidence, no untracked mutation, GitHub CURRENT docs, `aos_memory`, Notion-last update, and explicit Revenue input contract.
+The next portfolio owner is **not preassigned**; it requires an explicit owner-approved handoff after WA closeout.

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,114 +1,98 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Status:** CURRENT / cross-program control  
-**Portfolio handoff baseline:** `main@addd14f2a57f06ec54b5ace10e042f4d8b69a85a`  
-**Runtime baseline inherited:** S15.3 / `ce7ca6ee1326646f22e9f70ef51eb25e7f9d4189`  
-**ACTIVE LOCK:** `CIA-F17/F18-CLOSEOUT`  
-**NEXT LOCK AFTER CIA:** `REV-F5/F7-CLOSEOUT`
+**Status:** CURRENT / explicit owner override  
+**Captured from baseline:** `main@93fcc9a5171703ee6750f67c3c17373a323dc2ab`  
+**Runtime inherited:** S15.3 / `ce7ca6ee1326646f22e9f70ef51eb25e7f9d4189`  
+**ACTIVE LOCK:** `WA-NOTIFICATIONS-CLOSEOUT`  
+**NEXT LOCK:** `UNASSIGNED` until WA closeout is certified.
+
+## Owner directive
+
+The owner explicitly ordered ASCENDA to stop parallel HIGH/CRITICAL project execution and finish the WhatsApp/Notifications workstream first: identify the regression, repair it, revalidate the complete WhatsApp + notification chain, preserve the learning, and certify it before moving to another project.
+
+This directive supersedes the earlier portfolio order that assigned the active lock to `CIA-F17/F18-CLOSEOUT`.
 
 ## Global rule
 
 At most **one HIGH/CRITICAL feature/data workstream may mutate ASCENDA at a time**.
 
-Canonical namespaces: `CIA-F*`, `REV-F*`, `WA-*`, `SEN-F*`, `K*`, `PARITY-*`, `BASELINE-*`, `CONTROL-*`.
+Canonical namespaces remain: `CIA-F*`, `REV-F*`, `WA-*`, `SEN-F*`, `K*`, `PARITY-*`, `BASELINE-*`, `CONTROL-*`.
 
-While `CIA-F17/F18-CLOSEOUT` owns the lock:
+While `WA-NOTIFICATIONS-CLOSEOUT` owns the lock:
 
-- Revenue, WhatsApp and KronIA are read-only/documentation-only;
-- no competing migrations/materializers/canaries/deploys are intentionally started;
-- Sentinel is regression-only unless a demonstrated production-safety incident receives an explicit maintenance lock;
-- #238/#250 are maintenance lanes and may only run a scoped CIA-required repair, not an independent history project;
-- FAST runners may execute isolated CIA/runtime regressions;
-- `ASCENDA-ZERO-COST-V2` is reserved for CIA-F17/F18 DB/security/release gates;
-- any unrelated `main` merge invalidates pending exact-head CIA certification until revalidated.
+- WhatsApp Revenue Hub plus S13/S14/S15.x notification transport may mutate only within the scoped recovery/certification plan;
+- CIA, Revenue, KronIA and migration-governance feature work are read-only/documentation-only;
+- Sentinel remains closed/regression-only unless a demonstrated Sentinel regression is caused by this release;
+- no competing migrations, materializers, canaries or deploys are intentionally started;
+- FAST runners may execute isolated WA/runtime regressions required by this workstream;
+- `ASCENDA-ZERO-COST-V2` is reserved for WA/notification DB/security/release gates when needed;
+- any unrelated advance of `main` invalidates a pending exact-head WA certificate until the diff is revalidated.
 
-## CURRENT runtime
+## Runtime CURRENT
 
-Railway outer command:
-
-`NODE_OPTIONS=--require ./sentinel-sentry-init.cjs node server-phase-s-f17.js`
-
-Effective chain:
+Railway chain:
 
 `Phase S F17 → Phase S → F17 → F5 → WA4 → WA3 → WA2 → F4 → lower/core`
 
-S15.3 fixes buffered HTTP framing for signed/governed WhatsApp traffic through F17. Railway was SUCCESS at the control handoff.
+S15.3 repaired invalid buffered HTTP framing between Phase S and F17 while preserving the chain.
 
-## CIA-F17 entry state
+## Live WA / Notifications checkpoint
 
-Live state immediately before this handoff:
+Physical canary `PRUEBA 6 S15.3` proved:
 
-- `contracts_active=true`
-- `whatsapp_bridge_validated=true`
-- `outbound_policy_validated=true`
-- `rollback_verified=true`
-- `webhook_replay_validated=false`
-- `canary_passed=false`
-- `ready_for_f18=false`
-- `illegal_send_states=0`
-- browser direct governed-table access=false
-- governed inbound facts=1
-- governed send requests=0
-- governed send events=0
-- WA message facts=12
+- signed WhatsApp inbound traverses the runtime again;
+- canonical message/event persistence succeeds;
+- conversation `zi vital` remains `HUMAN_ACTIVE` with owner CESAR;
+- WA2/WA3 state and counters update correctly;
+- Web Push dispatch executed but provider returned HTTP `410 Gone`.
 
-Interpretation: S15.3 improved real traffic traversal, but CIA-F17 remains **4/6**. Do not infer replay/idempotency or canary from a single inbound fact.
+The retired CESAR PWA endpoint is intentionally inactive with `failure_count=1`.
 
-## CIA-F17 closeout contract
+Production Supabase already contains:
 
-Work only from CURRENT.
+`20260818013809_s15_4_push_retired_subscription_recovery`
 
-1. Re-read `main`, Railway status and live readiness before each mutable gate.
-2. Treat PR #261 as `EVIDENCE_ONLY`; do not merge/rebase it wholesale.
-3. Inventory unresolved F17 history/parity against CURRENT and preserve only still-needed owner scope.
-4. Run F17 isolated DB/history replay/security/rollback using the active lock's Zero-Cost runner.
-5. Prove authentic Meta-signed webhook traversal.
-6. Prove duplicate/replay/idempotency through governed F17 evidence.
-7. Execute a real canary only against the explicit owner-approved allowlist; broad send remains OFF.
-8. Reconcile requests/events/inbound/provider outcomes and require `illegal_send_states=0`.
-9. Re-run rollback/recovery.
-10. Re-read `aos_cia_f18_readiness_v1()` and require all six gates true + `ready_for_f18=true`.
-11. Only then mark `CIA-F17=100_COMPLETE` and unlock CIA-F18.
+Its contract refuses to resurrect a provider-terminal endpoint with the same endpoint+keys and returns `reset_required=true`. Execute privilege remains service-role-only.
 
-## CIA-F18 gate
+## Active closeout sequence
 
-CIA-F18 cannot start before F17 returns the certified readiness marker (`READY_F18_MULTICHANNEL_CERTIFIED` or equivalent canonical gate) and `ready_for_f18=true`.
+1. Integrate S15.4 client self-healing on exact CURRENT.
+2. Require exact-head S14/S15/Ascenda CI PASS.
+3. Require Railway SUCCESS on the exact merge commit.
+4. Reopen the installed ASCENDA PWA and verify the retired endpoint stays inactive while a new active subscription is created.
+5. Fully close ASCENDA and send a new real inbound WhatsApp canary.
+6. Require canonical WA message/event persistence and Push dispatch `DELIVERED`.
+7. Require native Windows notification and successful click/deep-link into ASCENDA/WhatsApp.
+8. Verify no duplicate notification storm when ASCENDA is visible.
+9. Only then execute the pending legacy notification ACL cutover and verify service-role-only legacy access.
+10. Resolve the separate Meta outbound `TOKEN_INVALID_OR_EXPIRED` blocker with an approved long-lived System User token in Railway; never put the token in GitHub/chat.
+11. Run the controlled outbound canary and revalidate WA1/WA2/WA3/WA4/Phase S/S13/S14/S15.
+12. Only after all declared WA/notification gates close may the owner assign the next global workstream lock.
 
-F18 must be completed under the same CIA lock before the portfolio transitions to Revenue.
+## Paused project state
 
-## Paused projects
+### CIA
+CIA-F0..F16 closed; CIA-F17 remains 4/6 and CIA-F18 blocked. No CIA closeout mutation while WA owns the lock. Existing CIA evidence remains valid input but does not authorize parallel execution.
 
 ### Revenue
-`REV-F5` remains 1000/15498 staged, 3950 clusters, 0 members, 0 previews at handoff. No ingest/rebuild/apply while CIA owns lock; canonical mutation remains forbidden.
-
-### WhatsApp
-WA1=98%, WA4=70%, WA5–WA8 pending. No Meta canary/AI activation/WA5+ project execution while CIA owns lock. CIA may use the shared Meta transport only for CIA-F17's explicitly scoped governed canary; that evidence does not auto-close WA phases.
+REV-F1..F4 closed; REV-F5/F6/F7 paused. No historical ingest/rebuild/apply or canonical patient mutation.
 
 ### KronIA
-K0 closed. K1–K8 pending. PR #94/#175 are closed evidence-only. No K1 materialization/cutover while CIA owns lock.
+K0 closed; K1–K8 paused. Historical K1 branches remain evidence-only.
 
 ### Sentinel
-SEN-F1..F13 remains 100_COMPLETE/regression-only. PR #271 is paused maintenance evidence.
+SEN-F1..F13 remains closed/regression-only.
 
 ## Runner policy
 
-- Zero-Cost DB runner belongs to CIA while this lock is active.
+- shared runners are execution capacity, never source of truth;
+- source of truth is exact Git commit/diff + production deployment SHA + live Supabase evidence;
 - unique DB/container/project names per run;
 - cleanup on success/failure;
-- no production PII/PHI/secrets as fixtures;
-- queued/pending = capacity wait, not failure;
-- no hosted paid fallback merely to bypass queue.
+- no production secrets or PHI/PII as CI fixtures;
+- queued/pending means capacity wait, not product failure;
+- a PASS from another workstream is only regression evidence, never WA certification.
 
-## Lock transition
+## Handoff rule
 
-The lock may move from CIA to Revenue only after:
-
-1. CIA-F17/F18 exact `main`/runtime captured;
-2. live readiness and production evidence reconciled;
-3. CIA PRs classified/closed;
-4. CI/canary/rollback state recorded;
-5. no untracked CIA production mutation remains;
-6. GitHub CURRENT docs updated;
-7. `aos_memory` updated;
-8. Notion updated last;
-9. explicit Revenue input contract written.
+Do not move the lock automatically. A future handoff requires exact main/runtime, live Supabase state, PR classification, CI/canary/rollback evidence, final GitHub CURRENT docs, `aos_memory`, Notion-last reconciliation and an explicit owner-approved next workstream.


### PR DESCRIPTION
## Owner override
The owner explicitly instructed ASCENDA to stop parallel HIGH/CRITICAL project execution and finish/revalidate/certify WhatsApp + Notifications first.

## Problem
CURRENT GitHub control had drifted back to `CIA-F17/F18-CLOSEOUT`, contradicting the active owner instruction and enabling other agents to continue writing `main` while WA recovery was underway.

## Change
Documentation/control only. Reassigns the one global mutable lock to `WA-NOTIFICATIONS-CLOSEOUT`, pauses CIA/Revenue/KronIA/migration feature mutation, keeps Sentinel regression-only, preserves current project states, records S15.3/S15.4 evidence, and removes automatic handoff to another project after WA.

## Safety
No app/runtime code. No DDL. No business data. No secrets. No deploy behavior change.

## Exit rule
WA retains the lock until physical closed-PWA Push is DELIVERED/click-certified, legacy notification ACL cutover is audited, Meta outbound is repaired/canary-tested, and final WA regressions/cross-source reconciliation pass. The next project is assigned only by explicit owner handoff.