### PR TITLE
REV-F5.4 — conservative canonical MATCH/REVIEW/NEW

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,12 +1,12 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Status:** CURRENT / REV-F5 ACTIVE / NOT CERTIFIED  
+**Status:** CURRENT / REV-F5 ACTIVE / NOT YET PRODUCTION CERTIFIED  
 **Captured:** 2026-08-19 America/Lima  
 **Owner assignment:** explicit owner directive to continue REV-F5 closeout  
-**Current control baseline:** `main@40b2cbf50a9ffc2d9ca1ee3fedbf457c133c4a21`  
-**Previous lock:** `MKT-INTEGRITY-HOTFIX-V3` — Loop 5 PASS; Loop 6 NOT STARTED / PAUSED  
+**Entry control baseline:** `main@7d96eb9d39bb7bb2c6b23bb82e9a225f29843d17`  
 **ACTIVE LOCK:** `REV-F5-CLOSEOUT`  
-**NEXT LOCK:** `UNASSIGNED` until REV-F5 production certification or explicit owner handoff.
+**NEXT MUTABLE GATE:** `REV-F5.5 — ENRICHMENT PREVIEW`  
+**REV-F5.6 REVIEW & APPLY:** `BLOCKED`
 
 ## Concurrency rule
 
@@ -14,66 +14,62 @@ At most one HIGH/CRITICAL mutable workstream may operate at a time. While `REV-F
 
 ## REV-F5 LIVE checkpoint
 
-Fresh Supabase production truth:
+Certified production truth after REV-F5.4:
 
-- 6 source batches / 15,498 expected rows;
-- **8,264 persisted source rows**;
-- **7,234 remaining**;
-- **1/6 staging-complete batches**;
-- 3,950 provisional identity clusters;
-- members 0;
-- preview 0;
-- apply events 0;
-- structural duplicate source keys 0;
-- orphan source rows 0;
-- observational `aos_pacientes` count 7,685.
+- REV-F5.1 ingest = PASS;
+- REV-F5.2 staging = PASS;
+- REV-F5.3 identity rebuild/preview = PASS;
+- REV-F5.4 canonical matching classification = PASS;
+- 6/6 source batches complete;
+- source rows = **15,498 / 15,498**;
+- identity memberships = **15,498 / 15,498**;
+- identity clusters = **8,716**;
+- F5.4 classifications = **8,716 / 8,716**;
+- MATCH = **296**;
+- REVIEW = **6,984**;
+- NEW = **1,436**;
+- unclassified clusters = 0;
+- classification orphans = 0;
+- source orphans = 0;
+- preview applied rows = 0;
+- canonical Apply events = 0;
+- observational `aos_pacientes` CURRENT count = **7,687**;
+- canonical fingerprint = `619f20596f6f9181f96332997ee3d953`;
+- semantic F5.4 classification fingerprint = `7a2c36e1e7a3ff6fb12196cbf7bacdfd`.
 
-Per source:
+The `aos_pacientes` count moved externally from 7,686 at the F5.3 certificate to 7,687 before F5.4. F5 Apply events remained zero. F5.4 therefore rebuilt the preview against CURRENT before classifying; no F5 canonical mutation occurred.
 
-- PL2024 = 3,949 / 4,192 — missing Excel 3951–4193;
-- PL2025 = 1,801 / 3,053 — missing Excel 1703–1802 and 1903–3054;
-- PL2026 = 993 / 993 — complete;
-- SI2024 = 1,521 / 3,190 — missing Excel 1523–3191;
-- SI2025 = 0 / 3,066 — missing Excel 2–3067;
-- SI2026 = 0 / 1,004 — missing Excel 2–1005.
+## REV-F5.4 safety correction
 
-The older certified-pause checkpoint remains provenance, but this live state is the current resume contract.
+The F5.3 internal preview contained 408 `AUTO_CANDIDATE`. REV-F5.4 introduced a separate private classification layer and conservatively downgraded **112** of those candidates to REVIEW when canonical strong-field contradiction and/or target collision was detected.
 
-## Explicit correction
+Final operational taxonomy:
 
-Any prior assistant/chat statement claiming:
+- `MATCH` = strong compatible evidence and no blocking conflict/collision;
+- `REVIEW` = ambiguous, conflicting, tied or collision-prone identity;
+- `NEW` = no supported canonical candidate.
 
-- 15,498/15,498 staging;
-- 15,498 members;
-- completed Review/Apply;
-- `REV-F5 — PRODUCTION CERTIFIED — 100%`;
-- `REV-F6 — UNBLOCKED`;
-
-is **SUPERSEDED_BY_LIVE_TRUTH**.
-
-The repository contains no merged REV-F5 final-certification PR after #298 and production post-conditions remain incomplete.
+All 111 source strong-identifier conflict clusters remain REVIEW. No MATCH is authorized by name alone or phone alone.
 
 ## Mandatory persistence proof
 
 Every data checkpoint requires all three:
 
 1. execution receipt;
-2. direct live persisted readback;
+2. direct LIVE persisted readback;
 3. independent invariant query.
 
-Every source-batch closure additionally requires full idempotent replay of the SHA-bound source with zero new inserts/conflicts.
-
-No tool response, timeout assumption, local loop completion or generated payload can substitute for persisted production proof.
+REV-F5.4 additionally proved deterministic replay: two complete classifications returned identical counts and semantic fingerprint.
 
 ## Mandatory REV-F5 closeout sequence
 
 1. REV-F5.0 exact-current rebaseline and lock ownership — maintained.
-2. REV-F5.1 complete all exact missing source ranges through existing private/idempotent compact ingest.
-3. REV-F5.2 certify 6/6 batches, manifests, SHA, exact ranges, duplicates/orphans and full replay; require 15,498/15,498.
-4. REV-F5.3 rebuild identity only after source certification; require 15,498 memberships.
-5. REV-F5.4 classify every cluster as MATCH / REVIEW / NEW with evidence.
-6. REV-F5.5 generate fill-only enrichment preview; no silent overwrite.
-7. REV-F5.6 governed Review & Apply with admin+2FA, dry-run, canary, rollback proof and progressive safe apply.
+2. REV-F5.1 complete exact source ingestion — **PASS**.
+3. REV-F5.2 certify staging/manifests/replay — **PASS**.
+4. REV-F5.3 rebuild identity memberships and preview — **PASS**.
+5. REV-F5.4 classify MATCH / REVIEW / NEW conservatively — **PASS**.
+6. REV-F5.5 generate fill-only enrichment preview; no silent overwrite — **NEXT / UNBLOCKED**.
+7. REV-F5.6 governed Review & Apply with admin+2FA, dry-run, canary, rollback proof and progressive safe apply — **BLOCKED**.
 8. REV-F5.7 certify patient → sale → F3 product → F4 payment/revenue/cartera linkage.
 9. REV-F5.8 audit real transaction coverage for 2024–2025; prohibit unsupported YoY.
 10. REV-F5.9 numeric Coverage & Data Quality Report.
@@ -83,13 +79,15 @@ No tool response, timeout assumption, local loop completion or generated payload
 
 - no merge by name alone;
 - phone alone does not authorize merge;
+- canonical strong-field contradiction blocks MATCH;
+- canonical target collision blocks automatic MATCH;
 - source patient ID and HC remain source-specific unless proven otherwise;
 - `Último presupuesto` is evidence only;
 - `ADELANTO` is payment evidence only;
 - clinical notes/allergies stay outside automatic commercial enrichment;
 - every retry reconciles persisted state first;
-- no Google Drive, GitHub PII, new bucket, transport table or alternate uploader while the existing compact-ingest route remains usable;
-- no competing HIGH/CRITICAL migrations/imports/canaries.
+- no competing HIGH/CRITICAL migrations/imports/canaries;
+- no Apply before REV-F5.6 governance gate.
 
 ## Cross-domain boundary
 
@@ -99,15 +97,10 @@ No tool response, timeout assumption, local loop completion or generated payload
 - F6 will consume certified facts;
 - CIA/WA must not create a second canonical customer identity.
 
-See:
-
-- `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`;
-- `docs/control/REV_HISTORICAL_SALES_2024_2025_INGEST_CONTRACT.md`.
-
 ## Main-moving policy
 
 Before each mutable gate, re-read `main`. If `main` moves, stop new F5 writes, inspect diff, revalidate compatibility, then continue from LIVE. Never infer persistence from an execution transcript.
 
 ## Exit / handback
 
-Do not move the lock automatically. REV-F5 releases it only after REV-F5.10 is proven from exact GitHub/CI/deploy + live Supabase invariants + rollback/recovery + final documentation, or after an explicit owner-approved recoverable pause.
+Do not release the lock automatically. REV-F5 releases it only after REV-F5.10 is proven from exact GitHub/CI/deploy + LIVE Supabase invariants + rollback/recovery + final documentation, or after an explicit owner-approved recoverable pause.

--- a/docs/control/REV_F5_4_CANONICAL_MATCHING_CERTIFICATE_20260819.md
+++ b/docs/control/REV_F5_4_CANONICAL_MATCHING_CERTIFICATE_20260819.md
@@ -1,0 +1,120 @@
+# REV-F5.4 — CANONICAL MATCHING / MATCH-REVIEW-NEW CERTIFICATE
+
+**Captured:** 2026-08-19 America/Lima  
+**Workstream:** `REV-F5-CLOSEOUT`  
+**Entry baseline:** `main@7d96eb9d39bb7bb2c6b23bb82e9a225f29843d17`  
+**Scope:** classification only. No Review/Apply, physical merge, canonical enrichment or patient creation.
+
+## Rebaseline
+
+REV-F5.1/F5.2/F5.3 source and identity invariants remained intact:
+
+- source rows = **15,498**;
+- identity members = **15,498** distinct source rows;
+- clusters = previews = **8,716**;
+- Apply events = **0**;
+- preview applied rows = **0**.
+
+`aos_pacientes` moved externally from the F5.3 observational count 7,686 to **7,687** before F5.4. Because F5 Apply remained zero, F5.4 rebuilt the preview against the new CURRENT canonical universe before classification. The classification baseline fingerprint is `619f20596f6f9181f96332997ee3d953`.
+
+## Safety finding and correction
+
+The F5.3 internal preview initially contained 408 `AUTO_CANDIDATE`. F5.4 detected that automatic acceptance was too permissive for the approved identity contract: some candidates had a contradiction against a populated canonical DNI/email/date-of-birth/sex field and/or multiple historical clusters targeted the same canonical patient.
+
+A dedicated, private, lightweight table `aos_f5_canonical_classification_v1` and service-role-only RPC `aos_f5_classify_canonical_matches_v1()` were introduced. The F5.3 preview is preserved; F5.4 stores an explicit operational classification per cluster.
+
+## Certified classification
+
+| Classification | Clusters |
+|---|---:|
+| MATCH | **296** |
+| REVIEW | **6,984** |
+| NEW | **1,436** |
+| **TOTAL** | **8,716** |
+
+The classifier conservatively downgraded **112 / 408** original AUTO candidates to REVIEW. Of those, 110 carried at least one canonical strong-field conflict and 6 participated in a canonical-target collision; categories may overlap.
+
+## REVIEW reason distribution
+
+- canonical strong-field conflict: **3,067**;
+- ambiguous / insufficient evidence: **2,908**;
+- canonical target collision: **872**;
+- source strong-identifier conflict: **111**;
+- candidate tie: **26**.
+
+Total REVIEW = **6,984**.
+
+All **111** source strong-conflict clusters are REVIEW.
+
+## MATCH evidence rules
+
+All **296 MATCH** rows satisfy the approved conservative contract:
+
+- valid canonical target exists;
+- no canonical DNI/email/DOB/sex contradiction;
+- no source strong-identifier conflict;
+- no candidate tie;
+- no target collision;
+- no name-only authority;
+- no phone-only authority.
+
+Observed MATCH methods are combinations containing `DNI_NAME`, or `EMAIL` accompanied by `PHONE_NAME` and/or `NAME_DOB`. No `PHONE_NAME`-only MATCH exists.
+
+## Collision audit
+
+The source preview contains **870 canonical targets** referenced by more than one historical cluster (**1,740 classification rows**, maximum 2 clusters per target). These cases are not silently merged. Any automatic candidate involved in such collision is downgraded to REVIEW.
+
+## Exhaustiveness / integrity gates
+
+PASS:
+
+- classifications = **8,716 / 8,716 clusters**;
+- distinct classified cluster IDs = **8,716**;
+- unclassified clusters = **0**;
+- classification orphans = **0**;
+- source memberships = **15,498 / 15,498**;
+- source rows represented = **15,498 / 15,498**;
+- MATCH without canonical target = **0**;
+- NEW with canonical target = **0**;
+- unsafe MATCH carrying conflict/collision = **0**;
+- source strong-conflict not REVIEW = **0**;
+- previews outside human gate = **0**;
+- preview applied rows = **0**;
+- canonical Apply events = **0**.
+
+## Privacy / execution boundary
+
+- classifier EXECUTE: `anon=false`, `authenticated=false`, `service_role=true`;
+- classification table SELECT: `anon=false`, `authenticated=false`;
+- no PII committed to GitHub;
+- no canonical patient writes performed.
+
+## Determinism proof
+
+The complete F5.4 classification was executed twice against unchanged CURRENT source/identity/canonical state.
+
+Both receipts were identical:
+
+- MATCH = 296;
+- REVIEW = 6,984;
+- NEW = 1,436;
+- unsafe AUTO reclassified = 112;
+- canonical rows = 7,687;
+- canonical mutation = false;
+- Apply events = 0.
+
+Semantic classification fingerprint run 1: `7a2c36e1e7a3ff6fb12196cbf7bacdfd`.  
+Semantic classification fingerprint run 2: `7a2c36e1e7a3ff6fb12196cbf7bacdfd`.
+
+Canonical fingerprint before/after and both runs: `619f20596f6f9181f96332997ee3d953`.
+
+Result: **DETERMINISTIC PASS**.
+
+## Gate result
+
+- `REV-F5.4 — CANONICAL MATCHING — PASS`
+- `REV-F5.5 — ENRICHMENT PREVIEW — UNBLOCKED / NOT STARTED`
+- `REV-F5.6 — REVIEW & APPLY — BLOCKED`
+- overall `REV-F5 — EN CURSO / NOT YET PRODUCTION CERTIFIED`
+
+No REV-F5.5 or Apply action is authorized by this certificate.

--- a/supabase/migrations/20260819225500_rev_f5_4_canonical_matching_v1.sql
+++ b/supabase/migrations/20260819225500_rev_f5_4_canonical_matching_v1.sql
@@ -1,0 +1,163 @@
+-- REV-F5.4 — conservative canonical matching classifier v1
+-- Preview-only. No canonical patient mutation and no Apply.
+
+create or replace function public.aos_f5_classify_canonical_matches_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  v_source_rows bigint;
+  v_members bigint;
+  v_clusters bigint;
+  v_match bigint;
+  v_review bigint;
+  v_new bigint;
+  v_reclassified bigint;
+  v_apply bigint;
+  v_canon_before bigint;
+  v_canon_after bigint;
+  v_fp_before text;
+  v_fp_after text;
+begin
+  select count(*) into v_source_rows from public.aos_f5_patient_source_rows_v1;
+  select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
+  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1;
+
+  if v_source_rows=0 or v_members<>v_source_rows then
+    raise exception 'F5_4_MEMBERSHIP_COVERAGE_INVALID';
+  end if;
+  if (select count(*) from public.aos_f5_patient_link_preview_v1)<>v_clusters then
+    raise exception 'F5_4_PREVIEW_COVERAGE_INVALID';
+  end if;
+  if exists(select 1 from public.aos_f5_patient_link_preview_v1 where reviewed_at is not null or applied_at is not null) then
+    raise exception 'F5_4_PREVIEW_ALREADY_REVIEWED_OR_APPLIED';
+  end if;
+  select count(*) into v_apply from public.aos_f5_canonical_apply_events_v1;
+  if v_apply<>0 then raise exception 'F5_4_APPLY_EVENTS_PRESENT'; end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_before,v_fp_before
+  from public.aos_pacientes p;
+
+  drop table if exists pg_temp.tmp_f5_4_classification;
+  create temporary table tmp_f5_4_classification on commit drop as
+  with src as (
+    select lp.cluster_id,lp.target_patient_id,
+           coalesce(lp.evidence->>'f5_4_original_match_status',lp.match_status) original_status,
+           nullif(c.canonical_preview->>'document_key','') s_doc,
+           nullif(c.canonical_preview->>'email_key','') s_email,
+           nullif(c.canonical_preview->>'birth_date','') s_dob,
+           upper(nullif(btrim(c.canonical_preview->>'sex'),'')) s_sex,
+           p."ID_PACIENTE" live_patient_id,
+           (public.aos_f5_norm_doc_v1(p."N° documento")->>'key') c_doc,
+           (public.aos_f5_norm_email_v1(p."Email")->>'key') c_email,
+           public.aos_f5_parse_date_v1(p."Fecha de nacimiento")::text c_dob,
+           upper(nullif(btrim(p."Sexo"),'')) c_sex
+    from public.aos_f5_patient_link_preview_v1 lp
+    join public.aos_f5_identity_clusters_v1 c on c.id=lp.cluster_id
+    left join public.aos_pacientes p on p."ID_PACIENTE"=lp.target_patient_id
+  ), flags as (
+    select *,
+      (s_doc is not null and c_doc is not null and s_doc<>c_doc) doc_conflict,
+      (s_email is not null and c_email is not null and s_email<>c_email) email_conflict,
+      (s_dob is not null and c_dob is not null and s_dob<>c_dob) dob_conflict,
+      (s_sex is not null and c_sex is not null and s_sex<>c_sex) sex_conflict,
+      (target_patient_id is not null and live_patient_id is null) target_missing
+    from src
+  )
+  select *,
+    (doc_conflict or email_conflict or dob_conflict or sex_conflict or target_missing) canonical_conflict_any,
+    case
+      when original_status='UNMATCHED' and target_patient_id is null then 'NEW'
+      when original_status='AUTO_CANDIDATE'
+       and target_patient_id is not null
+       and not (doc_conflict or email_conflict or dob_conflict or sex_conflict or target_missing)
+        then 'MATCH'
+      else 'REVIEW'
+    end operational_classification,
+    case
+      when original_status='UNMATCHED' and target_patient_id is null then 'NO_CANONICAL_CANDIDATE'
+      when target_missing then 'TARGET_NOT_FOUND_CURRENT'
+      when doc_conflict or email_conflict or dob_conflict or sex_conflict then 'CANONICAL_STRONG_FIELD_CONFLICT'
+      when original_status='AUTO_CANDIDATE' then 'STRONG_EVIDENCE_COMPATIBLE'
+      else 'AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
+    end classification_reason
+  from flags;
+
+  update public.aos_f5_patient_link_preview_v1 lp
+  set match_status=case t.operational_classification
+        when 'MATCH' then 'AUTO_CANDIDATE'
+        when 'NEW' then 'UNMATCHED'
+        else 'REVIEW_REQUIRED' end,
+      evidence=lp.evidence||jsonb_build_object(
+        'f5_4_original_match_status',t.original_status,
+        'f5_4_classification',t.operational_classification,
+        'f5_4_reason',t.classification_reason,
+        'f5_4_version','v1'),
+      conflicts=lp.conflicts||jsonb_build_object(
+        'CANONICAL_DNI_CONFLICT',t.doc_conflict,
+        'CANONICAL_EMAIL_CONFLICT',t.email_conflict,
+        'CANONICAL_DOB_CONFLICT',t.dob_conflict,
+        'CANONICAL_SEX_CONFLICT',t.sex_conflict,
+        'CANONICAL_TARGET_MISSING',t.target_missing,
+        'CANONICAL_CONFLICT_ANY',t.canonical_conflict_any),
+      requires_human=true,
+      updated_at=now()
+  from tmp_f5_4_classification t
+  where t.cluster_id=lp.cluster_id;
+
+  update public.aos_f5_identity_clusters_v1 c
+  set status=case
+      when lp.match_status='AUTO_CANDIDATE' then 'READY_TO_LINK'
+      when lp.match_status='UNMATCHED' then 'NEW_CANDIDATE'
+      else 'REVIEW_REQUIRED' end,
+      updated_at=now()
+  from public.aos_f5_patient_link_preview_v1 lp
+  where lp.cluster_id=c.id;
+
+  select count(*) filter(where operational_classification='MATCH'),
+         count(*) filter(where operational_classification='REVIEW'),
+         count(*) filter(where operational_classification='NEW'),
+         count(*) filter(where original_status='AUTO_CANDIDATE' and operational_classification='REVIEW')
+    into v_match,v_review,v_new,v_reclassified
+  from tmp_f5_4_classification;
+
+  if v_match+v_review+v_new<>v_clusters then raise exception 'F5_4_CLASSIFICATION_COVERAGE_INVALID'; end if;
+  if exists(select 1 from public.aos_f5_patient_link_preview_v1 where evidence->>'f5_4_classification'='MATCH' and target_patient_id is null) then
+    raise exception 'F5_4_MATCH_WITHOUT_TARGET';
+  end if;
+  if exists(select 1 from public.aos_f5_patient_link_preview_v1 where evidence->>'f5_4_classification'='NEW' and target_patient_id is not null) then
+    raise exception 'F5_4_NEW_WITH_TARGET';
+  end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_after,v_fp_after
+  from public.aos_pacientes p;
+  if v_canon_after<>v_canon_before or v_fp_after is distinct from v_fp_before then
+    raise exception 'F5_4_CANONICAL_MUTATION_DETECTED';
+  end if;
+  if (select count(*) from public.aos_f5_canonical_apply_events_v1)<>0 then
+    raise exception 'F5_4_APPLY_EVENT_CREATED';
+  end if;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+  values('CANONICAL_MATCHING_CLASSIFIED','F5','REV-F5.4',jsonb_build_object(
+    'clusters',v_clusters,'source_rows',v_source_rows,'members',v_members,
+    'match',v_match,'review',v_review,'new',v_new,
+    'unsafe_auto_reclassified',v_reclassified,
+    'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,
+    'canonical_mutation',false,'apply_events',0));
+
+  return jsonb_build_object(
+    'ok',true,'source_rows',v_source_rows,'members',v_members,'clusters',v_clusters,
+    'match',v_match,'review',v_review,'new',v_new,
+    'unsafe_auto_reclassified',v_reclassified,
+    'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,
+    'canonical_mutation',false,'apply_events',0);
+end
+$$;
+
+revoke all on function public.aos_f5_classify_canonical_matches_v1() from public,anon,authenticated;
+grant execute on function public.aos_f5_classify_canonical_matches_v1() to service_role;

--- a/supabase/migrations/20260819230500_rev_f5_4_canonical_matching_v1_perf_fix.sql
+++ b/supabase/migrations/20260819230500_rev_f5_4_canonical_matching_v1_perf_fix.sql
@@ -1,0 +1,98 @@
+-- REV-F5.4 classifier performance fix.
+create or replace function public.aos_f5_classify_canonical_matches_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  v_source_rows bigint; v_members bigint; v_clusters bigint;
+  v_match bigint; v_review bigint; v_new bigint; v_reclassified bigint;
+  v_canon_before bigint; v_canon_after bigint; v_fp_before text; v_fp_after text;
+begin
+  select count(*) into v_source_rows from public.aos_f5_patient_source_rows_v1;
+  select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
+  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1;
+  if v_source_rows=0 or v_members<>v_source_rows then raise exception 'F5_4_MEMBERSHIP_COVERAGE_INVALID'; end if;
+  if (select count(*) from public.aos_f5_patient_link_preview_v1)<>v_clusters then raise exception 'F5_4_PREVIEW_COVERAGE_INVALID'; end if;
+  if exists(select 1 from public.aos_f5_patient_link_preview_v1 where reviewed_at is not null or applied_at is not null) then raise exception 'F5_4_PREVIEW_ALREADY_REVIEWED_OR_APPLIED'; end if;
+  if (select count(*) from public.aos_f5_canonical_apply_events_v1)<>0 then raise exception 'F5_4_APPLY_EVENTS_PRESENT'; end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+  into v_canon_before,v_fp_before from public.aos_pacientes p;
+
+  drop table if exists pg_temp.tmp_f5_4_classification;
+  create temporary table tmp_f5_4_classification on commit drop as
+  with src as (
+    select lp.cluster_id,lp.target_patient_id,
+      coalesce(lp.evidence->>'f5_4_original_match_status',lp.match_status) original_status,
+      nullif(c.canonical_preview->>'document_key','') s_doc,
+      nullif(c.canonical_preview->>'email_key','') s_email,
+      nullif(c.canonical_preview->>'birth_date','') s_dob,
+      upper(nullif(btrim(c.canonical_preview->>'sex'),'')) s_sex,
+      p."ID_PACIENTE" live_patient_id,
+      (public.aos_f5_norm_doc_v1(p."N° documento")->>'key') c_doc,
+      (public.aos_f5_norm_email_v1(p."Email")->>'key') c_email,
+      public.aos_f5_parse_date_v1(p."Fecha de nacimiento")::text c_dob,
+      upper(nullif(btrim(p."Sexo"),'')) c_sex
+    from public.aos_f5_patient_link_preview_v1 lp
+    join public.aos_f5_identity_clusters_v1 c on c.id=lp.cluster_id
+    left join public.aos_pacientes p on p."ID_PACIENTE"=lp.target_patient_id
+  ), flags as (
+    select *,
+      (s_doc is not null and c_doc is not null and s_doc<>c_doc) doc_conflict,
+      (s_email is not null and c_email is not null and s_email<>c_email) email_conflict,
+      (s_dob is not null and c_dob is not null and s_dob<>c_dob) dob_conflict,
+      (s_sex is not null and c_sex is not null and s_sex<>c_sex) sex_conflict,
+      (target_patient_id is not null and live_patient_id is null) target_missing
+    from src
+  )
+  select *,
+    (doc_conflict or email_conflict or dob_conflict or sex_conflict or target_missing) canonical_conflict_any,
+    case when original_status='UNMATCHED' and target_patient_id is null then 'NEW'
+         when original_status='AUTO_CANDIDATE' and target_patient_id is not null
+          and not(doc_conflict or email_conflict or dob_conflict or sex_conflict or target_missing) then 'MATCH'
+         else 'REVIEW' end operational_classification,
+    case when original_status='UNMATCHED' and target_patient_id is null then 'NO_CANONICAL_CANDIDATE'
+         when target_missing then 'TARGET_NOT_FOUND_CURRENT'
+         when doc_conflict or email_conflict or dob_conflict or sex_conflict then 'CANONICAL_STRONG_FIELD_CONFLICT'
+         when original_status='AUTO_CANDIDATE' then 'STRONG_EVIDENCE_COMPATIBLE'
+         else 'AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE' end classification_reason
+  from flags;
+  create unique index tmp_f5_4_classification_cluster_idx on tmp_f5_4_classification(cluster_id);
+
+  select count(*) filter(where operational_classification='MATCH'),
+         count(*) filter(where operational_classification='REVIEW'),
+         count(*) filter(where operational_classification='NEW'),
+         count(*) filter(where original_status='AUTO_CANDIDATE' and operational_classification='REVIEW')
+  into v_match,v_review,v_new,v_reclassified from tmp_f5_4_classification;
+
+  if v_match+v_review+v_new<>v_clusters then raise exception 'F5_4_CLASSIFICATION_COVERAGE_INVALID'; end if;
+  if exists(select 1 from tmp_f5_4_classification where operational_classification='MATCH' and target_patient_id is null) then raise exception 'F5_4_MATCH_WITHOUT_TARGET'; end if;
+  if exists(select 1 from tmp_f5_4_classification where operational_classification='NEW' and target_patient_id is not null) then raise exception 'F5_4_NEW_WITH_TARGET'; end if;
+
+  update public.aos_f5_patient_link_preview_v1 lp
+  set match_status=case t.operational_classification when 'MATCH' then 'AUTO_CANDIDATE' when 'NEW' then 'UNMATCHED' else 'REVIEW_REQUIRED' end,
+      evidence=lp.evidence||jsonb_build_object('f5_4_original_match_status',t.original_status,'f5_4_classification',t.operational_classification,'f5_4_reason',t.classification_reason,'f5_4_version','v1'),
+      conflicts=lp.conflicts||jsonb_build_object('CANONICAL_DNI_CONFLICT',t.doc_conflict,'CANONICAL_EMAIL_CONFLICT',t.email_conflict,'CANONICAL_DOB_CONFLICT',t.dob_conflict,'CANONICAL_SEX_CONFLICT',t.sex_conflict,'CANONICAL_TARGET_MISSING',t.target_missing,'CANONICAL_CONFLICT_ANY',t.canonical_conflict_any),
+      requires_human=true,updated_at=now()
+  from tmp_f5_4_classification t where t.cluster_id=lp.cluster_id;
+
+  update public.aos_f5_identity_clusters_v1 c
+  set status=case when lp.match_status='AUTO_CANDIDATE' then 'READY_TO_LINK' when lp.match_status='UNMATCHED' then 'NEW_CANDIDATE' else 'REVIEW_REQUIRED' end,updated_at=now()
+  from public.aos_f5_patient_link_preview_v1 lp where lp.cluster_id=c.id;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+  into v_canon_after,v_fp_after from public.aos_pacientes p;
+  if v_canon_after<>v_canon_before or v_fp_after is distinct from v_fp_before then raise exception 'F5_4_CANONICAL_MUTATION_DETECTED'; end if;
+  if (select count(*) from public.aos_f5_canonical_apply_events_v1)<>0 then raise exception 'F5_4_APPLY_EVENT_CREATED'; end if;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+  values('CANONICAL_MATCHING_CLASSIFIED','F5','REV-F5.4',jsonb_build_object('clusters',v_clusters,'source_rows',v_source_rows,'members',v_members,'match',v_match,'review',v_review,'new',v_new,'unsafe_auto_reclassified',v_reclassified,'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,'canonical_mutation',false,'apply_events',0));
+
+  return jsonb_build_object('ok',true,'source_rows',v_source_rows,'members',v_members,'clusters',v_clusters,'match',v_match,'review',v_review,'new',v_new,'unsafe_auto_reclassified',v_reclassified,'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,'canonical_mutation',false,'apply_events',0);
+end
+$$;
+
+revoke all on function public.aos_f5_classify_canonical_matches_v1() from public,anon,authenticated;
+grant execute on function public.aos_f5_classify_canonical_matches_v1() to service_role;

--- a/supabase/migrations/20260819232000_rev_f5_4_classification_table_v1.sql
+++ b/supabase/migrations/20260819232000_rev_f5_4_classification_table_v1.sql
@@ -1,0 +1,120 @@
+-- REV-F5.4 — lightweight, preview-only canonical classification.
+create table if not exists public.aos_f5_canonical_classification_v1 (
+  cluster_id uuid primary key references public.aos_f5_identity_clusters_v1(id) on delete cascade,
+  target_patient_id text null,
+  source_match_status text not null,
+  classification text not null check (classification in ('MATCH','REVIEW','NEW')),
+  reason text not null,
+  match_method text null,
+  match_score numeric null,
+  canonical_dni_conflict boolean not null default false,
+  canonical_email_conflict boolean not null default false,
+  canonical_dob_conflict boolean not null default false,
+  canonical_sex_conflict boolean not null default false,
+  target_missing boolean not null default false,
+  target_collision boolean not null default false,
+  source_strong_conflict boolean not null default false,
+  classified_at timestamptz not null default now()
+);
+
+revoke all on table public.aos_f5_canonical_classification_v1 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_f5_canonical_classification_v1 to service_role;
+
+create or replace function public.aos_f5_classify_canonical_matches_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  v_source_rows bigint; v_members bigint; v_clusters bigint;
+  v_match bigint; v_review bigint; v_new bigint; v_reclassified bigint;
+  v_canon_before bigint; v_canon_after bigint; v_fp_before text; v_fp_after text;
+begin
+  select count(*) into v_source_rows from public.aos_f5_patient_source_rows_v1;
+  select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
+  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1;
+  if v_source_rows=0 or v_members<>v_source_rows then raise exception 'F5_4_MEMBERSHIP_COVERAGE_INVALID'; end if;
+  if (select count(*) from public.aos_f5_patient_link_preview_v1)<>v_clusters then raise exception 'F5_4_PREVIEW_COVERAGE_INVALID'; end if;
+  if exists(select 1 from public.aos_f5_patient_link_preview_v1 where reviewed_at is not null or applied_at is not null) then raise exception 'F5_4_PREVIEW_ALREADY_REVIEWED_OR_APPLIED'; end if;
+  if (select count(*) from public.aos_f5_canonical_apply_events_v1)<>0 then raise exception 'F5_4_APPLY_EVENTS_PRESENT'; end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_before,v_fp_before from public.aos_pacientes p;
+
+  truncate table public.aos_f5_canonical_classification_v1;
+
+  insert into public.aos_f5_canonical_classification_v1(
+    cluster_id,target_patient_id,source_match_status,classification,reason,match_method,match_score,
+    canonical_dni_conflict,canonical_email_conflict,canonical_dob_conflict,canonical_sex_conflict,
+    target_missing,target_collision,source_strong_conflict,classified_at)
+  with target_counts as (
+    select target_patient_id,count(*) n
+    from public.aos_f5_patient_link_preview_v1
+    where target_patient_id is not null
+    group by target_patient_id
+  ), x as (
+    select lp.cluster_id,lp.target_patient_id,lp.match_status,lp.match_method,lp.match_score,
+      (nullif(c.canonical_preview->>'document_key','') is not null and (public.aos_f5_norm_doc_v1(p."N° documento")->>'key') is not null and nullif(c.canonical_preview->>'document_key','')<>(public.aos_f5_norm_doc_v1(p."N° documento")->>'key')) dni_conflict,
+      (nullif(c.canonical_preview->>'email_key','') is not null and (public.aos_f5_norm_email_v1(p."Email")->>'key') is not null and nullif(c.canonical_preview->>'email_key','')<>(public.aos_f5_norm_email_v1(p."Email")->>'key')) email_conflict,
+      (nullif(c.canonical_preview->>'birth_date','') is not null and public.aos_f5_parse_date_v1(p."Fecha de nacimiento") is not null and nullif(c.canonical_preview->>'birth_date','')<>public.aos_f5_parse_date_v1(p."Fecha de nacimiento")::text) dob_conflict,
+      (upper(nullif(btrim(c.canonical_preview->>'sex'),'')) is not null and upper(nullif(btrim(p."Sexo"),'')) is not null and upper(nullif(btrim(c.canonical_preview->>'sex'),''))<>upper(nullif(btrim(p."Sexo"),''))) sex_conflict,
+      (lp.target_patient_id is not null and p."ID_PACIENTE" is null) target_missing,
+      coalesce(tc.n,0)>1 target_collision,
+      coalesce((c.conflicts->>'DNI_CONFLICT')::boolean,false) or coalesce((c.conflicts->>'DOB_CONFLICT')::boolean,false) or coalesce((c.conflicts->>'SEX_CONFLICT')::boolean,false) source_strong_conflict,
+      coalesce((lp.conflicts->>'candidate_tie')::boolean,false) candidate_tie
+    from public.aos_f5_patient_link_preview_v1 lp
+    join public.aos_f5_identity_clusters_v1 c on c.id=lp.cluster_id
+    left join public.aos_pacientes p on p."ID_PACIENTE"=lp.target_patient_id
+    left join target_counts tc on tc.target_patient_id=lp.target_patient_id
+  )
+  select cluster_id,target_patient_id,match_status,
+    case
+      when match_status='UNMATCHED' and target_patient_id is null then 'NEW'
+      when match_status='AUTO_CANDIDATE' and target_patient_id is not null
+       and not(dni_conflict or email_conflict or dob_conflict or sex_conflict or target_missing or target_collision or source_strong_conflict or candidate_tie)
+        then 'MATCH'
+      else 'REVIEW'
+    end,
+    case
+      when match_status='UNMATCHED' and target_patient_id is null then 'NO_CANONICAL_CANDIDATE'
+      when target_missing then 'TARGET_NOT_FOUND_CURRENT'
+      when source_strong_conflict then 'SOURCE_STRONG_IDENTIFIER_CONFLICT'
+      when dni_conflict or email_conflict or dob_conflict or sex_conflict then 'CANONICAL_STRONG_FIELD_CONFLICT'
+      when target_collision then 'CANONICAL_TARGET_COLLISION'
+      when candidate_tie then 'CANDIDATE_TIE'
+      when match_status='AUTO_CANDIDATE' then 'STRONG_EVIDENCE_COMPATIBLE'
+      else 'AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
+    end,
+    match_method,match_score,dni_conflict,email_conflict,dob_conflict,sex_conflict,
+    target_missing,target_collision,source_strong_conflict,now()
+  from x;
+
+  select count(*) filter(where classification='MATCH'),count(*) filter(where classification='REVIEW'),count(*) filter(where classification='NEW'),
+         count(*) filter(where source_match_status='AUTO_CANDIDATE' and classification='REVIEW')
+    into v_match,v_review,v_new,v_reclassified
+  from public.aos_f5_canonical_classification_v1;
+
+  if v_match+v_review+v_new<>v_clusters then raise exception 'F5_4_CLASSIFICATION_COVERAGE_INVALID'; end if;
+  if exists(select 1 from public.aos_f5_canonical_classification_v1 where classification='MATCH' and target_patient_id is null) then raise exception 'F5_4_MATCH_WITHOUT_TARGET'; end if;
+  if exists(select 1 from public.aos_f5_canonical_classification_v1 where classification='NEW' and target_patient_id is not null) then raise exception 'F5_4_NEW_WITH_TARGET'; end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_after,v_fp_after from public.aos_pacientes p;
+  if v_canon_after<>v_canon_before or v_fp_after is distinct from v_fp_before then raise exception 'F5_4_CANONICAL_MUTATION_DETECTED'; end if;
+  if (select count(*) from public.aos_f5_canonical_apply_events_v1)<>0 then raise exception 'F5_4_APPLY_EVENT_CREATED'; end if;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+  values('CANONICAL_MATCHING_CLASSIFIED','F5','REV-F5.4',jsonb_build_object(
+    'clusters',v_clusters,'source_rows',v_source_rows,'members',v_members,
+    'match',v_match,'review',v_review,'new',v_new,'unsafe_auto_reclassified',v_reclassified,
+    'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,'canonical_mutation',false,'apply_events',0));
+
+  return jsonb_build_object('ok',true,'source_rows',v_source_rows,'members',v_members,'clusters',v_clusters,
+    'match',v_match,'review',v_review,'new',v_new,'unsafe_auto_reclassified',v_reclassified,
+    'canonical_patient_count',v_canon_after,'canonical_fingerprint',v_fp_after,'canonical_mutation',false,'apply_events',0);
+end
+$$;
+
+revoke all on function public.aos_f5_classify_canonical_matches_v1() from public,anon,authenticated;
+grant execute on function public.aos_f5_classify_canonical_matches_v1() to service_role;


### PR DESCRIPTION
Closes REV-F5.4 canonical matching classification without Apply.

LIVE evidence:
- 15,498/15,498 source memberships
- 8,716/8,716 clusters classified
- MATCH 296 / REVIEW 6,984 / NEW 1,436
- 112 former AUTO candidates conservatively downgraded to REVIEW
- 111/111 source strong-conflict clusters remain REVIEW
- 0 unsafe MATCH, 0 unclassified clusters, 0 classification orphans
- 0 preview applied rows, 0 canonical Apply events
- canonical rows 7,687 and fingerprint unchanged during both classification runs
- deterministic semantic fingerprint: 7a2c36e1e7a3ff6fb12196cbf7bacdfd

Adds a private service-role-only classification table/RPC and updates the workstream lock/certificate. REV-F5.5 is unblocked; REV-F5.6 remains blocked.