### PR TITLE
CONTROL — MKT Integrity V3 Loop 1 freeze and BEFORE package

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,36 +1,33 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Status:** CURRENT / REV-F5 REACTIVATED  
-**Owner assignment:** 2026-08-18 Lima — resume definitive REV-F5 closeout  
-**Certified hotfix merge:** `main@d260a5e060e840d8db6baca9581bbc5386539d10` / PR #284  
-**Previous lock:** `HOTFIX-WILMER-AGENDA-MARKETING-2-20260818` — CLOSED / PRODUCTION CERTIFIED  
-**ACTIVE LOCK:** `REV-F5-CLOSEOUT`  
-**NEXT LOCK:** `UNASSIGNED` until REV-F5 is production-certified.
+**Status:** CURRENT / REV-F5 PAUSED RECOVERABLY / MKT-INTEGRITY-HOTFIX-V3 ACTIVE  
+**Owner assignment:** 2026-08-18 Lima — Marketing Integrity & Call Center Semantics V3  
+**Source main before transfer:** `6ffdd18542d9636704e5b107e0692beb29405af9`  
+**Previous lock:** `REV-F5-CLOSEOUT` — `PAUSED_RECOVERABLY`  
+**ACTIVE LOCK:** `MKT-INTEGRITY-HOTFIX-V3`  
+**NEXT LOCK:** `REV-F5-CLOSEOUT` after MKT Integrity production certification and handback.
 
-## Hotfix-2 certification
+## Authorized scope
 
-Canonical evidence:
+The user explicitly authorized the 13-loop Marketing Integrity & Call Center Semantics V3 roadmap. **Only Loop 1 is complete/authorized as executed at this checkpoint. Loop 2 has not started.**
 
-- `docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_WILMER_AGENDA_HOTFIX2.md`;
-- `docs/control/WILMER_AGENDA_SEMANTICS_HOTFIX2_CERT_20260818.md`;
-- migration `wilmer_agenda_semantics_hotfix2_20260818`;
-- migration `late_lead_agenda_origin_marketing_fix_20260818`;
-- PR #284 merged at `d260a5e060e840d8db6baca9581bbc5386539d10`.
+Loop 1 authorizes governance/control writes only:
 
-Certified business semantics:
+- revalidate exact `main`;
+- reconcile live REV-F5;
+- create recoverable F5 checkpoint;
+- capture BEFORE/rollback baselines;
+- transfer the single global mutable HIGH/CRITICAL lock.
 
-- 12 Wilmer scheduling/reagenda rows from 2026-08-18 were removed from `aos_llamadas` after full JSON audit archival;
-- all 12 corresponding Agenda rows remain intact;
-- 9 classified `PACIENTE_CONTINUIDAD`, 3 `REAGENDA_NO_COMERCIAL`;
-- the two later cases `910303293` and `982093872` remain as valid Agenda reagendas and retain direct Marketing lead attribution;
-- future continuation/reagenda confirmations are archived as non-commercial and suppressed from `aos_llamadas`, preventing Home/Calls/Marketing KPI inflation;
-- Agenda/CITA_MANUAL created before a unique same-day Marketing lead, with no registered call and no prior clinical conversion, receives direct Agenda attribution only; no call is fabricated;
-- one deterministic historical Mireya Agenda-only late-lead case (`935740326` → lead 4610) was reconciled.
+No Marketing rule, RPC, frontend, call, Agenda, lead, sale, attribution, LTV or F5 functional data was mutated by Loop 1.
 
-## REV-F5 resume state
+## REV-F5 recoverable pause
 
-Production Supabase remained unchanged through hotfix-2:
+Canonical checkpoint: `docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md`.
 
+Live F5-owned state captured 2026-08-18 20:30:10 Lima:
+
+- live batch table: **`aos_f5_source_batches_v1`** (older references to `aos_f5_patient_source_batches_v1` are stale documentation);
 - source batches: **6**;
 - expected source rows: **15,498**;
 - `aos_f5_patient_source_rows_v1`: **7,064**;
@@ -39,10 +36,48 @@ Production Supabase remained unchanged through hotfix-2:
 - `aos_f5_identity_cluster_members_v1`: **0**;
 - `aos_f5_patient_link_preview_v1`: **0**;
 - `aos_f5_canonical_apply_events_v1`: **0**;
-- `aos_pacientes`: **7,679**.
+- observational `aos_pacientes`: **7,684** at capture, **not an F5 invariant** because normal production can continue creating/updating patients.
 
-Resume REV-F5 from **7,064/15,498**, reconciling persisted state before any retry. Never restart from the obsolete 1,000-row snapshot.
+F5 recovery hashes:
 
-## Global rule
+- batches: `807f03e96e5786203d867938c3938154`
+- source rows: `62b8fbedaa5da450a38c2471dd23b6b9`
+- clusters: `2d39d9ac990fee61a7ecb6ffa52efb64`
 
-At most one HIGH/CRITICAL mutable workstream may operate at a time. While `REV-F5-CLOSEOUT` owns the lock, Calls/Agenda/Marketing remains regression-only unless another explicit recoverable pause is authorized.
+Resume REV-F5 from **7,064 / 15,498** only after re-reading live state at handback. If the F5-owned hashes/counts are unchanged, continue from this checkpoint. If a higher idempotent state exists, reconcile before resuming. Never restart from obsolete snapshots.
+
+## MKT-INTEGRITY-HOTFIX-V3 BEFORE package
+
+Canonical manifest: `docs/control/MKT_INTEGRITY_V3_LOOP1_BEFORE_MANIFEST_20260818.md`.
+
+It contains timestamped counts/hashes for:
+
+- `aos_llamadas`, `aos_agenda_citas`, `aos_leads`, `aos_ventas`;
+- Attribution V2 and Acquisition V2;
+- LTV and Marketing Histórico 2026;
+- Modal Leads summary;
+- Home/Monitoreo explicit Lima-date snapshot;
+- Mireya callback/inbound cases;
+- late-lead candidate reconciliation;
+- pending buyer attribution cases;
+- relevant function definition hashes.
+
+## Reconciliation findings from Loop 1
+
+1. The previous control file was stale: it still referenced Hotfix-2/PR #284 and patient count 7,679 while `main` had already advanced to Hotfix-3B.
+2. `aos_pacientes` is operationally live and must not be used as the sole REV-F5 freeze invariant.
+3. The planning shorthand `19 strong / 17 compatible / 2 mismatches` for late leads is not canonical. In particular, `961780427` has a prior CAPILAR lead (`4650`) before its CAPILAR call/Agenda and must not be grouped with the true CAPILAR↔BIO mismatch `957549186` without re-derivation.
+4. Audit records prove Mireya calls `37108` and `37110` were inserted as `CITA CONFIRMADA / MARKETING` and then deleted; restoration is deferred to Loop 5.
+
+## Concurrency rule
+
+At most one HIGH/CRITICAL mutable workstream may operate at a time. While `MKT-INTEGRITY-HOTFIX-V3` owns the lock:
+
+- REV-F5 is read/audit/documentation only;
+- CIA, Sentinel, WhatsApp and other mutable HIGH/CRITICAL workstreams remain paused/regression-only;
+- open stale/draft PRs do not acquire ownership by existing;
+- any `main` advance requires exact-head revalidation before the next hotfix loop.
+
+## Exit / handback gate
+
+The lock returns to `REV-F5-CLOSEOUT` only after the Marketing Integrity work is production-certified, all required canaries/read-backs pass, GitHub/Notion control is reconciled, and REV-F5 hashes/counts are re-read.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP1_BEFORE_MANIFEST_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP1_BEFORE_MANIFEST_20260818.md
@@ -1,0 +1,117 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 1 BEFORE / Rollback Manifest
+
+**Snapshot window:** 2026-08-18 20:30–20:33 Lima  
+**Source main:** `6ffdd18542d9636704e5b107e0692beb29405af9`  
+**Supabase:** `ituyqwstonmhnfshnaqz`  
+**Functional mutations performed by this Loop:** **0**
+
+This manifest is the immutable BEFORE reference for later loops. Live operational tables may continue receiving ordinary clinic/call-center traffic after this timestamp; later gates must compare targeted deltas and stored hashes rather than assume live totals remain fixed.
+
+## 1. Core table snapshot
+
+| Table | Rows | High-water mark | Snapshot hash |
+|---|---:|---|---|
+| `aos_llamadas` | 35,291 | id 37,179 / created `2026-08-19T01:30:23.024Z` | `19b245f2ce5ec0b74fdfb342ca8727c0` |
+| `aos_agenda_citas` | 3,125 | created `2026-08-19T01:27:27.462Z` | `43615c7e574412ef9c029c6536093dad` |
+| `aos_leads` | 5,669 | id 5,677 / created `2026-08-18T20:56:01.892862Z` | `d83ce41d8e2330012860455089e99e97` |
+| `aos_ventas` | 1,299 | id 2,360 / created `2026-08-15T22:34:30.648078Z` | `6f4f870906bded56cc909f881974b995` |
+
+## 2. Marketing V2 BEFORE
+
+- Acquisition V2: **54 customers**, hash `d24f202651fc38db76c58d8de8254e26`.
+- Attribution V2: **126 operations / S/45,158.70**, hash `06857a37f7efb476922ce5bbb0150c93`.
+- LTV 2026 hash: `c325a02972fd27d01ce45bcb6c7f097a`.
+- Histórico 2026 hash: `458a81d8a09f2f43007a02c4da7cdd9d`.
+- Modal summary 2026-01-01..2026-08-18: **5,669 total / 5,460 llamados / 746 con cita / 56 vendidos / 207 sin contacto / S/101,959.85**.
+- Modal summary August 1..18: **658 total / 612 llamados / 44 con cita / 5 vendidos / 44 sin contacto / S/2,402**.
+
+### LTV acquisition BEFORE by cohort
+
+Jan 9 · Feb 5 · Mar 9 · Apr 3 · May 8 · Jun 8 · Jul 8 · Aug 4 = **54**.
+
+Approved future fallback may add exactly one acquisition (`973438607` → lead `2135`), but **Loop 1 does not apply it**.
+
+## 3. Marketing/HOME function definition hashes
+
+- `aos_hotfix_call_guard_v1`: `d05de50205e7c716cc048c4a5e6923a2`
+- `aos_hotfix_manual_agenda_cleanup_v1`: `85398da8c4bf74366d10020abade08b4`
+- `aos_marketing_acquisition_customers_v2`: `7851ca8c9163625bda8fcf987a1def87`
+- `aos_marketing_attribution_v2_preview`: `630c46e0425e6941283f1b200d3a5ce2`
+- `aos_marketing_call_lead_match_v2`: `bcdfc95ac762bfc10dfa0a60c5a9a354`
+- `aos_marketing_cohortes_ltv_v2_preview`: `b6d2035a3420c6956e3b0248d56e86f6`
+- `aos_marketing_historico_v2_preview`: `8147cc91935da68ab550435cf7016556`
+- `aos_marketing_leads_detalle_v2`: `f25d7c4f052f70e3a3aa901b0afdcf18`
+- `aos_marketing_leads_detalle_v2_paged`: `9b1d34f0230f4a4870bfba7185a73402`
+- `aos_marketing_leads_detalle_v2_summary`: `cbd625a744f312bb6e44b28d3b586da4`
+- `aos_marketing_period_summary_v2`: `eef10aee61e44898864e355f6197bc1f`
+- `aos_panel_asesor`: `3dc5f2275c84af5efbaf19b337174ea9`
+- `aos_monitoreo_equipo`: `a961d4a99dd35435fe1cf681d7ca8ee9`
+
+## 4. Explicit Lima-date Home/Monitoreo snapshot
+
+Captured with business date parameters `2026-08-18` / month start `2026-08-01`, avoiding the known UTC reset defect.
+
+| Asesor | Calls today | Citas today | Calls Aug | Citas Aug | Asist Aug | Ventas Aug | Fact Aug |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| MIREYA | 38 | 4 | 1,574 | 52 | 13 | 23 | S/9,655 |
+| RUVILA | 21 | 2 | 313 | 13 | 6 | 17 | S/8,304 |
+| WILMER | 182 | 6 | 1,506 | 103 | 25 | 33 | S/8,471 |
+
+These totals are operational snapshots and can grow after capture. The restoration gate for Mireya must be a targeted **+2 calls / +2 citas delta** relative to the live baseline at execution, not a hard-coded final total.
+
+## 5. Mireya callback/inbound BEFORE evidence
+
+### `991144656`
+- Marketing lead `5664`, CAPILAR, ad `CAPILAR- INJERTO REEL4`.
+- Existing call `37062`: MIREYA, `SIN CONTACTO`, duration 635 sec.
+- Agenda `6b1c4962-a597-45d8-8b72-d721d71c20f4`: PENDIENTE, 2026-08-20 15:00, `CITA_MANUAL`, CAPILAR; no direct lead/call IDs yet.
+- Audit log IDs `51949` INSERT and `51948` DELETE prove call `37108` was inserted as `CITA CONFIRMADA`, MIREYA, `MARKETING`, ad `CAPILAR- INJERTO REEL4`, then deleted in the same operation window.
+
+### `980547287`
+- Marketing lead `5599`, CAPILAR, ad `CAPILAR- INJERTO REEL4`.
+- Existing failed call `36912`: WILMER, `SIN CONTACTO`, duration 51 sec.
+- Agenda `d80a4d17-5f2e-4169-8814-c5d5c50eac5c`: PENDIENTE, 2026-08-22 16:00, `CITA_MANUAL`, CAPILAR; no direct lead/call IDs yet.
+- Audit log IDs `51954` INSERT and `51953` DELETE prove call `37110` was inserted as `CITA CONFIRMADA`, MIREYA, `MARKETING`, ad `CAPILAR- INJERTO REEL4`, then deleted.
+
+`aos_gestiones_no_comerciales` currently contains no archive rows for 37108/37110, so later restoration must use audit evidence + lead + agenda; do not assume an archived full payload exists.
+
+## 6. Buyer gaps / acquisition reference cases
+
+- `992829013`: call `29445` (MIREYA, HIFU, CITA CONFIRMADA) before late-created lead `3963`; Agenda `7d8fbb56...` ASISTIO; 5 sales totaling **S/2,467**. Already an Acquisition V2 customer; operations remain a targeted Attribution V3 gap.
+- `998564399`: call `30320` (WILMER, EXOSOMAS CAPILARES, CITA CONFIRMADA) before lead `4045`; initial Agenda `33dc643c...`; 4 later sales totaling **S/1,567**. Already an Acquisition V2 customer; later CONTINUIDAD agendas must not become new acquisition events.
+- `973438607`: prior HIFU leads `1150` (05/02) and `2135` (11/03); first commercial conversion/sale 12/03 (TOXINA S/399 + product S/189). Approved nearest-prior fallback target is lead **2135**. Loop 1 does not mutate it.
+
+## 7. Late-lead reconciliation correction discovered in Loop 1
+
+The earlier planning shorthand **“19 strong / 17 compatible / 2 mismatches” is not canonical**. A live re-derivation exposed classifier drift.
+
+- `961780427` must **not** be treated as a true CAPILAR↔BIO late-lead mismatch: CAPILAR lead `4650` existed ~1 hour **before** call `32014` and its CAPILAR Agenda; later BIO lead `4653` is a separate touchpoint. Loop 4 must test prior-lead matching first.
+- `957549186` remains REVIEW: call `35976` and Agenda are CAPILAR while the identified later lead `5420` is BIO ESTIMULADOR and no equivalent compatible prior lead was established in this Loop.
+
+A conservative re-derivation of null-direct-link, call+Agenda co-temporal cases identified at least these compatible candidates for later review/backfill: calls `14828,15076,15468,15750,19391,20704,20733,30320,33358,35858,36025`; `35976` remains mismatch REVIEW. This list is an analysis candidate set, **not an authorization to mutate**.
+
+## 8. Existing call-lead matcher distribution BEFORE
+
+2026 through 2026-08-18:
+- DIRECT_LEAD_ID 100%: 22
+- UNIQUE_PRIOR_LEAD 90%: 523
+- UNIQUE_PRIOR_BY_TREATMENT 85%: 1
+- AMBIGUOUS_PRIOR_LEAD 40%: 3
+- NO_PRIOR_MARKETING_LEAD: 260
+
+## 9. Concurrency / portfolio observations
+
+Open PRs exist (#271 Sentinel maintenance, #277 CIA-F17, and legacy #126/#122). None is the current global mutable lock owner. They must remain isolated while this hotfix owns the lock.
+
+## 10. Rollback contract
+
+Before any later functional change:
+1. exact-head revalidation is mandatory;
+2. re-query the target rows immediately before mutation;
+3. store affected row IDs and BEFORE JSON in the migration/execution report or existing audit mechanism;
+4. preserve Agenda rows unless the specific loop explicitly proves a duplicate;
+5. do not duplicate Acquisition/LTV customers when repairing operation-level attribution;
+6. on rollback, restore target rows/links to this BEFORE state and compare the V2 function hashes and aggregate hashes above;
+7. REV-F5 recovery is governed by `REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md`.
+
+**Manifest status:** `BEFORE_CAPTURED / NO_FUNCTIONAL_MUTATION`.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP1_EXECUTION_REPORT_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP1_EXECUTION_REPORT_20260818.md
@@ -1,0 +1,56 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 1 Execution Report
+
+**Scope:** Control, freeze and rollback package only  
+**Business date:** 2026-08-18 Lima  
+**Source main:** `6ffdd18542d9636704e5b107e0692beb29405af9`  
+**Functional changes:** **NONE**
+
+## Gate results
+
+### G1 — Exact HEAD
+**PASS.** `main` was revalidated immediately before control writes and remained `6ffdd18542d9636704e5b107e0692beb29405af9`.
+
+### G2 — Global lock reconciliation
+**PASS WITH DOCUMENTATION DRIFT CORRECTED.** The previous CURRENT file still claimed the Hotfix-2/PR #284 era. Live GitHub had advanced through Hotfix-3/3B. The active owner before this Loop remained `REV-F5-CLOSEOUT`; stale references were reconciled in CURRENT without changing functional systems.
+
+### G3 — REV-F5 live checkpoint
+**PASS.** F5-owned state remains 7,064 / 15,498 source rows, 3,950 clusters, 0 members, 0 preview and 0 apply events. Recovery hashes were captured. The physical batch table is `aos_f5_source_batches_v1`.
+
+### G4 — BEFORE package
+**PASS.** The manifest captures core table hashes/counts, function definition hashes, Acquisition/Attribution/LTV/Historical outputs, Modal summary, explicit Lima-date advisor KPIs and targeted cases.
+
+### G5 — Mireya evidence
+**PASS.** Audit log IDs 51948/51949 and 51953/51954 prove calls 37108/37110 were inserted as Marketing CITA CONFIRMADA and then deleted. Restoration is explicitly deferred to Loop 5.
+
+### G6 — Late-lead reconciliation
+**PASS / PLAN CORRECTION RECORDED.** The previous 19/17/2 shorthand is not safe as a canonical mutation list. `961780427` has prior CAPILAR lead 4650 and is not equivalent to the true CAPILAR↔BIO mismatch `957549186`. Loop 4 must re-derive candidates from live evidence.
+
+### G7 — Zero functional mutation
+**PASS.** No SQL INSERT/UPDATE/DELETE/DDL was executed; Supabase activity in Loop 1 was SELECT-only. No RPC, trigger, frontend, migration, calls, Agenda, leads, sales, Attribution, Acquisition, LTV or REV-F5 data was changed by this Loop.
+
+## Read-only query errors encountered
+
+Two reconciliation queries initially referenced stale/wrong column/table names and failed before execution of any mutation:
+
+- stale documented batch table name `aos_f5_patient_source_batches_v1` → corrected to live `aos_f5_source_batches_v1`;
+- `aos_atenciones.telefono` → corrected to live `aos_atenciones.numero_limpio`;
+- one ambiguous SQL alias (`anuncio`) was corrected.
+
+These failures were read-only and had zero side effects.
+
+## Portfolio concurrency
+
+Open PRs observed include Sentinel #271, CIA-F17 #277 and legacy #126/#122. None owns the global mutable lock. They remain isolated while `MKT-INTEGRITY-HOTFIX-V3` is active.
+
+## Control artifacts
+
+- `docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP1_BEFORE_MANIFEST_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP1_EXECUTION_REPORT_20260818.md`
+- `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md` updated to active owner `MKT-INTEGRITY-HOTFIX-V3`.
+
+## Loop result before merge/read-back
+
+`PASS_PENDING_CONTROL_MERGE_READBACK`.
+
+Loop 2 must **not** start until the docs-only control diff is merged to `main`, CURRENT is read back from the merged head, F5-owned hashes are rechecked, and Notion is updated with the resulting main SHA.

--- a/docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md
+++ b/docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md
@@ -1,0 +1,48 @@
+# REV-F5 — Recoverable Pause Checkpoint for MKT-INTEGRITY-HOTFIX-V3
+
+**Captured:** 2026-08-18 20:30:10 Lima  
+**Source main:** `6ffdd18542d9636704e5b107e0692beb29405af9`  
+**Supabase project:** `ituyqwstonmhnfshnaqz`  
+**Purpose:** freeze a recoverable REV-F5 state before transferring the single mutable HIGH/CRITICAL lock to `MKT-INTEGRITY-HOTFIX-V3`.
+
+## Live reconciliation
+
+The live batch table is **`aos_f5_source_batches_v1`**. Older control text that refers to `aos_f5_patient_source_batches_v1` is stale documentation and must not be used as a physical table name.
+
+| Invariant | Live checkpoint |
+|---|---:|
+| Source batches | 6 |
+| Expected source rows | 15,498 |
+| Persisted source rows | 7,064 |
+| Remaining source rows | 8,434 |
+| Identity clusters | 3,950 |
+| Cluster members | 0 |
+| Link preview rows | 0 |
+| Canonical apply events | 0 |
+| `aos_pacientes` observational count | 7,684 |
+
+`aos_pacientes` is **not** a REV-F5 freeze invariant because normal production workflows can create/update patients while REV-F5 is paused. The F5-owned staging/identity counts and hashes below are the recovery invariants.
+
+## Content hashes
+
+- `aos_f5_source_batches_v1`: `807f03e96e5786203d867938c3938154`
+- `aos_f5_patient_source_rows_v1`: `62b8fbedaa5da450a38c2471dd23b6b9`
+- `aos_f5_identity_clusters_v1`: `2d39d9ac990fee61a7ecb6ffa52efb64`
+- members/preview/apply counts: all `0`
+
+## Resume contract
+
+REV-F5 is recoverable from **7,064 / 15,498** persisted source rows and **3,950** clusters. On handback:
+
+1. re-read live F5-owned tables;
+2. compare the three hashes and counts above;
+3. if equal, resume from 7,064 without replaying prior batches;
+4. if a higher idempotent persisted state exists, reconcile it before continuing;
+5. never restart from obsolete 1,000-row snapshots;
+6. do not treat changes in `aos_pacientes` alone as REV-F5 drift.
+
+## Pause scope
+
+While `MKT-INTEGRITY-HOTFIX-V3` owns the lock, REV-F5 may be read/audited/documented only. No F5 staging, cluster membership, preview or canonical apply mutation is authorized.
+
+**Checkpoint status:** `CERTIFIED_RECOVERABLE_PAUSE`.


### PR DESCRIPTION
## MKT-INTEGRITY-HOTFIX-V3 — LOOP 1 only

Governance/control-only change. No app, RPC, migration or Supabase functional mutation.

### Adds
- recoverable REV-F5 pause checkpoint with live counts + content hashes;
- Marketing Integrity V3 BEFORE/rollback manifest;
- Loop 1 execution report;
- CURRENT global lock transfer from REV-F5-CLOSEOUT to MKT-INTEGRITY-HOTFIX-V3.

### Key reconciliation
- live batch table is `aos_f5_source_batches_v1`;
- REV-F5 remains 7,064/15,498 source rows, 3,950 clusters, 0 members/preview/apply;
- `aos_pacientes` is observational only and was 7,684 at checkpoint;
- previous late-lead shorthand is marked non-canonical; `961780427` has a prior CAPILAR lead 4650 and is not equivalent to `957549186` mismatch;
- audit proves Mireya 37108/37110 INSERT→DELETE but restoration is deferred to Loop 5.

### Gate
Diff must remain `docs/control/**` only. Loop 2 is explicitly not started.