### PR TITLE
FIX — unblock MKT Integrity V3 Loop 5 and certify historical inferred calls

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -2,7 +2,7 @@
 
 **Status:** CURRENT / REV-F5 PAUSED RECOVERABLY / MKT-INTEGRITY-HOTFIX-V3 ACTIVE  
 **Owner assignment:** 2026-08-18 Lima — Marketing Integrity & Call Center Semantics V3  
-**Certified main before Loop 5:** `488eb8d703f25e46d330161bdc8cf8c695bed5e9`  
+**Loop-5R entry main:** `19c326a7f3193ec88dc3ec7755aa29391b091dfd`  
 **Previous lock:** `REV-F5-CLOSEOUT` — `PAUSED_RECOVERABLY`  
 **ACTIVE LOCK:** `MKT-INTEGRITY-HOTFIX-V3`  
 **NEXT LOCK:** `REV-F5-CLOSEOUT` only after MKT Integrity production certification and handback.
@@ -13,129 +13,139 @@
 - LOOP 2 — Marketing V3 Shadow: **PASS**.
 - LOOP 3 — Acquisition V2↔V3 parity: **PASS**.
 - LOOP 4 — Deterministic late-lead backfill: **PASS**.
-- LOOP 5 — Mireya repair / inbound-manual semantics: **BLOCKED / STOPPED_PRE_PRODUCT**.
+- LOOP 5 — Mireya repair / inbound-manual semantics: **PASS_PENDING_GITHUB_MERGE_READBACK**.
 - LOOP 6 — Semántica Call Center + modal paciente existente: **NOT STARTED**.
 
-Loop 5 did not perform productive DML. Do not begin Loop 6 automatically.
+Loop 5 was unblocked by the narrowly scoped prerequisite `LOOP 5R — cleanup semantics + historical inferred reconciliation`. Do not begin Loop 6 automatically.
 
 ## REV-F5 recoverable pause
 
 Canonical checkpoint: `docs/control/REV_F5_PAUSE_CHECKPOINT_20260818_MKT_INTEGRITY_V3.md`.
 
-Current certified frozen state remains:
+Current frozen state remains:
 
-- `aos_f5_source_batches_v1`: **6 batches / 15,498 expected rows**;
-- `aos_f5_patient_source_rows_v1`: **7,064**;
-- remaining: **8,434**;
-- `aos_f5_identity_clusters_v1`: **3,950**;
-- members: **0**;
-- preview: **0**;
-- apply events: **0**.
+- 6 source batches / **15,498** expected rows;
+- **7,064** source rows;
+- **8,434** remaining;
+- **3,950** identity clusters;
+- members **0**;
+- preview **0**;
+- apply events **0**.
 
-High-water timestamps remain:
+Canonical Loop-1 recovery hashes remain:
 
-- batch/source: `2026-08-18T20:13:13.549661Z`;
-- cluster update: `2026-08-15T22:23:56.291622Z`.
+- batches `807f03e96e5786203d867938c3938154`
+- source rows `62b8fbedaa5da450a38c2471dd23b6b9`
+- clusters `2d39d9ac990fee61a7ecb6ffa52efb64`
 
-Loop-1 canonical hashes remain the recovery contract:
+## Marketing acquisition/revenue invariants
 
-- batches: `807f03e96e5786203d867938c3938154`
-- source rows: `62b8fbedaa5da450a38c2471dd23b6b9`
-- clusters: `2d39d9ac990fee61a7ecb6ffa52efb64`
-
-## Marketing V3 baseline preserved
-
-Acquisition:
-
-- V2 = **54**;
-- V3 = **55**;
-- V3-only = exactly `973438607 → lead 2135`;
-- deterministic V3 hash = `3223caf0ec5d1b264c4494775c6f7d58`;
-- duplicate acquisitions = **0**;
+- Acquisition V2 = **54**.
+- Acquisition V3 = **55**.
+- V3-only = exactly `973438607 → lead 2135`.
+- deterministic V3 hash = `3223caf0ec5d1b264c4494775c6f7d58`.
+- duplicate acquisitions = **0**.
 - post-sale lead attribution = **0**.
 
-Attribution remains shadow-only:
+Attribution remains shadow-only and unchanged:
 
-- V2 = **126 ops / S/45,158.70**;
-- V3 = **173 ops / S/66,644.10**;
-- delta = **+47 ops / +S/21,485.40**.
+- V2 = **126 ops / S/45,158.70**.
+- V3 = **173 ops / S/66,644.10**.
 
-The Attribution delta remains reserved for Loop 9; no cutover occurred.
+The +47 ops / +S/21,485.40 V3 delta remains reserved for Loop 9; no cutover occurred.
 
-## Loop 4 — certified state preserved
+## Loop 4 state preserved
 
-Loop 4 remains PASS with:
+Loop 4 remains PASS with 24 deterministic call links + 6 Agenda direct links. No Loop-4 repair was reverted by Loop 5R.
 
-- 24 exact call direct links;
-- 6 exact Agenda lead+call links;
-- 30 NO-ACTION candidates unchanged;
-- `35858` remains prior-lead territory;
-- `961780427` remains prior-lead 4650;
-- `957549186` remains NO_MATCH.
-
-No Loop-4 repair was touched by Loop 5.
-
-## Loop 5 — stopped restoration attempt
+## Loop 5R — cleanup semantic prerequisite
 
 Canonical artifacts:
 
-- `docs/control/MKT_INTEGRITY_V3_LOOP5_IMPACT_REPORT_20260818.md`
-- `docs/control/MKT_INTEGRITY_V3_LOOP5_RESTORATION_EVIDENCE_20260818.md`
-- `docs/control/MKT_INTEGRITY_V3_LOOP5_EXECUTION_REPORT_20260818.md`
-- `docs/control/MKT_INTEGRITY_V3_LOOP5_ROLLBACK_20260818.sql`
+- `docs/control/MKT_INTEGRITY_V3_LOOP5R_IMPACT_REPORT_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP5R_EXECUTION_REPORT_20260818.md`
+- `docs/control/MKT_INTEGRITY_V3_LOOP5R_ROLLBACK_20260818.sql`
+- `supabase/migrations/20260819033000_mkt_integrity_v3_loop5r_cleanup_semantics.sql`
+- `supabase/backfills/20260818_mkt_integrity_v3_loop5r_historical_and_mireya.sql`
 
-Targets:
+Applied migration:
 
-- historical call `37108` / phone `991144656` / lead `5664` / MIREYA;
-- historical call `37110` / phone `980547287` / lead `5599` / MIREYA.
+`mkt_integrity_v3_loop5r_cleanup_semantics`
 
-Mandatory transaction simulation used exact evidence-supported historical timestamps with all production triggers enabled.
+Current cleanup function hash:
 
-Result after AFTER INSERT triggers:
+`a6f918f64ac56f587a75ed0aebde0e09`
 
-- `37108` surviving rows = **0**;
-- `37110` surviving rows = **0**;
-- noncommercial archive rows = **0**;
-- target Agenda links remained NULL.
+The cleanup continues deleting generic legacy `LLAMADA` side-effect calls but preserves explicitly semantic calls:
 
-Exact blocker:
+- `LLAMADA_MANUAL_COMERCIAL`
+- `CALLBACK_INBOUND`
+- `INFERIDA_HISTORICA`
 
-`trg_aos_hotfix_manual_agenda_cleanup_call_v1` → `aos_hotfix_manual_agenda_cleanup_v1()`.
+Canary with all triggers enabled:
 
-The cleanup deletes same-phone/same-advisor `CITA CONFIRMADA` rows when a `CITA_MANUAL` Agenda exists within ±10 seconds. Reconstructed target deltas are:
+- generic `LLAMADA` surviving rows = **0**;
+- `LLAMADA_MANUAL_COMERCIAL` = **1**;
+- `CALLBACK_INBOUND` = **1**;
+- `INFERIDA_HISTORICA` = **1**.
 
-- 37108 ↔ Agenda `6b1c4962-a597-45d8-8b72-d721d71c20f4`: **0.933s**;
-- 37110 ↔ Agenda `d80a4d17-5f2e-4169-8814-c5d5c50eac5c`: **0.821s**.
+No trigger was disabled.
 
-The Loop-5 contract forbids disabling or changing this guard/cleanup as a workaround. Therefore the transaction was rolled back and productive restore was not attempted.
+## Loop 5 — Mireya restoration completed
 
-Post-rollback certified target state:
+Restored observed calls:
 
-- 37108 absent;
-- 37110 absent;
-- Agenda `6b1c...`: lead/call NULL; row hash unchanged `94283cb5aa386ae270579da7436d2dbe`;
-- Agenda `d80a...`: lead/call NULL; row hash unchanged `2f79f71ca0d8764c1d77007bff75eae4`;
-- call `37062`: preserved; hash `d0c795e583e1890d61236ef822c04d2e`;
-- call `36912`: preserved; hash `b76540d9a065e6e21c99a8575d813469`;
-- transaction-local test audit rows persisted: 0.
+- `37108` → `991144656` → lead `5664` → MIREYA → `LLAMADA_MANUAL_COMERCIAL`.
+- `37110` → `980547287` → lead `5599` → MIREYA → `LLAMADA_MANUAL_COMERCIAL`.
 
-Mireya baseline/readback remained **51 calls / 4 citas** on business date 2026-08-18; productive delta = **0 / 0** because no product DML was authorized.
+Existing Agenda links:
 
-## Blocker ownership
+- `6b1c4962-a597-45d8-8b72-d721d71c20f4` → lead 5664 / call 37108.
+- `d80a4d17-5f2e-4169-8814-c5d5c50eac5c` → lead 5599 / call 37110.
 
-The blocking defect belongs to:
+Prior failed calls remain unchanged:
 
-`LOOP 7 — Guards, cleanup e idempotencia`.
+- `36912` WILMER / SIN CONTACTO / hash `b76540d9a065e6e21c99a8575d813469`.
+- `37062` MIREYA / SIN CONTACTO / hash `d0c795e583e1890d61236ef822c04d2e`.
 
-A future fix must distinguish a real commercial callback/inbound/manual conversion from a fabricated call that exists only as the technical side effect of creating a `CITA_MANUAL` Agenda. The two historical restorations may only be retried after that guard/cleanup correction is independently certified.
+Mireya business-date KPI 2026-08-18:
+
+- before: **51 calls / 4 citas**;
+- after: **53 calls / 6 citas**;
+- exact targeted delta: **+2 / +2**.
+
+Agenda total remained **3,126**.
+
+## Historical inferred reconciliation approved and applied
+
+Historical imported Agenda/venta alone does not prove an observed call. A synthetic call is only allowed when a Marketing lead predates first conversion and there is no call through that conversion. Such rows are explicitly marked `INFERIDA_HISTORICA`, use `lead_fecha` as a proxy date and `00:00:00` as a sentinel/proxy time, and document that the real call time is unknown.
+
+Exactly four strict live cases qualified:
+
+- call `37199` / `954848810` / lead 51 / WILMER.
+- call `37200` / `960381839` / lead 571 / MIREYA.
+- call `37201` / `964633863` / lead 667 / MIREYA.
+- call `37202` / `930260184` / lead 661 / WILMER.
+
+Each corresponding historical attended/effective Agenda is now directly linked to the inferred call and lead. No Agenda row was created.
+
+## Idempotency
+
+Post-apply dry-run predicates:
+
+- Mireya calls still needing insert = **0**.
+- inferred historical calls still needing insert = **0**.
+- Agenda rows still needing link = **0**.
 
 ## Concurrency rule
 
 At most one HIGH/CRITICAL mutable workstream may operate at a time. `MKT-INTEGRITY-HOTFIX-V3` continues to own the global mutable lock. REV-F5 and all other HIGH/CRITICAL workstreams remain read/audit/documentation or regression-only.
 
-## Next action
+## Next sequential loop
 
-Do **not** start Loop 6 automatically. Loop 5 is blocked, not passed. Resolve sequencing/governance explicitly before any next functional loop.
+`LOOP 6 — Semántica Call Center + modal paciente existente`
+
+Loop 6 is **NOT STARTED** and requires explicit invocation after Loop-5 final GitHub/Notion readback.
 
 ## Exit / handback
 

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_EXECUTION_REPORT_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_EXECUTION_REPORT_20260818.md
@@ -1,0 +1,158 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 5R Execution Report
+
+**Purpose:** unblock and complete Loop 5 after explicit historical-conversion semantics were approved.  
+**Entry main:** `19c326a7f3193ec88dc3ec7755aa29391b091dfd`  
+**Active lock:** `MKT-INTEGRITY-HOTFIX-V3`  
+**Result:** `PASS_PENDING_GITHUB_MERGE_READBACK`
+
+## 1. Cleanup prerequisite
+
+Applied migration:
+
+`mkt_integrity_v3_loop5r_cleanup_semantics`
+
+New cleanup function hash:
+
+`a6f918f64ac56f587a75ed0aebde0e09`
+
+The function now preserves only explicitly semantic calls:
+
+- `LLAMADA_MANUAL_COMERCIAL`
+- `CALLBACK_INBOUND`
+- `INFERIDA_HISTORICA`
+
+All existing rows before this change used `tipo_gestion=LLAMADA`; therefore the current productive generic flow retained its previous cleanup behavior.
+
+### Canary
+
+Transaction-only canary with all triggers enabled:
+
+- generic `LLAMADA` at the same CITA_MANUAL timestamp → surviving rows **0**;
+- `LLAMADA_MANUAL_COMERCIAL` → **1**;
+- `CALLBACK_INBOUND` → **1**;
+- `INFERIDA_HISTORICA` → **1**.
+
+PASS. No trigger was disabled.
+
+## 2. Historical inferred rule
+
+Strict live derivation found exactly four cases with:
+
+- sale + ASISTIO/EFECTIVA Agenda;
+- no call through first conversion;
+- prior Marketing lead;
+- no conversion before selected lead;
+- nearest prior lead selected;
+- advisor taken from the conversion Agenda.
+
+Rows created:
+
+| Call ID | Phone | Lead | Proxy date | Advisor | Type |
+|---:|---|---:|---|---|---|
+| 37199 | 954848810 | 51 | 2026-01-14 | WILMER | INFERIDA_HISTORICA |
+| 37200 | 960381839 | 571 | 2026-01-22 | MIREYA | INFERIDA_HISTORICA |
+| 37201 | 964633863 | 667 | 2026-01-26 | MIREYA | INFERIDA_HISTORICA |
+| 37202 | 930260184 | 661 | 2026-01-26 | WILMER | INFERIDA_HISTORICA |
+
+Each row explicitly documents in `observacion` that the call is inferred, that `fecha` is a lead-date proxy, and that real call time is unavailable. `00:00:00` is a sentinel/proxy, not an observed time.
+
+Four existing historical conversion Agenda rows were direct-linked to those calls/leads. No Agenda row was created.
+
+## 3. Mireya restoration / Loop 5 closure
+
+Restored observed historical calls:
+
+- `37108` → phone `991144656` → lead `5664` → MIREYA → `LLAMADA_MANUAL_COMERCIAL`.
+- `37110` → phone `980547287` → lead `5599` → MIREYA → `LLAMADA_MANUAL_COMERCIAL`.
+
+Both survived all active triggers after the semantic cleanup fix.
+
+Existing Agenda direct links:
+
+- `6b1c4962-a597-45d8-8b72-d721d71c20f4` → lead 5664 / call 37108.
+- `d80a4d17-5f2e-4169-8814-c5d5c50eac5c` → lead 5599 / call 37110.
+
+Prior failed attempts remain unchanged:
+
+- call 36912 = WILMER / SIN CONTACTO / hash `b76540d9a065e6e21c99a8575d813469`.
+- call 37062 = MIREYA / SIN CONTACTO / hash `d0c795e583e1890d61236ef822c04d2e`.
+
+## 4. KPI delta
+
+Immediate pre-apply Mireya baseline for business date 2026-08-18:
+
+- calls = **51**
+- CITA CONFIRMADA = **4**
+
+Post-apply:
+
+- calls = **53**
+- CITA CONFIRMADA = **6**
+
+Targeted delta:
+
+- calls **+2**
+- citas **+2**
+
+Agenda total remained **3,126**, so no new Agenda was fabricated.
+
+Historical inferred rows add exactly:
+
+- MIREYA: +2 historical proxy calls/citas in January;
+- WILMER: +2 historical proxy calls/citas in January.
+
+## 5. Marketing invariants
+
+Unchanged after simulation and productive apply:
+
+- Acquisition V2 = **54**;
+- Acquisition V3 = **55**;
+- deterministic V3 hash = `3223caf0ec5d1b264c4494775c6f7d58`;
+- V3-only remains exactly `973438607 → lead 2135`;
+- duplicate acquisitions = **0**;
+- post-sale lead attribution = **0**.
+
+Attribution also remained unchanged:
+
+- V2 = **126 ops / S/45,158.70**;
+- V3 = **173 ops / S/66,644.10**.
+
+No revenue cutover was performed.
+
+## 6. REV-F5
+
+Unchanged:
+
+- batches 6;
+- expected 15,498;
+- source rows 7,064;
+- clusters 3,950;
+- members 0;
+- preview 0;
+- apply 0.
+
+## 7. Idempotency
+
+Second dry-run predicates after apply:
+
+- Mireya calls still needing insert = **0**;
+- inferred historical calls still needing insert = **0**;
+- Agenda rows still needing link = **0**.
+
+PASS.
+
+## 8. Rollback
+
+Canonical rollback:
+
+`docs/control/MKT_INTEGRITY_V3_LOOP5R_ROLLBACK_20260818.sql`
+
+It clears only exact repaired Agenda links, deletes the four inferred rows by unique sync_key/type/business semantics, deletes 37108/37110 only if exact AFTER semantics still match, and can restore the prior cleanup function definition.
+
+## Certification
+
+Functional/data gates for Loop 5R and the previously blocked Loop 5 now pass.
+
+`LOOP 5 = PASS_PENDING_GITHUB_MERGE_READBACK`
+
+`LOOP 6 = NOT STARTED`

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_FINAL_READBACK_PREMERGE_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_FINAL_READBACK_PREMERGE_20260818.md
@@ -1,0 +1,21 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 5R Pre-Merge Readback
+
+Functional production state before GitHub merge:
+
+- cleanup semantic migration applied; hash `a6f918f64ac56f587a75ed0aebde0e09`;
+- 37108 restored → lead 5664 / MIREYA / LLAMADA_MANUAL_COMERCIAL;
+- 37110 restored → lead 5599 / MIREYA / LLAMADA_MANUAL_COMERCIAL;
+- inferred historical calls created: 37199, 37200, 37201, 37202;
+- six target Agenda rows direct-linked; Agenda total unchanged at 3,126;
+- Mireya 2026-08-18: 51/4 → 53/6, exact +2/+2;
+- prior calls 36912 and 37062 unchanged;
+- Acquisition V2/V3 54/55;
+- V3 deterministic hash `3223caf0ec5d1b264c4494775c6f7d58`;
+- duplicates 0; post-sale 0;
+- Attribution V2 126 / S/45,158.70 unchanged;
+- Attribution V3 173 / S/66,644.10 unchanged;
+- REV-F5 remains 7,064/15,498 and 3,950 clusters, 0 members/preview/apply;
+- idempotency predicates: 0 Mireya inserts / 0 inferred inserts / 0 Agenda links pending;
+- frontend `app/**` unchanged; current generic manual flow still emits LLAMADA and therefore retains legacy cleanup behavior until Loop 6.
+
+Result: functional Loop 5 gates PASS; GitHub/Notion final merge/readback pending.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_GITHUB_READY_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_GITHUB_READY_20260818.md
@@ -1,0 +1,11 @@
+# Loop 5R GitHub readiness
+
+Branch `fix/mkt-integrity-v3-loop5r-guard-historical` is ready for PR after successful production canaries/apply/readback.
+
+Expected blast radius only:
+- docs/control Loop 5R artifacts;
+- one cleanup semantic migration;
+- one targeted backfill script;
+- CURRENT update.
+
+No `app/**`, no V2/V3 function migration, no REV-F5 change.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_IMPACT_REPORT_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_IMPACT_REPORT_20260818.md
@@ -1,0 +1,101 @@
+# MKT-INTEGRITY-HOTFIX-V3 — LOOP 5R Impact Report
+
+**Purpose:** unblock Loop 5 without bypassing guards, and formalize minimal historical-inferred call semantics approved on 2026-08-18 Lima.
+
+**Entry main:** `19c326a7f3193ec88dc3ec7755aa29391b091dfd`  
+**Active lock:** `MKT-INTEGRITY-HOTFIX-V3`  
+**REV-F5:** paused recoverably 7,064 / 15,498; 3,950 clusters; 0 members/preview/apply.  
+**Status:** PRE-DDL / PRE-DML.
+
+## Business rule approved
+
+Do not equate “record exists” with “old patient”. Historical imported Agenda/ventas can exist without a preserved call.
+
+For historical conversion reconciliation:
+
+1. If a person has sale + attended/effective Agenda but **no Marketing lead prior to first conversion**, treat as `PACIENTE_HISTORICO/LEGACY`; do not synthesize a Marketing call.
+2. If a person has a **Marketing lead prior to first conversion**, no call recorded through that conversion, and no conversion before the selected lead, the acquisition can be traced to the nearest valid prior lead.
+3. To close historical operational counts without adding a new schema column, create one explicitly marked call row using existing fields:
+   - `tipo_gestion = INFERIDA_HISTORICA`
+   - `fecha = lead_fecha` as documented proxy date
+   - `hora_llamada = 00:00:00` as documented sentinel/proxy; real call time is unknown
+   - `estado = CITA CONFIRMADA`
+   - `origen = MARKETING`
+   - direct `lead_id_origen`
+   - `observacion` must explicitly state that the call is inferred and that the date/time are proxies.
+4. This row counts as one historical call/cita for funnel reconciliation but remains distinguishable from an observed real call.
+5. Never apply this rule when a real call/audit event exists; observed evidence wins.
+
+## Current `tipo_gestion` compatibility
+
+Live audit before this patch:
+
+- all 35,309 current `aos_llamadas` rows use `tipo_gestion = LLAMADA`;
+- `aos_panel_asesor` does not filter on `tipo_gestion`;
+- `aos_monitoreo_equipo` does not filter on `tipo_gestion`.
+
+Therefore introducing explicit semantic values is additive and does not require a schema change.
+
+## Strict historical candidate derivation
+
+Criteria:
+
+- at least one `aos_ventas` row;
+- at least one Agenda `ASISTIO/ASISTIÓ/EFECTIVA` row;
+- no call on or before the first conversion date;
+- at least one Marketing lead dated on/before first conversion;
+- no sale or attended/effective Agenda before the selected lead;
+- choose nearest prior lead;
+- attribution to the advisor recorded on the conversion Agenda.
+
+Exactly **4** live cases currently pass:
+
+| Phone | Lead | Lead date | First attended | First sale | Agenda advisor | Lead treatment |
+|---|---:|---|---|---|---|---|
+| 954848810 | 51 | 2026-01-14 | 2026-01-15 | 2026-01-15 | WILMER | CAPILAR |
+| 960381839 | 571 | 2026-01-22 | 2026-01-23 | 2026-01-23 | MIREYA | ENZIMAS FACIALES |
+| 964633863 | 667 | 2026-01-26 | 2026-01-28 | 2026-01-28 | MIREYA | CRIOLIPOLISIS |
+| 930260184 | 661 | 2026-01-26 | 2026-02-10 | 2026-02-13 | WILMER | CRIOLIPOLISIS |
+
+All four are already Acquisition customers in both V2 and V3. Three already have Attribution V2 operations; `930260184` has V2 Attribution 0 while V3 currently recognizes 2 ops / S/394.
+
+This patch must **not create a fifth acquisition** or alter the certified V3-only customer `973438607 → lead 2135`.
+
+## Loop 5 blocker to remove
+
+Current function `aos_hotfix_manual_agenda_cleanup_v1()` deletes any same-phone/same-advisor `CITA CONFIRMADA` call within ±10 seconds of a `CITA_MANUAL` Agenda. Transaction simulation proved this deletes real historical calls `37108` and `37110`.
+
+Loop 5 contract prohibited bypassing/disabling the trigger. The safe prerequisite is therefore a semantic exception inside the cleanup itself.
+
+## Minimal cleanup change
+
+Preserve calls whose `tipo_gestion` is explicitly one of:
+
+- `LLAMADA_MANUAL_COMERCIAL`
+- `CALLBACK_INBOUND`
+- `INFERIDA_HISTORICA`
+
+All existing/productive generic rows remain `LLAMADA`, so current frontend behavior is unchanged until Loop 6 explicitly emits a commercial manual/inbound type.
+
+Both trigger directions must honor the exception:
+
+- Agenda inserted second must not delete an explicitly semantic call;
+- call inserted second must return without cleanup when its explicit semantic type is protected.
+
+No trigger is disabled. No table/schema change is required.
+
+## Required canaries after DDL
+
+1. Generic `LLAMADA` + `CITA_MANUAL` ±10s → legacy cleanup still deletes the technical side-effect call.
+2. `LLAMADA_MANUAL_COMERCIAL` + `CITA_MANUAL` ±10s → call survives.
+3. `CALLBACK_INBOUND` + `CITA_MANUAL` ±10s → call survives.
+4. `INFERIDA_HISTORICA` remains protected from cleanup.
+5. Transactional restoration of `37108/37110` with `LLAMADA_MANUAL_COMERCIAL` → 2/2 survive; no trigger bypass.
+6. Synthetic four-case historical batch → exactly 4 inferred calls and 4 direct Agenda links in simulation.
+7. Acquisition V2/V3 remains 54/55; V3-only remains `973438607→2135`; deterministic hash remains `3223caf0ec5d1b264c4494775c6f7d58`.
+8. Any Attribution change must be fully localized to the four historical candidates and/or the two Mireya targets.
+9. REV-F5 remains unchanged.
+
+## Stop conditions
+
+STOP if the legacy generic cleanup ceases working, a protected semantic call is still deleted, Acquisition changes, V3 hash changes, unrelated Attribution changes, or REV-F5 moves.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_POLICY_NOTE_20260818.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_POLICY_NOTE_20260818.md
@@ -1,0 +1,17 @@
+# Historical inferred-call policy — frozen for MKT-INTEGRITY-HOTFIX-V3
+
+A legacy/imported sale + attended/effective Agenda does not, by itself, prove an observed call.
+
+One historical call unit may be reconstructed only when:
+
+- a Marketing lead predates first conversion;
+- no call exists through that first conversion;
+- no prior sale or attended/effective conversion predates the selected lead;
+- the selected lead is the nearest valid prior Marketing touchpoint;
+- the conversion Agenda identifies the advisor.
+
+The reconstructed row must use `tipo_gestion=INFERIDA_HISTORICA`, `estado=CITA CONFIRMADA`, direct Marketing lead linkage, lead date as an explicit proxy date, `00:00:00` as a sentinel/proxy time, and an observation stating that real call time is unavailable.
+
+Rows without a prior Marketing lead remain historical/legacy patient conversions and do not receive a synthetic Marketing call.
+
+Observed call evidence always overrides inferred reconstruction.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP5R_ROLLBACK_20260818.sql
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP5R_ROLLBACK_20260818.sql
@@ -1,0 +1,60 @@
+-- Exact rollback contract for MKT-INTEGRITY-HOTFIX-V3 / LOOP 5R.
+-- Run only if the AFTER values still match this repair.
+
+begin;
+
+-- Clear inferred historical Agenda links first, resolving call ids by exact sync_key.
+update public.aos_agenda_citas a
+set lead_id_origen=null,llamada_id_origen=null
+where (a.id,a.lead_id_origen,a.llamada_id_origen) in (
+  select 'f0dec87b-38f1-4a07-b128-1c563ad508ac'::uuid,51::bigint,l.id from public.aos_llamadas l where l.sync_key='954848810_2026-01-14_00:00:00_WILMER' and l.tipo_gestion='INFERIDA_HISTORICA'
+  union all
+  select 'ec5533f7-4ab7-4ca4-a3d3-8a1a079ba60b'::uuid,571::bigint,l.id from public.aos_llamadas l where l.sync_key='960381839_2026-01-22_00:00:00_MIREYA' and l.tipo_gestion='INFERIDA_HISTORICA'
+  union all
+  select 'fedb1bab-4cd2-4d90-9b4e-7f5d785caf26'::uuid,667::bigint,l.id from public.aos_llamadas l where l.sync_key='964633863_2026-01-26_00:00:00_MIREYA' and l.tipo_gestion='INFERIDA_HISTORICA'
+  union all
+  select '76334df7-21e1-492e-9a09-72e588932c59'::uuid,661::bigint,l.id from public.aos_llamadas l where l.sync_key='930260184_2026-01-26_00:00:00_WILMER' and l.tipo_gestion='INFERIDA_HISTORICA'
+);
+
+-- Clear Mireya direct links only if they still point to the exact restored calls/leads.
+update public.aos_agenda_citas set lead_id_origen=null,llamada_id_origen=null where id='6b1c4962-a597-45d8-8b72-d721d71c20f4' and lead_id_origen=5664 and llamada_id_origen=37108;
+update public.aos_agenda_citas set lead_id_origen=null,llamada_id_origen=null where id='d80a4d17-5f2e-4169-8814-c5d5c50eac5c' and lead_id_origen=5599 and llamada_id_origen=37110;
+
+-- Delete inferred rows only when all semantic identifiers match.
+delete from public.aos_llamadas where tipo_gestion='INFERIDA_HISTORICA' and sync_key in (
+ '954848810_2026-01-14_00:00:00_WILMER',
+ '960381839_2026-01-22_00:00:00_MIREYA',
+ '964633863_2026-01-26_00:00:00_MIREYA',
+ '930260184_2026-01-26_00:00:00_WILMER'
+) and upper(coalesce(estado,''))='CITA CONFIRMADA' and upper(coalesce(origen,''))='MARKETING';
+
+-- Delete restored observed rows only if exact AFTER semantics still match.
+delete from public.aos_llamadas where id=37108 and numero_limpio='991144656' and asesor='MIREYA' and estado='CITA CONFIRMADA' and tipo_gestion='LLAMADA_MANUAL_COMERCIAL' and lead_id_origen=5664 and origen='MARKETING';
+delete from public.aos_llamadas where id=37110 and numero_limpio='980547287' and asesor='MIREYA' and estado='CITA CONFIRMADA' and tipo_gestion='LLAMADA_MANUAL_COMERCIAL' and lead_id_origen=5599 and origen='MARKETING';
+
+-- Restore previous cleanup definition exactly if a full Loop 5R rollback is required.
+create or replace function public.aos_hotfix_manual_agenda_cleanup_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+declare v_call_ts timestamptz; v_agenda_ts timestamptz; v_num text;
+begin
+  if tg_table_name='aos_agenda_citas' then
+    if upper(coalesce(new.origen_cita,''))<>'CITA_MANUAL' then return new; end if;
+    v_num:=regexp_replace(coalesce(nullif(new.numero_limpio,''),new.numero,''),'[^0-9]','','g'); v_agenda_ts:=coalesce(new.ts_creado,now());
+    delete from public.aos_llamadas l where l.numero_limpio=v_num and upper(coalesce(l.asesor,''))=upper(coalesce(new.asesor,'')) and (upper(coalesce(l.estado,''))='CITA CONFIRMADA' or (upper(coalesce(l.estado,''))='SEGUIMIENTO' and upper(coalesce(l.sub_estado,''))='CITA YA EXISTENTE')) and abs(extract(epoch from(public.aos_llamada_event_ts(l.fecha,l.hora_llamada,l.created_at,l.ult_ts,l.ts_log)-v_agenda_ts)))<=10;
+    return new;
+  end if;
+  if tg_table_name='aos_llamadas' then
+    if not (upper(coalesce(new.estado,''))='CITA CONFIRMADA' or (upper(coalesce(new.estado,''))='SEGUIMIENTO' and upper(coalesce(new.sub_estado,''))='CITA YA EXISTENTE')) then return new; end if;
+    v_num:=regexp_replace(coalesce(nullif(new.numero_limpio,''),new.numero,''),'[^0-9]','','g'); v_call_ts:=public.aos_llamada_event_ts(new.fecha,new.hora_llamada,new.created_at,new.ult_ts,new.ts_log);
+    if exists(select 1 from public.aos_agenda_citas a where a.numero_limpio=v_num and upper(coalesce(a.asesor,''))=upper(coalesce(new.asesor,'')) and upper(coalesce(a.origen_cita,''))='CITA_MANUAL' and abs(extract(epoch from(coalesce(a.ts_creado,a.fecha_cita::timestamptz)-v_call_ts)))<=10) then delete from public.aos_llamadas where id=new.id; end if;
+    return new;
+  end if;
+  return new;
+end;
+$function$;
+
+commit;

--- a/supabase/backfills/20260818_mkt_integrity_v3_loop5r_historical_and_mireya.sql
+++ b/supabase/backfills/20260818_mkt_integrity_v3_loop5r_historical_and_mireya.sql
@@ -1,0 +1,58 @@
+-- MKT-INTEGRITY-HOTFIX-V3 / LOOP 5R
+-- Requires cleanup semantic migration already applied.
+-- Atomic targeted repair: 2 observed Mireya calls + 4 explicitly inferred historical calls.
+
+begin;
+
+-- Exact observed historical calls.
+insert into public.aos_llamadas(id,fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion)
+select 37108,'2026-08-18'::date,'991144656','991144656','CAPILAR','CITA CONFIRMADA','19:16:08','MIREYA','ZIV-003',1,'2026-08-19T00:16:08.933Z'::timestamptz,'LLAMADA_MANUAL_COMERCIAL'
+where not exists(select 1 from public.aos_llamadas where id=37108);
+
+insert into public.aos_llamadas(id,fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion)
+select 37110,'2026-08-18'::date,'980547287','980547287','CAPILAR','CITA CONFIRMADA','19:23:27','MIREYA','ZIV-003',1,'2026-08-19T00:23:27.821Z'::timestamptz,'LLAMADA_MANUAL_COMERCIAL'
+where not exists(select 1 from public.aos_llamadas where id=37110);
+
+-- Existing Agenda direct links for observed calls.
+update public.aos_agenda_citas
+set lead_id_origen=5664,llamada_id_origen=37108
+where id='6b1c4962-a597-45d8-8b72-d721d71c20f4'
+  and lead_id_origen is null and llamada_id_origen is null;
+
+update public.aos_agenda_citas
+set lead_id_origen=5599,llamada_id_origen=37110
+where id='d80a4d17-5f2e-4169-8814-c5d5c50eac5c'
+  and lead_id_origen is null and llamada_id_origen is null;
+
+-- Historical inferred calls: proxy date = lead date; 00:00:00 is an explicit sentinel/proxy, not an observed time.
+insert into public.aos_llamadas(fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion,lead_id_origen,origen,anuncio,observacion)
+select '2026-01-14','954848810','954848810','CAPILAR','CITA CONFIRMADA','00:00:00','WILMER','ZIV-004',1,now(),'INFERIDA_HISTORICA',51,'MARKETING','CAPILAR - Cabello debil','[AOS HISTÓRICO] Gestión inferida por lead previo + primera conversión. Fecha proxy=fecha del lead; hora real no disponible.'
+where not exists(select 1 from public.aos_llamadas where sync_key='954848810_2026-01-14_00:00:00_WILMER');
+
+insert into public.aos_llamadas(fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion,lead_id_origen,origen,anuncio,observacion)
+select '2026-01-22','960381839','960381839','ENZIMAS FACIALES','CITA CONFIRMADA','00:00:00','MIREYA','ZIV-003',1,now(),'INFERIDA_HISTORICA',571,'MARKETING','ENZI . Solucion papada marcada','[AOS HISTÓRICO] Gestión inferida por lead previo + primera conversión. Fecha proxy=fecha del lead; hora real no disponible.'
+where not exists(select 1 from public.aos_llamadas where sync_key='960381839_2026-01-22_00:00:00_MIREYA');
+
+insert into public.aos_llamadas(fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion,lead_id_origen,origen,anuncio,observacion)
+select '2026-01-26','964633863','964633863','CRIOLIPOLISIS','CITA CONFIRMADA','00:00:00','MIREYA','ZIV-003',1,now(),'INFERIDA_HISTORICA',667,'MARKETING','CRIO - reedfine tu cilueta','[AOS HISTÓRICO] Gestión inferida por lead previo + primera conversión. Fecha proxy=fecha del lead; hora real no disponible.'
+where not exists(select 1 from public.aos_llamadas where sync_key='964633863_2026-01-26_00:00:00_MIREYA');
+
+insert into public.aos_llamadas(fecha,numero,numero_limpio,tratamiento,estado,hora_llamada,asesor,id_asesor,intento,created_at,tipo_gestion,lead_id_origen,origen,anuncio,observacion)
+select '2026-01-26','930260184','930260184','CRIOLIPOLISIS','CITA CONFIRMADA','00:00:00','WILMER','ZIV-004',1,now(),'INFERIDA_HISTORICA',661,'MARKETING','CRIO - reedfine tu cilueta','[AOS HISTÓRICO] Gestión inferida por lead previo + primera conversión. Fecha proxy=fecha del lead; hora real no disponible.'
+where not exists(select 1 from public.aos_llamadas where sync_key='930260184_2026-01-26_00:00:00_WILMER');
+
+-- Link the historical conversion Agenda to the inferred direct call.
+update public.aos_agenda_citas set lead_id_origen=51,llamada_id_origen=(select id from public.aos_llamadas where sync_key='954848810_2026-01-14_00:00:00_WILMER') where id='f0dec87b-38f1-4a07-b128-1c563ad508ac' and lead_id_origen is null and llamada_id_origen is null;
+update public.aos_agenda_citas set lead_id_origen=571,llamada_id_origen=(select id from public.aos_llamadas where sync_key='960381839_2026-01-22_00:00:00_MIREYA') where id='ec5533f7-4ab7-4ca4-a3d3-8a1a079ba60b' and lead_id_origen is null and llamada_id_origen is null;
+update public.aos_agenda_citas set lead_id_origen=667,llamada_id_origen=(select id from public.aos_llamadas where sync_key='964633863_2026-01-26_00:00:00_MIREYA') where id='fedb1bab-4cd2-4d90-9b4e-7f5d785caf26' and lead_id_origen is null and llamada_id_origen is null;
+update public.aos_agenda_citas set lead_id_origen=661,llamada_id_origen=(select id from public.aos_llamadas where sync_key='930260184_2026-01-26_00:00:00_WILMER') where id='76334df7-21e1-492e-9a09-72e588932c59' and lead_id_origen is null and llamada_id_origen is null;
+
+-- Assertions: two observed + four inferred calls and six Agenda links must exist.
+do $$
+begin
+  if (select count(*) from public.aos_llamadas where id in (37108,37110)) <> 2 then raise exception 'Loop5R expected 2 observed Mireya calls'; end if;
+  if (select count(*) from public.aos_llamadas where tipo_gestion='INFERIDA_HISTORICA' and sync_key in ('954848810_2026-01-14_00:00:00_WILMER','960381839_2026-01-22_00:00:00_MIREYA','964633863_2026-01-26_00:00:00_MIREYA','930260184_2026-01-26_00:00:00_WILMER')) <> 4 then raise exception 'Loop5R expected 4 inferred historical calls'; end if;
+  if (select count(*) from public.aos_agenda_citas where id in ('6b1c4962-a597-45d8-8b72-d721d71c20f4','d80a4d17-5f2e-4169-8814-c5d5c50eac5c','f0dec87b-38f1-4a07-b128-1c563ad508ac','ec5533f7-4ab7-4ca4-a3d3-8a1a079ba60b','fedb1bab-4cd2-4d90-9b4e-7f5d785caf26','76334df7-21e1-492e-9a09-72e588932c59') and lead_id_origen is not null and llamada_id_origen is not null) <> 6 then raise exception 'Loop5R expected 6 Agenda links'; end if;
+end $$;
+
+commit;

--- a/supabase/migrations/20260819033000_mkt_integrity_v3_loop5r_cleanup_semantics.sql
+++ b/supabase/migrations/20260819033000_mkt_integrity_v3_loop5r_cleanup_semantics.sql
@@ -1,0 +1,83 @@
+-- MKT-INTEGRITY-HOTFIX-V3 / LOOP 5R
+-- Additive semantic exception only. Existing LLAMADA behavior remains unchanged.
+
+create or replace function public.aos_hotfix_manual_agenda_cleanup_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_call_ts timestamptz;
+  v_agenda_ts timestamptz;
+  v_num text;
+begin
+  if tg_table_name='aos_agenda_citas' then
+    if upper(coalesce(new.origen_cita,''))<>'CITA_MANUAL' then
+      return new;
+    end if;
+
+    v_num:=regexp_replace(coalesce(nullif(new.numero_limpio,''),new.numero,''),'[^0-9]','','g');
+    v_agenda_ts:=coalesce(new.ts_creado,now());
+
+    delete from public.aos_llamadas l
+    where l.numero_limpio=v_num
+      and upper(coalesce(l.asesor,''))=upper(coalesce(new.asesor,''))
+      and upper(coalesce(l.tipo_gestion,'LLAMADA')) not in (
+        'LLAMADA_MANUAL_COMERCIAL',
+        'CALLBACK_INBOUND',
+        'INFERIDA_HISTORICA'
+      )
+      and (
+        upper(coalesce(l.estado,''))='CITA CONFIRMADA'
+        or (
+          upper(coalesce(l.estado,''))='SEGUIMIENTO'
+          and upper(coalesce(l.sub_estado,''))='CITA YA EXISTENTE'
+        )
+      )
+      and abs(extract(epoch from(
+        public.aos_llamada_event_ts(l.fecha,l.hora_llamada,l.created_at,l.ult_ts,l.ts_log)-v_agenda_ts
+      )))<=10;
+
+    return new;
+  end if;
+
+  if tg_table_name='aos_llamadas' then
+    if upper(coalesce(new.tipo_gestion,'LLAMADA')) in (
+      'LLAMADA_MANUAL_COMERCIAL',
+      'CALLBACK_INBOUND',
+      'INFERIDA_HISTORICA'
+    ) then
+      return new;
+    end if;
+
+    if not (
+      upper(coalesce(new.estado,''))='CITA CONFIRMADA'
+      or (
+        upper(coalesce(new.estado,''))='SEGUIMIENTO'
+        and upper(coalesce(new.sub_estado,''))='CITA YA EXISTENTE'
+      )
+    ) then
+      return new;
+    end if;
+
+    v_num:=regexp_replace(coalesce(nullif(new.numero_limpio,''),new.numero,''),'[^0-9]','','g');
+    v_call_ts:=public.aos_llamada_event_ts(new.fecha,new.hora_llamada,new.created_at,new.ult_ts,new.ts_log);
+
+    if exists(
+      select 1
+      from public.aos_agenda_citas a
+      where a.numero_limpio=v_num
+        and upper(coalesce(a.asesor,''))=upper(coalesce(new.asesor,''))
+        and upper(coalesce(a.origen_cita,''))='CITA_MANUAL'
+        and abs(extract(epoch from(coalesce(a.ts_creado,a.fecha_cita::timestamptz)-v_call_ts)))<=10
+    ) then
+      delete from public.aos_llamadas where id=new.id;
+    end if;
+
+    return new;
+  end if;
+
+  return new;
+end;
+$function$;


### PR DESCRIPTION
## MKT-INTEGRITY-HOTFIX-V3 — LOOP 5R / LOOP 5 CLOSURE

This PR version-controls a production fix already validated with canaries, transaction simulation, productive apply and post-apply readback.

### Cleanup semantics
- Generic legacy `LLAMADA` + `CITA_MANUAL` ±10s continues to be deleted.
- Explicit `LLAMADA_MANUAL_COMERCIAL`, `CALLBACK_INBOUND`, and `INFERIDA_HISTORICA` are preserved.
- No trigger was disabled.

### Mireya
- Restored 37108 → lead 5664 → MIREYA.
- Restored 37110 → lead 5599 → MIREYA.
- Preserved prior SIN CONTACTO calls 37062 / 36912.
- Mireya 2026-08-18: 51/4 → 53/6 = exact +2/+2.
- Agenda total unchanged.

### Historical inferred calls
Strict derivation yielded exactly four cases:
- 37199 → 954848810 → lead 51 → WILMER.
- 37200 → 960381839 → lead 571 → MIREYA.
- 37201 → 964633863 → lead 667 → MIREYA.
- 37202 → 930260184 → lead 661 → WILMER.

Each is marked `INFERIDA_HISTORICA`, uses lead date as proxy date and 00:00:00 as sentinel/proxy time, and explicitly documents that real call time is unknown.

### Invariants
- Acquisition 54/55 unchanged.
- V3 hash `3223caf0ec5d1b264c4494775c6f7d58` unchanged.
- Attribution V2/V3 unchanged.
- REV-F5 unchanged.
- Idempotency 0/0/0.
- No `app/**` changes.

Loop 6 remains NOT STARTED.