### PR TITLE
MKT Integrity V3 — Loop 2 shadow layer

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -2,72 +2,104 @@
 
 **Status:** CURRENT / REV-F5 PAUSED RECOVERABLY / MKT-INTEGRITY-HOTFIX-V3 ACTIVE  
 **Owner assignment:** 2026-08-18 Lima — Marketing Integrity & Call Center Semantics V3  
-**Source main before transfer:** `6ffdd18542d9636704e5b107e0692beb29405af9`  
+**Loop-2 entry main:** `d2113e6e5be91210e111a33813f6d8167b1eb54e`  
 **Previous lock:** `REV-F5-CLOSEOUT` — `PAUSED_RECOVERABLY`  
 **ACTIVE LOCK:** `MKT-INTEGRITY-HOTFIX-V3`  
 **NEXT LOCK:** `REV-F5-CLOSEOUT` after MKT Integrity production certification and handback.
 
-## Authorized scope
+## Roadmap execution state
 
-The user explicitly authorized the 13-loop Marketing Integrity & Call Center Semantics V3 roadmap. **Only Loop 1 is complete/authorized as executed at this checkpoint. Loop 2 has not started.**
+- LOOP 1 — Control / freeze / BEFORE package: **PASS** (PR #287 / main `d2113e6e5be91210e111a33813f6d8167b1eb54e`).
+- LOOP 2 — Marketing V3 Shadow: **PASS_PENDING_FINAL_MERGE_READBACK** on branch `feat/mkt-integrity-v3-loop2-shadow`.
+- LOOP 3 — Acquisition V2↔V3 parity: **NOT STARTED**.
 
-Loop 1 authorizes governance/control writes only:
-
-- revalidate exact `main`;
-- reconcile live REV-F5;
-- create recoverable F5 checkpoint;
-- capture BEFORE/rollback baselines;
-- transfer the single global mutable HIGH/CRITICAL lock.
-
-No Marketing rule, RPC, frontend, call, Agenda, lead, sale, attribution, LTV or F5 functional data was mutated by Loop 1.
+The user authorized the 13-loop roadmap, but loops must execute sequentially and each loop must stop after certification. Do not infer permission to skip gates or begin the next loop automatically.
 
 ## REV-F5 recoverable pause
 
 Canonical checkpoint: `docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md`.
 
-Live F5-owned state captured 2026-08-18 20:30:10 Lima:
+Frozen F5-owned state:
 
-- live batch table: **`aos_f5_source_batches_v1`** (older references to `aos_f5_patient_source_batches_v1` are stale documentation);
+- live batch table: `aos_f5_source_batches_v1`;
 - source batches: **6**;
 - expected source rows: **15,498**;
-- `aos_f5_patient_source_rows_v1`: **7,064**;
-- remaining source rows: **8,434**;
-- `aos_f5_identity_clusters_v1`: **3,950**;
-- `aos_f5_identity_cluster_members_v1`: **0**;
-- `aos_f5_patient_link_preview_v1`: **0**;
-- `aos_f5_canonical_apply_events_v1`: **0**;
-- observational `aos_pacientes`: **7,684** at capture, **not an F5 invariant** because normal production can continue creating/updating patients.
+- persisted source rows: **7,064**;
+- remaining: **8,434**;
+- identity clusters: **3,950**;
+- cluster members: **0**;
+- link preview: **0**;
+- canonical apply events: **0**.
 
-F5 recovery hashes:
+Loop-1 canonical recovery hashes:
 
 - batches: `807f03e96e5786203d867938c3938154`
 - source rows: `62b8fbedaa5da450a38c2471dd23b6b9`
 - clusters: `2d39d9ac990fee61a7ecb6ffa52efb64`
 
-Resume REV-F5 from **7,064 / 15,498** only after re-reading live state at handback. If the F5-owned hashes/counts are unchanged, continue from this checkpoint. If a higher idempotent state exists, reconcile before resuming. Never restart from obsolete snapshots.
+Loop 2 verified that the maximum F5 write timestamps predate the Loop-1 freeze and all F5 counts remain unchanged. A separately recomputed ad-hoc JSON hash differed because the exact Loop-1 hash serialization SQL was not persisted; treat this as hash-method mismatch, not F5 data drift. Original hashes above remain the canonical handback references.
 
-## MKT-INTEGRITY-HOTFIX-V3 BEFORE package
+## Loop 2 — Marketing V3 Shadow
 
-Canonical manifest: `docs/control/MKT_INTEGRITY_V3_LOOP1_BEFORE_MANIFEST_20260818.md`.
+Canonical artifacts:
 
-It contains timestamped counts/hashes for:
+- `docs/control/MKT_INTEGRITY_V3_LOOP2_IMPACT_REPORT_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP2_SHADOW_BASELINE_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP2_EXECUTION_REPORT_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP2_ROLLBACK_20260818.sql`
+- migration source `supabase/migrations/20260819015100_mkt_integrity_v3_shadow_loop2.sql`
+- live migration `20260819015951_mkt_integrity_v3_shadow_loop2_20260818`.
 
-- `aos_llamadas`, `aos_agenda_citas`, `aos_leads`, `aos_ventas`;
-- Attribution V2 and Acquisition V2;
-- LTV and Marketing Histórico 2026;
-- Modal Leads summary;
-- Home/Monitoreo explicit Lima-date snapshot;
-- Mireya callback/inbound cases;
-- late-lead candidate reconciliation;
-- pending buyer attribution cases;
-- relevant function definition hashes.
+Loop 2 created only V3 shadow/read-path objects:
 
-## Reconciliation findings from Loop 1
+1. `aos_marketing_treatment_family_v3(text)`
+2. `aos_marketing_call_lead_match_v3_preview(date,date)`
+3. `aos_marketing_agenda_lead_match_v3_preview(date,date)`
+4. `aos_marketing_acquisition_customers_v3_preview()`
+5. `aos_marketing_attribution_v3_preview(date,date)`
+6. `aos_marketing_touchpoint_rollup_v3_preview(date,date)`
+7. `aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer)`
+8. `aos_marketing_leads_detalle_v3_summary(date,date,text,text)`
 
-1. The previous control file was stale: it still referenced Hotfix-2/PR #284 and patient count 7,679 while `main` had already advanced to Hotfix-3B.
-2. `aos_pacientes` is operationally live and must not be used as the sole REV-F5 freeze invariant.
-3. The planning shorthand `19 strong / 17 compatible / 2 mismatches` for late leads is not canonical. In particular, `961780427` has a prior CAPILAR lead (`4650`) before its CAPILAR call/Agenda and must not be grouped with the true CAPILAR↔BIO mismatch `957549186` without re-derivation.
-4. Audit records prove Mireya calls `37108` and `37110` were inserted as `CITA CONFIRMADA / MARKETING` and then deleted; restoration is deferred to Loop 5.
+Exact Loop-2 objects are restricted to postgres/service_role. No production frontend was redirected to them.
+
+## Loop 2 shadow baseline
+
+Acquisition:
+
+- V2 = **54** customers.
+- V3 shadow = **55** customers.
+- V3-only = exactly `973438607 → lead 2135`, method `NEAREST_PRIOR_FIRST_SALE`.
+- V2-only = 0.
+
+Attribution 2026-01-01..2026-08-18:
+
+- V2 = **126 ops / S/45,158.70**.
+- V3 shadow = **173 ops / S/66,644.10**.
+- Delta = **+47 ops / +S/21,485.40**.
+
+This operation-level delta is **not approved for cutover**. It is an explicit Loop-3/Loop-9 parity subject. V3 remains shadow.
+
+Reference cases:
+
+- `961780427`, call 32014 → prior CAPILAR lead `4650`, confidence 80.
+- `957549186`, call 35976 → no automatic lead; remains REVIEW/unresolved.
+- `992829013` → V3 exposes 2 first-sale-day operations / S1,018; later sales remain outside shadow acquisition attribution.
+- `998564399` → V3 exposes 4 operations / S1,567 without creating a duplicate acquisition customer.
+- Mireya calls `37108` / `37110` remain deleted; restoration is still Loop 5.
+
+## Safety status
+
+Loop 2 did **not**:
+
+- update/insert/delete `aos_llamadas`, `aos_agenda_citas`, `aos_leads` or `aos_ventas`;
+- perform late-lead backfills;
+- restore Mireya calls;
+- modify any certified V2 function definition;
+- modify frontend, Home, Monitoreo or Call Center;
+- modify REV-F5.
+
+The shadow migration was first compiled inside a transaction and rolled back successfully. A reverse-order schema-only rollback artifact is stored in `docs/control/MKT_INTEGRITY_V3_LOOP2_ROLLBACK_20260818.sql`.
 
 ## Concurrency rule
 
@@ -76,8 +108,16 @@ At most one HIGH/CRITICAL mutable workstream may operate at a time. While `MKT-I
 - REV-F5 is read/audit/documentation only;
 - CIA, Sentinel, WhatsApp and other mutable HIGH/CRITICAL workstreams remain paused/regression-only;
 - open stale/draft PRs do not acquire ownership by existing;
-- any `main` advance requires exact-head revalidation before the next hotfix loop.
+- every future `main` advance requires exact-head revalidation before another mutable loop.
 
-## Exit / handback gate
+## Next authorized step after Loop-2 final merge/readback
 
-The lock returns to `REV-F5-CLOSEOUT` only after the Marketing Integrity work is production-certified, all required canaries/read-backs pass, GitHub/Notion control is reconciled, and REV-F5 hashes/counts are re-read.
+If and only if Loop 2 receives final PASS after merge + Supabase/GitHub/Notion readback, the next loop is:
+
+`LOOP 3 — PARITY ACQUISITION V2 ↔ V3`
+
+Do not start it automatically.
+
+## Exit / handback
+
+The global lock returns to `REV-F5-CLOSEOUT` only after MKT-INTEGRITY-HOTFIX-V3 reaches full production certification at Loop 13 and REV-F5 is revalidated against its recoverable checkpoint.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP2_EXECUTION_REPORT_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP2_EXECUTION_REPORT_20260818.md
@@ -1,0 +1,189 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 2 Execution Report
+
+**Scope:** Marketing V3 Shadow only  
+**Business date:** 2026-08-18 Lima  
+**Entry main:** `d2113e6e5be91210e111a33813f6d8167b1eb54e`  
+**Active lock:** `MKT-INTEGRITY-HOTFIX-V3`  
+**Loop 3:** NOT STARTED
+
+## Result before GitHub merge/read-back
+
+`PASS_PENDING_GITHUB_MERGE_AND_FINAL_READBACK`
+
+## G1 — Exact-head / lock / REV-F5
+
+PASS.
+
+- main remained `d2113e6e5be91210e111a33813f6d8167b1eb54e` through pre-flight and branch creation.
+- CURRENT lock confirmed `MKT-INTEGRITY-HOTFIX-V3` as the sole mutable HIGH/CRITICAL owner.
+- REV-F5 counts remain 6 batches / 15,498 expected / 7,064 source rows / 3,950 clusters / 0 members / 0 preview / 0 apply.
+- F5 max write timestamps precede the Loop 1 freeze; no F5 write occurred during Loop 2.
+- A pre-flight hash recalculation used a different JSON serialization from Loop 1 and therefore produced different ad-hoc MD5s. Since Loop 1 did not persist its hash SQL formula, this is recorded as **hash-method mismatch, not data drift**. Frozen counts plus write timestamps establish no F5 mutation; original Loop 1 hashes remain canonical handback references.
+
+## G2 — Impact Report before DDL
+
+PASS.
+
+`docs/control/MKT_INTEGRITY_V3_LOOP2_IMPACT_REPORT_20260818.md` was committed on the Loop-2 branch before any persistent DDL was applied.
+
+## G3 — Transactional compile/rollback
+
+PASS.
+
+A complete create-function transaction was executed and ended with `ROLLBACK_OK` before the real migration. An initial read/compile attempt failed on an ambiguous `fecha_cita` reference; because it was inside the transaction, no object persisted. The qualified column was corrected before the successful rollback test.
+
+## G4 — Shadow migration
+
+PASS.
+
+Applied Supabase migration:
+
+- version: `20260819015951`
+- name: `mkt_integrity_v3_shadow_loop2_20260818`
+
+Repository source:
+
+- `supabase/migrations/20260819015100_mkt_integrity_v3_shadow_loop2.sql`
+
+The migration contains CREATE/REPLACE FUNCTION, ACL and COMMENT statements only. It contains no INSERT/UPDATE/DELETE against business tables.
+
+## G5 — V3 objects
+
+Created eight exact Loop-2 shadow objects:
+
+1. `aos_marketing_treatment_family_v3(text)`
+2. `aos_marketing_call_lead_match_v3_preview(date,date)`
+3. `aos_marketing_agenda_lead_match_v3_preview(date,date)`
+4. `aos_marketing_acquisition_customers_v3_preview()`
+5. `aos_marketing_attribution_v3_preview(date,date)`
+6. `aos_marketing_touchpoint_rollup_v3_preview(date,date)`
+7. `aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer)`
+8. `aos_marketing_leads_detalle_v3_summary(date,date,text,text)`
+
+All exact objects are executable only by postgres/service_role in Loop 2. No anon/authenticated/public grant exists.
+
+Definition hashes are frozen in `MKT_INTEGRITY_V3_LOOP2_SHADOW_BASELINE_20260818.md`.
+
+## G6 — V2 intact
+
+PASS.
+
+Every certified V2 function-definition hash remained byte-for-byte identical after the V3 migration. Operational V2 remained Acquisition 54 and Attribution 126 operations / S/45,158.70 during the shadow comparison.
+
+## G7 — 0 business-data writes / 0 backfills / 0 Mireya restoration
+
+PASS.
+
+Core business row counts immediately before persistent DDL:
+
+- `aos_llamadas`: 35,296
+- `aos_agenda_citas`: 3,125
+- `aos_leads`: 5,669
+- `aos_ventas`: 1,299
+
+Post-migration/pre-merge counts remain exactly the same:
+
+- `aos_llamadas`: 35,296
+- `aos_agenda_citas`: 3,125
+- `aos_leads`: 5,669
+- `aos_ventas`: 1,299
+
+Calls `37108` and `37110` remain absent (`count=0`). No late-lead backfill was performed.
+
+## G8 — Frontend remains production path
+
+PASS.
+
+No frontend file was changed on the Loop-2 branch. The existing Marketing modal still calls its current productive RPC `aos_marketing_leads_detalle`; no V3 shadow RPC is referenced or granted to anon/authenticated. V3 cannot be an accidental browser cutover in Loop 2.
+
+## G9 — Shadow Acquisition result
+
+PASS for Loop-2 objective; parity decision deferred to Loop 3.
+
+- V2 = 54 customers.
+- V3 = 55 customers.
+- V2-only = 0.
+- V3-only = exactly `973438607 → lead 2135`, `NEAREST_PRIOR_FIRST_SALE`, confidence 55.
+
+This is the single approved delta expected for Loop 3.
+
+## G10 — Shadow Attribution result
+
+PASS as an inspectable shadow delta; NOT approved for production cutover.
+
+2026-01-01..2026-08-18:
+
+- V2 = 126 operations / S/45,158.70.
+- V3 = 173 operations / S/66,644.10.
+- Delta = +47 operations / +S/21,485.40.
+
+V3-only:
+
+- 45 ops / 18 persons / S/20,897.40 via `ACQUISITION_HISTORICAL_UNIQUE_MATCH`;
+- 2 ops / 1 person / S/588 via `ACQUISITION_NEAREST_PRIOR_FIRST_SALE`.
+
+This expansion is caused by V3 including all operations on a recognized first-sale date. It requires semantic review in later parity/revenue loops and is one reason V3 remains service-role shadow only.
+
+## G11 — Reference cases
+
+PASS.
+
+- `973438607` → lead 2135, acquisition shadow candidate.
+- `961780427`, call 32014 → lead 4650 CAPILAR, confidence 80.
+- `957549186`, call 35976 → no automatic lead, confidence 0; remains REVIEW/unresolved.
+- `992829013`: V3 exposes 2 acquisition-day ops / S1,018; actual 5 / S2,467, so later revenue semantics still required.
+- `998564399`: V3 exposes all 4 recorded ops / S1,567 without creating another acquisition customer.
+- `37108`/`37110`: not restored.
+
+## G12 — Server-side pagination and dimensional filters
+
+PASS.
+
+- annual V3 effective universe = 5,628 touchpoints / 5,338 unique persons;
+- offset 0 and offset 1,000 both return valid 100-row pages with `total_rows=5,628`;
+- `CON CITA` is non-exclusive and contains sold touchpoints;
+- `VENDIDO` is independently filterable;
+- phone `998719392` is split into separate touchpoints instead of copying the same phone-level metrics to every lead.
+
+## G13 — Determinism
+
+PASS.
+
+Two independent Acquisition V3 reads produced identical MD5:
+
+`71fd02f5cf3b913675269f4c71f9f09d`
+
+Two independent annual summary reads also produced identical JSON.
+
+## G14 — Rollback
+
+PASS / CERTIFIED REVERSIBLE.
+
+A create→read→ROLLBACK test passed before persistent application. The permanent rollback artifact is:
+
+`docs/control/MKT_INTEGRITY_V3_LOOP2_ROLLBACK_20260818.sql`
+
+It drops only the eight Loop-2 objects in reverse dependency order and never touches V2 or business tables.
+
+## G15 — Risks carried into Loop 3
+
+1. Attribution V3 adds +47 operations / +S21,485.40; do not promote automatically.
+2. Annual V3 cita count (480 touchpoints / 478 persons) is much lower than V2's 746 touchpoint rows because V3 resolves appointments to one touchpoint instead of copying phone-window appointments. This requires parity explanation by cohort/person.
+3. August V3 sold/amount is 4 acquisitions / S2,352 vs V2 modal 5 / S2,402. V3 matches current M0 acquisition/LTV amount; the extra V2 S50 must be classified rather than silently dropped or adopted.
+4. `957549186` remains unresolved.
+5. F5 original MD5 formula is not reproducible from docs; future handback should use frozen counts/write timestamps plus original hashes unless the canonical hash SQL is recovered.
+
+## Certification before merge
+
+Loop 2 has achieved its functional scope:
+
+- Marketing V3 shadow functional;
+- V2 intact;
+- no business-data writes;
+- no backfills;
+- no Mireya restoration;
+- no frontend cutover;
+- reversible rollback available;
+- REV-F5 untouched.
+
+Final PASS requires the expected branch diff, atomic PR merge, final `main` exact-head/read-back, CURRENT and Notion reconciliation. Loop 3 must not start automatically.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP2_IMPACT_REPORT_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP2_IMPACT_REPORT_20260818.md
@@ -1,0 +1,131 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 2 Impact Report
+
+**Loop:** 2 — Marketing V3 Shadow  
+**Business date:** 2026-08-18 Lima  
+**Pre-flight main:** `d2113e6e5be91210e111a33813f6d8167b1eb54e`  
+**Active lock:** `MKT-INTEGRITY-HOTFIX-V3`  
+**REV-F5:** `PAUSED_RECOVERABLY` at 7,064 / 15,498 source rows, 3,950 clusters, 0 members/preview/apply.  
+**Supabase:** `ituyqwstonmhnfshnaqz`
+
+## Purpose
+
+Create a **shadow/read-only Marketing V3 layer** beside V2. V2 remains the production source of truth for all current consumers. Loop 2 does not backfill business data, restore Mireya calls, redirect frontend, or alter V2 definitions.
+
+## Pre-flight evidence
+
+- `main` revalidated at `d2113e6e5be91210e111a33813f6d8167b1eb54e`.
+- `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md` confirms `MKT-INTEGRITY-HOTFIX-V3` as the sole mutable HIGH/CRITICAL owner.
+- F5 counts remain 6 batches / 15,498 expected / 7,064 persisted / 3,950 clusters / 0 members / 0 preview / 0 apply.
+- No F5 write timestamp is later than the Loop 1 freeze. The recomputed ad-hoc hashes used during this Loop differ because the Loop 1 hash serialization SQL was not persisted; therefore F5 immutability is verified through frozen counts plus max write timestamps, while the original Loop 1 recovery hashes remain the canonical handback values.
+- All V2 **function-definition hashes** match the Loop 1 manifest exactly:
+  - `aos_marketing_acquisition_customers_v2`: `7851ca8c9163625bda8fcf987a1def87`
+  - `aos_marketing_attribution_v2_preview`: `630c46e0425e6941283f1b200d3a5ce2`
+  - `aos_marketing_call_lead_match_v2`: `bcdfc95ac762bfc10dfa0a60c5a9a354`
+  - `aos_marketing_cohortes_ltv_v2_preview`: `b6d2035a3420c6956e3b0248d56e86f6`
+  - `aos_marketing_historico_v2_preview`: `8147cc91935da68ab550435cf7016556`
+  - `aos_marketing_leads_detalle_v2`: `f25d7c4f052f70e3a3aa901b0afdcf18`
+  - `aos_marketing_leads_detalle_v2_paged`: `9b1d34f0230f4a4870bfba7185a73402`
+  - `aos_marketing_leads_detalle_v2_summary`: `cbd625a744f312bb6e44b28d3b586da4`
+  - `aos_marketing_period_summary_v2`: `eef10aee61e44898864e355f6197bc1f`
+  - `aos_panel_asesor`: `3dc5f2275c84af5efbaf19b337174ea9`
+  - `aos_monitoreo_equipo`: `a961d4a99dd35435fe1cf681d7ca8ee9`
+
+Operational V2 baseline remains Acquisition 54 and Attribution 126 operations / S/45,158.70 at the pre-flight read.
+
+## New objects permitted in Loop 2
+
+Required:
+
+1. `aos_marketing_acquisition_customers_v3_preview()`
+2. `aos_marketing_attribution_v3_preview(date,date)`
+3. `aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer)`
+4. `aos_marketing_leads_detalle_v3_summary(date,date,text,text)`
+
+Auxiliary shadow/read-path objects are allowed when V3-namespaced and fully reversible. Planned auxiliaries:
+
+- `aos_marketing_treatment_family_v3(text)` — deterministic normalization helper.
+- `aos_marketing_call_lead_match_v3_preview(date,date)` — shadow call→touchpoint resolver with explicit/prior/late compatible methods.
+- `aos_marketing_agenda_lead_match_v3_preview(date,date)` — shadow Agenda→touchpoint resolver using explicit links, call links, prior touchpoint and controlled late-lead matching.
+- `aos_marketing_touchpoint_rollup_v3_preview(date,date)` — one-row-per-touchpoint rollup used by paged/summary functions so calls/citas/sales do not multiply across multiple leads of one phone.
+
+## Production objects explicitly NOT modified
+
+- every `*_v2*` function;
+- `aos_llamadas`;
+- `aos_agenda_citas`;
+- `aos_leads`;
+- `aos_ventas`;
+- Home/Monitoreo RPCs;
+- Call Center frontend (`app/public/calls.js`);
+- Agenda frontend;
+- Marketing frontend/modal;
+- LTV/Historical productive functions;
+- REV-F5 tables/functions.
+
+## Shadow semantics
+
+V3 is prepared to distinguish:
+
+- ADQUISICION;
+- RECUPERACION_LEAD;
+- ORGANICO;
+- REACTIVACION;
+- SEGUIMIENTO;
+- AGENDA_NORMAL / CONTINUIDAD;
+- REVIEW / AMBIGUOUS.
+
+Attribution precedence:
+
+1. explicit `lead_id_origen`;
+2. explicit/strong call+cita chain;
+3. compatible late lead, same phone and controlled temporal window;
+4. unique prior touchpoint before first sale;
+5. nearest prior touchpoint before first sale as final fallback;
+6. real treatment mismatch remains REVIEW.
+
+No sale may be attributed to a touchpoint after that sale. A prior NO ASISTIO/CANCELADA alone is not evidence of a converted patient.
+
+## Cases that must remain read-only in Loop 2
+
+- `973438607` may appear as the single shadow nearest-prior acquisition candidate (`lead 2135`), but V2 is not changed.
+- `992829013` and `998564399` must remain existing Acquisition V2 customers; operation-level gaps may be surfaced but not backfilled.
+- `37108` / `37110` remain deleted in business data; restoration is Loop 5.
+- `961780427` must prefer its prior CAPILAR lead `4650` when evidence supports it.
+- `957549186` remains REVIEW for CAPILAR↔BIO mismatch unless new evidence appears.
+
+## Business-data no-write invariant
+
+Before and after the DDL migration, record row counts/high-water marks for:
+
+- `aos_llamadas`;
+- `aos_agenda_citas`;
+- `aos_leads`;
+- `aos_ventas`.
+
+Ordinary production traffic may increase counts while the loop runs; therefore the gate is **no writes attributable to this migration**, not frozen global totals. The migration itself contains CREATE FUNCTION / COMMENT / GRANT only and no DML against business tables.
+
+## Rollback
+
+Rollback is schema-only and may DROP only the V3 objects created by Loop 2. It must not touch V2 or business tables. After rollback simulation/inspection:
+
+- V2 definition hashes must remain identical;
+- frontend must still reference V2;
+- REV-F5 counts/write timestamps must remain unchanged by this workstream.
+
+## Validation plan
+
+1. apply one DDL migration containing V3 shadow objects only;
+2. inspect `pg_get_functiondef` and hashes for all V3 objects;
+3. execute SELECT-only shadow comparisons V2↔V3 by month and reference case;
+4. verify no V2 definition hash changed;
+5. inspect repository frontend references to confirm V2 remains wired;
+6. re-read REV-F5 counts/write timestamps;
+7. revalidate exact `main` before PR merge;
+8. merge only migrations + `docs/control/**` expected for Loop 2;
+9. read back Supabase and Notion; stop before Loop 3.
+
+## Stop conditions
+
+STOP if V3 requires modifying V2, writing business data, redirecting frontend, modifying REV-F5, or if any unexplained V2 definition change appears.
+
+**Impact gate status:** `APPROVED_FOR_SHADOW_DDL_ONLY`.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP2_ROLLBACK_20260818.sql
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP2_ROLLBACK_20260818.sql
@@ -1,0 +1,22 @@
+-- MKT-INTEGRITY-HOTFIX-V3 / LOOP 2
+-- Reversible schema-only rollback. DO NOT run during normal operation.
+-- Drops only objects created by Loop 2, in reverse dependency order.
+
+begin;
+
+drop function if exists public.aos_marketing_leads_detalle_v3_summary(date,date,text,text);
+drop function if exists public.aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer);
+drop function if exists public.aos_marketing_touchpoint_rollup_v3_preview(date,date);
+drop function if exists public.aos_marketing_attribution_v3_preview(date,date);
+drop function if exists public.aos_marketing_acquisition_customers_v3_preview();
+drop function if exists public.aos_marketing_agenda_lead_match_v3_preview(date,date);
+drop function if exists public.aos_marketing_call_lead_match_v3_preview(date,date);
+drop function if exists public.aos_marketing_treatment_family_v3(text);
+
+commit;
+
+-- Post-rollback gates (execute separately):
+-- 1) compare V2 pg_get_functiondef hashes with Loop 1 BEFORE manifest;
+-- 2) verify no app/public reference to *_v3_* shadow RPCs;
+-- 3) re-read REV-F5 7,064/15,498 + 3,950 clusters + zero members/preview/apply;
+-- 4) never touch aos_llamadas/aos_agenda_citas/aos_leads/aos_ventas as part of this rollback.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP2_SHADOW_BASELINE_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP2_SHADOW_BASELINE_20260818.md
@@ -1,0 +1,173 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 2 Shadow Baseline
+
+**Business date:** 2026-08-18 Lima  
+**Pre-flight main:** `d2113e6e5be91210e111a33813f6d8167b1eb54e`  
+**Supabase migration:** `20260819015951_mkt_integrity_v3_shadow_loop2_20260818`  
+**Mode:** SHADOW / service_role only / frontend unchanged
+
+## V3 objects and definition hashes
+
+| Object | Args | Definition MD5 |
+|---|---|---|
+| `aos_marketing_acquisition_customers_v3_preview` | `()` | `07762236ceb159ec29c34cc2eb1c5b3a` |
+| `aos_marketing_agenda_lead_match_v3_preview` | `(date,date)` | `49c13d3f034b059871b2dc7aa0c7c981` |
+| `aos_marketing_attribution_v3_preview` | `(date,date)` | `ef613afdbf9175c27ebc34bb0763961e` |
+| `aos_marketing_call_lead_match_v3_preview` | `(date,date)` | `8d9ff10aaee45542e6bb527142cea178` |
+| `aos_marketing_leads_detalle_v3_paged` | `(date,date,text,text,integer,integer)` | `5ef19386a24f069a69675e096b96249f` |
+| `aos_marketing_leads_detalle_v3_summary` | `(date,date,text,text)` | `c4cfc9ae3fb4f1aa57e5b9ee76383429` |
+| `aos_marketing_touchpoint_rollup_v3_preview` | `(date,date)` | `c9c735e3d8416f8b27fc7053a0579fdc` |
+| `aos_marketing_treatment_family_v3` | `(text)` | `3aceda874d6a8fb6e787ab51a5abc9fc` |
+
+ACL for every exact Loop-2 object is restricted to `postgres` + `service_role`; no anon/authenticated/public execution is granted in Loop 2.
+
+## V2 definition hashes after V3 migration
+
+All are identical to Loop 1 BEFORE:
+
+- Acquisition V2 `7851ca8c9163625bda8fcf987a1def87`
+- Attribution V2 `630c46e0425e6941283f1b200d3a5ce2`
+- Call→Lead V2 `bcdfc95ac762bfc10dfa0a60c5a9a354`
+- Cohort LTV V2 `b6d2035a3420c6956e3b0248d56e86f6`
+- Histórico V2 `8147cc91935da68ab550435cf7016556`
+- Leads detalle V2 `f25d7c4f052f70e3a3aa901b0afdcf18`
+- Leads paged V2 `9b1d34f0230f4a4870bfba7185a73402`
+- Leads summary V2 `cbd625a744f312bb6e44b28d3b586da4`
+- Period summary V2 `eef10aee61e44898864e355f6197bc1f`
+- Panel asesor `3dc5f2275c84af5efbaf19b337174ea9`
+- Monitoreo `a961d4a99dd35435fe1cf681d7ca8ee9`
+
+## Acquisition shadow parity seed
+
+- V2: **54 customers**.
+- V3 shadow: **55 customers**.
+- V2-only: **0**.
+- V3-only: exactly **1**.
+
+V3-only row:
+
+- phone `973438607`;
+- selected touchpoint `lead 2135`;
+- lead date `2026-03-11`;
+- first sale date `2026-03-12`;
+- method `NEAREST_PRIOR_FIRST_SALE`;
+- confidence `55`.
+
+This is the user-approved expected candidate for Loop 3 parity. Loop 2 does not modify V2 or LTV.
+
+## Attribution shadow delta
+
+2026-01-01 through 2026-08-18:
+
+| Metric | V2 | V3 shadow | Delta |
+|---|---:|---:|---:|
+| Operations | 126 | 173 | +47 |
+| Attributed amount | S/45,158.70 | S/66,644.10 | +S/21,485.40 |
+
+V3-only breakdown:
+
+- `ACQUISITION_HISTORICAL_UNIQUE_MATCH`: **45 ops / 18 persons / S/20,897.40**.
+- `ACQUISITION_NEAREST_PRIOR_FIRST_SALE`: **2 ops / 1 person / S/588** (`973438607`).
+
+Interpretation: Loop-2 V3 attribution adds all operations occurring on the already-recognized first-sale date when an acquisition touchpoint is known. This is intentionally shadow and is **not approved for production cutover** yet. Loop 3/9 must decide whether the operation-level expansion is semantically correct before any reporting migration.
+
+## Buyer reference cases
+
+### `992829013`
+
+- Acquisition customer remains lead `3963` HIFU.
+- V2 attributed operations: **0 / S0**.
+- V3 shadow: **2 / S1,018** on first-sale day.
+- Actual sales recorded: **5 / S2,467**.
+- Remaining S/1,449 is not auto-promoted by Loop 2 and requires later acquisition-vs-followup semantics.
+
+### `998564399`
+
+- Acquisition customer remains lead `4045` CAPILAR.
+- V2 attributed operations: **0 / S0**.
+- V3 shadow: **4 / S1,567**.
+- Actual sales: **4 / S1,567**.
+- Later patient continuities are not turned into new acquisition events by this shadow acquisition function.
+
+## Call→Lead shadow methods, 2026 through 18 Aug
+
+- DIRECT_LEAD_ID: **33**
+- LATE_SAME_DAY_COMPATIBLE: **44**
+- TIMELINE_NEAREST_PRIOR: **647**
+- TIMELINE_NEAREST_PRIOR_FAMILY: **29,970**
+- NO_MATCH: **4,602**
+
+Review/unresolved reasons:
+
+- NO_MARKETING_TOUCHPOINT: **4,164**
+- PRIOR_TREATMENT_MISMATCH: **438**
+
+These are diagnostic shadow classifications, not a backfill list.
+
+Reference gates:
+
+- call `32014` / `961780427` → lead **4650 CAPILAR**, `TIMELINE_NEAREST_PRIOR_FAMILY`, confidence 80, no review.
+- call `35976` / `957549186` → **no automatic lead**, `NO_MATCH`, confidence 0. It remains review-only.
+- Mireya calls `37108` and `37110`: still **absent** from `aos_llamadas` in Loop 2; restoration remains Loop 5.
+
+## Leads modal shadow summary
+
+### Annual 2026 through 18 Aug
+
+V2 current summary:
+
+- total 5,669;
+- llamados 5,460;
+- con cita 746;
+- vendidos 56;
+- sin contacto 207;
+- monto S/101,959.85.
+
+V3 shadow:
+
+- effective touchpoints **5,628**;
+- unique persons **5,338**;
+- called touchpoints **5,444** / unique called persons **5,331**;
+- touchpoints with attributed cita **480** / unique persons **478**;
+- sold/attributed touchpoints **55** / unique sold persons **55**;
+- no-contact touchpoints **184** / unique persons **163**;
+- acquisitions **55**;
+- attributed sales operations **173**;
+- attributed amount **S/66,644.10**.
+
+The large cita/revenue difference is expected at this shadow stage because V2 copies phone-window events across touchpoints while V3 resolves events to one touchpoint. It is a parity subject, not a production replacement decision in Loop 2.
+
+### August 2026 through 18 Aug
+
+V2: 658 total / 612 called / 44 con cita / 5 sold / 44 sin contacto / S/2,402.
+
+V3 shadow: 651 effective touchpoints / 643 persons / 610 called / 43 con cita / 4 sold / 41 sin contacto / **4 acquisitions / 10 sale operations / S/2,352**.
+
+The V3 amount matches the current August M0 acquisition/LTV amount S/2,352; V2 modal includes a broader phone-window amount. Keep both visible for Loop 3/9 analysis.
+
+## Non-exclusive filters proven
+
+V3 `CON CITA` annual filter returns 480 touchpoints and includes **42 sold touchpoints**. Therefore sold leads no longer disappear from the `CON CITA` dimension in the shadow contract.
+
+V3 `VENDIDO` annual filter returns 55 sold touchpoints/persons, with 42 also having an attributed cita.
+
+## Pagination proven beyond 1,000
+
+- offset 0 / limit 100 → 100 rows, `total_rows=5,628`.
+- offset 1,000 / limit 100 → 100 rows, `total_rows=5,628`.
+
+Thus the V3 paged contract has no 1,000-row universe ceiling.
+
+## Duplicate-phone reference `998719392`
+
+V3 returns two separate touchpoints without repeating the old phone-level aggregate onto both:
+
+- lead `4681` (2026-07-22): **1 call / 0 citas / 0 attributed sales**;
+- lead `5203` (2026-08-07): **5 calls / 2 citas / 0 attributed sales**.
+
+Its old-customer/re-activation revenue is intentionally not forced into acquisition V3; reactivation attribution belongs to later loops.
+
+## Determinism / cutover status
+
+The functions are SQL STABLE/IMMUTABLE shadow functions. Loop 2 only reads them. They are not frontend-addressable by anon/authenticated roles, and production frontend was not changed.
+
+**Shadow baseline status:** `CAPTURED_FOR_LOOP3_PARITY`.

--- a/supabase/migrations/20260819015100_mkt_integrity_v3_shadow_loop2.sql
+++ b/supabase/migrations/20260819015100_mkt_integrity_v3_shadow_loop2.sql
@@ -1,0 +1,264 @@
+-- MKT-INTEGRITY-HOTFIX-V3 / LOOP 2
+-- Shadow/read-only Marketing V3. No business-table DML. V2 remains production.
+
+create or replace function public.aos_marketing_treatment_family_v3(p_text text)
+returns text language sql immutable parallel safe as $$
+select case
+  when nullif(btrim(coalesce(p_text,'')),'') is null then null
+  when upper(p_text) like '%CAPIL%' or upper(p_text) like '%EXOSOM%' then 'CAPILAR'
+  when upper(p_text) like '%BIO%ESTIM%' then 'BIOESTIMULADOR'
+  when upper(p_text) like '%ENZIM%' then 'ENZIMAS'
+  when upper(p_text) like '%HIFU%' then 'HIFU'
+  when upper(p_text) like '%TOXIN%' then 'TOXINA'
+  when upper(p_text) like '%HIALUR%' then 'ACIDO_HIALURONICO'
+  when upper(p_text) like '%CRIOLIP%' then 'CRIOLIPOLISIS'
+  when upper(p_text) like '%HIDRO%' then 'HIDROFACIAL'
+  when upper(p_text) like '%VITAM%' then 'VITAMINAS'
+  when upper(p_text) like '%PINK%' or upper(p_text) like '%INTIMATE%' then 'PINK_INTIMATE'
+  when upper(p_text) like '%RADIOFRECUENCIA%' then 'RADIOFRECUENCIA'
+  else upper(regexp_replace(btrim(p_text),'\s+',' ','g'))
+end;
+$$;
+
+create or replace function public.aos_marketing_call_lead_match_v3_preview(p_desde date default null, p_hasta date default null)
+returns table(llamada_id bigint,llamada_ts timestamptz,numero_limpio text,llamada_tratamiento text,lead_id bigint,lead_ts timestamptz,lead_tratamiento text,metodo_match text,confidence integer,temporal_relation text,review_code text)
+language sql stable as $$
+with tp as materialized (
+  select * from public.aos_marketing_touchpoints_v2(null,null) where not es_duplicado_tecnico_probable
+), calls as materialized (
+  select ll.id llamada_id,public.aos_llamada_event_ts(ll.fecha,ll.hora_llamada,ll.created_at,ll.ult_ts,ll.ts_log) llamada_ts,
+         ll.numero_limpio,ll.tratamiento llamada_tratamiento,public.aos_marketing_treatment_family_v3(ll.tratamiento) llamada_family,ll.lead_id_origen
+  from public.aos_llamadas ll
+  where ll.numero_limpio is not null and ll.numero_limpio<>'' and (p_desde is null or ll.fecha>=p_desde) and (p_hasta is null or ll.fecha<=p_hasta)
+), prior_ranked as (
+  select c.llamada_id,t.lead_id,t.lead_ts,t.tratamiento lead_tratamiento,public.aos_marketing_treatment_family_v3(t.tratamiento) lead_family,
+         row_number() over(partition by c.llamada_id order by t.lead_ts desc,t.lead_id desc) rn
+  from calls c join tp t on t.numero_limpio=c.numero_limpio and t.lead_ts<=c.llamada_ts where c.lead_id_origen is null
+), prior_best as (select * from prior_ranked where rn=1),
+future_candidates as (
+  select c.llamada_id,t.lead_id,t.lead_ts,t.tratamiento lead_tratamiento,count(*) over(partition by c.llamada_id) n_compatible,
+         row_number() over(partition by c.llamada_id order by t.lead_ts,t.lead_id) rn
+  from calls c
+  left join prior_best pb on pb.llamada_id=c.llamada_id
+  join tp t on t.numero_limpio=c.numero_limpio and t.lead_ts>c.llamada_ts and t.lead_ts<=c.llamada_ts+interval '12 hours'
+           and (t.lead_ts at time zone 'America/Lima')::date=(c.llamada_ts at time zone 'America/Lima')::date
+  where c.lead_id_origen is null
+    and (pb.llamada_id is null or (c.llamada_family is not null and pb.lead_family is distinct from c.llamada_family))
+    and (c.llamada_family is null or public.aos_marketing_treatment_family_v3(t.tratamiento)=c.llamada_family)
+), future_best as (select * from future_candidates where rn=1),
+future_any as (
+  select c.llamada_id,count(*) n_any
+  from calls c join tp t on t.numero_limpio=c.numero_limpio and t.lead_ts>c.llamada_ts and t.lead_ts<=c.llamada_ts+interval '12 hours'
+   and (t.lead_ts at time zone 'America/Lima')::date=(c.llamada_ts at time zone 'America/Lima')::date
+  group by c.llamada_id
+)
+select c.llamada_id,c.llamada_ts,c.numero_limpio,c.llamada_tratamiento,
+ case when c.lead_id_origen is not null then c.lead_id_origen
+      when pb.lead_id is not null and (c.llamada_family is null or pb.lead_family=c.llamada_family) then pb.lead_id
+      when fb.n_compatible=1 then fb.lead_id else null end,
+ case when c.lead_id_origen is not null then dl.lead_ts
+      when pb.lead_id is not null and (c.llamada_family is null or pb.lead_family=c.llamada_family) then pb.lead_ts
+      when fb.n_compatible=1 then fb.lead_ts else null end,
+ case when c.lead_id_origen is not null then dl.tratamiento
+      when pb.lead_id is not null and (c.llamada_family is null or pb.lead_family=c.llamada_family) then pb.lead_tratamiento
+      when fb.n_compatible=1 then fb.lead_tratamiento else null end,
+ case when c.lead_id_origen is not null then 'DIRECT_LEAD_ID'
+      when pb.lead_id is not null and c.llamada_family is not null and pb.lead_family=c.llamada_family then 'TIMELINE_NEAREST_PRIOR_FAMILY'
+      when pb.lead_id is not null and c.llamada_family is null then 'TIMELINE_NEAREST_PRIOR'
+      when fb.n_compatible=1 then 'LATE_SAME_DAY_COMPATIBLE'
+      when coalesce(fb.n_compatible,0)>1 then 'LATE_AMBIGUOUS' else 'NO_MATCH' end,
+ case when c.lead_id_origen is not null then 100
+      when pb.lead_id is not null and c.llamada_family is not null and pb.lead_family=c.llamada_family then 80
+      when pb.lead_id is not null and c.llamada_family is null then 65
+      when fb.n_compatible=1 then 75 when coalesce(fb.n_compatible,0)>1 then 40 else 0 end,
+ case when c.lead_id_origen is not null then 'DIRECT'
+      when pb.lead_id is not null and (c.llamada_family is null or pb.lead_family=c.llamada_family) then 'PRIOR'
+      when fb.n_compatible=1 then 'LATE' else 'UNRESOLVED' end,
+ case when c.lead_id_origen is not null or (pb.lead_id is not null and (c.llamada_family is null or pb.lead_family=c.llamada_family)) or fb.n_compatible=1 then null
+      when coalesce(fb.n_compatible,0)>1 then 'MULTIPLE_LATE_COMPATIBLE'
+      when pb.lead_id is not null and c.llamada_family is not null and pb.lead_family is distinct from c.llamada_family then 'PRIOR_TREATMENT_MISMATCH'
+      when coalesce(fa.n_any,0)>0 then 'LATE_TREATMENT_MISMATCH' else 'NO_MARKETING_TOUCHPOINT' end
+from calls c
+left join tp dl on dl.lead_id=c.lead_id_origen
+left join prior_best pb on pb.llamada_id=c.llamada_id
+left join future_best fb on fb.llamada_id=c.llamada_id
+left join future_any fa on fa.llamada_id=c.llamada_id;
+$$;
+
+create or replace function public.aos_marketing_agenda_lead_match_v3_preview(p_desde date default null, p_hasta date default null)
+returns table(cita_id text,cita_ts timestamptz,fecha_cita date,numero_limpio text,asesor text,cita_tratamiento text,lead_id bigint,llamada_id bigint,metodo_match text,confidence integer,review_code text)
+language sql stable as $$
+with tp as materialized (select * from public.aos_marketing_touchpoints_v2(null,null) where not es_duplicado_tecnico_probable),
+cm as materialized (select * from public.aos_marketing_call_lead_match_v3_preview(null,null)),
+citas as materialized (
+ select c.id cita_id,coalesce(c.ts_creado,c.fecha_cita::timestamptz) cita_ts,c.fecha_cita,c.numero_limpio,c.asesor,c.tratamiento cita_tratamiento,
+        public.aos_marketing_treatment_family_v3(c.tratamiento) cita_family,c.lead_id_origen,c.llamada_id_origen,c.origen_cita,c.origen
+ from public.aos_agenda_citas c
+ where c.numero_limpio is not null and c.numero_limpio<>'' and (p_desde is null or c.fecha_cita>=p_desde) and (p_hasta is null or c.fecha_cita<=p_hasta)
+), near_call_ranked as (
+ select c.cita_id,m.llamada_id,m.lead_id,m.metodo_match,m.confidence,row_number() over(partition by c.cita_id order by abs(extract(epoch from(m.llamada_ts-c.cita_ts))),m.confidence desc,m.llamada_id desc) rn
+ from citas c join cm m on m.numero_limpio=c.numero_limpio and m.lead_id is not null
+ join public.aos_llamadas ll on ll.id=m.llamada_id
+ where upper(coalesce(ll.estado,''))='CITA CONFIRMADA' and upper(coalesce(ll.asesor,''))=upper(coalesce(c.asesor,'')) and abs(extract(epoch from(m.llamada_ts-c.cita_ts)))<=600
+), near_call as (select * from near_call_ranked where rn=1),
+prior_ranked as (
+ select c.cita_id,t.lead_id,t.lead_ts,t.tratamiento lead_tratamiento,public.aos_marketing_treatment_family_v3(t.tratamiento) lead_family,
+        row_number() over(partition by c.cita_id order by t.lead_ts desc,t.lead_id desc) rn
+ from citas c join tp t on t.numero_limpio=c.numero_limpio and t.lead_ts<=c.cita_ts
+ where c.lead_id_origen is null and c.llamada_id_origen is null and upper(coalesce(c.origen_cita,'')) in ('CALL_CENTER','CITA_MANUAL','CALL_CENTER_MANUAL')
+), prior_best as (select * from prior_ranked where rn=1),
+future_candidates as (
+ select c.cita_id,t.lead_id,t.lead_ts,t.tratamiento lead_tratamiento,count(*) over(partition by c.cita_id) n_compatible,
+        row_number() over(partition by c.cita_id order by t.lead_ts,t.lead_id) rn
+ from citas c
+ left join prior_best pb on pb.cita_id=c.cita_id
+ left join near_call nc on nc.cita_id=c.cita_id
+ join tp t on t.numero_limpio=c.numero_limpio and t.lead_ts>c.cita_ts and t.lead_ts<=c.cita_ts+interval '12 hours'
+  and (t.lead_ts at time zone 'America/Lima')::date=(c.cita_ts at time zone 'America/Lima')::date
+ where c.lead_id_origen is null and c.llamada_id_origen is null and nc.cita_id is null
+  and upper(coalesce(c.origen_cita,'')) in ('CALL_CENTER','CITA_MANUAL','CALL_CENTER_MANUAL')
+  and (pb.cita_id is null or (c.cita_family is not null and pb.lead_family is distinct from c.cita_family))
+  and (c.cita_family is null or public.aos_marketing_treatment_family_v3(t.tratamiento)=c.cita_family)
+), future_best as (select * from future_candidates where rn=1)
+select c.cita_id,c.cita_ts,c.fecha_cita,c.numero_limpio,c.asesor,c.cita_tratamiento,
+ case when c.lead_id_origen is not null then c.lead_id_origen
+      when c.llamada_id_origen is not null and dm.lead_id is not null then dm.lead_id
+      when nc.lead_id is not null then nc.lead_id
+      when pb.lead_id is not null and (c.cita_family is null or pb.lead_family=c.cita_family) then pb.lead_id
+      when fb.n_compatible=1 then fb.lead_id else null end,
+ case when c.llamada_id_origen is not null then c.llamada_id_origen when nc.llamada_id is not null then nc.llamada_id else null end,
+ case when c.lead_id_origen is not null then 'DIRECT_LEAD_ID'
+      when c.llamada_id_origen is not null and dm.lead_id is not null then 'DIRECT_LLAMADA_ID'
+      when nc.lead_id is not null then 'NEAR_CONFIRMED_CALL'
+      when pb.lead_id is not null and (c.cita_family is null or pb.lead_family=c.cita_family) then 'AGENDA_TIMELINE_PRIOR'
+      when fb.n_compatible=1 then 'AGENDA_LATE_SAME_DAY_COMPATIBLE'
+      when coalesce(fb.n_compatible,0)>1 then 'AGENDA_LATE_AMBIGUOUS' else 'NO_MATCH' end,
+ case when c.lead_id_origen is not null then 100
+      when c.llamada_id_origen is not null and dm.lead_id is not null then least(dm.confidence,98)
+      when nc.lead_id is not null then least(nc.confidence,90)
+      when pb.lead_id is not null and (c.cita_family is null or pb.lead_family=c.cita_family) then 60
+      when fb.n_compatible=1 then 70 when coalesce(fb.n_compatible,0)>1 then 40 else 0 end,
+ case when c.llamada_id_origen is not null and dm.lead_id is null then 'DIRECT_CALL_WITHOUT_LEAD'
+      when coalesce(fb.n_compatible,0)>1 then 'MULTIPLE_LATE_COMPATIBLE'
+      when pb.lead_id is not null and c.cita_family is not null and pb.lead_family is distinct from c.cita_family and fb.lead_id is null then 'PRIOR_TREATMENT_MISMATCH'
+      when c.lead_id_origen is null and c.llamada_id_origen is null and nc.lead_id is null and pb.lead_id is null and fb.lead_id is null and upper(coalesce(c.origen_cita,'')) not in ('CALL_CENTER','CITA_MANUAL','CALL_CENTER_MANUAL') then 'AGENDA_NON_CALLCENTER'
+      when c.lead_id_origen is null and coalesce(dm.lead_id,nc.lead_id,case when pb.lead_id is not null and (c.cita_family is null or pb.lead_family=c.cita_family) then pb.lead_id end,case when fb.n_compatible=1 then fb.lead_id end) is null then 'NO_MARKETING_TOUCHPOINT'
+      else null end
+from citas c
+left join cm dm on dm.llamada_id=c.llamada_id_origen
+left join near_call nc on nc.cita_id=c.cita_id
+left join prior_best pb on pb.cita_id=c.cita_id
+left join future_best fb on fb.cita_id=c.cita_id;
+$$;
+
+create or replace function public.aos_marketing_acquisition_customers_v3_preview()
+returns table(numero_limpio text,lead_id bigint,lead_fecha date,lead_anuncio text,lead_tratamiento text,first_sale_date date,attribution_method text,confidence integer)
+language sql stable as $$
+with first_sale as materialized (
+ select v.numero_limpio,min(v.fecha) first_sale_date from public.aos_ventas v where v.numero_limpio is not null and v.numero_limpio<>'' group by v.numero_limpio
+), direct_attrs as materialized (
+ select a.* from public.aos_marketing_attribution_v2_preview(null,null) a join first_sale f on f.numero_limpio=a.numero_limpio and a.venta_fecha=f.first_sale_date where a.lead_id is not null
+), direct_ranked as (
+ select a.*,row_number() over(partition by a.numero_limpio order by a.confidence desc,a.lead_fecha desc,a.lead_id) rn from direct_attrs a
+), direct_best as (
+ select d.numero_limpio,d.lead_id,d.lead_fecha,d.lead_anuncio,d.lead_tratamiento,f.first_sale_date,d.metodo_match attribution_method,d.confidence from direct_ranked d join first_sale f using(numero_limpio) where d.rn=1
+), unresolved as (select f.* from first_sale f left join direct_best d using(numero_limpio) where d.numero_limpio is null),
+prior_candidates as (
+ select u.numero_limpio,u.first_sale_date,t.lead_id,t.fecha,t.anuncio,t.tratamiento,t.lead_ts,count(*) over(partition by u.numero_limpio) candidate_count,
+        row_number() over(partition by u.numero_limpio order by t.lead_ts desc,t.lead_id desc) rn
+ from unresolved u join public.aos_marketing_touchpoints_v2(null,null) t on t.numero_limpio=u.numero_limpio and not t.es_duplicado_tecnico_probable and t.fecha<=u.first_sale_date and t.lead_ts<(u.first_sale_date+interval '1 day')
+), prior_best as (select * from prior_candidates where rn=1)
+select d.numero_limpio,d.lead_id,d.lead_fecha,d.lead_anuncio,d.lead_tratamiento,d.first_sale_date,d.attribution_method,d.confidence from direct_best d
+union all
+select p.numero_limpio,p.lead_id,p.fecha,p.anuncio,p.tratamiento,p.first_sale_date,case when p.candidate_count=1 then 'HISTORICAL_UNIQUE_MATCH' else 'NEAREST_PRIOR_FIRST_SALE' end,case when p.candidate_count=1 then 60 else 55 end from prior_best p;
+$$;
+
+create or replace function public.aos_marketing_attribution_v3_preview(p_desde date default null,p_hasta date default null)
+returns table(venta_pk bigint,venta_id text,venta_fecha date,monto numeric,tratamiento_compra text,numero_limpio text,lead_id bigint,lead_fecha date,lead_anuncio text,lead_tratamiento text,llamada_id bigint,cita_id text,metodo_match text,confidence integer,tipo_atribucion text,anomaly_code text)
+language sql stable as $$
+with base as materialized (select * from public.aos_marketing_attribution_v2_preview(p_desde,p_hasta)),acq as materialized (select * from public.aos_marketing_acquisition_customers_v3_preview()),
+fallback as (
+ select v.id::bigint,v.venta_id,v.fecha,v.monto,v.tratamiento,v.numero_limpio,a.lead_id,a.lead_fecha,a.lead_anuncio,a.lead_tratamiento,null::bigint,null::text,
+        ('ACQUISITION_'||a.attribution_method)::text,least(a.confidence,60)::integer,'ADQUISICION'::text,null::text
+ from public.aos_ventas v join acq a on a.numero_limpio=v.numero_limpio and v.fecha=a.first_sale_date left join base b on b.venta_pk=v.id
+ where b.venta_pk is null and (p_desde is null or v.fecha>=p_desde) and (p_hasta is null or v.fecha<=p_hasta)
+)
+select b.venta_pk,b.venta_id,b.venta_fecha,b.monto,b.tratamiento_compra,b.numero_limpio,b.lead_id,b.lead_fecha,b.lead_anuncio,b.lead_tratamiento,b.llamada_id,b.cita_id,b.metodo_match,b.confidence,b.tipo_atribucion,b.anomaly_code from base b
+union all select * from fallback;
+$$;
+
+create or replace function public.aos_marketing_touchpoint_rollup_v3_preview(p_fecha_desde date default null,p_fecha_hasta date default null)
+returns table(lead_id bigint,fecha date,hora_ingreso timestamptz,celular text,numero_limpio text,tratamiento text,anuncio text,preguntas text,llamadas_total bigint,ultima_llamada timestamptz,ultimo_estado text,ultimo_asesor text,llamada_match_method text,llamada_match_confidence integer,citas_total bigint,proxima_cita_fecha date,proxima_cita_estado text,cita_match_method text,cita_match_confidence integer,ventas_total bigint,monto_facturado numeric,venta_match_method text,venta_match_confidence integer,es_llamado boolean,tiene_cita boolean,es_vendido boolean,es_adquisicion boolean,categoria_comercial text,review_required boolean)
+language sql stable as $$
+with tp as materialized (
+ select t.*,l.celular,l.preguntas from public.aos_marketing_touchpoints_v2(p_fecha_desde,p_fecha_hasta) t join public.aos_leads l on l.id=t.lead_id where not t.es_duplicado_tecnico_probable
+), cm as materialized (select * from public.aos_marketing_call_lead_match_v3_preview(null,null) where lead_id is not null),
+ca as (
+ select cm.lead_id,count(*)::bigint total,max(cm.llamada_ts) ultima_ts,(array_agg(ll.estado order by cm.llamada_ts desc,ll.id desc))[1] ultimo_estado,
+        (array_agg(ll.asesor order by cm.llamada_ts desc,ll.id desc))[1] ultimo_asesor,(array_agg(cm.metodo_match order by cm.confidence desc,cm.llamada_ts desc))[1] metodo,max(cm.confidence)::integer confidence
+ from cm join public.aos_llamadas ll on ll.id=cm.llamada_id group by cm.lead_id
+), am as materialized (select * from public.aos_marketing_agenda_lead_match_v3_preview(null,null) where lead_id is not null),
+aa as (
+ select am.lead_id,count(distinct am.cita_id)::bigint total,min(am.fecha_cita) filter(where am.fecha_cita >= (now() at time zone 'America/Lima')::date) proxima_fecha,
+        (array_agg(c.estado_cita order by am.fecha_cita asc,am.cita_ts desc) filter(where am.fecha_cita >= (now() at time zone 'America/Lima')::date))[1] proxima_estado,
+        (array_agg(am.metodo_match order by am.confidence desc,am.cita_ts desc))[1] metodo,max(am.confidence)::integer confidence
+ from am join public.aos_agenda_citas c on c.id=am.cita_id group by am.lead_id
+), sv as materialized (select * from public.aos_marketing_attribution_v3_preview(null,null) where lead_id is not null),
+sa as (
+ select sv.lead_id,count(distinct sv.venta_pk)::bigint total,coalesce(sum(sv.monto),0)::numeric monto_total,(array_agg(sv.metodo_match order by sv.confidence desc,sv.venta_fecha desc,sv.venta_pk desc))[1] metodo,
+        max(sv.confidence)::integer confidence,bool_or(sv.tipo_atribucion='REACTIVACION') has_reactivation,bool_or(sv.tipo_atribucion='SEGUIMIENTO_HISTORICO') has_followup
+ from sv group by sv.lead_id
+), acq as materialized (select * from public.aos_marketing_acquisition_customers_v3_preview())
+select tp.lead_id,tp.fecha,tp.hora_ingreso,tp.celular,tp.numero_limpio,tp.tratamiento,tp.anuncio,tp.preguntas,
+ coalesce(ca.total,0),ca.ultima_ts,ca.ultimo_estado,ca.ultimo_asesor,ca.metodo,coalesce(ca.confidence,0),
+ coalesce(aa.total,0),aa.proxima_fecha,aa.proxima_estado,aa.metodo,coalesce(aa.confidence,0),
+ coalesce(sa.total,0),coalesce(sa.monto_total,0),sa.metodo,coalesce(sa.confidence,0),
+ (coalesce(ca.total,0)>0),(coalesce(aa.total,0)>0),(coalesce(sa.total,0)>0),(acq.lead_id is not null),
+ case when acq.lead_id is not null then 'ADQUISICION' when coalesce(sa.has_reactivation,false) then 'REACTIVACION' when coalesce(sa.has_followup,false) then 'SEGUIMIENTO_HISTORICO' when coalesce(aa.total,0)>0 then 'RECUPERACION_LEAD' when coalesce(ca.total,0)>0 then 'EN_GESTION' else 'SIN_CONTACTO' end::text,
+ ((coalesce(ca.confidence,100)>0 and coalesce(ca.confidence,100)<60) or (coalesce(aa.confidence,100)>0 and coalesce(aa.confidence,100)<60) or (coalesce(sa.confidence,100)>0 and coalesce(sa.confidence,100)<50))::boolean
+from tp left join ca on ca.lead_id=tp.lead_id left join aa on aa.lead_id=tp.lead_id left join sa on sa.lead_id=tp.lead_id left join acq on acq.lead_id=tp.lead_id;
+$$;
+
+create or replace function public.aos_marketing_leads_detalle_v3_paged(p_fecha_desde date,p_fecha_hasta date,p_search text default null,p_estado text default null,p_limit integer default 50,p_offset integer default 0)
+returns table(total_rows bigint,lead_id bigint,fecha date,hora_ingreso timestamptz,celular text,numero_limpio text,tratamiento text,anuncio text,preguntas text,llamadas_total bigint,ultima_llamada timestamptz,ultimo_estado text,ultimo_asesor text,llamada_match_method text,llamada_match_confidence integer,citas_total bigint,proxima_cita_fecha date,proxima_cita_estado text,cita_match_method text,cita_match_confidence integer,ventas_total bigint,monto_facturado numeric,venta_match_method text,venta_match_confidence integer,es_llamado boolean,tiene_cita boolean,es_vendido boolean,es_adquisicion boolean,categoria_comercial text,review_required boolean)
+language sql stable as $$
+with base as materialized (select * from public.aos_marketing_touchpoint_rollup_v3_preview(p_fecha_desde,p_fecha_hasta)),filtered as (
+ select b.* from base b where (coalesce(btrim(p_search),'')='' or coalesce(b.numero_limpio,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.celular,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.tratamiento,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.anuncio,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.ultimo_asesor,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.categoria_comercial,'') ilike '%'||btrim(p_search)||'%')
+ and case upper(coalesce(btrim(p_estado),'TODOS')) when '' then true when 'TODOS' then true when 'CON CITA' then b.tiene_cita when 'VENDIDO' then b.es_vendido when 'EN GESTION' then b.es_llamado and not b.tiene_cita and not b.es_vendido when 'SIN CONTACTO' then not b.es_llamado when 'ADQUISICION' then b.es_adquisicion when 'REACTIVACION' then b.categoria_comercial='REACTIVACION' when 'RECUPERACION LEAD' then b.categoria_comercial='RECUPERACION_LEAD' when 'REVIEW' then b.review_required else true end
+),ranked as (select f.*,count(*) over() total_rows from filtered f)
+select r.total_rows,r.lead_id,r.fecha,r.hora_ingreso,r.celular,r.numero_limpio,r.tratamiento,r.anuncio,r.preguntas,r.llamadas_total,r.ultima_llamada,r.ultimo_estado,r.ultimo_asesor,r.llamada_match_method,r.llamada_match_confidence,r.citas_total,r.proxima_cita_fecha,r.proxima_cita_estado,r.cita_match_method,r.cita_match_confidence,r.ventas_total,r.monto_facturado,r.venta_match_method,r.venta_match_confidence,r.es_llamado,r.tiene_cita,r.es_vendido,r.es_adquisicion,r.categoria_comercial,r.review_required
+from ranked r order by r.fecha desc,r.hora_ingreso desc nulls last,r.lead_id desc limit greatest(1,least(coalesce(p_limit,50),200)) offset greatest(coalesce(p_offset,0),0);
+$$;
+
+create or replace function public.aos_marketing_leads_detalle_v3_summary(p_fecha_desde date default null,p_fecha_hasta date default null,p_search text default null,p_estado text default null)
+returns jsonb language sql stable as $$
+with base as materialized (select * from public.aos_marketing_touchpoint_rollup_v3_preview(p_fecha_desde,p_fecha_hasta)),filtered as (
+ select b.* from base b where (coalesce(btrim(p_search),'')='' or coalesce(b.numero_limpio,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.celular,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.tratamiento,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.anuncio,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.ultimo_asesor,'') ilike '%'||btrim(p_search)||'%' or coalesce(b.categoria_comercial,'') ilike '%'||btrim(p_search)||'%')
+ and case upper(coalesce(btrim(p_estado),'TODOS')) when '' then true when 'TODOS' then true when 'CON CITA' then b.tiene_cita when 'VENDIDO' then b.es_vendido when 'EN GESTION' then b.es_llamado and not b.tiene_cita and not b.es_vendido when 'SIN CONTACTO' then not b.es_llamado when 'ADQUISICION' then b.es_adquisicion when 'REACTIVACION' then b.categoria_comercial='REACTIVACION' when 'RECUPERACION LEAD' then b.categoria_comercial='RECUPERACION_LEAD' when 'REVIEW' then b.review_required else true end
+)
+select jsonb_build_object('total',count(*),'touchpoints',count(*),'personasUnicas',count(distinct numero_limpio),'llamados',count(*) filter(where es_llamado),'personasLlamadas',count(distinct numero_limpio) filter(where es_llamado),'conCita',count(*) filter(where tiene_cita),'personasConCita',count(distinct numero_limpio) filter(where tiene_cita),'vendidos',count(*) filter(where es_vendido),'personasVendidas',count(distinct numero_limpio) filter(where es_vendido),'sinContacto',count(*) filter(where not es_llamado),'personasSinContacto',count(distinct numero_limpio) filter(where not es_llamado),'adquisiciones',count(*) filter(where es_adquisicion),'personasAdquiridas',count(distinct numero_limpio) filter(where es_adquisicion),'montoFacturado',coalesce(sum(monto_facturado),0),'operacionesVenta',coalesce(sum(ventas_total),0)) from filtered;
+$$;
+
+-- Shadow-only ACL: no anon/public frontend access in Loop 2.
+revoke all on function public.aos_marketing_treatment_family_v3(text) from public,anon,authenticated;
+revoke all on function public.aos_marketing_call_lead_match_v3_preview(date,date) from public,anon,authenticated;
+revoke all on function public.aos_marketing_agenda_lead_match_v3_preview(date,date) from public,anon,authenticated;
+revoke all on function public.aos_marketing_acquisition_customers_v3_preview() from public,anon,authenticated;
+revoke all on function public.aos_marketing_attribution_v3_preview(date,date) from public,anon,authenticated;
+revoke all on function public.aos_marketing_touchpoint_rollup_v3_preview(date,date) from public,anon,authenticated;
+revoke all on function public.aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer) from public,anon,authenticated;
+revoke all on function public.aos_marketing_leads_detalle_v3_summary(date,date,text,text) from public,anon,authenticated;
+
+grant execute on function public.aos_marketing_treatment_family_v3(text) to service_role;
+grant execute on function public.aos_marketing_call_lead_match_v3_preview(date,date) to service_role;
+grant execute on function public.aos_marketing_agenda_lead_match_v3_preview(date,date) to service_role;
+grant execute on function public.aos_marketing_acquisition_customers_v3_preview() to service_role;
+grant execute on function public.aos_marketing_attribution_v3_preview(date,date) to service_role;
+grant execute on function public.aos_marketing_touchpoint_rollup_v3_preview(date,date) to service_role;
+grant execute on function public.aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer) to service_role;
+grant execute on function public.aos_marketing_leads_detalle_v3_summary(date,date,text,text) to service_role;
+
+comment on function public.aos_marketing_acquisition_customers_v3_preview() is 'MKT Integrity V3 Loop 2 shadow only; V2 remains production.';
+comment on function public.aos_marketing_attribution_v3_preview(date,date) is 'MKT Integrity V3 Loop 2 shadow only; no business-data writes.';
+comment on function public.aos_marketing_leads_detalle_v3_paged(date,date,text,text,integer,integer) is 'MKT Integrity V3 Loop 2 server-side paged shadow detail.';
+comment on function public.aos_marketing_leads_detalle_v3_summary(date,date,text,text) is 'MKT Integrity V3 Loop 2 full-universe shadow summary.';


### PR DESCRIPTION
## LOOP 2 — Marketing V3 Shadow

Scope is strictly shadow/read-only infrastructure. V2 remains production.

### Adds
- Impact Report committed before persistent DDL.
- One additive Supabase migration with 8 V3 service-role-only shadow functions.
- Server-side paged/summary contracts without 1,000-row ceiling.
- Acquisition shadow 54→55 with exactly one expected delta (`973438607 → lead 2135`).
- Inspectable Attribution shadow delta (126/S45,158.70 → 173/S66,644.10) explicitly NOT approved for cutover.
- Rollback SQL + execution/baseline docs.
- CURRENT updated; lock remains `MKT-INTEGRITY-HOTFIX-V3`.

### Safety
- No app/frontend files changed.
- No V2 function definitions changed.
- No business-table DML.
- No backfills.
- No restore of Mireya 37108/37110.
- REV-F5 unchanged at 7,064/15,498 and 3,950 clusters.
- Loop 3 is NOT started.

Expected diff: `docs/control/**` + one `supabase/migrations/**` file only.