### PR TITLE
CONTROL — REV-F5→F6 identity bridge, Patient 360 and Sentinel roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file defines mandatory operating rules for every AI/Codex/development agent
 8. the CURRENT Control Maestro / phase checkpoint of **one selected project only**
 9. exact GitHub `main`, branch/PR/checks and live Supabase/Railway evidence
 10. for Revenue F5 / identity / historical data work, `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`
+11. for F5→F6 identity/Patient 360 work, `docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md`, `docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`, `docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md` and `docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md`.
 
 Historical documents may contain useful context, but they do not override CURRENT.
 
@@ -192,11 +193,21 @@ Requires Zero-Cost certificate, negative tests, read-only production preflight, 
 - production is not a test environment;
 - every HIGH/CRITICAL data gate follows Persistence Triple-Proof.
 
-### Identifiers
+### Patient identity / duplicate resolution
 
-Treat `numero_limpio/contact_key` as a transversal bridge until an explicitly certified canonical identity supersedes it. Identity changes require cross-domain impact review.
+- `canonical_patient_id` is the durable identity target once REV-F5 certifies it;
+- `numero_limpio/contact_key` remains an import/search/compatibility bridge, never sole merge authority;
+- preserve old/current phones, emails and source-scoped IDs as governed aliases when identity is proven;
+- same name alone never merges patients;
+- same phone alone never merges patients;
+- approximate/numeric-near phone values are **not** identity evidence; heuristics such as phone `±3` are prohibited;
+- exact normalized name+surname+phone+valid document with zero strong conflicts may be `AUTO_ELIGIBLE_EXACT`, but physical consolidation still requires governed admin+2FA, dry-run, canary, audit and rollback;
+- strong evidence with changed phone/name formatting routes to `REVIEW_STRONG` unless already verified;
+- conflicting valid documents/DOB/sex or an identifier mapped to another canonical patient routes to `BLOCK_CONFLICT`;
+- absorbed profiles/identifiers remain provenance/aliases; do not erase history;
+- the legacy `aos_fusionar_pacientes` and `aos_duplicados_paciente` must not become F5 batch authority without dependency/security/versioning audit.
 
-For patients/customers, F5 governed identity/provenance is the canonical resolution layer. CIA, WA, F6 and future historical-sales imports must not create competing customer identity truth. Phone equality alone is never merge authority.
+F5 governed identity/provenance is the canonical patient resolution layer. CIA, WA, F6, Patient 360 and historical-sales imports must not create competing customer identity truth.
 
 ### RPC
 
@@ -206,7 +217,7 @@ Before modifying an RPC: identify reads/writes, callers, SECURITY DEFINER/search
 
 Root `SECURITY.md` is authoritative.
 
-Never commit/log/print real passwords, API keys, service-role keys or provider tokens. Never put service credentials in browser code. Never trust browser-supplied role/permission as authority. Never grant agents arbitrary production write SQL. Never weaken a control just to make CI green.
+Never commit/log/print real passwords, API keys, service-role keys or provider tokens. Never store real credentials in skills, examples, README files, prompts or agent memory. Never put service credentials in browser code. Never trust browser-supplied role/permission as authority. Never grant agents arbitrary production write SQL. Never weaken a control just to make CI green.
 
 Secrets come from environment/vault/secret manager. Removing an exposed secret from HEAD does not replace provider-side rotation/revocation.
 
@@ -218,19 +229,21 @@ CIA owns provider-neutral Audience/Activation/channel governance and F17/F18 rea
 A Meta canary may provide evidence to both, but closing CIA-F17 does not close WA1/WA4 and vice versa.
 
 ### Revenue
-Revenue F5 owns historical patient/source identity and canonical enrichment review. Do not run it concurrently with channel/runtime releases.
+Revenue F5 owns historical patient/source identity, duplicate resolution and canonical enrichment review. Do not run it concurrently with channel/runtime releases.
 
 Canonical Revenue responsibility:
 
 - REV-F3 = product/service identity for sales;
 - REV-F4 = payment/revenue/cartera/reconciliation truth;
-- REV-F5 = historical patient identity + provenance + governed canonical enrichment;
-- REV-F6 = intelligence derived from certified F3/F4/F5 facts.
+- REV-F5 = historical patient identity + provenance + duplicate resolution + governed canonical enrichment;
+- REV-F6 = Patient Commercial 360/read-model intelligence derived from certified F3/F4/F5 facts.
 
 Historical 2024–2025 transaction imports must reuse those domains rather than create a new product/customer/revenue model. See `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`.
 
+The existing Patient 360 (`app/public/patients.html` / `aos_paciente_360`) must be evolved, not duplicated. V2 resolves lookup identifiers through canonical identity/aliases before aggregating history.
+
 ### Sentinel
-Sentinel SEN-F1..F13 is closed. Run regressions as sensors for other projects; reopen Sentinel only on a demonstrated Sentinel regression.
+Sentinel SEN-F1..F13 is closed. Run regressions as sensors for other projects; reopen Sentinel only on a demonstrated Sentinel regression or explicit maintenance handoff. Data-integrity signals use `docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`: aggregate/zero-PII observation only; Sentinel never silently repairs business data.
 
 ### KronIA
 KronIA is K0–K8. CIA-F15 Tool Registry + Agent Registry SHADOW + Policy Gate are canonical reusable inputs. Do not build a second incompatible registry. Fresh K1 starts from CURRENT when it receives the portfolio lock; historical K1 PRs are evidence-only.
@@ -294,7 +307,7 @@ No chat should reconstruct a project from informal memory when these sources exi
 
 ## Prohibitions
 
-Do not run multiple HIGH/CRITICAL projects concurrently on shared CI/DB infrastructure; experiment in production; broad DROP/TRUNCATE/DELETE for convenience; force-push production history; blind-rewrite migration history; copy secrets between environments; use real Zi Vital data as generic SaaS seed; hide failing tests; infer project closure from sibling certificates; infer data persistence from tool output alone; certify a phase whose live post-conditions are not present; or revive stale branches without CURRENT revalidation.
+Do not run multiple HIGH/CRITICAL projects concurrently on shared CI/DB infrastructure; experiment in production; broad DROP/TRUNCATE/DELETE for convenience; force-push production history; blind-rewrite migration history; copy secrets between environments; use real Zi Vital data as generic SaaS seed; hide failing tests; infer project closure from sibling certificates; infer data persistence from tool output alone; certify a phase whose live post-conditions are not present; merge patient identities from name/phone/approximate-phone alone; or revive stale branches without CURRENT revalidation.
 
 ## Long-term objective
 

--- a/docs/MEMORY_CURRENT.md
+++ b/docs/MEMORY_CURRENT.md
@@ -1,6 +1,6 @@
 # ASCENDA OS — MEMORY CURRENT
 
-**Captured from exact baseline:** `main@40b2cbf50a9ffc2d9ca1ee3fedbf457c133c4a21`  
+**Captured from exact baseline:** `main@1d964d99f018cbdb671ddce90e52ece6bac0a8bd`  
 **Captured:** 2026-08-19 America/Lima  
 **ACTIVE WORKSTREAM:** `REV-F5-CLOSEOUT`
 
@@ -14,25 +14,25 @@ Read in order:
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`
 5. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`
 6. `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`
-7. exact GitHub + live Supabase/Railway
-8. `aos_memory`
-9. Notion
+7. `docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md`
+8. `docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`
+9. `docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md`
+10. `docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md`
+11. exact GitHub + live Supabase/Railway
+12. `aos_memory`
+13. Notion
 
 Historical documents/chat checkpoints never override CURRENT or live persisted state.
 
 ## Global state
 
-MKT Integrity V3 Loop 5 is closed; Loop 6 is not started. The owner handed the global mutable lock back to Revenue. `REV-F5-CLOSEOUT` is the only active HIGH/CRITICAL mutable workstream.
+MKT Integrity V3 Loop 5 is closed; Loop 6 is not started. `REV-F5-CLOSEOUT` is the only active HIGH/CRITICAL mutable workstream. Other programs remain read-only/regression-only unless needed as sensors for F5.
 
 Production runtime chain remains:
 
 `server-phase-s-f17.js → server-phase-s.js → server-f17.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → lower/core`.
 
-Do not change runtime topology as part of F5 unless a demonstrated blocker requires it and exact-chain regression evidence is added.
-
-## REV-F5 LIVE truth
-
-Fresh Supabase production readback proves:
+## REV-F5 LIVE truth at registered baseline
 
 - manifests: **6**;
 - expected source rows: **15,498**;
@@ -43,7 +43,7 @@ Fresh Supabase production readback proves:
 - identity members: **0**;
 - patient link previews: **0**;
 - canonical apply events: **0**;
-- structural duplicate `(batch_id, source_row_num)` keys: **0**;
+- structural duplicate keys: **0**;
 - orphan source rows: **0**;
 - observational canonical patients: **7,685**.
 
@@ -56,94 +56,119 @@ Per source:
 - SI2025: **0 / 3,066** — missing Excel 2–3067;
 - SI2026: **0 / 1,004** — missing Excel 2–1005.
 
-All six original private XLSX files remain source-of-truth inputs and their manifest SHA values remain the identity of each source.
+Always rederive LIVE before mutation.
 
-## Superseded false-closeout claim
+## Persistence rule
 
-A prior assistant narrative stated that REV-F5 had reached 15,498/15,498, rebuilt 15,498 members, completed Review/Apply and was production-certified.
-
-That narrative is **invalid** because live Supabase post-conditions do not support it and GitHub has no merged REV-F5 final-certification PR after #298.
-
-Institutional rule:
-
-**No tool response, local loop, assistant statement, expected counter or generated payload may close a data gate without persisted production readback + independent invariant query.**
-
-## Persistence Triple-Proof
-
-Every F5 data checkpoint requires:
+Every HIGH/CRITICAL data checkpoint uses Persistence Triple-Proof:
 
 1. execution receipt;
-2. direct live persisted delta;
+2. direct live persisted readback;
 3. independent invariant query.
 
-Every source-batch closure additionally requires full idempotent replay of the exact SHA-bound source with zero new inserts/conflicts.
+Every source batch closes only after full idempotent replay of the SHA-bound source with zero new inserts/conflicts.
 
-Timeout/blocked call → read live state before retry. Never infer persistence.
+## Identity / duplicate audit learning
 
-## REV-F5 execution point
+Current read-only duplicate profile at registration:
 
-REV-F5 remains **ACTIVE / NOT CERTIFIED**.
+- 174 same normalized name+surname groups;
+- 69 of those span multiple phones;
+- 57 span multiple documents;
+- 110 duplicate name+surname+phone groups;
+- 30 of those contain >1 non-empty document;
+- 27 duplicate name+surname+document groups;
+- 15 of those contain >1 non-empty phone;
+- 14 groups / 29 patient rows currently match exact name+surname+phone+document.
 
-Correct next sequence:
+Interpretation: repeated names are not automatically duplicates. The exact four-signal set is a high-confidence candidate pool, not permission for silent merge.
 
-1. finish the exact missing staging ranges from live state;
-2. certify each source with structural checks + full replay;
-3. require 15,498/15,498 and 6/6 complete;
-4. only then run identity rebuild and require 15,498 members;
-5. classify MATCH/REVIEW/NEW conservatively;
-6. generate fill-only enrichment preview;
-7. run governed Review/Apply with 2FA, dry-run, canary and rollback proof;
-8. calculate patient→sale→F3 product→F4 payment/cartera linkage;
-9. state real transaction coverage for 2024–2025;
-10. numeric Coverage/DQ;
-11. independent F5.10 final certification.
+The legacy duplicate detector contains a prohibited approximate-phone heuristic based on numeric proximity and the legacy merge RPC is phone-pair-centric. Neither becomes F5 batch authority without a versioned dependency/security/rollback audit.
 
-REV-F6 stays blocked until that final audit passes.
+## Identity Bridge V2 decision
 
-## Cross-domain architecture to preserve
+`numero_limpio/contact_key` remains important for Excel imports, search and compatibility but is no longer the identity target.
 
-Do not create competing identity/revenue truth.
+Target:
 
-- **F3:** canonical product/service identity for sales.
-- **F4:** payment/revenue/cartera/reconciliation truth.
-- **F5:** historical patient identity, provenance and governed canonical enrichment.
-- **F6:** intelligence derived from certified F3/F4/F5 facts.
-- **CIA:** acquisition/activation attribution using governed explicit evidence.
-- **WA:** conversation product consuming permitted identity/commercial context.
+`identifier → governed alias/evidence → canonical_patient_id → unified history`.
 
-Existing explicit bridges include `lead_id_origen`, `llamada_id_origen`, `venta_id_match`, sale IDs, `cotizacion_id`, plan/item IDs and `numero_limpio`. Prefer explicit IDs; `numero_limpio` remains a bridge, never merge authority by itself.
+A canonical patient may retain multiple current/historical phone aliases. Old and new phone can therefore resolve to the same patient after governed review. Shared phone/homonym conflicts remain explicit.
+
+Existing `aos_cia_contact_identity_v1` has a useful phone/contact compatibility view and must be reused rather than replaced by a competing CIA identity. F5 owns richer identity semantics.
+
+## Patient Commercial 360 V2
+
+The existing `app/public/patients.html` / `aos_paciente_360` remains the product surface. Do not create a second patient master.
+
+V2 target:
+
+- canonical identity + historical aliases;
+- identity confidence/review/conflict state;
+- customer lifecycle;
+- acquisition/contact/agenda/sales/product/payment timeline;
+- observed revenue with explicit transaction coverage;
+- merge/audit status;
+- metric trust: coverage, confidence, freshness, sample size;
+- role-gated clinical boundary.
+
+Phone lookup remains backward compatible but resolves server-side to canonical identity before history aggregation.
+
+## REV-F6 prepared contracts
+
+REV-F6 remains BLOCKED until actual F5.10 PASS. Once unblocked it must implement:
+
+- identity-aware Patient Commercial 360 V2;
+- lifecycle: `NEW_PATIENT`, `RETURNING_PATIENT`, `HISTORICAL_REACTIVATED`, `ACTIVE_REPEAT`, `DORMANT`, `UNRESOLVED_IDENTITY`;
+- Identity Confidence Contract;
+- metric trust fields `coverage`, `confidence`, `freshness`, `sample_size`;
+- Sales Intelligence read models from certified F3/F4/F5 facts;
+- future 2024/2025 sales as a plug-in through the existing historical-sales ingest contract, not a redesign.
+
+## Sentinel data integrity
+
+Registered design: `docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`.
+
+Sentinel should eventually detect aggregate zero-PII failures such as source batch mismatch, membership mismatch, identity collision, canonical apply without governance, product-sale orphan, reconciliation orphan and stale/low-coverage F6 read models. Sentinel observes and routes; it does not silently repair business data.
+
+## Cross-domain ownership
+
+- F3 = product identity.
+- F4 = payment/revenue/cartera truth.
+- F5 = patient identity, provenance and duplicate resolution.
+- F6 = intelligence/read models.
+- CIA = governed acquisition/activation attribution.
+- WA = conversation/channel product consuming permitted context.
+- Sentinel = observability/integrity.
+
+Prefer explicit IDs (`lead_id_origen`, `llamada_id_origen`, `venta_id_match`, sale/cotization/plan/item IDs) before identity-bridge fallback.
 
 ## Future historical sales 2024–2025
-
-The architecture is ready to accept future transaction exports without redesigning identity/product/revenue.
 
 Use `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`:
 
 `source manifest/SHA → row provenance/staging → canonical sale → F3 product → F5 patient → F4 payment/cartera → F6 intelligence`.
 
-Do not fabricate 2024/2025 YoY from patient history or `Último presupuesto` while certified transaction sources are absent.
+Do not fabricate 2024/2025 YoY from patient history or `Último presupuesto` while certified transaction ledgers are absent.
+
+## Execution prompts
+
+- Definitive F5 closeout prompt: `docs/control/prompts/REV_F5_CLOSEOUT_EXECUTION_PROMPT.md`.
+- F6 template returned only after real F5.10 certification: `docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md`.
+
+At F5.10 PASS the executing agent must bind the F6 template to the final exact SHA/LIVE counts and return it to the owner; do not silently start F6.
 
 ## Safety rules specific to F5
 
-- no canonical patient mutation before complete provenance, preview and governed review gate;
 - no merge by name alone;
-- phone alone is not merge authority;
+- no merge by phone alone;
+- approximate/numeric-near phone is prohibited identity evidence;
+- physical patient merge is CRITICAL: admin+2FA, dependency audit, dry-run, canary, immutable event and rollback/recovery;
+- preserve absorbed aliases/provenance;
 - source patient IDs/HC remain source-specific unless proven otherwise;
 - fill-only enrichment by default;
 - clinical notes/allergies stay outside automatic commercial apply;
 - `Último presupuesto` is evidence only;
 - `ADELANTO` is payment evidence only;
 - every retry reconciles persisted state first;
-- every gate records exact SHA, live counters, missing ranges, protected-table invariants and next step.
-
-## Institutional learning
-
-- one global HIGH/CRITICAL mutable workstream;
-- exact-current revalidation after unrelated `main` advances;
-- runner/job activity is execution state, not source of truth;
-- code/pipeline completion is not data completion;
-- staging completeness precedes identity rebuild;
-- local/generated success must never be promoted to production certification without live post-conditions;
-- production Supabase + exact GitHub/CI/deploy evidence outrank documentation;
-- documentation must explicitly supersede false or stale claims rather than silently preserving them;
 - Notion is reconciled last.

--- a/docs/adn/AGENTS_CURRENT.md
+++ b/docs/adn/AGENTS_CURRENT.md
@@ -15,19 +15,21 @@ Before any write:
 3. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
 4. `docs/MEMORY_CURRENT.md`;
 5. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`;
-6. `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md` for REV-F5/data-pipeline work;
-7. exact GitHub `main`, Railway status/runtime and live Supabase state;
-8. the current project checkpoint only.
+6. `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`;
+7. `docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md`;
+8. patient identity/360/lifecycle contracts under `docs/control/REV_PATIENT_*` and `REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md` when relevant;
+9. exact GitHub `main`, Railway status/runtime and live Supabase state;
+10. the current project checkpoint only.
 
 Historical chat statements never override CURRENT or live persisted state.
 
 ## Portfolio Controller
 
-Declare `WORKSTREAM_ID=REV-F5-CLOSEOUT`. Enforce one global HIGH/CRITICAL mutable workstream. CIA, WA feature releases, KronIA and migration-governance mutation remain read-only/regression-only while F5 owns the lock.
+Declare `WORKSTREAM_ID=REV-F5-CLOSEOUT`. Enforce one global HIGH/CRITICAL mutable workstream. CIA, WA feature releases, KronIA and unrelated Sentinel mutation remain read-only/regression-only while F5 owns the lock.
 
 ## Revenue / Patient Identity Agent
 
-Current production truth at this capture:
+Current production truth at the registered baseline:
 
 - 6 source batches / 15,498 expected rows;
 - **8,264 persisted source rows**;
@@ -39,15 +41,15 @@ Current production truth at this capture:
 - 0 structural duplicate keys;
 - 0 orphan source rows.
 
-Do not claim REV-F5 production certification from local/tool execution output. The previous 15,498/15,498 / F5=100% narrative is superseded by live production evidence.
+Always rederive LIVE before write. Do not claim REV-F5 production certification from local/tool execution output.
 
-## Persistence Triple-Proof — mandatory for data work
+## Persistence Triple-Proof
 
-A HIGH/CRITICAL data checkpoint may close only when all are true:
+A HIGH/CRITICAL data checkpoint closes only when all are true:
 
-1. execution receipt says the intended mutation succeeded;
-2. direct production readback shows the persisted delta;
-3. an independent invariant query proves expected count/range/uniqueness/orphans/conflicts/protected-table state.
+1. execution receipt;
+2. direct production readback showing the persisted delta;
+3. independent invariant query proving expected count/range/uniqueness/orphans/conflicts/protected-table state.
 
 At batch closure also require full idempotent replay of the exact SHA-bound source with zero new inserts/conflicts.
 
@@ -55,51 +57,92 @@ At batch closure also require full idempotent replay of the exact SHA-bound sour
 
 ## Recovery loop
 
-Use:
-
 `OBSERVE LIVE → IDENTIFY EXACT GAP → MUTATE ONLY GAP → READ BACK → VERIFY → CHECKPOINT → CONTINUE`.
 
-If a call times out or is blocked, reconcile persisted state before retrying. Never skip a range because an execution attempt looked successful.
+If a call times out or is blocked, reconcile persisted state before retrying.
 
-## Identity rules
+## Canonical identity / duplicate rules
 
-- historical rows are evidence, not canonical patients;
-- source patient ID and HC are source-specific unless proven otherwise;
+Historical rows are evidence, not canonical patients. The durable subject is `canonical_patient_id` once F5 certifies it.
+
+- source patient ID/HC remain source-scoped unless proven global;
 - name alone never merges;
 - phone alone never merges;
-- DNI+compatible name is strong evidence;
-- email is strong evidence with compatible context;
-- phone+name and name+DOB are supporting evidence;
-- conflict/tie → human review;
-- enrichment defaults to fill-only;
-- clinical notes/allergies are excluded from automatic commercial apply;
-- `Último presupuesto` = evidence only;
-- `ADELANTO` = payment evidence only.
+- approximate/numeric-near phone is not evidence; phone ±3 heuristics are prohibited;
+- exact normalized name+surname+phone+valid document with no strong conflicts may be `AUTO_ELIGIBLE_EXACT`, but physical merge remains CRITICAL/governed;
+- same valid document + compatible person evidence with changed phone can be `REVIEW_STRONG`/verified after review;
+- conflicting document/DOB/sex or identifier already bound elsewhere = `BLOCK_CONFLICT`;
+- absorbed phones/emails/source IDs remain aliases/provenance;
+- no physical merge without admin+2FA, dependency audit, dry-run, canary, immutable audit event and rollback/recovery.
+
+Current read-only duplicate profile at registration: 174 same-name groups; 69 span multiple phones; 57 span multiple documents; 14 groups/29 rows matched exact name+surname+phone+document. Recompute before action.
+
+Legacy `aos_duplicados_paciente`/`aos_fusionar_pacientes` are evidence/legacy tools, not the new F5 batch authority until audited/versioned.
+
+## Identity Bridge V2
+
+Reuse existing `aos_cia_contact_identity_v1` for compatibility evidence but do not let its phone-centric contact key become the final identity model.
+
+Target:
+
+`phone/document/email/source-scoped ID/HC → governed alias/evidence → canonical_patient_id or REVIEW/CONFLICT/UNRESOLVED`.
+
+CIA, WA, imports, Patient 360 and F6 consume this same identity; none creates a second customer identity truth.
+
+## Patient Commercial 360 V2
+
+Evolve existing `app/public/patients.html` / `aos_paciente_360`; do not create another patient panel/master.
+
+Phone lookup remains supported, but backend resolution becomes:
+
+`lookup identifier → Identity Bridge V2 → canonical_patient_id → all permitted aliases/history`.
+
+V2 adds identity confidence/review state, lifecycle, commercial timeline, canonical product/revenue facts and metric trust (`coverage`, `confidence`, `freshness`, `sample_size`), while preserving role-gated PHI.
+
+## REV-F6 lifecycle / trust contract
+
+Prepare after real F5 certification:
+
+- `NEW_PATIENT`
+- `RETURNING_PATIENT`
+- `HISTORICAL_REACTIVATED`
+- `ACTIVE_REPEAT`
+- `DORMANT`
+- `UNRESOLVED_IDENTITY`
+
+Every inferred/aggregate insight must carry period/coverage, confidence, freshness and sample size. Incomplete transaction history must reduce claim strength.
 
 ## Cross-domain rule
-
-Do not build a second customer identity system in CIA, WA, F6 or historical-sales import.
 
 Canonical responsibilities:
 
 - F3 = product identity;
 - F4 = payment/revenue/cartera truth;
-- F5 = patient identity + provenance;
-- F6 = intelligence derived from certified F3/F4/F5 facts;
+- F5 = patient identity + provenance + duplicate resolution;
+- F6 = intelligence/read models from certified F3/F4/F5;
 - CIA = governed acquisition/activation attribution;
-- WA = conversation/channel product consuming permitted identity context.
+- WA = conversation/channel product consuming permitted identity context;
+- Sentinel = observation/integrity, never business truth.
 
-Prefer explicit IDs (`lead_id_origen`, `llamada_id_origen`, `venta_id_match`, sale IDs, cotización/plan/item IDs) before phone inference. `numero_limpio` is a bridge, not merge authority.
+Prefer explicit IDs (`lead_id_origen`, `llamada_id_origen`, `venta_id_match`, sale IDs, cotización/plan/item IDs) before identity-bridge fallback.
 
 ## Future 2024–2025 sales
 
-When historical sales files arrive, use `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`.
+Use `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`:
 
-Do not mass-insert them directly as trusted revenue. Require source SHA/provenance → sales staging/dedup → F3 product resolution → F5 patient resolution → F4 payment/cartera reconciliation → coverage report.
+`source SHA/provenance → sales staging/dedup → canonical sale → F3 product → F5 patient → F4 payment/cartera → F6 recomputation`.
+
+No parallel historical customer/product/revenue architecture and no unsupported YoY while ledgers are absent.
+
+## Sentinel data-integrity handoff
+
+Use `docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`. Signals are aggregate/zero-PII and should detect source batch mismatch, membership mismatch, identity collision, apply without governance, product-sale orphan, reconciliation orphan and F6 freshness/coverage regression.
+
+Sentinel observes and routes to the owning workstream; it does not silently repair production.
 
 ## Security Guardian
 
-Use root `SECURITY.md`. Do not move PII/PHI through GitHub, logs or public artifacts. GitHub contains contracts/hashes/counts/rules, never raw patient rows.
+Use root `SECURITY.md`. Do not move PII/PHI through GitHub, logs or public artifacts. Never store real credentials in skills/docs/examples/prompts; use authorized auth/secret stores.
 
 ## CI/Runner Governor
 
@@ -117,26 +160,24 @@ At each material incident or gate:
 2. read live production state;
 3. record persisted counters/missing ranges/invariants;
 4. update CURRENT docs;
-5. update `aos_memory` only after the live baseline is proven;
+5. update `aos_memory` only after live baseline is proven;
 6. update Notion last;
-7. explicitly supersede incorrect historical claims instead of silently editing history.
-
-Institutional lesson from REV-F5: a convincing execution transcript can still diverge from the database. Certification is a property of persisted post-conditions, not narrative completion.
+7. explicitly supersede incorrect historical claims.
 
 ## Release Certifier
 
 REV-F5 cannot be `PRODUCTION CERTIFIED` and REV-F6 cannot be unblocked until a fresh independent final audit proves:
 
-- 15,498/15,498 staging;
-- 6/6 exact source replays;
+- 15,498/15,498 staging and 6/6 full source replays;
 - 15,498/15,498 identity memberships;
-- exhaustive MATCH/REVIEW/NEW classification;
-- fill-only enrichment rules;
-- governed Review/Apply with rollback evidence;
-- patient→sale→product→payment/cartera coverage;
-- explicit 2024–2025 transaction-coverage statement;
+- exhaustive MATCH/REVIEW/NEW plus duplicate resolution states;
+- governed Identity Bridge V2 semantics / explicit conflicts;
+- fill-only enrichment;
+- governed Review/Apply and any physical patient consolidation with rollback evidence;
+- patient→sale→F3 product→F4 payment/cartera coverage;
+- explicit 2024–2025 transaction coverage statement;
 - numeric coverage/DQ report;
 - exact-head GitHub/CI/deploy + live Supabase reconciliation;
 - CURRENT docs/aos_memory/Notion reconciled after live proof.
 
-Until then: `REV-F5 = ACTIVE / NOT CERTIFIED`.
+At real F5.10 PASS, return the rebound REV-F6 execution prompt from `docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md`; do not silently start F6.

--- a/docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md
+++ b/docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md
@@ -1,0 +1,145 @@
+# REV — CUSTOMER LIFECYCLE & IDENTITY CONFIDENCE CONTRACT
+
+**Owner:** REV-F6 analytics/read models  
+**Dependency:** REV-F5 certified canonical identity + declared transaction/activity coverage  
+**Purpose:** deterministic lifecycle classification and visible metric trust.
+
+## 1. Customer Lifecycle Contract
+
+Lifecycle is derived from canonical patient identity plus observed events. It is not a manual marketing label and it must expose the evidence window used.
+
+### Required states
+
+#### `UNRESOLVED_IDENTITY`
+Use when the event/contact cannot be confidently resolved to one canonical patient. No patient-level lifetime/repeat claim is allowed.
+
+#### `NEW_PATIENT`
+Canonical patient whose first qualifying observed patient event is recent and who has no qualifying prior event inside the certified historical coverage.
+
+Qualifying event priority: completed/attended clinical appointment and/or canonical sale, according to the metric being computed. The model must state which event definition it used.
+
+#### `HISTORICAL_REACTIVATED`
+Canonical patient with a prior qualifying patient event, an inactivity gap of at least 180 days, and a new qualifying event inside the current reactivation window. Default reactivation window: first 30 days after return.
+
+#### `ACTIVE_REPEAT`
+Canonical patient with at least two qualifying observed events/purchases and recent activity (default <=90 days), excluding the short `HISTORICAL_REACTIVATED` window.
+
+#### `RETURNING_PATIENT`
+Canonical patient with prior history who returned/repeated but does not currently meet the stricter `ACTIVE_REPEAT` or `HISTORICAL_REACTIVATED` definition.
+
+#### `DORMANT`
+Canonical patient with prior qualifying history, no qualifying activity for >180 days and no known future confirmed appointment. The inactivity threshold is configurable but must be visible with the metric.
+
+## 2. State precedence
+
+To keep states mutually exclusive for a current-state field:
+
+1. `UNRESOLVED_IDENTITY`
+2. `HISTORICAL_REACTIVATED`
+3. `NEW_PATIENT`
+4. `ACTIVE_REPEAT`
+5. `RETURNING_PATIENT`
+6. `DORMANT`
+
+If evidence cannot distinguish states because history is incomplete, return the most conservative state plus reduced coverage/confidence; never invent a prior/no-prior claim.
+
+## 3. Event-specific flags
+
+Lifecycle current state may coexist with analytical flags such as:
+
+- `is_first_observed_sale`;
+- `is_repeat_sale`;
+- `reactivation_gap_days`;
+- `has_future_appointment`;
+- `observed_purchase_count`;
+- `observed_active_months`.
+
+These flags preserve nuance without multiplying lifecycle states.
+
+## 4. Identity Confidence Contract
+
+Every identity resolution should expose:
+
+- `identity_status`: `RESOLVED`, `REVIEW_REQUIRED`, `CONFLICT`, `UNRESOLVED`;
+- `confidence_band`: `VERIFIED`, `HIGH`, `MEDIUM`, `LOW`, `UNRESOLVED`;
+- `confidence_score`: optional 0–100 explainable score;
+- `match_method`;
+- `strong_signal_count`;
+- `conflict_count`;
+- `reviewed`: boolean;
+- provenance reference(s).
+
+### Recommended bands
+
+- `VERIFIED`: explicitly reviewed/approved or certified exact multi-strong-signal identity with zero conflicts;
+- `HIGH`: strong multi-signal evidence, no contradiction, not yet manually verified where policy permits automatic resolution;
+- `MEDIUM`: useful candidate evidence but requires review for merge-sensitive decisions;
+- `LOW`: weak/fallback evidence only; never authorizes physical merge;
+- `UNRESOLVED`: no safe canonical assignment.
+
+A numeric score never overrides a hard conflict.
+
+## 5. Metric Trust Contract
+
+Every inferred/aggregate F6 insight must carry:
+
+### `coverage`
+What fraction of the relevant universe is represented. Include numerator/denominator where possible and the covered date range.
+
+Examples:
+
+- identity coverage = resolved canonical subjects / eligible subjects;
+- historical sales coverage = certified transaction rows / expected transaction rows when denominator exists;
+- demographic coverage = patients with field / canonical patients in metric cohort.
+
+### `confidence`
+Trust band for the derivation, separate from business performance. It may combine identity confidence, source quality and reconciliation quality.
+
+### `freshness`
+`as_of` timestamp/date and source age. A dashboard must not silently show stale read models as current.
+
+### `sample_size`
+Actual denominator behind patterns such as cross-sell, cohort retention, advisor comparison or demographic segmentation.
+
+## 6. Coverage-period rule
+
+A metric must distinguish:
+
+- `observed_lifetime_value` from true lifetime value;
+- `observed_first_sale` from absolute first sale when earlier transaction coverage is absent;
+- `2026-only` facts from multi-year facts;
+- patient-history coverage from transaction-ledger coverage.
+
+Until 2024/2025 sales ledgers are certified, no F6 metric may claim complete 2024/2025 revenue or YoY.
+
+## 7. Patient 360 presentation
+
+Direct canonical facts may display normally. Derived intelligence should expose compact trust metadata, for example:
+
+`LTV observado S/ X · cobertura 2026 · HIGH · n=4 compras · actualizado hoy`
+
+Do not overwhelm normal users with raw technical metadata; allow expanded details for admin/audit.
+
+## 8. CIA / WA handoff
+
+Lifecycle and confidence are read-only commercial signals. They do not themselves authorize campaign delivery or autonomous outreach.
+
+CIA/WA may consume:
+
+- lifecycle state;
+- commercial recency/frequency;
+- identity status/confidence;
+- recommended analytical segment/signals;
+
+subject to their own policy/consent/channel governance.
+
+## 9. Certification tests
+
+- mutually exclusive current lifecycle state;
+- deterministic results for same as-of date/input facts;
+- unresolved identity never appears as known patient;
+- hard identity conflicts never become high confidence by score accumulation;
+- 180/90/30-day defaults are explicit/configurable;
+- historical coverage gaps reduce claim strength;
+- every aggregate insight carries coverage, confidence, freshness and sample_size;
+- no unsupported YoY/lifetime wording.

--- a/docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md
+++ b/docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md
@@ -1,0 +1,151 @@
+# REV-F5 → REV-F6 IMPLEMENTATION ROADMAP CURRENT
+
+**Captured:** 2026-08-19 America/Lima  
+**Baseline:** `main@1d964d99f018cbdb671ddce90e52ece6bac0a8bd`  
+**Active mutable workstream:** `REV-F5-CLOSEOUT`  
+**Rule:** design/docs may advance now; production mutations outside REV-F5 remain blocked until handoff.
+
+## Goal
+
+Close REV-F5 against LIVE truth, make patient identity stable beyond `numero_limpio`, consolidate true duplicates safely, upgrade the existing Patient 360 instead of creating a second panel, and prepare REV-F6 intelligence + Sentinel data-integrity monitoring without creating competing sources of truth.
+
+## Current LIVE starting point
+
+- expected source rows: 15,498;
+- persisted: 8,264;
+- pending: 7,234;
+- complete batches: 1/6;
+- members: 0;
+- previews: 0;
+- apply events: 0;
+- duplicates/orphans in F5 staging: 0/0;
+- canonical patients observed: 7,685.
+
+Missing ranges are defined in `ASCENDA_WORKSTREAM_LOCK_CURRENT.md` and MUST be re-derived from LIVE before every write.
+
+## Architecture ownership
+
+- **REV-F3:** product/service identity.
+- **REV-F4:** payment/revenue/cartera/reconciliation truth.
+- **REV-F5:** patient identity, historical provenance, duplicate resolution and governed enrichment.
+- **REV-F6:** analytics/read-models built from certified F3/F4/F5 facts.
+- **CIA:** acquisition/activation/attribution. It may consume patient identity but may not own a competing customer identity.
+- **WA:** conversation/routing/booking/revenue UX. It consumes permitted identity/commercial context.
+- **Sentinel:** observes integrity/health; it never becomes business truth.
+
+## REV-F5 closeout additions
+
+### F5-A — Finish source truth
+
+Complete exact LIVE gaps only, through existing SHA-bound idempotent compact ingest. Every checkpoint requires Persistence Triple-Proof. Every source closes only after full idempotent replay.
+
+### F5-B — Identity rebuild
+
+After 15,498/15,498 + 6/6 source certification, rebuild identity and require exactly 15,498 memberships, 0 orphan memberships and auditable cluster evidence.
+
+### F5-C — Canonical duplicate resolution
+
+Use F5 identity evidence to classify current `aos_pacientes` duplicates into:
+
+- `AUTO_ELIGIBLE_EXACT`: normalized name + surname + phone + document all exact, no conflicting strong field;
+- `REVIEW_STRONG`: same document + compatible person evidence but changed phone/name formatting, or other strong multi-signal case;
+- `BLOCK_CONFLICT`: same name/phone but conflicting document/DOB/sex, same document with incompatible person evidence, or other strong contradiction;
+- `NO_MERGE`: name-only, phone-only, approximate phone, weak/fuzzy similarity.
+
+Current read-only profile is evidence, not a fixed future denominator: 174 same-name groups; 69 span multiple phones; 57 span multiple documents; 14 groups / 29 rows currently match exact name+surname+phone+document.
+
+**Hard prohibition:** phone numeric proximity (for example ±3) is never identity evidence.
+
+Physical consolidation is CRITICAL. Before changing a canonical patient, require admin+2FA, dry-run, dependency inventory, rollback journal/snapshot, 1-row canary, live readback and progressive apply. Never delete provenance. Absorbed identifiers remain historical aliases.
+
+### F5-D — Identity Bridge V2 foundation
+
+After identity decisions are certified, create/version a governed bridge from multiple identifiers to one stable `canonical_patient_id`. Reuse the existing `aos_cia_contact_identity_v1` as input/compatibility evidence; do not create a competing identity truth.
+
+Phone remains an accepted lookup/import key, but not the canonical identity key.
+
+### F5-E — Enrichment / Review & Apply
+
+Fill-only by default. Conflicting non-empty values require review. Clinical notes/allergies remain outside automatic commercial apply. `Último presupuesto` stays evidence-only. `ADELANTO` stays payment evidence only.
+
+### F5-F — Patient→Revenue linkage
+
+Certify patient → sale → F3 product → F4 payment/revenue/cartera using explicit IDs first and identity bridge evidence second. Do not manufacture historical revenue where transaction sources are absent.
+
+### F5-G — F5.10 terminal gate
+
+REV-F5 may close only when exact-head GitHub/CI/deploy and LIVE DB independently prove every declared gate. Then update CURRENT docs, `aos_memory`, Notion last, release the lock and emit the REV-F6 prompt.
+
+## Existing Patient 360 — upgrade, do not replace
+
+Current product surface is `app/public/patients.html`; current RPC includes `aos_paciente_360`. The V2 target keeps this UX and adds:
+
+1. stable canonical patient identity;
+2. historical identifier aliases, especially old/new phones;
+3. identity confidence + review state;
+4. lifecycle state;
+5. acquisition/contact/agenda/sales/product/payment timeline;
+6. coverage/freshness/sample-size metadata;
+7. duplicate-resolution evidence and merge history;
+8. role-gated clinical sections separated from commercial context.
+
+Backward compatibility: lookup by phone continues, but server-side resolution becomes `identifier → canonical_patient_id → all aliases/history`.
+
+## REV-F6 internal roadmap
+
+### REV-F6.0 — Rebaseline & Data Contract
+Require F5 PRODUCTION CERTIFIED, acquire lock, revalidate F3/F4/F5 coverage, exact-head and historical transaction coverage.
+
+### REV-F6.1 — Identity-aware Patient Commercial 360 V2
+Implement read models/RPCs that resolve canonical patient + aliases and enrich the current panel. No second patient master.
+
+### REV-F6.2 — Customer Lifecycle Contract
+Implement deterministic lifecycle states: `NEW_PATIENT`, `RETURNING_PATIENT`, `HISTORICAL_REACTIVATED`, `ACTIVE_REPEAT`, `DORMANT`, `UNRESOLVED_IDENTITY`, with explicit precedence and evidence windows.
+
+### REV-F6.3 — Identity Confidence / Metric Trust Contract
+Every relevant metric/read-model exposes `coverage`, `confidence`, `freshness`, `sample_size` and coverage period. No exact-looking insight without denominator and source window.
+
+### REV-F6.4 — Sales Intelligence 3.0
+Executive Revenue, cohorts/retention, observed LTV, product/cross-sell, advisor/sede performance, acquisition-to-revenue facts where attribution is defendable.
+
+### REV-F6.5 — Historical-sales plug-in contract
+When 2024/2025 sales XLSX arrive, ingest via `REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`; reuse F3/F4/F5 and recompute affected F6 read models idempotently.
+
+### REV-F6.6 — Sentinel data-integrity handoff
+Register aggregate/zero-PII integrity signals. Implementation in Sentinel remains regression/read-only until Sentinel or the active Revenue scope explicitly owns the needed mutation.
+
+### REV-F6.7 — Certification
+Performance/read-model tests, metric reconciliation, coverage/freshness display, role/privacy checks, visual acceptance and exact live certification before REV-F7.
+
+## Sentinel integrity targets
+
+At minimum:
+
+- F5 batch complete flag vs expected/staged mismatch;
+- `identity_members != source_rows` after rebuild;
+- duplicate membership / orphan membership;
+- canonical apply event missing governed preview/review;
+- product sale fact orphaned from sale;
+- reconciliation row orphaned from sale/payment/cotization evidence;
+- identity bridge identifier collision mapping to multiple canonical patients;
+- F6 read model freshness/coverage below declared contract.
+
+Signals contain counts/status/contract IDs only — no names, phones, emails, documents, clinical notes or message payloads.
+
+## Future 2024–2025 sales
+
+Do not redesign when files arrive. Expected path:
+
+`XLSX → manifest/SHA → row provenance → sales staging → canonical sale → F3 product → F5 patient identity → F4 financial evidence → F6 intelligence`.
+
+Existing 2026 intelligence remains valid for its declared window; 2024/2025 additions expand coverage and trigger deterministic recomputation rather than manual rebuilding.
+
+## Exit contract
+
+F5 completion must return to the owner:
+
+1. final certification summary;
+2. exact `main` SHA and LIVE post-conditions;
+3. unresolved review/conflict inventory without PII;
+4. historical transaction coverage statement;
+5. the exact `REV-F6` execution prompt from `docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md`, rebound to the final F5-certified baseline.

--- a/docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md
+++ b/docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md
@@ -1,0 +1,141 @@
+# REV — PATIENT COMMERCIAL 360 V2 CONTRACT
+
+**Existing UI to evolve:** `app/public/patients.html`  
+**Existing RPC to evolve:** `aos_paciente_360`  
+**Owner:** REV-F6 read/intelligence layer consuming certified REV-F5 identity  
+**Rule:** upgrade the existing Pacientes 360; do not create a second patient master/panel.
+
+## Current limitation
+
+The current Patient 360 and several histories are resolved primarily through `numero_limpio`/last 9 digits. This is useful for compatibility but can fragment one person across historical phones or accidentally aggregate shared-phone records.
+
+## V2 subject
+
+The V2 subject is `canonical_patient_id`.
+
+Backward-compatible lookup inputs may be:
+
+- canonical patient ID;
+- current phone;
+- historical phone alias;
+- reviewed document/email alias where role policy permits.
+
+All inputs resolve first through Identity Bridge V2. The panel then queries history by canonical identity and explicit linked facts, not by an unbounded phone-only scan.
+
+## V2 sections
+
+### 1. Identity card
+
+Expose role-appropriate:
+
+- canonical name;
+- current primary contact;
+- canonical patient ID internally;
+- current document/email only where permitted;
+- identity status;
+- confidence band;
+- review/conflict indicator;
+- data completeness;
+- provenance summary;
+- alias count / historical-contact indicator without unnecessary PII display.
+
+### 2. Commercial summary
+
+Derived from canonical facts:
+
+- observed total sales/facturation within declared transaction coverage;
+- observed paid/reconciled amount where F4 supports it;
+- purchase count;
+- first/last observed sale;
+- first/last appointment/activity;
+- future appointment state;
+- top canonical products/services;
+- current lifecycle state;
+- observed reactivation count;
+- sede history.
+
+Never present incomplete historical coverage as lifetime truth. Display period/coverage metadata.
+
+### 3. Unified timeline
+
+Ordered events with explicit provenance/type:
+
+- acquisition lead;
+- call/contact;
+- WhatsApp conversation milestone where permitted;
+- appointment;
+- sale;
+- canonical product fact;
+- payment/reconciliation fact;
+- reactivation event.
+
+Use explicit IDs (`lead_id_origen`, `llamada_id_origen`, `venta_id_match`, sale IDs, cotization/plan IDs) before inferred contact-key joins.
+
+### 4. Identity aliases & merge history
+
+Admin-only identity block:
+
+- current canonical profile;
+- historical identifiers/aliases as restricted evidence;
+- fused/absorbed profile count;
+- merge/apply event history;
+- unresolved conflicts;
+- rollback/recovery status when relevant.
+
+No clinical content is needed to make commercial identity visible.
+
+### 5. Intelligence card
+
+From REV-F6:
+
+- lifecycle state;
+- repeat/retention signals;
+- observed LTV with time window;
+- cross-sell/next-product patterns with sample size/confidence;
+- acquisition-to-revenue attribution only where evidence is certified;
+- reactivation opportunity signal as analysis, not an autonomous send command.
+
+Each insight must expose metric trust metadata.
+
+### 6. Clinical boundary
+
+Clinical notes, allergies, evaluations, images and other PHI remain role-gated. Commercial agents/WA/CIA do not receive broad clinical context merely because it exists in Patient 360.
+
+## Duplicate UX target
+
+Replace a generic duplicate warning with evidence classes:
+
+- `EXACT_SAFE_CANDIDATE`;
+- `STRONG_REVIEW`;
+- `IDENTITY_CONFLICT`;
+- `HOMONYM / DO_NOT_MERGE`.
+
+Show why the case was classified without using weak heuristics. Physical merge actions remain admin+2FA and governed.
+
+## Trust metadata displayed by the panel
+
+Every derived metric/insight may include:
+
+- `coverage` — fraction/period of relevant source universe represented;
+- `confidence` — trust in identity/metric derivation;
+- `freshness` — as-of timestamp / age of source model;
+- `sample_size` — denominator behind analytic patterns.
+
+A value without these fields may still be shown if it is a direct canonical fact, but inferred/aggregate intelligence must not look equally certain when evidence is weak.
+
+## Historical sales plug-in
+
+When 2024/2025 sales are ingested, Patient 360 must expand automatically through canonical sale/F3/F4/F5 facts. No manual patient-page reconstruction or new 2024/2025-specific code path.
+
+## Acceptance gates
+
+- old/new phone aliases resolve to same canonical patient where reviewed;
+- shared phone does not collapse incompatible patients;
+- fused aliases preserve historical sales/agenda/contact access;
+- commercial totals reconcile to canonical sale/payment facts;
+- current phone lookup still works;
+- exact canonical ID lookup works;
+- unresolved identity is visibly unresolved, not silently assigned;
+- no PHI leak to commercial roles;
+- coverage/confidence/freshness/sample size display works for F6 intelligence;
+- existing Patient 360 navigation/session/edit/cotization flows remain functional.

--- a/docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md
+++ b/docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md
@@ -1,0 +1,147 @@
+# REV — PATIENT IDENTITY BRIDGE V2 CONTRACT
+
+**Owner:** REV-F5 identity/provenance  
+**Consumers:** REV-F6, CIA, WA, Agenda/Calls, imports, Patient 360  
+**Status:** DESIGN FROZEN / IMPLEMENT AFTER F5 SOURCE+IDENTITY GATES  
+**Compatibility input:** `aos_cia_contact_identity_v1` remains useful but phone-centric.
+
+## Problem
+
+`numero_limpio` is currently a transversal bridge, but a patient can change phone, share a family phone, be imported with formatting drift, or have historical rows under several numbers. Phone is therefore a lookup identifier, not canonical identity.
+
+## Canonical key
+
+The stable cross-domain subject is `canonical_patient_id`, referencing the surviving canonical patient profile. Consumers must not derive a new patient identity independently.
+
+## Identifier model
+
+One canonical patient may own zero or many governed identifiers:
+
+- `PHONE` — current or historical alias;
+- `DOCUMENT` — normalized document, where valid;
+- `EMAIL` — normalized email;
+- `SOURCE_PATIENT_ID` — always scoped by source batch/system;
+- `HC` — always scoped unless a global uniqueness contract is proven;
+- `CONTACT_KEY_V1` — compatibility bridge from CIA V1.
+
+Each association needs at least:
+
+- `canonical_patient_id`;
+- `identifier_type`;
+- restricted normalized identifier value or protected key;
+- `source_scope` / provenance;
+- `status` (`ACTIVE`, `HISTORICAL_ALIAS`, `CONFLICT`, `RETIRED`, `UNRESOLVED`);
+- `confidence_band`;
+- `evidence_method`;
+- `valid_from` / `valid_to` where known;
+- `review_state` / reviewer audit;
+- timestamps.
+
+Do not put raw PII into GitHub, logs, Sentinel events or broad analytics views.
+
+## Resolution order
+
+1. explicit canonical IDs / reviewed bridge relation;
+2. exact strong identifier with compatible evidence;
+3. multi-signal candidate to governed review;
+4. weak/fuzzy evidence remains unresolved.
+
+`numero_limpio` can locate candidate identity evidence but cannot alone authorize a merge.
+
+## Duplicate classification contract
+
+### AUTO_ELIGIBLE_EXACT
+
+All must hold:
+
+- exact normalized names;
+- exact normalized surnames;
+- exact normalized phone;
+- exact normalized valid document;
+- no conflicting DOB/sex/strong email/person evidence;
+- no dependency/invariant blocker;
+- dry-run and rollback contract available.
+
+This means eligible for governed progressive apply, not silent background merging.
+
+### REVIEW_STRONG
+
+Examples:
+
+- same valid document + compatible name but changed phone;
+- name+surname+phone where document is missing on one side and there is no contradiction;
+- historical source cluster provides multiple compatible strong signals.
+
+Requires human approval.
+
+### BLOCK_CONFLICT
+
+Examples:
+
+- same name+phone but different valid documents;
+- same document with incompatible person evidence;
+- DOB/sex contradiction not explained by obvious data-quality error;
+- one identifier already reviewed to another canonical patient.
+
+Must not merge automatically.
+
+### NO_MERGE
+
+- name-only;
+- phone-only;
+- approximate phone;
+- numeric phone proximity;
+- fuzzy spelling without strong evidence.
+
+## Explicit deprecation
+
+The legacy heuristic that treats 9-digit phone values within a numeric distance such as `ABS(phoneA-phoneB) <= 3` as duplicate evidence is **prohibited for identity decisions**.
+
+The legacy physical merge RPC `aos_fusionar_pacientes` must not be used as the new F5 batch authority until it is dependency-audited and wrapped/versioned with:
+
+- admin+2FA authorization;
+- deterministic candidate ID, not phone pair as sole authority;
+- dry-run impact counts;
+- field conflict report;
+- immutable merge/apply event;
+- rollback/recovery path;
+- preservation of absorbed identifiers as aliases;
+- post-merge reference/orphan checks.
+
+## Merge semantics
+
+Canonical consolidation means:
+
+- choose one canonical profile by evidence/governance, not simply newest record;
+- move/repoint permitted business references safely;
+- preserve historical source rows unchanged;
+- preserve old phone/email/document aliases with provenance;
+- mark absorbed profile non-canonical/fused rather than erasing its audit history;
+- recompute derived totals from canonical facts, never sum cached totals blindly;
+- do not collapse clinical records without clinical-domain dependency checks.
+
+## Import compatibility
+
+Existing Excel/import flows may continue to present `numero_limpio`. Import resolution becomes:
+
+`raw phone → normalized phone alias → candidate canonical_patient_id → corroborating evidence → resolved/review/unresolved`.
+
+If a patient changed phone, both old and new phone aliases may resolve to the same canonical patient after governed identity review.
+
+## CIA compatibility
+
+`aos_cia_contact_identity_v1` should remain a V1 phone/contact view for existing CIA consumers. Identity Bridge V2 becomes the richer governed source; CIA can receive a compatibility view that still exposes `contact_key → canonical_patient_id` where unambiguous.
+
+Do not let CIA own a separate patient merge algorithm.
+
+## Certification
+
+Identity Bridge V2 is certified only when:
+
+- every resolved alias maps to exactly one canonical patient;
+- conflicts remain explicit, not coerced;
+- no forbidden phone-proximity heuristic is used;
+- absorbed aliases still resolve historically;
+- Patient 360, WA/CIA compatibility and imports pass known-current regression;
+- no unauthorized PII exposure is introduced;
+- rollback/recovery is proven for physical consolidations.

--- a/docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md
+++ b/docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md
@@ -1,0 +1,125 @@
+# SENTINEL — DATA INTEGRITY SIGNALS CONTRACT
+
+**Status:** DESIGN REGISTERED / NO RUNTIME MUTATION IN THIS PR  
+**Current Sentinel baseline:** SEN-F1..F13 certified/regression-only  
+**Purpose:** extend Sentinel from application/runtime errors into aggregate business-data integrity without exposing PHI/PII.
+
+Sentinel F2 already permits later phases to add `signal_contracts` without redefining domain identity. This contract uses that extension point.
+
+## Principles
+
+1. Sentinel observes; it never becomes business truth.
+2. Signals contain counts, states, timestamps, contract IDs and safe internal references only.
+3. Never send names, phones, emails, documents, clinical notes, message bodies, payment references or source-row payloads into Sentry/Telegram/general logs.
+4. A signal must identify exact violated invariant and owning workstream.
+5. A failed signal does not auto-repair production unless a separately governed recovery action is explicitly authorized.
+
+## Signal registry
+
+### `SEN-DQ-F5-001 SOURCE_BATCH_MISMATCH`
+Trigger when a batch has `staging_complete=true` but persisted row count != manifest expected rows, or when expected range continuity fails.
+
+Severity: HIGH.  
+Payload: batch safe ID/hash prefix, expected count, actual count, missing/extra counts.
+
+### `SEN-DQ-F5-002 IDENTITY_MEMBERSHIP_MISMATCH`
+After F5 identity rebuild/certification, trigger when `members != source_rows`, orphan member count >0, or source row has invalid membership multiplicity.
+
+Severity: CRITICAL after F5 certification; HIGH during controlled rebuild.
+
+### `SEN-DQ-F5-003 IDENTITY_BRIDGE_COLLISION`
+Trigger when one reviewed/active identifier resolves to >1 canonical patient or one supposedly resolved subject has a hard conflict.
+
+Severity: CRITICAL for verified identifiers; HIGH for unresolved/review candidates.
+
+No raw identifier value in signal payload.
+
+### `SEN-DQ-F5-004 APPLY_WITHOUT_GOVERNANCE`
+Trigger when a canonical F5 apply/merge event lacks required preview/review/admin authorization/audit relationship, or protected apply invariants diverge.
+
+Severity: CRITICAL.
+
+### `SEN-DQ-F5-005 DUPLICATE_PROFILE_DRIFT`
+Track aggregate duplicate-candidate distribution by class (`AUTO_ELIGIBLE_EXACT`, `REVIEW_STRONG`, `BLOCK_CONFLICT`, `NO_MERGE`). Alert only on abnormal regression thresholds, not merely because review candidates exist.
+
+Severity: MEDIUM/HIGH depending on drift.
+
+### `SEN-DQ-REV-001 PRODUCT_SALE_ORPHAN`
+Trigger when a current product sale fact references no canonical sale or a resolved sale product loses its required canonical product relation outside an approved lifecycle state.
+
+Severity: HIGH.
+
+### `SEN-DQ-REV-002 RECONCILIATION_ORPHAN`
+Trigger when active revenue/cartera reconciliation references missing sale/payment/cotization evidence or impossible relation multiplicity.
+
+Severity: HIGH/CRITICAL according to financial effect.
+
+### `SEN-DQ-F6-001 READMODEL_STALE`
+Trigger when a certified F6 read model exceeds its declared freshness SLA or version no longer matches source contract version.
+
+Severity: MEDIUM; HIGH for executive/operational decision surfaces.
+
+### `SEN-DQ-F6-002 COVERAGE_REGRESSION`
+Trigger when a certified metric's coverage falls materially below its baseline/contract without an expected source-window change.
+
+Severity: MEDIUM/HIGH.
+
+### `SEN-DQ-360-001 PATIENT360_IDENTITY_RESOLUTION_REGRESSION`
+Trigger when Patient 360 canonical resolution error/unresolved rate materially increases after Identity Bridge V2 deployment, or when alias lookup unexpectedly maps to conflict.
+
+Severity: HIGH.
+
+## Health semantics
+
+Suggested states:
+
+- `OK` — invariant satisfied;
+- `DEGRADED` — non-destructive coverage/freshness issue;
+- `REVIEW_REQUIRED` — ambiguity requires human resolution;
+- `BROKEN` — integrity invariant violated;
+- `UNKNOWN` — sensor cannot prove health.
+
+Never return green from missing telemetry.
+
+## Collection model
+
+Preferred pattern:
+
+- read-only aggregate SQL/RPC sensor;
+- deterministic zero-PII result envelope;
+- Sentinel evaluates contract;
+- deduplicate alerts by `signal_id + affected_contract + state_digest`;
+- recovery notification includes owning workstream and safe diagnostic counts.
+
+Do not query/transport raw patient records merely to produce health signals.
+
+## Frequency
+
+- structural F5/F6 post-write checks: immediately at gate completion + scheduled regression;
+- stable data-integrity health: hourly is sufficient unless an active migration/rebuild needs faster gate-local checks;
+- freshness checks: according to declared read-model SLA.
+
+## UI integration target
+
+Sentinel panel/map should be able to show:
+
+`Revenue → F5 Identity → Membership mismatch`  
+`Revenue → F4 Reconciliation → orphan evidence`  
+`Revenue → F6 Intelligence → stale read model`
+
+with severity, first/last seen, current aggregate values and runbook link — never raw PHI/PII.
+
+## Implementation boundary
+
+This document registers the contract now. Runtime/DB implementation must respect the global mutable workstream lock. During REV-F5, only F5-local validation queries required for its certification may mutate/rebuild F5; Sentinel itself remains observation/regression-only unless explicitly handed a maintenance lock.
+
+After REV-F5/REV-F6 define stable contracts, add these signals to Sentinel registry/telemetry using the established machine-readable registry and zero-PII boundary.
+
+## Acceptance
+
+- synthetic negative tests trigger each signal;
+- green requires actual evidence, not absence of errors;
+- no PHI/PII appears in payload/log/notification;
+- state dedup prevents alert storms;
+- runbook points to exact owning workstream;
+- F5 false-certification class of error would have produced a HIGH/CRITICAL alert from source/membership mismatch.

--- a/docs/control/prompts/REV_F5_CLOSEOUT_EXECUTION_PROMPT.md
+++ b/docs/control/prompts/REV_F5_CLOSEOUT_EXECUTION_PROMPT.md
@@ -1,0 +1,240 @@
+# PROMPT — REV-F5 DEFINITIVE CLOSEOUT LOOP
+
+Use this prompt to resume and finish REV-F5. It grants continuous execution across REV-F5 only, subject to the safety/lock gates below.
+
+---
+
+**EXECUTE `REV-F5-CLOSEOUT` FROM LIVE TRUTH UNTIL F5.10 IS ACTUALLY CERTIFIED.**
+
+You are working on `CESARJAUREGUITORRES/ascenda-os`. The active namespace is `REV-F5`; never use bare F5 when crossing workstreams.
+
+## OWNER AUTHORIZATION
+
+I authorize the complete REV-F5 closeout loop, including its necessary GitHub branches/PRs, safe Supabase data operations through audited/versioned routes, exact-current CI, controlled canaries, governed admin+2FA Review/Apply, rollback proof, documentation and final certification. This authorization does **not** authorize bypassing 2FA/admin/security, exposing PII/PHI/secrets, inventing data, destructive broad cleanup, or mutating another HIGH/CRITICAL workstream.
+
+Do not ask me to approve each file/year/chunk. Continue automatically inside REV-F5 while every gate passes. Stop only on a genuine external owner action/security blocker or a hard contradiction that cannot be safely resolved from existing evidence.
+
+## 0 — MANDATORY BOOTSTRAP / AUTHORITY
+
+Read fresh before any write:
+
+1. `AGENTS.md`
+2. `SECURITY.md`
+3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`
+4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`
+5. `docs/MEMORY_CURRENT.md`
+6. `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`
+7. `docs/control/REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md`
+8. `docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`
+9. `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`
+10. exact GitHub `main`, PR/checks/deploy and Supabase LIVE.
+
+Production/live state outranks old chats, Notion and expected results.
+
+Require `REV-F5-CLOSEOUT` as the sole mutable HIGH/CRITICAL lock. If `main` advanced, inspect/revalidate the diff before new writes.
+
+## 1 — PERSISTENCE TRIPLE-PROOF
+
+Never certify data from tool output alone. Every mutable checkpoint requires:
+
+1. execution receipt;
+2. direct live persisted readback;
+3. independently constructed invariant query.
+
+Every source batch closure additionally requires full idempotent replay of the exact SHA-bound source with zero new inserts/conflicts.
+
+On timeout/block/ambiguous response:
+
+`OBSERVE LIVE → IDENTIFY EXACT GAP → MUTATE ONLY GAP → READ BACK → VERIFY → CONTINUE`.
+
+Never skip ahead because a local loop said COMPLETE.
+
+## 2 — REBASELINE REV-F5.0
+
+Freshly derive, do not assume, all six manifests, expected/staged rows, exact missing ranges, SHA, duplicate structural keys, orphans, F5 members/previews/apply events, active ingest and protected canonical counts.
+
+Known prior checkpoint for comparison only: expected 15,498 and a previously observed 8,264 staged. Treat the fresh query as truth.
+
+Confirm all six original XLSX sources by exact SHA before ingest. Do not ask owner to re-upload if they are recoverable from the current file/library/runtime context. No GitHub PII, no new bucket/transport/uploader while the existing compact-ingest route is usable.
+
+## 3 — REV-F5.1 SOURCE INGEST
+
+Use the existing audited private/idempotent compact ingest path. Resume only exact missing rows. Complete one source safely, certify it, then advance automatically to the next incomplete source.
+
+For each chunk:
+
+- source SHA exact;
+- request row numbers exact;
+- require RPC success semantics;
+- immediately read LIVE persisted count/range;
+- verify inserted+existing=requested;
+- on raw conflict isolate exact row/range and compare against source; never overwrite blindly;
+- no canonical patient mutation.
+
+When a source reaches expected count:
+
+- continuity min/max/range exact;
+- zero missing/extra/multiplicity anomalies;
+- zero duplicate structural keys/orphans;
+- `staging_complete=true` only if count/range really match;
+- full-source replay: all rows existing, zero new inserts/conflicts.
+
+Continue until **15,498/15,498 and 6/6 complete**.
+
+## 4 — REV-F5.2 SOURCE CERTIFICATION
+
+Run two independent global structural audits. Require:
+
+- 15,498 distinct source rows;
+- six exact manifests/SHA;
+- exact ranges per source;
+- no missing/out-of-range/multiplicity error;
+- no F5 canonical apply before identity/review gate;
+- audit/replay consistency.
+
+If any check fails, repair only the failing source/range and repeat.
+
+## 5 — REV-F5.3 IDENTITY REBUILD
+
+Only after F5.2 PASS, run the existing F5 identity rebuild. Require:
+
+- 15,498 memberships for 15,498 source rows;
+- one valid membership per source row according to contract;
+- zero orphan memberships;
+- auditable cluster evidence;
+- no silent canonical-patient mutation.
+
+## 6 — REV-F5.4 MATCH / REVIEW / NEW + DUPLICATE RESOLUTION
+
+Classify historical clusters conservatively and also audit current `aos_pacientes` duplicate profiles.
+
+### Patient duplicate rules
+
+Use fresh aggregates; do not assume old counts.
+
+`AUTO_ELIGIBLE_EXACT` requires exact normalized name + surname + phone + valid document, with no conflict in DOB/sex/strong email/person evidence and no dependency blocker.
+
+`REVIEW_STRONG`: strong multi-signal evidence such as same valid document + compatible person evidence with changed phone, or other non-conflicting strong combinations.
+
+`BLOCK_CONFLICT`: strong contradictions such as same name+phone but different valid documents, incompatible DOB/sex, or identifier already resolved to another canonical patient.
+
+`NO_MERGE`: name-only, phone-only, fuzzy name only, approximate phone.
+
+**Never use numeric phone proximity (for example ±3) as duplicate evidence.**
+
+Do not use the legacy `aos_fusionar_pacientes` as batch authority without first auditing/versioning/hardening it for F5. Physical consolidation is CRITICAL and must preserve provenance and absorbed identifier aliases.
+
+Preferred result: stable `canonical_patient_id`; absorbed/old phones remain historical aliases so imports and prior facts still resolve to the same person.
+
+## 7 — IDENTITY BRIDGE V2
+
+Implement/version the governed bridge defined in `REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md` only after identity evidence is ready.
+
+Do not create a competing CIA/customer identity. Reuse `aos_cia_contact_identity_v1` as compatibility input/view where useful.
+
+Required behavior:
+
+`identifier (phone/document/email/source-scoped ID/HC) → governed evidence → canonical_patient_id or REVIEW/CONFLICT/UNRESOLVED`.
+
+Phone remains accepted for existing Excel imports and lookups but is no longer canonical identity authority.
+
+For any physical duplicate consolidation:
+
+- admin+2FA;
+- dry-run impact/dependency counts;
+- immutable merge/apply audit event;
+- 1-row canary;
+- rollback/recovery proof;
+- post-merge orphan/reference checks;
+- preserve old identifiers as aliases;
+- progressive safe apply only to eligible cases.
+
+## 8 — REV-F5.5 ENRICHMENT PREVIEW
+
+Generate fill-only proposed patches from certified provenance. Never silently overwrite conflicting non-empty canonical fields. Clinical notes/allergies stay outside commercial auto-apply. Budget/payment semantics remain separated.
+
+Require exhaustive preview classification and protected-field checks.
+
+## 9 — REV-F5.6 GOVERNED REVIEW & APPLY
+
+Use existing or safely versioned admin+2FA review/apply/rollback mechanisms. Prove:
+
+`Review → DRY_RUN → APPLY → live verify → ROLLBACK → live verify → re-APPLY`.
+
+Then scale progressively (1 → 10 → 50 → 100 → safe remainder), isolating conflicts rather than forcing them.
+
+For duplicate patient consolidation, use the same governed/canary/rollback discipline and do not delete source provenance.
+
+## 10 — REV-F5.7 PATIENT→REVENUE LINKAGE
+
+Certify linkage using explicit IDs first:
+
+`canonical patient → sale → REV-F3 canonical product → REV-F4 payment/revenue/cartera`.
+
+Use Identity Bridge evidence only where explicit business IDs are unavailable. Quantify resolved/review/unresolved coverage; no name-only or phone-only revenue ownership claim.
+
+## 11 — REV-F5.8 HISTORICAL TRANSACTION COVERAGE
+
+Audit whether detailed 2024/2025 sales ledgers are actually present. If absent, explicitly state that Patient History 2024–2026 exists but complete 2024/2025 revenue does not yet exist. Do not fabricate YoY.
+
+The future files must enter through `REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md` and reuse F3/F4/F5.
+
+## 12 — REV-F5.9 COVERAGE & DATA QUALITY
+
+Emit numeric report with numerator/denominator and period for at least:
+
+- source/staging;
+- canonical identity resolution;
+- REVIEW/CONFLICT/UNRESOLVED;
+- DNI/phone/email/DOB/sex/geography coverage;
+- duplicate consolidation coverage;
+- sales→patient linkage;
+- product resolution;
+- payment/cartera linkage;
+- transaction years actually covered.
+
+Persist only safe aggregate/audit evidence; no PII in GitHub/Sentinel/logs.
+
+## 13 — SENTINEL CONTRACT HANDOFF
+
+Do not reopen Sentinel as a competing mutable project. Register/validate the aggregate zero-PII invariants from `SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md` as F5 runbook/contract evidence. The final F5 state must be monitorable for source mismatch, membership mismatch, identity collision and apply-without-governance.
+
+## 14 — REV-F5.10 FINAL INDEPENDENT CERTIFICATION
+
+Before claiming completion:
+
+- re-read exact `main` and lock;
+- require relevant exact-head CI/deploy green;
+- independently query all F5 terminal invariants from scratch;
+- prove no active ingest/temporary residue;
+- verify merge/apply audit and rollback consistency;
+- verify Identity Bridge uniqueness/conflicts are explicit;
+- verify no forbidden auto-merge heuristic;
+- verify current Patient 360/import compatibility is not broken by identity changes;
+- reconcile GitHub CURRENT docs + `aos_memory` + Notion last.
+
+Only then declare exactly:
+
+`REV-F5 — PRODUCTION CERTIFIED — 100%`
+
+and release/unassign the REV-F5 lock according to governance.
+
+## 15 — REQUIRED TERMINAL OUTPUT: HAND ME REV-F6 PROMPT
+
+Immediately after real F5.10 PASS, do **not** start REV-F6 automatically unless the owner explicitly asks execution in that same turn.
+
+Instead:
+
+1. fetch `docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md`;
+2. replace template placeholders with the exact final F5-certified `main` SHA, live F5 terminal counts, identity/duplicate coverage and historical-sales coverage;
+3. save/reconcile the rebound prompt in GitHub if the template contract requires it;
+4. return the complete copy/paste-ready REV-F6 prompt to me.
+
+Your final response must distinguish:
+
+- what was actually persisted/certified;
+- unresolved human-review/conflict inventory (aggregate only);
+- what 2024/2025 transaction coverage still lacks;
+- exact next prompt for REV-F6.
+
+---

--- a/docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md
+++ b/docs/control/prompts/REV_F6_EXECUTION_PROMPT_TEMPLATE.md
@@ -1,0 +1,173 @@
+# PROMPT TEMPLATE — REV-F6 SALES INTELLIGENCE 3.0
+
+**Do not execute from this template until REV-F5 is genuinely production-certified.** At F5 closeout, bind the placeholders to exact current evidence and return the complete prompt to the owner.
+
+---
+
+**EXECUTE `REV-F6 — SALES INTELLIGENCE 3.0` FROM THE CERTIFIED F5 BASELINE UNTIL F6 FINAL CERTIFICATION.**
+
+Repository: `CESARJAUREGUITORRES/ascenda-os`  
+Certified F5 baseline `main`: `{{FINAL_F5_MAIN_SHA}}`  
+F5 source rows: `{{F5_SOURCE_ROWS}} / {{F5_EXPECTED_ROWS}}`  
+F5 identity members: `{{F5_MEMBERS}}`  
+F5 canonical identity coverage: `{{F5_IDENTITY_COVERAGE}}`  
+F5 review/conflict/unresolved aggregates: `{{F5_REVIEW_CONFLICT_SUMMARY}}`  
+Historical transaction coverage: `{{TRANSACTION_COVERAGE_YEARS}}`
+
+## OWNER AUTHORIZATION
+
+I authorize the complete REV-F6 loop: read models, versioned schema/RPC additions where necessary, current Patient 360 upgrade, Identity Bridge consumer integration, Sales Intelligence analytics, tests/CI, safe canaries, performance tuning, documentation and final certification. This does not authorize bypassing auth/2FA/RLS, exposing PII/PHI/secrets, inventing unsupported historical metrics, altering another HIGH/CRITICAL workstream, or turning analytics directly into unauthorized campaign sends.
+
+Do not ask for intermediate approval inside REV-F6 while gates pass. Stop only for real external owner actions/security blockers or evidence contradictions that cannot be safely resolved.
+
+## 0 — BOOTSTRAP / LOCK
+
+Read fresh:
+
+1. `AGENTS.md`
+2. `SECURITY.md`
+3. portfolio/lock/MEMORY CURRENT
+4. final REV-F5 certificate + `REV_F5_F6_IMPLEMENTATION_ROADMAP_CURRENT_20260819.md`
+5. `REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`
+6. `REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md`
+7. `REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md`
+8. `REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`
+9. `SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`
+10. exact GitHub `main`, Railway/runtime and Supabase LIVE.
+
+Acquire `REV-F6` as the only mutable HIGH/CRITICAL workstream through the canonical lock/handoff. If main advanced after F5 certification, inspect/revalidate compatibility before writing.
+
+## REV-F6.0 — REBASELINE & REVENUE DATA CONTRACT
+
+Prove from LIVE:
+
+- F5 remains certified and has not regressed;
+- F3 product facts/current resolution coverage;
+- F4 payment/cartera/reconciliation coverage;
+- sales transaction date range and row counts;
+- historical 2024/2025 transaction availability or explicit absence;
+- Identity Bridge V2/current compatibility state;
+- Patient 360 current runtime contract.
+
+Create a machine-readable/readable REV-F6 Data Contract version containing source periods, coverage and freshness rules.
+
+## REV-F6.1 — IDENTITY-AWARE PATIENT COMMERCIAL 360 V2
+
+Upgrade the existing `app/public/patients.html` / current Patient 360 path; do not create a second patient master.
+
+Server/read model behavior:
+
+`lookup input (canonical ID/current phone/historical alias) → Identity Bridge V2 → canonical_patient_id → unified explicit facts/aliases`.
+
+Add role-appropriate:
+
+- identity status/confidence;
+- alias/history indicator;
+- duplicate/merge audit status;
+- lifecycle state;
+- observed revenue/purchases with coverage period;
+- unified acquisition/contact/agenda/sale/product/payment timeline;
+- coverage/confidence/freshness/sample-size metadata for inferred intelligence.
+
+Preserve navigation/session/edit/cotization/clinical role boundaries. No phone-only aggregation when identity is ambiguous.
+
+## REV-F6.2 — CUSTOMER LIFECYCLE CONTRACT
+
+Implement deterministic mutually-exclusive current state using the frozen contract:
+
+- `UNRESOLVED_IDENTITY`
+- `HISTORICAL_REACTIVATED`
+- `NEW_PATIENT`
+- `ACTIVE_REPEAT`
+- `RETURNING_PATIENT`
+- `DORMANT`
+
+Use explicit as-of date, event definition and coverage window. Defaults: recent/active <=90 days, dormant/reactivation gap >=180 days, reactivated window first 30 days after return, unless a versioned contract changes them.
+
+If transaction coverage is incomplete, reduce claim strength rather than invent prior/no-prior history.
+
+## REV-F6.3 — IDENTITY CONFIDENCE + METRIC TRUST
+
+Expose for identity and relevant F6 insights:
+
+- `coverage`;
+- `confidence`;
+- `freshness`;
+- `sample_size`;
+- covered period/as-of.
+
+Identity exposes `identity_status`, `confidence_band`, `match_method`, conflicts/review state. A numeric score never overrides hard conflicts.
+
+Dashboards must visually distinguish direct canonical facts from inferred/partial-coverage intelligence.
+
+## REV-F6.4 — SALES INTELLIGENCE 3.0 READ MODELS
+
+Build performant read models, not mega-queries, for at least:
+
+1. Executive Revenue: MTD/YTD/ticket/transactions, facturado vs F4-supported cobrado/reconciled, target/projection where target exists.
+2. Cohorts/Retention: first observed purchase, repeat rate, time-to-second purchase, reactivation, retention by cohort with declared coverage.
+3. Observed LTV: only observed value over a stated window, never modelled future value presented as fact.
+4. Product/Cross-sell: canonical F3 products, sequence/next-product patterns with sample size/confidence.
+5. Sede/Advisor: performance where identity/product/revenue coverage supports comparison.
+6. Acquisition-to-Revenue: only explicit/bounded CIA lead/call/agenda evidence; no unlimited phone-match attribution.
+7. Demographic/geographic analysis only where field coverage clears declared thresholds.
+
+## REV-F6.5 — FUTURE 2024/2025 SALES PLUG-IN
+
+If historical sales files are not yet supplied, leave the ingestion contract ready and mark corresponding metrics `coverage=partial` / period-limited.
+
+When owner later provides 2024/2025 XLSX, use the existing contract:
+
+`manifest/SHA → row provenance → canonical sale → F3 product → F5 patient → F4 payment/cartera → recompute F6 read models`.
+
+No architecture restart and no parallel 2024/2025 patient/product/revenue masters.
+
+## REV-F6.6 — SENTINEL DATA-INTEGRITY HANDOFF
+
+Implement/register safe zero-PII sensors as permitted by the portfolio lock and Sentinel architecture, including:
+
+- F5 source/membership regression;
+- Identity Bridge collision;
+- apply/merge governance violation;
+- product-sale orphan;
+- reconciliation orphan;
+- F6 read-model freshness/coverage regression;
+- Patient 360 resolution regression.
+
+Prefer read-only aggregate sensor contracts. Sentinel observes; it does not silently repair data.
+
+## REV-F6.7 — UI / PERFORMANCE / ACCEPTANCE
+
+Require:
+
+- bounded read-model latency;
+- no N+1/mega-query regression;
+- role/privacy tests;
+- empty/loading/error/responsive states;
+- known Patient 360 workflows preserved;
+- metric reconciliation against independent SQL;
+- coverage/confidence/freshness/sample-size visible and truthful;
+- owner visual acceptance when UI materially changes.
+
+## REV-F6 FINAL CERTIFICATION
+
+Use Persistence Triple-Proof for any data/read-model materialization and independent metric reconciliation for analytics.
+
+Before closing:
+
+- exact-head CI/deploy green;
+- F5 remains non-regressed;
+- F3/F4/F5 dependencies reconciled;
+- lifecycle deterministic tests pass;
+- Patient 360 identity alias tests pass;
+- no unsupported YoY/lifetime claims;
+- Sentinel integrity contracts green/known;
+- GitHub CURRENT docs + `aos_memory` + Notion reconciled last.
+
+Only then declare:
+
+`REV-F6 — PRODUCTION CERTIFIED — 100%`
+
+Do not automatically start REV-F7. Return a concise closeout and the next governed handoff/prompt for REV-F7 only after its scope is freshly revalidated.
+
+---

--- a/docs/skill-clinica-crm/SKILL.md
+++ b/docs/skill-clinica-crm/SKILL.md
@@ -1,215 +1,186 @@
 ---
 name: skill-clinica-crm
-description: Lógica de negocio específica de clínicas estéticas y wellness para AscendaOS. Usar cuando se construyan módulos de call center, pacientes, citas, ventas, comisiones o seguimientos. Contiene el modelo de datos, terminología, flujos operativos y reglas de negocio validadas con Zi Vital (Lima, Perú).
+description: Lógica de negocio específica de clínicas estéticas y wellness para AscendaOS. Usar cuando se construyan módulos de call center, pacientes, citas, ventas, comisiones o seguimientos. Contiene modelo de datos, terminología, flujos operativos y reglas de negocio validadas para la implementación clínica de referencia.
 ---
 
-# Clínica CRM — AscendaOS / Zi Vital
+# Clínica CRM — AscendaOS / implementación de referencia
 
 ## CONTEXTO DEL NEGOCIO
 
-**Cliente piloto:** Zi Vital — clínica de estética y wellness
-**Sedes:** San Isidro y Pueblo Libre (Lima, Perú)
-**Equipo:** 1 Admin (César) + 4 Asesoras (Wilmer, Ruvila, Mireya, Carmen)
-**Credenciales:**
-```
-ZIV-001 ADMIN  cesar123
-ZIV-002 ASESOR ruvila123
-ZIV-003 ASESOR mireya123
-ZIV-004 ASESOR wilmer123
-ZIV-005 ASESOR carmen123
-```
+La implementación de referencia opera múltiples sedes y perfiles (administración, asesoría, recepción y personal clínico). **Nunca almacenar credenciales reales, contraseñas, tokens o secretos en skills, prompts, README, ejemplos o memoria versionada.** Las credenciales pertenecen exclusivamente a los mecanismos de autenticación/secret manager autorizados.
 
-## TAXONOMÍA DE BASES (3 dimensiones aprobadas)
+## IDENTIDAD CANÓNICA DEL PACIENTE — REGLA MADRE
 
-```
-DIM1 — ESTADO del lead/paciente:
-  Virgen          → nunca contactado, nunca tuvo cita
-  SinContacto     → contactado antes pero sin respuesta reciente
-  Contactado      → se habló pero sin cita agendada
-  ConCita         → tiene cita programada
-  PacienteActivo  → vino al menos una vez, sigue activo
-  Inactivo        → más de 90 días sin actividad
-  Provincia       → fuera de Lima, no viable
-  Retirado        → pidió no ser contactado
-  ConAdelanto     → pagó adelanto, espera servicio
+La identidad comercial/operativa ya no debe depender únicamente de `numero_limpio`.
 
-DIM2 — ORIGEN del lead:
-  Campaña         → viene de campaña de marketing pagada
-  Tratamiento     → interés en tratamiento específico
-  Orgánico        → referido o búsqueda orgánica
-  MesIngreso      → clasificación temporal
-  BaseAntigua     → lead de más de 6 meses
-  PacientesHistóricos → atendidos antes, potencial recompra
+Modelo objetivo:
 
-DIM3 — AGENDA:
-  Asistió         → vino a su cita
-  NoAsistió       → no se presentó
-  Canceló         → canceló con aviso
-  CitaPendiente   → tiene cita futura
-  ConVentaEnCita  → vino y compró
-  ControlRecurrente → cita de seguimiento de tratamiento
-```
+`identificador de entrada → evidencia/alias gobernado → canonical_patient_id → historial/timeline`
+
+Reglas:
+
+- `canonical_patient_id` es el sujeto estable una vez certificado REV-F5;
+- `numero_limpio/contact_key` sigue siendo útil para búsqueda/importación/compatibilidad;
+- un paciente puede conservar múltiples teléfonos históricos como aliases;
+- mismo nombre **no** implica misma persona;
+- mismo teléfono **no** implica misma persona;
+- teléfono aproximado o numéricamente cercano nunca es evidencia de identidad;
+- mismo nombre+apellido+teléfono+documento exactos y sin conflictos puede ser candidato de máxima confianza, pero la fusión física sigue gobernada y reversible;
+- mismo documento con teléfono cambiado puede ser evidencia fuerte, pero requiere reglas de compatibilidad/revisión;
+- conflicto de DNI/DOB/sexo o identifier ya asignado a otro paciente bloquea auto-merge;
+- filas absorbidas/fusionadas conservan provenance y aliases históricos;
+- CIA, WA, F6, Patient 360 e importadores consumen la misma identidad F5; no crean otra verdad de cliente.
+
+Contratos actuales:
+
+- `docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`
+- `docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md`
+- `docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md`
+
+## TAXONOMÍA DE BASES
+
+### DIM1 — ESTADO operativo del lead/paciente
+
+- Virgen → nunca contactado, nunca tuvo cita.
+- SinContacto → contactado antes pero sin respuesta reciente.
+- Contactado → se habló pero sin cita agendada.
+- ConCita → tiene cita programada.
+- PacienteActivo → vino al menos una vez, sigue activo.
+- Inactivo → sin actividad según la ventana vigente.
+- Provincia → fuera del ámbito operativo definido.
+- Retirado → pidió no ser contactado.
+- ConAdelanto → existe evidencia de adelanto; **no equivale automáticamente a deuda/saldo**.
+
+### DIM2 — ORIGEN
+
+- Campaña.
+- Tratamiento/interés.
+- Orgánico/referido.
+- MesIngreso.
+- BaseAntigua.
+- PacientesHistóricos.
+
+### DIM3 — AGENDA
+
+- Asistió.
+- NoAsistió.
+- Canceló.
+- CitaPendiente.
+- ConVentaEnCita.
+- ControlRecurrente.
+
+## CUSTOMER LIFECYCLE REV-F6
+
+El lifecycle analítico es independiente de los estados operativos anteriores y se deriva de hechos certificados:
+
+- `NEW_PATIENT`
+- `RETURNING_PATIENT`
+- `HISTORICAL_REACTIVATED`
+- `ACTIVE_REPEAT`
+- `DORMANT`
+- `UNRESOLVED_IDENTITY`
+
+Toda métrica inferida debe exponer, cuando aplique: `coverage`, `confidence`, `freshness`, `sample_size` y período observado.
 
 ## SEMÁNTICA DE CAMPAÑA VS TRATAMIENTO
 
-```
-CAMPAÑA (campo marketing):
-  = LEAD_COL.TRAT = LLAM_COL.TRATAMIENTO
-  = tipo de campaña que capturó el lead
-  Valores: HIFU, ENZIMAS FACIALES, CAPILAR, HIDROFACIAL, etc.
-  → Es el gancho que usó marketing para atraer al lead
+**CAMPAÑA** = gancho/origen de marketing que captó el lead.  
+**TRATAMIENTO** = servicio realmente vendido/aplicado.
 
-TRATAMIENTO (campo clínico):
-  = VENT_COL.TRATAMIENTO
-  = servicio realmente aplicado en clínica
-  → Puede ser distinto a la campaña de origen
-  
-⚠️ NUNCA mezclar estos dos campos en cálculos de conversión
-```
+Nunca mezclar ambos campos en cálculos de conversión o producto real. REV-F3 es la autoridad de producto canónico de ventas; CIA es la autoridad de adquisición/atribución gobernada.
 
 ## DEFINICIÓN DE CONVERSIÓN
 
-```
-Un lead se considera CONVERTIDO cuando:
-  → Tuvo su PRIMERA cita en el período analizado
-  → O tiene un VENTA_ID vinculado a su número
+Una conversión debe estar respaldada por evidencia explícita del funnel correspondiente (por ejemplo cita/venta), con período y denominador definidos. No atribuir ventas a campañas mediante coincidencia ilimitada de teléfono.
 
-La tasa de conversión = convertidos / total leads del período
-```
+## LÓGICA MADRE DE CALL CENTER
 
-## LÓGICA MADRE DE CALL CENTER (8 pasos — columna vertebral)
+Priorización base:
 
-```
-El call center opera con esta priorización diaria:
+1. Vírgenes mes actual.
+2. No asistió cita reciente.
+3. Vírgenes históricos.
+4. Sin contacto mes actual.
+5. Canceló o reprogramó.
+6. Base antigua sin convertir.
+7. Pacientes activos/recompra según ventana.
+8. Sin contacto histórico.
 
-PASO 1: Vírgenes mes actual
-  → Leads nuevos que ingresaron este mes, nunca llamados
-  → Prioridad máxima: están "frescos"
-
-PASO 2: No asistió cita en últimas 2 semanas
-  → Tenían cita, no vinieron → oportunidad de re-agendado
-
-PASO 3: Vírgenes históricos
-  → Leads de meses anteriores nunca contactados
-  → Base de recuperación
-
-PASO 4: Sin contacto mes actual
-  → Leads que no recibieron llamada este mes
-
-PASO 5: Canceló o reprogramó
-  → Querían venir pero algo pasó → segundo intento
-
-PASO 6: Base antigua sin convertir
-  → Más de 6 meses sin convertir → último intento
-
-PASO 7: Pacientes activos recompra 90 días
-  → Vinieron hace ~90 días → proponer siguiente tratamiento
-
-PASO 8: Sin contacto histórico
-  → Base fría, último recurso del día
-
-ANTI-DUPLICADO DIARIO:
-  CacheService key: COLA_HOY_[ASESOR]_[FECHA]
-  → Cada asesor no recibe el mismo lead dos veces en el día
-
-DISTRIBUCIÓN:
-  PropertiesService key: DIST_CONFIG_[ASESOR_NORM]
-  → Configura cuántos de cada tipo recibe cada asesor
-```
+El anti-duplicado diario de cola no sustituye la identidad canónica del paciente.
 
 ## TIPIFICACIONES DE LLAMADA
 
-```
-CONTACTADO_INTERESADO    → habló, quiere agendar
-CONTACTADO_NO_INTERESADO → habló, no le interesa ahora
-NO_CONTESTA             → llamada sin respuesta
-BUZÓN                   → llegó a buzón de voz
-NÚMERO_EQUIVOCADO       → dato incorrecto en base
-CITA_AGENDADA           → éxito: tiene cita
-REAGENDADO              → tenía cita, se movió a nueva fecha
-CANCELÓ                 → canceló definitivamente
-VOLVER_A_LLAMAR         → pidió que llamen en otro momento
-PROVINCIA               → confirmado fuera de Lima
-```
+- CONTACTADO_INTERESADO
+- CONTACTADO_NO_INTERESADO
+- NO_CONTESTA
+- BUZÓN
+- NÚMERO_EQUIVOCADO
+- CITA_AGENDADA
+- REAGENDADO
+- CANCELÓ
+- VOLVER_A_LLAMAR
+- PROVINCIA
 
-## SEGUIMIENTOS PROGRAMADOS POR TRATAMIENTO
+## SEGUIMIENTOS PROGRAMADOS
 
-```
-Toxina botulínica    → recontactar a los 4-6 meses
-Ácido hialurónico   → recontactar a los 12-18 meses
-HIFU                → recontactar a los 12 meses
-Productos con dosis → calcular fin = (unidades / dosis_diaria) días
-                      alertar X días antes de fecha fin
-```
+Las ventanas de recompra/recontacto por tratamiento son reglas comerciales configurables y deben derivarse del producto/tratamiento canónico y de la última evidencia real, no de texto libre cuando exista F3.
 
-## HISTORIA CLÍNICA MINSA (campos obligatorios)
+## HISTORIA CLÍNICA / PRIVACIDAD
 
-```
-Identificación: DNI, nombre completo, fecha_nac, sexo, estado_civil,
-                ocupación, distrito, dirección, contacto_emergencia
-
-Antecedentes: alergias, enfermedades_crónicas, medicamentos_actuales,
-              cirugías_previas, tratamientos_estéticos_previos,
-              queloides (sí/no), implantes (tipo/ubicación)
-
-Campos para mujer: embarazo, lactancia, anticonceptivos, fecha_última_menstruación
-
-Hábitos: tabaco, alcohol, ejercicio, hidratación, protector_solar
-
-Consentimiento: obligatorio por procedimiento, firma digital o física
-```
+Identificación y campos clínicos sensibles requieren rol/política correspondiente. Notas clínicas, alergias, evaluaciones, imágenes y PHI no se exponen automáticamente a asesores, CIA o WA porque el Patient 360 comercial pueda resolver la identidad.
 
 ## ROLES Y PERMISOS
 
-```
-ADMIN:      todo + delete + merge pacientes + ver todas las sedes
-ASESOR:     lectura + notas_ventas + crear_citas + su propia cartera
-RECEPCIÓN:  citas + notas_recepción + ver datos básicos
-DOCTOR:     notas_médicas + recetas + historia_clínica_completa + descuentos
-ENFERMERO:  notas_enfermería + receta_enfermería + plan_cuidados
-```
+- ADMIN: administración y acciones críticas según auth/2FA y políticas.
+- ASESOR: contexto comercial permitido, citas/notas comerciales y cartera asignada.
+- RECEPCIÓN: agenda y datos básicos según política.
+- DOCTOR/ENFERMERÍA: módulos clínicos según rol y regulación.
 
-## TIPOS DE PDF
+**Patient merge = CRITICAL.** Requiere admin+2FA, dry-run, evidencia, audit event, canary y rollback/recovery. Nunca autorizar por UI/browser role solamente.
 
-```
-1. Comprobante de compra    → QR + código interno + datos de venta
-2. Cotización editable      → presupuesto para el paciente
-3. Receta médica            → requiere CMP del doctor
-4. Receta enfermería        → requiere registro técnico/licenciado
-```
+## SCORE / RECENCIA
 
-## SCORE DE PACIENTE
+Los umbrales operativos históricos (por ejemplo 90/180 días) pueden usarse como defaults, pero REV-F6 debe versionarlos, mostrar el `as_of` y separar lifecycle analítico de etiquetas operativas legacy.
 
-```
-ACTIVO:   última visita < 90 días
-RIESGO:   última visita 90-180 días
-INACTIVO: última visita > 180 días
+## FUNNEL DE CONVERSIÓN — MODELO ACTUALIZADO
 
-Campo: PACIENTES.SCORE_ESTADO + PACIENTES.DIAS_ULTIMA_VISITA
-Alerta visual: verde / amarillo / rojo en ficha del paciente
-```
+Preferir enlaces explícitos y canonical identity:
 
-## FUNNEL DE CONVERSIÓN
+`LEAD → lead_id_origen → LLAMADA → llamada_id_origen → AGENDA → venta_id_match/IDs explícitos → VENTA → F3 PRODUCTO → F4 REVENUE`
 
-```
-LEADS → join LLAMADAS (por NUMERO_LIMPIO) 
-      → join AGENDA_CITAS (por numero)
-      → join VENTAS (por NUMERO_LIMPIO)
+F5 resuelve el `canonical_patient_id` transversal.
 
-KPIs clave:
-  tasa_contacto    = contactados / total_leads
-  tasa_cita        = citas_agendadas / contactados  
-  tasa_asistencia  = asistidos / citas_agendadas
-  tasa_conversión  = ventas / asistidos
-  ticket_promedio  = total_ventas / cantidad_ventas
-```
+`numero_limpio` queda como fallback/compatibility bridge, no como prueba de identidad ni atribución por sí solo.
 
-## VERTICALES FUTUROS — ADAPTACIONES CLAVE
+KPIs deben definir claramente numerador, denominador, período, cobertura y fuente.
 
-```
-AscendaNails:    sin historia clínica MINSA, agenda por técnica
-AscendaLegal:    pacientes → clientes/casos, citas → audiencias
-AscendaPsych:    historia clínica psicológica, sesiones recurrentes
-AscendaBarber:   sin historial médico, servicios rápidos, fidelización
-AscendaEcommerce: sin agenda, pipeline de ventas, seguimiento pedidos
-```
+## PATIENT COMMERCIAL 360
+
+Evolucionar el panel existente `app/public/patients.html`; no crear un segundo patient master.
+
+Objetivo V2:
+
+- canonical identity + aliases históricos;
+- timeline lead/call/WA/agenda/sale/product/payment;
+- lifecycle;
+- revenue observado con cobertura temporal;
+- identity confidence;
+- coverage/freshness/sample-size para inteligencia;
+- duplicate/merge audit state;
+- separación estricta entre contexto comercial y PHI clínica.
+
+## SENTINEL — DATA INTEGRITY
+
+Sentinel debe poder observar invariantes agregados de identidad/revenue sin PII, según `docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`, incluyendo source mismatch, member mismatch, identity collision, apply sin governance, sale/product orphan y reconciliation orphan.
+
+## VERTICALES FUTUROS
+
+Al adaptar a otros verticales, conservar la separación entre:
+
+- identidad canónica;
+- eventos/operación;
+- producto/servicio;
+- dinero/revenue;
+- lifecycle/inteligencia;
+- activación/canales;
+- observabilidad.

--- a/docs/skills/skill-clinica-crm/SKILL.md
+++ b/docs/skills/skill-clinica-crm/SKILL.md
@@ -1,215 +1,186 @@
 ---
 name: skill-clinica-crm
-description: Lógica de negocio específica de clínicas estéticas y wellness para AscendaOS. Usar cuando se construyan módulos de call center, pacientes, citas, ventas, comisiones o seguimientos. Contiene el modelo de datos, terminología, flujos operativos y reglas de negocio validadas con Zi Vital (Lima, Perú).
+description: Lógica de negocio específica de clínicas estéticas y wellness para AscendaOS. Usar cuando se construyan módulos de call center, pacientes, citas, ventas, comisiones o seguimientos. Contiene modelo de datos, terminología, flujos operativos y reglas de negocio validadas para la implementación clínica de referencia.
 ---
 
-# Clínica CRM — AscendaOS / Zi Vital
+# Clínica CRM — AscendaOS / implementación de referencia
 
 ## CONTEXTO DEL NEGOCIO
 
-**Cliente piloto:** Zi Vital — clínica de estética y wellness
-**Sedes:** San Isidro y Pueblo Libre (Lima, Perú)
-**Equipo:** 1 Admin (César) + 4 Asesoras (Wilmer, Ruvila, Mireya, Carmen)
-**Credenciales:**
-```
-ZIV-001 ADMIN  cesar123
-ZIV-002 ASESOR ruvila123
-ZIV-003 ASESOR mireya123
-ZIV-004 ASESOR wilmer123
-ZIV-005 ASESOR carmen123
-```
+La implementación de referencia opera múltiples sedes y perfiles (administración, asesoría, recepción y personal clínico). **Nunca almacenar credenciales reales, contraseñas, tokens o secretos en skills, prompts, README, ejemplos o memoria versionada.** Las credenciales pertenecen exclusivamente a los mecanismos de autenticación/secret manager autorizados.
 
-## TAXONOMÍA DE BASES (3 dimensiones aprobadas)
+## IDENTIDAD CANÓNICA DEL PACIENTE — REGLA MADRE
 
-```
-DIM1 — ESTADO del lead/paciente:
-  Virgen          → nunca contactado, nunca tuvo cita
-  SinContacto     → contactado antes pero sin respuesta reciente
-  Contactado      → se habló pero sin cita agendada
-  ConCita         → tiene cita programada
-  PacienteActivo  → vino al menos una vez, sigue activo
-  Inactivo        → más de 90 días sin actividad
-  Provincia       → fuera de Lima, no viable
-  Retirado        → pidió no ser contactado
-  ConAdelanto     → pagó adelanto, espera servicio
+La identidad comercial/operativa ya no debe depender únicamente de `numero_limpio`.
 
-DIM2 — ORIGEN del lead:
-  Campaña         → viene de campaña de marketing pagada
-  Tratamiento     → interés en tratamiento específico
-  Orgánico        → referido o búsqueda orgánica
-  MesIngreso      → clasificación temporal
-  BaseAntigua     → lead de más de 6 meses
-  PacientesHistóricos → atendidos antes, potencial recompra
+Modelo objetivo:
 
-DIM3 — AGENDA:
-  Asistió         → vino a su cita
-  NoAsistió       → no se presentó
-  Canceló         → canceló con aviso
-  CitaPendiente   → tiene cita futura
-  ConVentaEnCita  → vino y compró
-  ControlRecurrente → cita de seguimiento de tratamiento
-```
+`identificador de entrada → evidencia/alias gobernado → canonical_patient_id → historial/timeline`
+
+Reglas:
+
+- `canonical_patient_id` es el sujeto estable una vez certificado REV-F5;
+- `numero_limpio/contact_key` sigue siendo útil para búsqueda/importación/compatibilidad;
+- un paciente puede conservar múltiples teléfonos históricos como aliases;
+- mismo nombre **no** implica misma persona;
+- mismo teléfono **no** implica misma persona;
+- teléfono aproximado o numéricamente cercano nunca es evidencia de identidad;
+- mismo nombre+apellido+teléfono+documento exactos y sin conflictos puede ser candidato de máxima confianza, pero la fusión física sigue gobernada y reversible;
+- mismo documento con teléfono cambiado puede ser evidencia fuerte, pero requiere reglas de compatibilidad/revisión;
+- conflicto de DNI/DOB/sexo o identifier ya asignado a otro paciente bloquea auto-merge;
+- filas absorbidas/fusionadas conservan provenance y aliases históricos;
+- CIA, WA, F6, Patient 360 e importadores consumen la misma identidad F5; no crean otra verdad de cliente.
+
+Contratos actuales:
+
+- `docs/control/REV_PATIENT_IDENTITY_BRIDGE_V2_CONTRACT.md`
+- `docs/control/REV_PATIENT_COMMERCIAL_360_V2_CONTRACT.md`
+- `docs/control/REV_CUSTOMER_LIFECYCLE_IDENTITY_CONFIDENCE_CONTRACT.md`
+
+## TAXONOMÍA DE BASES
+
+### DIM1 — ESTADO operativo del lead/paciente
+
+- Virgen → nunca contactado, nunca tuvo cita.
+- SinContacto → contactado antes pero sin respuesta reciente.
+- Contactado → se habló pero sin cita agendada.
+- ConCita → tiene cita programada.
+- PacienteActivo → vino al menos una vez, sigue activo.
+- Inactivo → sin actividad según la ventana vigente.
+- Provincia → fuera del ámbito operativo definido.
+- Retirado → pidió no ser contactado.
+- ConAdelanto → existe evidencia de adelanto; **no equivale automáticamente a deuda/saldo**.
+
+### DIM2 — ORIGEN
+
+- Campaña.
+- Tratamiento/interés.
+- Orgánico/referido.
+- MesIngreso.
+- BaseAntigua.
+- PacientesHistóricos.
+
+### DIM3 — AGENDA
+
+- Asistió.
+- NoAsistió.
+- Canceló.
+- CitaPendiente.
+- ConVentaEnCita.
+- ControlRecurrente.
+
+## CUSTOMER LIFECYCLE REV-F6
+
+El lifecycle analítico es independiente de los estados operativos anteriores y se deriva de hechos certificados:
+
+- `NEW_PATIENT`
+- `RETURNING_PATIENT`
+- `HISTORICAL_REACTIVATED`
+- `ACTIVE_REPEAT`
+- `DORMANT`
+- `UNRESOLVED_IDENTITY`
+
+Toda métrica inferida debe exponer, cuando aplique: `coverage`, `confidence`, `freshness`, `sample_size` y período observado.
 
 ## SEMÁNTICA DE CAMPAÑA VS TRATAMIENTO
 
-```
-CAMPAÑA (campo marketing):
-  = LEAD_COL.TRAT = LLAM_COL.TRATAMIENTO
-  = tipo de campaña que capturó el lead
-  Valores: HIFU, ENZIMAS FACIALES, CAPILAR, HIDROFACIAL, etc.
-  → Es el gancho que usó marketing para atraer al lead
+**CAMPAÑA** = gancho/origen de marketing que captó el lead.  
+**TRATAMIENTO** = servicio realmente vendido/aplicado.
 
-TRATAMIENTO (campo clínico):
-  = VENT_COL.TRATAMIENTO
-  = servicio realmente aplicado en clínica
-  → Puede ser distinto a la campaña de origen
-  
-⚠️ NUNCA mezclar estos dos campos en cálculos de conversión
-```
+Nunca mezclar ambos campos en cálculos de conversión o producto real. REV-F3 es la autoridad de producto canónico de ventas; CIA es la autoridad de adquisición/atribución gobernada.
 
 ## DEFINICIÓN DE CONVERSIÓN
 
-```
-Un lead se considera CONVERTIDO cuando:
-  → Tuvo su PRIMERA cita en el período analizado
-  → O tiene un VENTA_ID vinculado a su número
+Una conversión debe estar respaldada por evidencia explícita del funnel correspondiente (por ejemplo cita/venta), con período y denominador definidos. No atribuir ventas a campañas mediante coincidencia ilimitada de teléfono.
 
-La tasa de conversión = convertidos / total leads del período
-```
+## LÓGICA MADRE DE CALL CENTER
 
-## LÓGICA MADRE DE CALL CENTER (8 pasos — columna vertebral)
+Priorización base:
 
-```
-El call center opera con esta priorización diaria:
+1. Vírgenes mes actual.
+2. No asistió cita reciente.
+3. Vírgenes históricos.
+4. Sin contacto mes actual.
+5. Canceló o reprogramó.
+6. Base antigua sin convertir.
+7. Pacientes activos/recompra según ventana.
+8. Sin contacto histórico.
 
-PASO 1: Vírgenes mes actual
-  → Leads nuevos que ingresaron este mes, nunca llamados
-  → Prioridad máxima: están "frescos"
-
-PASO 2: No asistió cita en últimas 2 semanas
-  → Tenían cita, no vinieron → oportunidad de re-agendado
-
-PASO 3: Vírgenes históricos
-  → Leads de meses anteriores nunca contactados
-  → Base de recuperación
-
-PASO 4: Sin contacto mes actual
-  → Leads que no recibieron llamada este mes
-
-PASO 5: Canceló o reprogramó
-  → Querían venir pero algo pasó → segundo intento
-
-PASO 6: Base antigua sin convertir
-  → Más de 6 meses sin convertir → último intento
-
-PASO 7: Pacientes activos recompra 90 días
-  → Vinieron hace ~90 días → proponer siguiente tratamiento
-
-PASO 8: Sin contacto histórico
-  → Base fría, último recurso del día
-
-ANTI-DUPLICADO DIARIO:
-  CacheService key: COLA_HOY_[ASESOR]_[FECHA]
-  → Cada asesor no recibe el mismo lead dos veces en el día
-
-DISTRIBUCIÓN:
-  PropertiesService key: DIST_CONFIG_[ASESOR_NORM]
-  → Configura cuántos de cada tipo recibe cada asesor
-```
+El anti-duplicado diario de cola no sustituye la identidad canónica del paciente.
 
 ## TIPIFICACIONES DE LLAMADA
 
-```
-CONTACTADO_INTERESADO    → habló, quiere agendar
-CONTACTADO_NO_INTERESADO → habló, no le interesa ahora
-NO_CONTESTA             → llamada sin respuesta
-BUZÓN                   → llegó a buzón de voz
-NÚMERO_EQUIVOCADO       → dato incorrecto en base
-CITA_AGENDADA           → éxito: tiene cita
-REAGENDADO              → tenía cita, se movió a nueva fecha
-CANCELÓ                 → canceló definitivamente
-VOLVER_A_LLAMAR         → pidió que llamen en otro momento
-PROVINCIA               → confirmado fuera de Lima
-```
+- CONTACTADO_INTERESADO
+- CONTACTADO_NO_INTERESADO
+- NO_CONTESTA
+- BUZÓN
+- NÚMERO_EQUIVOCADO
+- CITA_AGENDADA
+- REAGENDADO
+- CANCELÓ
+- VOLVER_A_LLAMAR
+- PROVINCIA
 
-## SEGUIMIENTOS PROGRAMADOS POR TRATAMIENTO
+## SEGUIMIENTOS PROGRAMADOS
 
-```
-Toxina botulínica    → recontactar a los 4-6 meses
-Ácido hialurónico   → recontactar a los 12-18 meses
-HIFU                → recontactar a los 12 meses
-Productos con dosis → calcular fin = (unidades / dosis_diaria) días
-                      alertar X días antes de fecha fin
-```
+Las ventanas de recompra/recontacto por tratamiento son reglas comerciales configurables y deben derivarse del producto/tratamiento canónico y de la última evidencia real, no de texto libre cuando exista F3.
 
-## HISTORIA CLÍNICA MINSA (campos obligatorios)
+## HISTORIA CLÍNICA / PRIVACIDAD
 
-```
-Identificación: DNI, nombre completo, fecha_nac, sexo, estado_civil,
-                ocupación, distrito, dirección, contacto_emergencia
-
-Antecedentes: alergias, enfermedades_crónicas, medicamentos_actuales,
-              cirugías_previas, tratamientos_estéticos_previos,
-              queloides (sí/no), implantes (tipo/ubicación)
-
-Campos para mujer: embarazo, lactancia, anticonceptivos, fecha_última_menstruación
-
-Hábitos: tabaco, alcohol, ejercicio, hidratación, protector_solar
-
-Consentimiento: obligatorio por procedimiento, firma digital o física
-```
+Identificación y campos clínicos sensibles requieren rol/política correspondiente. Notas clínicas, alergias, evaluaciones, imágenes y PHI no se exponen automáticamente a asesores, CIA o WA porque el Patient 360 comercial pueda resolver la identidad.
 
 ## ROLES Y PERMISOS
 
-```
-ADMIN:      todo + delete + merge pacientes + ver todas las sedes
-ASESOR:     lectura + notas_ventas + crear_citas + su propia cartera
-RECEPCIÓN:  citas + notas_recepción + ver datos básicos
-DOCTOR:     notas_médicas + recetas + historia_clínica_completa + descuentos
-ENFERMERO:  notas_enfermería + receta_enfermería + plan_cuidados
-```
+- ADMIN: administración y acciones críticas según auth/2FA y políticas.
+- ASESOR: contexto comercial permitido, citas/notas comerciales y cartera asignada.
+- RECEPCIÓN: agenda y datos básicos según política.
+- DOCTOR/ENFERMERÍA: módulos clínicos según rol y regulación.
 
-## TIPOS DE PDF
+**Patient merge = CRITICAL.** Requiere admin+2FA, dry-run, evidencia, audit event, canary y rollback/recovery. Nunca autorizar por UI/browser role solamente.
 
-```
-1. Comprobante de compra    → QR + código interno + datos de venta
-2. Cotización editable      → presupuesto para el paciente
-3. Receta médica            → requiere CMP del doctor
-4. Receta enfermería        → requiere registro técnico/licenciado
-```
+## SCORE / RECENCIA
 
-## SCORE DE PACIENTE
+Los umbrales operativos históricos (por ejemplo 90/180 días) pueden usarse como defaults, pero REV-F6 debe versionarlos, mostrar el `as_of` y separar lifecycle analítico de etiquetas operativas legacy.
 
-```
-ACTIVO:   última visita < 90 días
-RIESGO:   última visita 90-180 días
-INACTIVO: última visita > 180 días
+## FUNNEL DE CONVERSIÓN — MODELO ACTUALIZADO
 
-Campo: PACIENTES.SCORE_ESTADO + PACIENTES.DIAS_ULTIMA_VISITA
-Alerta visual: verde / amarillo / rojo en ficha del paciente
-```
+Preferir enlaces explícitos y canonical identity:
 
-## FUNNEL DE CONVERSIÓN
+`LEAD → lead_id_origen → LLAMADA → llamada_id_origen → AGENDA → venta_id_match/IDs explícitos → VENTA → F3 PRODUCTO → F4 REVENUE`
 
-```
-LEADS → join LLAMADAS (por NUMERO_LIMPIO) 
-      → join AGENDA_CITAS (por numero)
-      → join VENTAS (por NUMERO_LIMPIO)
+F5 resuelve el `canonical_patient_id` transversal.
 
-KPIs clave:
-  tasa_contacto    = contactados / total_leads
-  tasa_cita        = citas_agendadas / contactados  
-  tasa_asistencia  = asistidos / citas_agendadas
-  tasa_conversión  = ventas / asistidos
-  ticket_promedio  = total_ventas / cantidad_ventas
-```
+`numero_limpio` queda como fallback/compatibility bridge, no como prueba de identidad ni atribución por sí solo.
 
-## VERTICALES FUTUROS — ADAPTACIONES CLAVE
+KPIs deben definir claramente numerador, denominador, período, cobertura y fuente.
 
-```
-AscendaNails:    sin historia clínica MINSA, agenda por técnica
-AscendaLegal:    pacientes → clientes/casos, citas → audiencias
-AscendaPsych:    historia clínica psicológica, sesiones recurrentes
-AscendaBarber:   sin historial médico, servicios rápidos, fidelización
-AscendaEcommerce: sin agenda, pipeline de ventas, seguimiento pedidos
-```
+## PATIENT COMMERCIAL 360
+
+Evolucionar el panel existente `app/public/patients.html`; no crear un segundo patient master.
+
+Objetivo V2:
+
+- canonical identity + aliases históricos;
+- timeline lead/call/WA/agenda/sale/product/payment;
+- lifecycle;
+- revenue observado con cobertura temporal;
+- identity confidence;
+- coverage/freshness/sample-size para inteligencia;
+- duplicate/merge audit state;
+- separación estricta entre contexto comercial y PHI clínica.
+
+## SENTINEL — DATA INTEGRITY
+
+Sentinel debe poder observar invariantes agregados de identidad/revenue sin PII, según `docs/control/SENTINEL_DATA_INTEGRITY_SIGNALS_CONTRACT.md`, incluyendo source mismatch, member mismatch, identity collision, apply sin governance, sale/product orphan y reconciliation orphan.
+
+## VERTICALES FUTUROS
+
+Al adaptar a otros verticales, conservar la separación entre:
+
+- identidad canónica;
+- eventos/operación;
+- producto/servicio;
+- dinero/revenue;
+- lifecycle/inteligencia;
+- activación/canales;
+- observabilidad.


### PR DESCRIPTION
Documentation/governance-only package. No runtime/DB mutation.

Adds:
- definitive REV-F5 closeout prompt and REV-F6 prompt template;
- F5→F6 implementation roadmap;
- Patient Identity Bridge V2 contract;
- Patient Commercial 360 V2 contract;
- Customer Lifecycle + Identity Confidence/Metric Trust contract;
- Sentinel zero-PII data-integrity signal contract.

Hardens agents/skills:
- patient identity is canonical_patient_id, not phone;
- phone remains import/search alias/bridge;
- prohibits approximate/numeric-near phone identity heuristic;
- governs physical patient merge with admin+2FA, dry-run/canary/audit/rollback;
- registers duplicate profile and future historical-sales path;
- removes plaintext credentials from clinic CRM skills and forbids secrets in skills/docs.

Current REV-F5 remains ACTIVE / NOT CERTIFIED; REV-F6 remains BLOCKED until real F5.10 PASS.