### PR TITLE
HOTFIX-3: restaurar recuperaciones válidas de Wilmer

### DIFF
--- a/docs/control/WILMER_VALID_RECOVERY_CORRECTION_CERT_20260818.md
+++ b/docs/control/WILMER_VALID_RECOVERY_CORRECTION_CERT_20260818.md
@@ -1,0 +1,59 @@
+# WILMER VALID RECOVERY CORRECTION — PRODUCTION CERTIFICATION
+
+**Date:** 2026-08-18 America/Lima  
+**Status:** PRODUCTION CERTIFIED
+
+## Corrected business rule
+
+A prior `NO ASISTIO` or `CANCELADA` appointment does **not** make a lead/patient non-commercial by itself.
+
+A Call Center `CITA CONFIRMADA` remains a valid commercial conversion when:
+
+- it comes from a Marketing lead, current or historical, and there is a real call/management event that produces a new appointment;
+- the lead had prior appointments but never converted clinically (`NO ASISTIO` / `CANCELADA` only), so the advisor is legitimately recovering the lead;
+- it is a manually entered organic number in Call Center with no prior lead/patient history, producing a real call and appointment.
+
+A `CITA CONFIRMADA` is excluded from commercial Calls KPIs only when there is evidence of actual patient continuity before the event, including prior sale, clinical attention, assisted/effective appointment, or explicit operational text such as session/control/debt/application/antiguo.
+
+## Wilmer correction
+
+Two records removed too aggressively by HOTFIX-2 were restored from their full audit payloads:
+
+- call `37045`, number `910303293`, CAPILAR, Marketing lead `5000`;
+- call `37060`, number `982093872`, ENZIMAS FACIALES, Marketing lead `4003`.
+
+Both are valid lead-recovery conversions. Their appointments remain in Agenda and were restored to `origen_cita='CALL_CENTER'` with direct `llamada_id_origen` + `lead_id_origen` traceability.
+
+The other ten Wilmer 2026-08-18 records remain excluded because they are proven patient continuity/sessions with prior clinical or commercial conversion evidence.
+
+At certification time (Lima day 2026-08-18):
+
+- Wilmer commercial calls: **107** (live count; can continue increasing);
+- Wilmer commercial `CITA CONFIRMADA`: **2**;
+- restored calls: **2/2**;
+- other ten excluded calls present in `aos_llamadas`: **0**.
+
+## Preventive rollback gates
+
+1. Marketing lead + prior `NO ASISTIO` only + real new call => persists as Marketing conversion.
+2. New manual organic number with no history => persists as `ORGANICO`; treatment remains measurable via `anuncio`.
+3. Prior real patient sale => call is suppressed from commercial calls and archived as patient continuity.
+
+All three gates passed under transaction rollback.
+
+## Production migration
+
+`wilmer_valid_recovery_correction_20260818`
+
+## REV-F5 isolation
+
+No REV-F5-owned state changed:
+
+- source rows: **7,064 / 15,498**;
+- clusters: **3,950**;
+- members: **0**;
+- preview: **0**;
+- apply events: **0**;
+- patients: **7,679**.
+
+REV-F5 remains/reclaims the sole mutable workstream after this correction.

--- a/docs/control/WILMER_VALID_RECOVERY_CORRECTION_HANDOFF_20260818.md
+++ b/docs/control/WILMER_VALID_RECOVERY_CORRECTION_HANDOFF_20260818.md
@@ -1,0 +1,3 @@
+# CONTROL HANDOFF — WILMER VALID RECOVERY CORRECTION
+
+Owner correction received 2026-08-18 Lima: prior `NO ASISTIO`/`CANCELADA` alone does not invalidate a real recovered lead conversion. Two Wilmer calls restored and future guard corrected. REV-F5 state remained unchanged and is the active workstream immediately after merge.

--- a/docs/control/WILMER_VALID_RECOVERY_CORRECTION_RULE.md
+++ b/docs/control/WILMER_VALID_RECOVERY_CORRECTION_RULE.md
@@ -1,0 +1,6 @@
+# Corrected recovery rule
+
+- Prior NO ASISTIO/CANCELADA only: recovered lead may count if a real new call produces a new appointment and there is no prior sale/clinical attention/assisted appointment.
+- Historical Marketing leads remain eligible for valid Call Center recovery.
+- New manual organic numbers with no history count as organic call + appointment.
+- Proven patient continuity (prior sale, clinical attention, assisted/effective appointment, explicit session/control/debt/application/antiguo) does not count as new commercial conversion.

--- a/supabase/migrations/20260819000500_wilmer_valid_recovery_correction.sql
+++ b/supabase/migrations/20260819000500_wilmer_valid_recovery_correction.sql
@@ -1,0 +1,91 @@
+-- HOTFIX-3: correct recovery semantics for Call Center.
+-- Prior NO ASISTIO/CANCELADA alone does not make a lead non-commercial.
+-- Only proven patient continuity (sale/clinical attention/assisted appointment/explicit session-control text) is excluded.
+
+create or replace function public.aos_hotfix_call_guard_v1()
+returns trigger language plpgsql security definer set search_path to 'public','pg_temp' as $$
+declare
+  v_num text; v_call_ts timestamptz; v_eff_trat text;
+  v_prior_count integer:=0; v_match_count integer:=0; v_any_leads integer:=0;
+  v_lead_id bigint; v_lead_trat text; v_lead_anuncio text;
+  v_noncommercial text; v_reason text;
+begin
+  v_num:=regexp_replace(coalesce(nullif(new.numero_limpio,''),new.numero,''),'[^0-9]','','g');
+  new.numero_limpio:=v_num;
+  if upper(trim(coalesce(new.estado,'')))<>'CITA CONFIRMADA' or v_num='' then return new; end if;
+  v_call_ts:=public.aos_llamada_event_ts(coalesce(new.fecha,(now() at time zone 'America/Lima')::date),new.hora_llamada,new.created_at,new.ult_ts,new.ts_log);
+
+  if exists(select 1 from public.aos_ventas v where v.numero_limpio=v_num and v.fecha<coalesce(new.fecha,(now() at time zone 'America/Lima')::date))
+     or exists(select 1 from public.aos_atenciones a where a.numero_limpio=v_num and a.fecha<coalesce(new.fecha,(now() at time zone 'America/Lima')::date))
+     or exists(select 1 from public.aos_agenda_citas a where a.numero_limpio=v_num and a.fecha_cita<coalesce(new.fecha,(now() at time zone 'America/Lima')::date) and upper(coalesce(a.estado_cita,'')) in ('ASISTIO','ASISTIÓ','EFECTIVA'))
+     or upper(coalesce(new.observacion,'')) ~ '(ANTIGU|SESION|SESIÓN|CONTROL|DEUDA|APLICACION|APLICACIÓN)'
+  then
+    v_noncommercial:='PACIENTE_CONTINUIDAD';
+    v_reason:='Paciente/continuidad: evidencia clínica, venta, asistencia o texto operativo previo.';
+  end if;
+
+  if v_noncommercial is not null then
+    insert into public.aos_gestiones_no_comerciales(source_call_id,clasificacion,motivo,asesor,numero_limpio,fecha,lead_id_origen,call_payload,agenda_ids,source)
+    values(new.id,v_noncommercial,v_reason,new.asesor,v_num,coalesce(new.fecha,(now() at time zone 'America/Lima')::date),new.lead_id_origen,to_jsonb(new),null,'CALL_GUARD_V3')
+    on conflict(source_call_id) do nothing;
+    return null;
+  end if;
+
+  if exists(select 1 from public.aos_llamadas l where l.numero_limpio=v_num and l.fecha=coalesce(new.fecha,(now() at time zone 'America/Lima')::date) and upper(coalesce(l.asesor,''))=upper(coalesce(new.asesor,'')) and upper(coalesce(l.estado,''))='CITA CONFIRMADA') then
+    new.estado:='SEGUIMIENTO';
+    new.sub_estado:='CITA YA EXISTENTE';
+    new.origen:=coalesce(nullif(new.origen,''),'FOLLOWUP_EXISTING_CITA');
+    new.observacion:=trim(concat_ws(' | ',nullif(new.observacion,''),'No suma nueva conversión: ya existía CITA CONFIRMADA para este número/asesor en el día.'));
+    return new;
+  end if;
+
+  v_eff_trat:=case when upper(coalesce(new.tratamiento,''))='ORGANICO' then coalesce(nullif(new.anuncio,''),new.tratamiento,'') else coalesce(new.tratamiento,'') end;
+  select count(*) into v_prior_count from public.aos_marketing_touchpoints_v2(null,null) t where t.numero_limpio=v_num and not t.es_duplicado_tecnico_probable and t.lead_ts<=v_call_ts;
+  if v_prior_count=1 then
+    select t.lead_id,t.tratamiento,t.anuncio into v_lead_id,v_lead_trat,v_lead_anuncio from public.aos_marketing_touchpoints_v2(null,null)t where t.numero_limpio=v_num and not t.es_duplicado_tecnico_probable and t.lead_ts<=v_call_ts order by t.lead_ts desc,t.lead_id desc limit 1;
+  elsif v_prior_count>1 and nullif(trim(v_eff_trat),'') is not null then
+    select count(*) into v_match_count from public.aos_marketing_touchpoints_v2(null,null)t where t.numero_limpio=v_num and not t.es_duplicado_tecnico_probable and t.lead_ts<=v_call_ts and regexp_replace(upper(coalesce(t.tratamiento,'')),'[^A-Z0-9]+','','g')=regexp_replace(upper(v_eff_trat),'[^A-Z0-9]+','','g');
+    if v_match_count=1 then
+      select t.lead_id,t.tratamiento,t.anuncio into v_lead_id,v_lead_trat,v_lead_anuncio from public.aos_marketing_touchpoints_v2(null,null)t where t.numero_limpio=v_num and not t.es_duplicado_tecnico_probable and t.lead_ts<=v_call_ts and regexp_replace(upper(coalesce(t.tratamiento,'')),'[^A-Z0-9]+','','g')=regexp_replace(upper(v_eff_trat),'[^A-Z0-9]+','','g') order by t.lead_ts desc,t.lead_id desc limit 1;
+    end if;
+  end if;
+
+  if v_lead_id is not null then
+    new.lead_id_origen:=v_lead_id;
+    new.origen:='MARKETING';
+    new.anuncio:=coalesce(nullif(new.anuncio,''),v_lead_anuncio);
+    if nullif(trim(coalesce(new.tratamiento,'')),'') is null or upper(coalesce(new.tratamiento,''))='ORGANICO' then new.tratamiento:=v_lead_trat; end if;
+  else
+    select count(*) into v_any_leads from public.aos_leads l where l.numero_limpio=v_num;
+    if v_any_leads=0 then
+      new.origen:='ORGANICO';
+      if upper(coalesce(new.tratamiento,''))<>'ORGANICO' then
+        new.anuncio:=coalesce(nullif(new.anuncio,''),nullif(new.tratamiento,''));
+        new.tratamiento:='ORGANICO';
+      end if;
+    else
+      new.origen:=coalesce(nullif(new.origen,''),'MARKETING_UNRESOLVED');
+    end if;
+  end if;
+  return new;
+end $$;
+
+insert into public.aos_llamadas
+select (jsonb_populate_record(null::public.aos_llamadas,g.call_payload)).*
+from public.aos_gestiones_no_comerciales g
+where g.source_call_id in (37045,37060)
+on conflict (id) do nothing;
+
+update public.aos_agenda_citas
+set origen_cita='CALL_CENTER',origen='MARKETING',lead_id_origen=5000,llamada_id_origen=37045
+where id='2fd19466-246f-4daa-9e57-f0f0c3d9c394';
+
+update public.aos_agenda_citas
+set origen_cita='CALL_CENTER',origen='MARKETING',lead_id_origen=4003,llamada_id_origen=37060
+where id='5a04bdf0-1456-48de-8d87-69ca1f261cb0';
+
+update public.aos_gestiones_no_comerciales
+set clasificacion='RESTORED_VALID_RECOVERY',
+    motivo='Corrección HOTFIX-3: lead/prospecto sin conversión clínica previa; recuperación comercial válida aunque existiera NO ASISTIO/CANCELADA.',
+    source='HOTFIX3_VALID_RECOVERY'
+where source_call_id in (37045,37060);


### PR DESCRIPTION
Corrige la semántica de recuperación comercial: una cita previa NO ASISTIO/CANCELADA no invalida por sí sola una nueva conversión si existe llamada real y no hubo venta/atención/asistencia previa. Restaura 37045 y 37060, conserva sus agendas y fortalece el guard futuro. Producción ya certificada; REV-F5 permanece sin cambios.