### PR TITLE
REV-F5.6 — governed Review & Apply with exact rollback

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -3,72 +3,93 @@
 **Status:** CURRENT / REV-F5 ACTIVE / NOT YET PRODUCTION CERTIFIED  
 **Captured:** 2026-08-19 America/Lima  
 **Owner assignment:** explicit owner directive to continue REV-F5 closeout  
-**REV-F5.5 entry baseline:** `main@a9e5d0940d5bf43d43d65589d4ad739bd02276f2`  
+**REV-F5.6 entry baseline:** `main@3c208712e136b4618b6618b7044096811b273f74`  
 **ACTIVE LOCK:** `REV-F5-CLOSEOUT`  
-**NEXT MUTABLE GATE:** `REV-F5.6 — REVIEW & APPLY`  
-**REV-F5.6 STATUS:** `BLOCKED PENDING EXPLICIT OWNER AUTHORIZATION`
+**REV-F5.6 STATUS:** `PASS — GOVERNED LOW-RISK REVIEW & APPLY`  
+**NEXT MUTABLE GATE:** `REV-F5.7 — HISTORICAL JOIN`  
 
 ## Concurrency rule
 
 At most one HIGH/CRITICAL mutable workstream may operate at a time. While `REV-F5-CLOSEOUT` owns the lock, other HIGH/CRITICAL feature/data workstreams remain read-only/documentation/regression-only unless explicitly required for REV-F5 validation.
 
-## REV-F5 LIVE checkpoint
-
-Certified production truth after REV-F5.5:
+## REV-F5 LIVE checkpoint after REV-F5.6
 
 - REV-F5.1 ingest = **PASS**;
 - REV-F5.2 staging = **PASS**;
 - REV-F5.3 identity rebuild/preview = **PASS**;
-- REV-F5.4 canonical matching classification = **PASS**;
-- REV-F5.5 fill-only enrichment preview = **PASS**;
-- 6/6 source batches complete;
+- REV-F5.4 canonical matching = **PASS**;
+- REV-F5.5 enrichment preview = **PASS**;
+- REV-F5.6 governed Review & Apply = **PASS**;
 - source rows = **15,498 / 15,498**;
 - identity memberships = **15,498 / 15,498**;
 - identity clusters = **8,716**;
-- classifications = **8,716 / 8,716**;
-- MATCH = **296**;
-- REVIEW = **6,984**;
-- NEW = **1,436**;
-- F5.5 MATCH patients with at least one fill-only proposal = **202**;
-- F5.5 field-level enrichment preview rows = **455**;
-- F5.5 policy states = **229 APPLY_ALLOWED / 23 POLICY_BLOCKED / 203 POLICY_UNDEFINED**;
-- ambiguous source-value previews = **0**;
-- canonical overwrite violations = **0**;
-- non-MATCH enrichment previews = **0**;
-- clinical-note/allergy enrichment previews = **0**;
-- F5.5 apply-eligible rows = **0**;
-- preview applied rows = **0**;
-- canonical Apply events = **0**;
-- `aos_pacientes` = **7,687**;
-- canonical fingerprint = `619f20596f6f9181f96332997ee3d953`;
-- F5.4 classification fingerprint = `7a2c36e1e7a3ff6fb12196cbf7bacdfd`;
-- F5.5 enrichment fingerprint = `d22f2542813dcf71e767abc9e78d1021`.
+- MATCH / REVIEW / NEW = **296 / 6,984 / 1,436**;
+- enrichment previews = **455** across **202** MATCH patients;
+- final REV-F5.6 policy = **229 APPLY_ALLOWED / 226 POLICY_BLOCKED / 0 POLICY_UNDEFINED**;
+- applied LOW-risk fields = **229 / 229**;
+- blocked fields applied = **0 / 226**;
+- applied distribution = **Sexo 121 / distrito 108 / departamento 0 / ciudad 0**;
+- F5 Apply events = **230 total / 229 active / 1 exact canary rollback**;
+- event ↔ canonical mismatches = **0**;
+- event ↔ preview mismatches = **0**;
+- invalid before/after hash events = **0**;
+- active events outside allowlist = **0**;
+- canonical patients = **7,688**;
+- final canonical fingerprint = `eee5a57717937a4f77049b3aebd8c525`.
 
-## REV-F5.5 enrichment boundary
+The canonical patient count moved externally from 7,687 to 7,688 before the first F5.6 canary while F5 still had zero reviews and zero Apply events. F5.6 stopped, rebuilt/revalidated F5.3→F5.5 against CURRENT and proved the external row did not change the 296/6,984/1,436 classification or the 455 enrichment proposals.
 
-F5.5 reuses the established F5.3 fill-only `proposed_patch` field semantics and materializes them only for REV-F5.4 MATCH identities.
+## REV-F5.6 governance boundary
 
-Every F5.5 preview row requires:
+F5.6 uses a field-level v2 path on top of the existing F5 classification, enrichment preview and Apply-event ledger.
 
-- canonical target field is empty;
-- exactly one distinct historical value for that field;
-- source-row provenance retained;
-- human review remains mandatory;
-- `apply_eligible=false`.
+Every mutation requires:
 
-The current 455 field proposals are:
+- service-role transport only;
+- active hierarchy-1 admin;
+- `two_factor=true`;
+- live non-revoked `PASSWORD_2FA` app session;
+- REV-F5.4 `MATCH` with no blocking canonical/source conflict or collision;
+- one-value F5.5 provenance;
+- explicit field review;
+- LOW-risk live policy;
+- canonical field still empty;
+- optimistic review snapshot hash;
+- locked target row;
+- before/after canonical row hashes;
+- private audit event.
 
-- Sexo **121**;
-- distrito **108**;
-- Fecha de nacimiento **75**;
-- Ocupación **67**;
-- Dirección **57**;
-- Email **23**;
-- N° documento **4**.
+Only these fields are Apply-allowed in REV-F5.6:
 
-The existing apply-field policy was not widened. `Email` remains explicitly blocked; fields without policy remain undefined. Even the 229 rows whose field policy is currently allowed are not Apply-authorized by F5.5.
+- `Sexo`;
+- `distrito`;
+- `departamento`;
+- `ciudad`.
 
-Potential fills for latest appointment (**201**) and acquisition channel/origin (**1**) remain deferred because their destination semantics are not yet governed by an approved canonical mapping. Phone has **0** current fill opportunities. Clinical notes/allergies remain excluded.
+Identity anchors, birth date, potentially stale address/occupation, unresolved acquisition/latest-visit mappings and clinical/free-text data remain blocked.
+
+## Canary and rollback proof
+
+A single `Sexo` canary passed DRY_RUN, APPLY and exact ROLLBACK before expansion.
+
+- pre-canary global fingerprint = `7ee00cb855f253c52c464b1d49eec289`;
+- target before hash = `7ccfca60d309dfdd5936e0d98fae43924947b06384327979ac08737448d99df4`;
+- target after hash = `90521400b8c1598e3a21f073ea78f43838e8471fbaef82a8b034e8ba37b5a103`;
+- rollback hash = exact before hash;
+- post-rollback global fingerprint = exact pre-canary fingerprint;
+- active events after rollback = 0;
+- rolled-back canary event retained in ledger = 1.
+
+Two implementation defects were caught fail-closed before unsafe expansion:
+
+1. dynamic SQL quoting in the first canary call — transaction aborted before mutation and canonical fingerprint stayed unchanged;
+2. legacy one-active-event-per-cluster index during the first 50-field expansion attempt — whole attempted batch rolled back; uniqueness was split into legacy cluster scope and v2 `(cluster,field)` scope without weakening idempotency.
+
+## Progressive expansion proof
+
+Successful batch sizes: **10 + 50 + 50 + 50 + 50 + 19 = 229**.
+
+Every successful checkpoint preserved patient count and produced exact event/preview deltas. Final replay processed **0** additional fields and preserved fingerprint `eee5a57717937a4f77049b3aebd8c525`.
 
 ## Mandatory persistence proof
 
@@ -78,7 +99,7 @@ Every data checkpoint requires all three:
 2. direct LIVE persisted readback;
 3. independent invariant query.
 
-F5.4 and F5.5 additionally proved deterministic replay with identical semantic fingerprints across two complete runs.
+REV-F5.6 additionally requires active-session 2FA proof, dry-run proof, exact canary rollback and field-level event/hash consistency.
 
 ## Mandatory REV-F5 closeout sequence
 
@@ -86,10 +107,10 @@ F5.4 and F5.5 additionally proved deterministic replay with identical semantic f
 2. REV-F5.1 exact source ingestion — **PASS**.
 3. REV-F5.2 staging/manifests/replay — **PASS**.
 4. REV-F5.3 identity memberships and preview — **PASS**.
-5. REV-F5.4 MATCH / REVIEW / NEW classification — **PASS**.
+5. REV-F5.4 MATCH / REVIEW / NEW — **PASS**.
 6. REV-F5.5 fill-only enrichment preview — **PASS**.
-7. REV-F5.6 governed Review & Apply with admin+2FA, dry-run, optimistic lock, canary, audit and rollback proof — **BLOCKED PENDING OWNER AUTHORIZATION**.
-8. REV-F5.7 patient → sale → F3 product → F4 payment/revenue/cartera linkage.
+7. REV-F5.6 governed Review & Apply — **PASS**.
+8. REV-F5.7 patient → sale → F3 product → F4 payment/revenue/cartera linkage — **NEXT / UNBLOCKED**.
 9. REV-F5.8 real transaction coverage for 2024–2025; prohibit unsupported YoY.
 10. REV-F5.9 numeric Coverage & Data Quality Report.
 11. REV-F5.10 independent exact-head/live final certification; only then can REV-F6 be unblocked.
@@ -99,15 +120,14 @@ F5.4 and F5.5 additionally proved deterministic replay with identical semantic f
 - no merge by name alone;
 - phone alone does not authorize merge;
 - canonical strong-field contradiction blocks MATCH;
-- canonical target collision blocks automatic MATCH;
-- no overwrite of populated canonical fields through F5.5;
-- source patient ID and HC remain source-specific unless proven otherwise;
-- `Último presupuesto` is evidence only;
-- `ADELANTO` is payment evidence only;
-- clinical notes/allergies stay outside automatic commercial enrichment;
+- target collision blocks MATCH;
+- no overwrite of populated canonical fields;
+- no Apply to identity anchors or blocked fields in F5.6;
+- clinical notes/allergies stay outside commercial enrichment;
+- `Último presupuesto` remains evidence only;
+- `ADELANTO` remains payment evidence only;
 - every retry reconciles persisted state first;
-- no competing HIGH/CRITICAL migrations/imports/canaries;
-- no Review/Apply before REV-F5.6 governance authorization.
+- no competing HIGH/CRITICAL mutable workstream.
 
 ## Cross-domain boundary
 

--- a/docs/control/REV_F5_6_REVIEW_APPLY_CERTIFICATE_20260819.md
+++ b/docs/control/REV_F5_6_REVIEW_APPLY_CERTIFICATE_20260819.md
@@ -1,0 +1,208 @@
+# REV-F5.6 — REVIEW & APPLY CERTIFICATE
+
+**Captured:** 2026-08-19 America/Lima  
+**Workstream:** `REV-F5-CLOSEOUT`  
+**Entry GitHub baseline:** `main@3c208712e136b4618b6618b7044096811b273f74`  
+**Scope:** governed fill-only enrichment Apply for LOW-risk fields only. Identity merge, overwrite, patient creation, clinical enrichment and blocked/undefined semantics remain out of scope.
+
+## Entry and CURRENT revalidation
+
+REV-F5.6 started from the certified REV-F5.5 state with 15,498 source rows, 15,498 identity memberships, 8,716 clusters, 296 MATCH / 6,984 REVIEW / 1,436 NEW, 455 enrichment previews and zero F5 Apply events.
+
+Before the first canary, `aos_pacientes` moved externally from 7,687 to **7,688** while F5 still had zero reviewed/applied previews and zero Apply events. The loop therefore stopped before mutation and rebuilt/revalidated REV-F5.3 → REV-F5.4 → REV-F5.5 against CURRENT.
+
+Rebaseline result:
+
+- source rows / members = **15,498 / 15,498**;
+- clusters = **8,716**;
+- MATCH / REVIEW / NEW = **296 / 6,984 / 1,436**;
+- unsafe AUTO reclassified = **112**;
+- enrichment previews = **455** across **202** MATCH patients;
+- CURRENT canonical patients = **7,688**;
+- pre-Apply canonical fingerprint = `7ee00cb855f253c52c464b1d49eec289`;
+- no F5 canonical mutation during rebaseline.
+
+The new external patient did not change F5.4 classification counts or the F5.5 proposal count.
+
+## Governance hardening
+
+REV-F5.6 found two legacy contract gaps before production Apply:
+
+1. the v1 admin assertion only proved that the user profile had `two_factor=true`; it did not prove a live 2FA-authenticated session;
+2. the v1 Apply path was cluster-patch oriented and required literal `conflicts={}`, incompatible with the conservative F5.4 classification layer (0/296 current MATCH rows had an empty conflict JSON even though all 296 were safe under F5.4 booleans).
+
+REV-F5.6 therefore introduced a field-level v2 path that reuses the existing F5 classification, enrichment preview and canonical Apply-event ledger.
+
+Mutation functions now require:
+
+- active admin user;
+- hierarchy level 1;
+- `two_factor=true`;
+- a non-revoked, non-expired `aos_app_sessions_v3` session with `assurance_level='PASSWORD_2FA'`;
+- service-role transport only (`anon=false`, `authenticated=false`, `service_role=true`);
+- REV-F5.4 `MATCH` with no canonical/source strong conflict, target collision or missing target;
+- F5.5 one-value provenance;
+- explicit field review;
+- LOW-risk live policy;
+- canonical field still empty;
+- optimistic review snapshot hash.
+
+## Final field policy
+
+The existing risk vocabulary was preserved: `LOW / MEDIUM / IDENTITY_ANCHOR / BLOCKED`.
+
+Apply-allowed in REV-F5.6:
+
+- `Sexo` — LOW;
+- `distrito` — LOW;
+- `departamento` — LOW;
+- `ciudad` — LOW.
+
+Blocked in REV-F5.6:
+
+- `Email` — IDENTITY_ANCHOR;
+- `N° documento` — IDENTITY_ANCHOR;
+- `Teléfono` — IDENTITY_ANCHOR;
+- `Fecha de nacimiento` — BLOCKED;
+- `Dirección` — MEDIUM / not apply-allowed;
+- `Ocupación` — MEDIUM / not apply-allowed;
+- acquisition-source mappings — BLOCKED pending semantic contract;
+- latest-visit mappings — BLOCKED pending semantic contract;
+- clinical/free-text fields — BLOCKED.
+
+After policy finalization, the 455 previews split into:
+
+- **229 APPLY_ALLOWED**;
+- **226 POLICY_BLOCKED**;
+- **0 POLICY_UNDEFINED**.
+
+The F5.5 invariant `apply_eligible=false` was evolved conservatively: `apply_eligible=true` is now permitted only after `APPROVE_FIELD`, with actor, timestamp, snapshot hash, LOW policy and one of the four allowlisted fields.
+
+## Dry-run and canary
+
+A single deterministic `Sexo` field was reviewed under an active `PASSWORD_2FA` admin session.
+
+Dry-run result:
+
+- mode = `DRY_RUN`;
+- scope = `CANARY`;
+- review snapshot hash = `802c77e0991fce2f38311e011a434703f2e198a97c045c82633f222c42143065`;
+- target row before hash = `7ccfca60d309dfdd5936e0d98fae43924947b06384327979ac08737448d99df4`;
+- canonical global fingerprint remained `7ee00cb855f253c52c464b1d49eec289`;
+- Apply events remained 0.
+
+### Fail-closed repair 1
+
+The first real canary call exposed a dynamic-SQL quoting defect before the UPDATE could execute. PostgreSQL aborted the transaction. Readback proved:
+
+- canonical fingerprint unchanged;
+- Apply events = 0;
+- applied previews = 0.
+
+The field UPDATE was repaired to use the patient row already held `FOR UPDATE`; the redundant dynamic emptiness predicate was removed. A second dry-run returned the exact same snapshot and row hashes.
+
+### Canary Apply
+
+The repaired canary produced exactly one field mutation and one event:
+
+- field = `Sexo`;
+- scope = `CANARY`;
+- before row hash = `7ccfca60d309dfdd5936e0d98fae43924947b06384327979ac08737448d99df4`;
+- after row hash = `90521400b8c1598e3a21f073ea78f43838e8471fbaef82a8b034e8ba37b5a103`;
+- one active canary event;
+- one applied preview;
+- zero current/after mismatches.
+
+## Mandatory rollback proof
+
+The canary was rolled back immediately before any expansion.
+
+Rollback result:
+
+- rollback row hash = `7ccfca60d309dfdd5936e0d98fae43924947b06384327979ac08737448d99df4`;
+- rollback hash equals exact before hash;
+- canonical global fingerprint returned exactly to `7ee00cb855f253c52c464b1d49eec289`;
+- active Apply events returned to 0;
+- applied previews returned to 0;
+- the canary event remains in the private ledger with `rolled_back_at` populated.
+
+Result: **APPLY → VERIFY → ROLLBACK EXACT PASS**.
+
+## Progressive LOW-risk expansion
+
+After rollback proof, expansion was limited to the 229 policy-allowed preview fields. Every field was processed sequentially as:
+
+`active admin+2FA → field review → fresh snapshot → locked-row Apply → event ledger → invariant readback`.
+
+Successful progressive batch sizes:
+
+- 10;
+- 50;
+- 50;
+- 50;
+- 50;
+- 19.
+
+### Fail-closed repair 2
+
+An attempted 50-field batch after the initial 10 exposed a legacy unique index allowing only one active event per cluster. The entire attempted batch rolled back atomically; the prior 10 remained intact.
+
+The ledger uniqueness contract was split without weakening idempotency:
+
+- legacy v1 events (`field_name IS NULL`) keep one active event per cluster;
+- v2 field events use one active event per `(cluster_id, field_name)`.
+
+The repaired 50-field batch then passed.
+
+## Final LIVE result
+
+- canonical patients = **7,688**;
+- final canonical fingerprint = `eee5a57717937a4f77049b3aebd8c525`;
+- total F5 Apply events = **230**;
+- active events = **229**;
+- rolled-back events = **1** (mandatory canary);
+- active batch events = **229**;
+- applied enrichment previews = **229**;
+- remaining LOW-risk unapplied previews = **0**;
+- blocked previews left unapplied = **226**;
+- active events outside allowlist = **0**;
+- invalid before/after hash events = **0**;
+- current canonical vs. event `after_patch` mismatches = **0**;
+- event ↔ preview mismatches = **0**;
+- applied policy/review violations = **0**;
+- applied-without-event rows = **0**;
+- legacy cluster-level link preview applied rows = **0**.
+
+Applied field distribution:
+
+| Field | Active applied fields |
+|---|---:|
+| `Sexo` | **121** |
+| `distrito` | **108** |
+| `departamento` | **0** |
+| `ciudad` | **0** |
+| **TOTAL** | **229** |
+
+Identity/staging invariants remain:
+
+- source rows = **15,498**;
+- identity members = **15,498**;
+- F5.4 MATCH / REVIEW / NEW = **296 / 6,984 / 1,436**.
+
+A final replay of the LOW-risk batch engine returned:
+
+- `processed=0`;
+- active events before/after = **229 / 229**;
+- applied previews before/after = **229 / 229**;
+- canonical fingerprint before/after = `eee5a57717937a4f77049b3aebd8c525`.
+
+Result: **IDEMPOTENT REPLAY PASS**.
+
+## Gate result
+
+- `REV-F5.6 — REVIEW & APPLY — PASS`
+- `REV-F5.7 — HISTORICAL JOIN — UNBLOCKED / NOT STARTED`
+- overall `REV-F5 — EN CURSO / NOT YET PRODUCTION CERTIFIED`
+- `REV-F6 — BLOCKED`
+
+This certificate authorizes no additional field classes beyond the 229 LOW-risk fills already applied. The 226 blocked previews remain governed evidence only until a later explicit contract changes their policy.

--- a/supabase/migrations/20260820002000_rev_f5_6_review_apply_v2.sql
+++ b/supabase/migrations/20260820002000_rev_f5_6_review_apply_v2.sql
@@ -22,9 +22,8 @@ create unique index if not exists aos_f5_one_active_field_apply_v2
   on public.aos_f5_canonical_apply_events_v1(cluster_id,field_name)
   where field_name is not null and rolled_back_at is null;
 
--- Final conservative field policy for REV-F5.6.
--- Only LOW-risk profile fields are eligible for this phase. Identity anchors,
--- potentially stale profile data and semantically unresolved mappings stay blocked.
+-- Existing risk-class contract is intentionally preserved:
+-- LOW / MEDIUM / IDENTITY_ANCHOR / BLOCKED.
 insert into public.aos_f5_apply_field_policy_v1(field_name,risk_class,apply_allowed,notes)
 values
   ('Sexo','LOW',true,'REV-F5.6 fill-only after explicit field review; canonical must still be empty'),
@@ -34,22 +33,21 @@ values
   ('Email','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity anchor requires a later dedicated contract'),
   ('N° documento','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity anchor requires a later dedicated contract'),
   ('Teléfono','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity/contact anchor requires a later dedicated contract'),
-  ('Fecha de nacimiento','IDENTITY_SENSITIVE',false,'Blocked in REV-F5.6; identity-sensitive field'),
-  ('Dirección','STALE_PROFILE',false,'Blocked in REV-F5.6; historical address may be stale'),
-  ('Ocupación','STALE_PROFILE',false,'Blocked in REV-F5.6; historical occupation may be stale'),
-  ('FUENTE','SEMANTIC_UNMAPPED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
-  ('fuente_datos','SEMANTIC_UNMAPPED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
-  ('ULTIMA_VISITA','SEMANTIC_UNMAPPED',false,'Blocked until latest-appointment canonical semantics are defined'),
-  ('ult_visita','SEMANTIC_UNMAPPED',false,'Blocked until latest-appointment canonical semantics are defined'),
-  ('NOTAS','CLINICAL_EXCLUDED',false,'Clinical/free-text notes are excluded from automatic commercial enrichment'),
-  ('Alergias','CLINICAL_EXCLUDED',false,'Clinical allergy data is excluded from automatic commercial enrichment')
+  ('Fecha de nacimiento','BLOCKED',false,'Blocked in REV-F5.6; identity-sensitive field'),
+  ('Dirección','MEDIUM',false,'Blocked in REV-F5.6; historical address may be stale'),
+  ('Ocupación','MEDIUM',false,'Blocked in REV-F5.6; historical occupation may be stale'),
+  ('FUENTE','BLOCKED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
+  ('fuente_datos','BLOCKED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
+  ('ULTIMA_VISITA','BLOCKED',false,'Blocked until latest-appointment canonical semantics are defined'),
+  ('ult_visita','BLOCKED',false,'Blocked until latest-appointment canonical semantics are defined'),
+  ('NOTAS','BLOCKED',false,'Clinical/free-text notes are excluded from automatic commercial enrichment'),
+  ('Alergias','BLOCKED',false,'Clinical allergy data is excluded from automatic commercial enrichment')
 on conflict (field_name) do update
 set risk_class=excluded.risk_class,
     apply_allowed=excluded.apply_allowed,
     notes=excluded.notes,
     updated_at=now();
 
--- Refresh the F5.5 policy snapshot without changing proposed values or provenance.
 update public.aos_f5_enrichment_preview_v1 e
 set policy_state=case when fp.apply_allowed then 'APPLY_ALLOWED' else 'POLICY_BLOCKED' end,
     policy_risk_class=fp.risk_class,
@@ -364,8 +362,6 @@ begin
 end
 $$;
 
--- Browser roles never receive mutation capability. Service role remains the sole transport;
--- the functions themselves additionally require an active PASSWORD_2FA admin session.
 revoke all on function public.aos_f5_assert_active_admin_2fa_v2(uuid) from public,anon,authenticated;
 revoke all on function public.aos_f5_review_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) from public,anon,authenticated;
 revoke all on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) from public,anon,authenticated;
@@ -375,11 +371,10 @@ grant execute on function public.aos_f5_review_enrichment_field_v2(uuid,text,uui
 grant execute on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) to service_role;
 grant execute on function public.aos_f5_rollback_enrichment_field_v2(uuid,uuid,text) to service_role;
 
--- Freeze legacy mutators behind service role; F5.6 certification uses only v2 field functions.
+-- Legacy mutators stay server-only; REV-F5.6 certification uses v2 field functions.
 revoke all on function public.aos_f5_review_decision_v1(uuid,uuid,text,text,timestamptz) from public,anon,authenticated;
 revoke all on function public.aos_f5_apply_reviewed_patch_v1(uuid,uuid,timestamptz,text) from public,anon,authenticated;
 revoke all on function public.aos_f5_rollback_apply_v1(uuid,uuid,text) from public,anon,authenticated;
-
 grant execute on function public.aos_f5_review_decision_v1(uuid,uuid,text,text,timestamptz) to service_role;
 grant execute on function public.aos_f5_apply_reviewed_patch_v1(uuid,uuid,timestamptz,text) to service_role;
 grant execute on function public.aos_f5_rollback_apply_v1(uuid,uuid,text) to service_role;

--- a/supabase/migrations/20260820002000_rev_f5_6_review_apply_v2.sql
+++ b/supabase/migrations/20260820002000_rev_f5_6_review_apply_v2.sql
@@ -1,0 +1,398 @@
+-- REV-F5.6 — Review & Apply v2
+-- Field-level, fill-only, active-admin-2FA gated, optimistic and reversible.
+-- Reuses F5 classification, enrichment preview and canonical apply-event ledger.
+
+alter table public.aos_f5_enrichment_preview_v1
+  add column if not exists review_decision text,
+  add column if not exists review_reason text,
+  add column if not exists reviewed_by uuid,
+  add column if not exists reviewed_at timestamptz,
+  add column if not exists reviewed_snapshot_hash text,
+  add column if not exists applied_at timestamptz,
+  add column if not exists apply_event_id uuid;
+
+alter table public.aos_f5_canonical_apply_events_v1
+  add column if not exists field_name text,
+  add column if not exists canonical_before_hash text,
+  add column if not exists canonical_after_hash text,
+  add column if not exists rollback_after_hash text,
+  add column if not exists apply_scope text not null default 'LEGACY';
+
+create unique index if not exists aos_f5_one_active_field_apply_v2
+  on public.aos_f5_canonical_apply_events_v1(cluster_id,field_name)
+  where field_name is not null and rolled_back_at is null;
+
+-- Final conservative field policy for REV-F5.6.
+-- Only LOW-risk profile fields are eligible for this phase. Identity anchors,
+-- potentially stale profile data and semantically unresolved mappings stay blocked.
+insert into public.aos_f5_apply_field_policy_v1(field_name,risk_class,apply_allowed,notes)
+values
+  ('Sexo','LOW',true,'REV-F5.6 fill-only after explicit field review; canonical must still be empty'),
+  ('distrito','LOW',true,'REV-F5.6 fill-only after explicit field review; canonical must still be empty'),
+  ('departamento','LOW',true,'REV-F5.6 fill-only after explicit field review; canonical must still be empty'),
+  ('ciudad','LOW',true,'REV-F5.6 fill-only after explicit field review; canonical must still be empty'),
+  ('Email','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity anchor requires a later dedicated contract'),
+  ('N° documento','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity anchor requires a later dedicated contract'),
+  ('Teléfono','IDENTITY_ANCHOR',false,'Blocked in REV-F5.6; identity/contact anchor requires a later dedicated contract'),
+  ('Fecha de nacimiento','IDENTITY_SENSITIVE',false,'Blocked in REV-F5.6; identity-sensitive field'),
+  ('Dirección','STALE_PROFILE',false,'Blocked in REV-F5.6; historical address may be stale'),
+  ('Ocupación','STALE_PROFILE',false,'Blocked in REV-F5.6; historical occupation may be stale'),
+  ('FUENTE','SEMANTIC_UNMAPPED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
+  ('fuente_datos','SEMANTIC_UNMAPPED',false,'Blocked until historical acquisition-channel mapping is contractually defined'),
+  ('ULTIMA_VISITA','SEMANTIC_UNMAPPED',false,'Blocked until latest-appointment canonical semantics are defined'),
+  ('ult_visita','SEMANTIC_UNMAPPED',false,'Blocked until latest-appointment canonical semantics are defined'),
+  ('NOTAS','CLINICAL_EXCLUDED',false,'Clinical/free-text notes are excluded from automatic commercial enrichment'),
+  ('Alergias','CLINICAL_EXCLUDED',false,'Clinical allergy data is excluded from automatic commercial enrichment')
+on conflict (field_name) do update
+set risk_class=excluded.risk_class,
+    apply_allowed=excluded.apply_allowed,
+    notes=excluded.notes,
+    updated_at=now();
+
+-- Refresh the F5.5 policy snapshot without changing proposed values or provenance.
+update public.aos_f5_enrichment_preview_v1 e
+set policy_state=case when fp.apply_allowed then 'APPLY_ALLOWED' else 'POLICY_BLOCKED' end,
+    policy_risk_class=fp.risk_class,
+    policy_apply_allowed=fp.apply_allowed,
+    apply_eligible=false,
+    requires_human=true
+from public.aos_f5_apply_field_policy_v1 fp
+where fp.field_name=e.field_name;
+
+create or replace function public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+begin
+  if p_actor_user_id is null or not exists (
+    select 1
+    from public.aos_usuarios u
+    where u.id=p_actor_user_id
+      and u.activo is true
+      and lower(coalesce(u.rol,''))='admin'
+      and u.nivel_jerarquia=1
+      and u.two_factor is true
+  ) then
+    raise exception 'F5_6_ACTIVE_ADMIN_2FA_REQUIRED';
+  end if;
+
+  if not exists (
+    select 1
+    from public.aos_app_sessions_v3 s
+    where s.user_id=p_actor_user_id
+      and s.revoked=false
+      and s.expires_at>now()
+      and s.assurance_level='PASSWORD_2FA'
+  ) then
+    raise exception 'F5_6_ACTIVE_2FA_SESSION_REQUIRED';
+  end if;
+end
+$$;
+
+create or replace function public.aos_f5_review_enrichment_field_v2(
+  p_cluster_id uuid,
+  p_field_name text,
+  p_actor_user_id uuid,
+  p_expected_generated_at timestamptz,
+  p_decision text,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  e public.aos_f5_enrichment_preview_v1%rowtype;
+  c public.aos_f5_canonical_classification_v1%rowtype;
+  fp public.aos_f5_apply_field_policy_v1%rowtype;
+  v_decision text:=upper(coalesce(p_decision,''));
+  v_reason text:=nullif(btrim(coalesce(p_reason,'')),'');
+  v_patient jsonb;
+  v_current jsonb;
+  v_canonical_hash text;
+  v_review_hash text;
+  v_target_hash text;
+begin
+  perform public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id);
+  if v_decision not in ('APPROVE_FIELD','REJECT_FIELD','DEFER') then raise exception 'F5_6_INVALID_REVIEW_DECISION'; end if;
+
+  select * into e
+  from public.aos_f5_enrichment_preview_v1
+  where cluster_id=p_cluster_id and field_name=p_field_name
+  for update;
+  if not found then raise exception 'F5_6_ENRICHMENT_PREVIEW_NOT_FOUND'; end if;
+  if p_expected_generated_at is null or e.generated_at<>p_expected_generated_at then raise exception 'F5_6_STALE_ENRICHMENT_PREVIEW'; end if;
+  if e.applied_at is not null then raise exception 'F5_6_FIELD_ALREADY_APPLIED'; end if;
+  if e.source_distinct_values<>1 or cardinality(e.source_row_ids)=0 or not e.canonical_empty or not e.requires_human then raise exception 'F5_6_PREVIEW_SAFETY_INVALID'; end if;
+
+  select * into c from public.aos_f5_canonical_classification_v1 where cluster_id=e.cluster_id;
+  if c.classification<>'MATCH' or c.target_patient_id is distinct from e.target_patient_id
+     or c.canonical_dni_conflict or c.canonical_email_conflict or c.canonical_dob_conflict or c.canonical_sex_conflict
+     or c.target_missing or c.target_collision or c.source_strong_conflict then
+    raise exception 'F5_6_MATCH_SAFETY_INVALID';
+  end if;
+
+  select * into fp from public.aos_f5_apply_field_policy_v1 where field_name=e.field_name;
+  if not found then raise exception 'F5_6_FIELD_POLICY_MISSING'; end if;
+
+  if v_decision='APPROVE_FIELD' then
+    if not fp.apply_allowed or fp.risk_class<>'LOW' or e.field_name not in ('Sexo','distrito','departamento','ciudad') then
+      raise exception 'F5_6_FIELD_NOT_APPROVABLE';
+    end if;
+    if coalesce(length(v_reason),0)<20 then raise exception 'F5_6_APPROVAL_REASON_REQUIRED'; end if;
+  elsif v_decision='REJECT_FIELD' and coalesce(length(v_reason),0)<10 then
+    raise exception 'F5_6_REJECTION_REASON_REQUIRED';
+  end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=e.target_patient_id;
+  if v_patient is null then raise exception 'F5_6_TARGET_PATIENT_NOT_FOUND'; end if;
+  v_current:=v_patient->e.field_name;
+  if v_decision='APPROVE_FIELD' and v_current is not null and v_current<>'null'::jsonb and nullif(btrim(v_current#>>'{}'),'') is not null then
+    raise exception 'F5_6_CANONICAL_FIELD_NOT_EMPTY';
+  end if;
+
+  v_canonical_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  v_review_hash:=encode(extensions.digest(convert_to(jsonb_build_object(
+    'cluster_id',e.cluster_id,
+    'target_patient_id',e.target_patient_id,
+    'field_name',e.field_name,
+    'proposed_value',e.proposed_value,
+    'source_row_ids',to_jsonb(e.source_row_ids),
+    'source_distinct_values',e.source_distinct_values,
+    'policy_updated_at',fp.updated_at,
+    'canonical_hash',v_canonical_hash
+  )::text,'UTF8'),'sha256'),'hex');
+  v_target_hash:=encode(extensions.digest(convert_to(e.target_patient_id,'UTF8'),'sha256'),'hex');
+
+  update public.aos_f5_enrichment_preview_v1
+  set review_decision=v_decision,
+      review_reason=v_reason,
+      reviewed_by=case when v_decision='DEFER' then null else p_actor_user_id end,
+      reviewed_at=case when v_decision='DEFER' then null else now() end,
+      reviewed_snapshot_hash=case when v_decision='DEFER' then null else v_review_hash end,
+      apply_eligible=case when v_decision='APPROVE_FIELD' then true else false end
+  where cluster_id=e.cluster_id and field_name=e.field_name;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,actor_user_id,details)
+  values('ENRICHMENT_FIELD_REVIEWED','F5_ENRICHMENT_FIELD',e.cluster_id::text||':'||e.field_name,p_actor_user_id,
+    jsonb_build_object('decision',v_decision,'field_name',e.field_name,'target_hash',v_target_hash,'review_snapshot_hash',v_review_hash,'policy_risk_class',fp.risk_class,'policy_apply_allowed',fp.apply_allowed));
+
+  return jsonb_build_object('ok',true,'decision',v_decision,'field_name',e.field_name,'target_hash',v_target_hash,'review_snapshot_hash',v_review_hash);
+end
+$$;
+
+create or replace function public.aos_f5_apply_enrichment_field_v2(
+  p_cluster_id uuid,
+  p_field_name text,
+  p_actor_user_id uuid,
+  p_expected_reviewed_at timestamptz,
+  p_mode text default 'DRY_RUN',
+  p_scope text default 'CANARY'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  e public.aos_f5_enrichment_preview_v1%rowtype;
+  c public.aos_f5_canonical_classification_v1%rowtype;
+  fp public.aos_f5_apply_field_policy_v1%rowtype;
+  v_mode text:=upper(coalesce(p_mode,'DRY_RUN'));
+  v_scope text:=upper(coalesce(p_scope,'CANARY'));
+  v_patient jsonb;
+  v_current jsonb;
+  v_before_hash text;
+  v_after_hash text;
+  v_review_hash text;
+  v_target_hash text;
+  v_value_hash text;
+  v_event uuid;
+  v_rows integer;
+  v_sql text;
+begin
+  perform public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id);
+  if v_mode not in ('DRY_RUN','APPLY') then raise exception 'F5_6_INVALID_APPLY_MODE'; end if;
+  if v_scope not in ('CANARY','BATCH') then raise exception 'F5_6_INVALID_APPLY_SCOPE'; end if;
+
+  select * into e
+  from public.aos_f5_enrichment_preview_v1
+  where cluster_id=p_cluster_id and field_name=p_field_name
+  for update;
+  if not found then raise exception 'F5_6_ENRICHMENT_PREVIEW_NOT_FOUND'; end if;
+  if e.review_decision<>'APPROVE_FIELD' or e.reviewed_by is distinct from p_actor_user_id or e.reviewed_at is null then raise exception 'F5_6_APPROVED_REVIEW_REQUIRED'; end if;
+  if p_expected_reviewed_at is null or e.reviewed_at<>p_expected_reviewed_at then raise exception 'F5_6_STALE_REVIEW'; end if;
+  if e.applied_at is not null then
+    return jsonb_build_object('ok',true,'idempotent',true,'field_name',e.field_name,'event_id',e.apply_event_id,'applied',true);
+  end if;
+  if not e.apply_eligible or e.source_distinct_values<>1 or cardinality(e.source_row_ids)=0 or not e.canonical_empty then raise exception 'F5_6_PREVIEW_NOT_APPLY_ELIGIBLE'; end if;
+
+  select * into c from public.aos_f5_canonical_classification_v1 where cluster_id=e.cluster_id;
+  if c.classification<>'MATCH' or c.target_patient_id is distinct from e.target_patient_id
+     or c.canonical_dni_conflict or c.canonical_email_conflict or c.canonical_dob_conflict or c.canonical_sex_conflict
+     or c.target_missing or c.target_collision or c.source_strong_conflict then
+    raise exception 'F5_6_MATCH_SAFETY_INVALID';
+  end if;
+
+  select * into fp from public.aos_f5_apply_field_policy_v1 where field_name=e.field_name;
+  if not found or not fp.apply_allowed or fp.risk_class<>'LOW' or e.field_name not in ('Sexo','distrito','departamento','ciudad') then
+    raise exception 'F5_6_LIVE_POLICY_BLOCKED';
+  end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=e.target_patient_id for update;
+  if v_patient is null then raise exception 'F5_6_TARGET_PATIENT_NOT_FOUND'; end if;
+  v_current:=v_patient->e.field_name;
+  if v_current is not null and v_current<>'null'::jsonb and nullif(btrim(v_current#>>'{}'),'') is not null then raise exception 'F5_6_CANONICAL_FIELD_NOT_EMPTY'; end if;
+
+  v_before_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  v_review_hash:=encode(extensions.digest(convert_to(jsonb_build_object(
+    'cluster_id',e.cluster_id,
+    'target_patient_id',e.target_patient_id,
+    'field_name',e.field_name,
+    'proposed_value',e.proposed_value,
+    'source_row_ids',to_jsonb(e.source_row_ids),
+    'source_distinct_values',e.source_distinct_values,
+    'policy_updated_at',fp.updated_at,
+    'canonical_hash',v_before_hash
+  )::text,'UTF8'),'sha256'),'hex');
+  if e.reviewed_snapshot_hash is null or e.reviewed_snapshot_hash<>v_review_hash then raise exception 'F5_6_REVIEW_SNAPSHOT_CHANGED'; end if;
+
+  v_target_hash:=encode(extensions.digest(convert_to(e.target_patient_id,'UTF8'),'sha256'),'hex');
+  v_value_hash:=encode(extensions.digest(convert_to(e.proposed_value,'UTF8'),'sha256'),'hex');
+
+  if v_mode='DRY_RUN' then
+    return jsonb_build_object('ok',true,'mode','DRY_RUN','scope',v_scope,'field_name',e.field_name,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'review_snapshot_hash',v_review_hash);
+  end if;
+
+  v_sql:=format('update public.aos_pacientes set %I=$1 where "ID_PACIENTE"=$2 and nullif(btrim(coalesce(%I,'')),'''') is null',e.field_name,e.field_name);
+  execute v_sql using e.proposed_value,e.target_patient_id;
+  get diagnostics v_rows=row_count;
+  if v_rows<>1 then raise exception 'F5_6_CONCURRENT_CANONICAL_CHANGE'; end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=e.target_patient_id;
+  v_after_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  if v_after_hash=v_before_hash then raise exception 'F5_6_APPLY_HASH_UNCHANGED'; end if;
+
+  insert into public.aos_f5_canonical_apply_events_v1(
+    cluster_id,target_patient_id,actor_user_id,before_patch,applied_patch,after_patch,preview_snapshot_hash,
+    field_name,canonical_before_hash,canonical_after_hash,apply_scope
+  ) values(
+    e.cluster_id,e.target_patient_id,p_actor_user_id,
+    jsonb_build_object(e.field_name,coalesce(v_current,'null'::jsonb)),
+    jsonb_build_object(e.field_name,e.proposed_value),
+    jsonb_build_object(e.field_name,e.proposed_value),
+    v_review_hash,e.field_name,v_before_hash,v_after_hash,v_scope
+  ) returning id into v_event;
+
+  update public.aos_f5_enrichment_preview_v1
+  set applied_at=now(),apply_event_id=v_event
+  where cluster_id=e.cluster_id and field_name=e.field_name;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,actor_user_id,details)
+  values('ENRICHMENT_FIELD_APPLIED','F5_ENRICHMENT_FIELD',e.cluster_id::text||':'||e.field_name,p_actor_user_id,
+    jsonb_build_object('event_id',v_event,'scope',v_scope,'field_name',e.field_name,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'canonical_after_hash',v_after_hash,'review_snapshot_hash',v_review_hash));
+
+  return jsonb_build_object('ok',true,'mode','APPLY','scope',v_scope,'field_name',e.field_name,'event_id',v_event,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'canonical_after_hash',v_after_hash);
+end
+$$;
+
+create or replace function public.aos_f5_rollback_enrichment_field_v2(
+  p_event_id uuid,
+  p_actor_user_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  ev public.aos_f5_canonical_apply_events_v1%rowtype;
+  v_patient jsonb;
+  v_current jsonb;
+  v_expected jsonb;
+  v_current_hash text;
+  v_rollback_hash text;
+  v_target_hash text;
+  v_sql text;
+  v_rows integer;
+begin
+  perform public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id);
+  if coalesce(length(btrim(coalesce(p_reason,''))),0)<20 then raise exception 'F5_6_ROLLBACK_REASON_REQUIRED'; end if;
+
+  select * into ev from public.aos_f5_canonical_apply_events_v1 where id=p_event_id for update;
+  if not found then raise exception 'F5_6_APPLY_EVENT_NOT_FOUND'; end if;
+  if ev.field_name is null or ev.canonical_before_hash is null or ev.canonical_after_hash is null then raise exception 'F5_6_NOT_A_V2_FIELD_EVENT'; end if;
+  if ev.rolled_back_at is not null then return jsonb_build_object('ok',true,'idempotent',true,'rolled_back',true,'event_id',p_event_id); end if;
+  if ev.field_name not in ('Sexo','distrito','departamento','ciudad') then raise exception 'F5_6_ROLLBACK_FIELD_INVALID'; end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=ev.target_patient_id for update;
+  if v_patient is null then raise exception 'F5_6_TARGET_PATIENT_NOT_FOUND'; end if;
+  v_current_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  if v_current_hash<>ev.canonical_after_hash then raise exception 'F5_6_ROLLBACK_BLOCKED_BY_NEWER_ROW_CHANGE'; end if;
+
+  v_current:=v_patient->ev.field_name;
+  v_expected:=ev.after_patch->ev.field_name;
+  if v_current is distinct from v_expected then raise exception 'F5_6_ROLLBACK_BLOCKED_BY_NEWER_FIELD_CHANGE'; end if;
+
+  v_sql:=format('update public.aos_pacientes set %I=$1 where "ID_PACIENTE"=$2',ev.field_name);
+  execute v_sql using (ev.before_patch->>ev.field_name),ev.target_patient_id;
+  get diagnostics v_rows=row_count;
+  if v_rows<>1 then raise exception 'F5_6_ROLLBACK_TARGET_UPDATE_FAILED'; end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=ev.target_patient_id;
+  v_rollback_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  if v_rollback_hash<>ev.canonical_before_hash then raise exception 'F5_6_ROLLBACK_HASH_MISMATCH'; end if;
+
+  update public.aos_f5_canonical_apply_events_v1
+  set rolled_back_at=now(),rolled_back_by=p_actor_user_id,rollback_reason=btrim(p_reason),rollback_after_hash=v_rollback_hash
+  where id=ev.id;
+
+  update public.aos_f5_enrichment_preview_v1
+  set applied_at=null,apply_event_id=null
+  where cluster_id=ev.cluster_id and field_name=ev.field_name and apply_event_id=ev.id;
+
+  v_target_hash:=encode(extensions.digest(convert_to(ev.target_patient_id,'UTF8'),'sha256'),'hex');
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,actor_user_id,details)
+  values('ENRICHMENT_FIELD_ROLLED_BACK','F5_ENRICHMENT_FIELD',ev.cluster_id::text||':'||ev.field_name,p_actor_user_id,
+    jsonb_build_object('event_id',ev.id,'scope',ev.apply_scope,'field_name',ev.field_name,'target_hash',v_target_hash,'canonical_after_hash',ev.canonical_after_hash,'rollback_after_hash',v_rollback_hash,'reason',btrim(p_reason)));
+
+  return jsonb_build_object('ok',true,'rolled_back',true,'event_id',ev.id,'scope',ev.apply_scope,'field_name',ev.field_name,'target_hash',v_target_hash,'rollback_after_hash',v_rollback_hash);
+end
+$$;
+
+-- Browser roles never receive mutation capability. Service role remains the sole transport;
+-- the functions themselves additionally require an active PASSWORD_2FA admin session.
+revoke all on function public.aos_f5_assert_active_admin_2fa_v2(uuid) from public,anon,authenticated;
+revoke all on function public.aos_f5_review_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) from public,anon,authenticated;
+revoke all on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) from public,anon,authenticated;
+revoke all on function public.aos_f5_rollback_enrichment_field_v2(uuid,uuid,text) from public,anon,authenticated;
+grant execute on function public.aos_f5_assert_active_admin_2fa_v2(uuid) to service_role;
+grant execute on function public.aos_f5_review_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) to service_role;
+grant execute on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) to service_role;
+grant execute on function public.aos_f5_rollback_enrichment_field_v2(uuid,uuid,text) to service_role;
+
+-- Freeze legacy mutators behind service role; F5.6 certification uses only v2 field functions.
+revoke all on function public.aos_f5_review_decision_v1(uuid,uuid,text,text,timestamptz) from public,anon,authenticated;
+revoke all on function public.aos_f5_apply_reviewed_patch_v1(uuid,uuid,timestamptz,text) from public,anon,authenticated;
+revoke all on function public.aos_f5_rollback_apply_v1(uuid,uuid,text) from public,anon,authenticated;
+
+grant execute on function public.aos_f5_review_decision_v1(uuid,uuid,text,text,timestamptz) to service_role;
+grant execute on function public.aos_f5_apply_reviewed_patch_v1(uuid,uuid,timestamptz,text) to service_role;
+grant execute on function public.aos_f5_rollback_apply_v1(uuid,uuid,text) to service_role;
+
+insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+values('REVIEW_APPLY_V2_POLICY_INSTALLED','F5','REV-F5.6',jsonb_build_object(
+  'mode','FIELD_LEVEL_FILL_ONLY',
+  'active_admin_2fa_required',true,
+  'optimistic_review_snapshot',true,
+  'canonical_before_after_hashes',true,
+  'rollback_hash_required',true,
+  'allowed_fields',jsonb_build_array('Sexo','distrito','departamento','ciudad'),
+  'identity_anchors_blocked',true,
+  'clinical_fields_blocked',true,
+  'installed_at',now()
+));

--- a/supabase/migrations/20260820002500_rev_f5_6_apply_eligibility_transition.sql
+++ b/supabase/migrations/20260820002500_rev_f5_6_apply_eligibility_transition.sql
@@ -1,0 +1,45 @@
+-- REV-F5.6 transition: F5.5 permanently-false apply eligibility becomes
+-- conditionally true only after a complete approved LOW-risk field review.
+
+alter table public.aos_f5_enrichment_preview_v1
+  drop constraint if exists aos_f5_enrichment_preview_v1_apply_eligible_check;
+
+alter table public.aos_f5_enrichment_preview_v1
+  add constraint aos_f5_enrichment_preview_v1_apply_eligible_check
+  check (
+    apply_eligible is false
+    or (
+      apply_eligible is true
+      and review_decision='APPROVE_FIELD'
+      and reviewed_by is not null
+      and reviewed_at is not null
+      and reviewed_snapshot_hash is not null
+      and policy_apply_allowed is true
+      and policy_risk_class='LOW'
+      and field_name in ('Sexo','distrito','departamento','ciudad')
+    )
+  );
+
+alter table public.aos_f5_enrichment_preview_v1
+  drop constraint if exists aos_f5_enrichment_preview_v1_apply_state_check;
+
+alter table public.aos_f5_enrichment_preview_v1
+  add constraint aos_f5_enrichment_preview_v1_apply_state_check
+  check (
+    (applied_at is null and apply_event_id is null)
+    or (
+      applied_at is not null
+      and apply_event_id is not null
+      and apply_eligible is true
+      and review_decision='APPROVE_FIELD'
+    )
+  );
+
+insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+values('APPLY_ELIGIBILITY_TRANSITION_INSTALLED','F5','REV-F5.6',jsonb_build_object(
+  'default_apply_eligible',false,
+  'requires_approved_review',true,
+  'requires_low_risk_policy',true,
+  'allowed_fields',jsonb_build_array('Sexo','distrito','departamento','ciudad'),
+  'installed_at',now()
+));

--- a/supabase/migrations/20260820003000_rev_f5_6_field_apply_sql_fix.sql
+++ b/supabase/migrations/20260820003000_rev_f5_6_field_apply_sql_fix.sql
@@ -1,0 +1,126 @@
+-- REV-F5.6 repair: the target patient row is already held FOR UPDATE and its
+-- field emptiness has already been verified. Use the locked-row update directly
+-- instead of a redundant dynamically quoted emptiness predicate.
+
+create or replace function public.aos_f5_apply_enrichment_field_v2(
+  p_cluster_id uuid,
+  p_field_name text,
+  p_actor_user_id uuid,
+  p_expected_reviewed_at timestamptz,
+  p_mode text default 'DRY_RUN',
+  p_scope text default 'CANARY'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  e public.aos_f5_enrichment_preview_v1%rowtype;
+  c public.aos_f5_canonical_classification_v1%rowtype;
+  fp public.aos_f5_apply_field_policy_v1%rowtype;
+  v_mode text:=upper(coalesce(p_mode,'DRY_RUN'));
+  v_scope text:=upper(coalesce(p_scope,'CANARY'));
+  v_patient jsonb;
+  v_current jsonb;
+  v_before_hash text;
+  v_after_hash text;
+  v_review_hash text;
+  v_target_hash text;
+  v_value_hash text;
+  v_event uuid;
+  v_rows integer;
+  v_sql text;
+begin
+  perform public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id);
+  if v_mode not in ('DRY_RUN','APPLY') then raise exception 'F5_6_INVALID_APPLY_MODE'; end if;
+  if v_scope not in ('CANARY','BATCH') then raise exception 'F5_6_INVALID_APPLY_SCOPE'; end if;
+
+  select * into e
+  from public.aos_f5_enrichment_preview_v1
+  where cluster_id=p_cluster_id and field_name=p_field_name
+  for update;
+  if not found then raise exception 'F5_6_ENRICHMENT_PREVIEW_NOT_FOUND'; end if;
+  if e.review_decision<>'APPROVE_FIELD' or e.reviewed_by is distinct from p_actor_user_id or e.reviewed_at is null then raise exception 'F5_6_APPROVED_REVIEW_REQUIRED'; end if;
+  if p_expected_reviewed_at is null or e.reviewed_at<>p_expected_reviewed_at then raise exception 'F5_6_STALE_REVIEW'; end if;
+  if e.applied_at is not null then return jsonb_build_object('ok',true,'idempotent',true,'field_name',e.field_name,'event_id',e.apply_event_id,'applied',true); end if;
+  if not e.apply_eligible or e.source_distinct_values<>1 or cardinality(e.source_row_ids)=0 or not e.canonical_empty then raise exception 'F5_6_PREVIEW_NOT_APPLY_ELIGIBLE'; end if;
+
+  select * into c from public.aos_f5_canonical_classification_v1 where cluster_id=e.cluster_id;
+  if c.classification<>'MATCH' or c.target_patient_id is distinct from e.target_patient_id
+     or c.canonical_dni_conflict or c.canonical_email_conflict or c.canonical_dob_conflict or c.canonical_sex_conflict
+     or c.target_missing or c.target_collision or c.source_strong_conflict then raise exception 'F5_6_MATCH_SAFETY_INVALID'; end if;
+
+  select * into fp from public.aos_f5_apply_field_policy_v1 where field_name=e.field_name;
+  if not found or not fp.apply_allowed or fp.risk_class<>'LOW' or e.field_name not in ('Sexo','distrito','departamento','ciudad') then raise exception 'F5_6_LIVE_POLICY_BLOCKED'; end if;
+
+  select to_jsonb(p) into v_patient
+  from public.aos_pacientes p
+  where p."ID_PACIENTE"=e.target_patient_id
+  for update;
+  if v_patient is null then raise exception 'F5_6_TARGET_PATIENT_NOT_FOUND'; end if;
+  v_current:=v_patient->e.field_name;
+  if v_current is not null and v_current<>'null'::jsonb and nullif(btrim(v_current#>>'{}'),'') is not null then raise exception 'F5_6_CANONICAL_FIELD_NOT_EMPTY'; end if;
+
+  v_before_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  v_review_hash:=encode(extensions.digest(convert_to(jsonb_build_object(
+    'cluster_id',e.cluster_id,
+    'target_patient_id',e.target_patient_id,
+    'field_name',e.field_name,
+    'proposed_value',e.proposed_value,
+    'source_row_ids',to_jsonb(e.source_row_ids),
+    'source_distinct_values',e.source_distinct_values,
+    'policy_updated_at',fp.updated_at,
+    'canonical_hash',v_before_hash
+  )::text,'UTF8'),'sha256'),'hex');
+  if e.reviewed_snapshot_hash is null or e.reviewed_snapshot_hash<>v_review_hash then raise exception 'F5_6_REVIEW_SNAPSHOT_CHANGED'; end if;
+
+  v_target_hash:=encode(extensions.digest(convert_to(e.target_patient_id,'UTF8'),'sha256'),'hex');
+  v_value_hash:=encode(extensions.digest(convert_to(e.proposed_value,'UTF8'),'sha256'),'hex');
+
+  if v_mode='DRY_RUN' then
+    return jsonb_build_object('ok',true,'mode','DRY_RUN','scope',v_scope,'field_name',e.field_name,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'review_snapshot_hash',v_review_hash);
+  end if;
+
+  -- Row is already locked and was verified empty above; this update cannot race.
+  v_sql:=format('update public.aos_pacientes set %I=$1 where "ID_PACIENTE"=$2',e.field_name);
+  execute v_sql using e.proposed_value,e.target_patient_id;
+  get diagnostics v_rows=row_count;
+  if v_rows<>1 then raise exception 'F5_6_CONCURRENT_CANONICAL_CHANGE'; end if;
+
+  select to_jsonb(p) into v_patient from public.aos_pacientes p where p."ID_PACIENTE"=e.target_patient_id;
+  v_after_hash:=encode(extensions.digest(convert_to(v_patient::text,'UTF8'),'sha256'),'hex');
+  if v_after_hash=v_before_hash then raise exception 'F5_6_APPLY_HASH_UNCHANGED'; end if;
+
+  insert into public.aos_f5_canonical_apply_events_v1(
+    cluster_id,target_patient_id,actor_user_id,before_patch,applied_patch,after_patch,preview_snapshot_hash,
+    field_name,canonical_before_hash,canonical_after_hash,apply_scope
+  ) values(
+    e.cluster_id,e.target_patient_id,p_actor_user_id,
+    jsonb_build_object(e.field_name,coalesce(v_current,'null'::jsonb)),
+    jsonb_build_object(e.field_name,e.proposed_value),
+    jsonb_build_object(e.field_name,e.proposed_value),
+    v_review_hash,e.field_name,v_before_hash,v_after_hash,v_scope
+  ) returning id into v_event;
+
+  update public.aos_f5_enrichment_preview_v1
+  set applied_at=now(),apply_event_id=v_event
+  where cluster_id=e.cluster_id and field_name=e.field_name;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,actor_user_id,details)
+  values('ENRICHMENT_FIELD_APPLIED','F5_ENRICHMENT_FIELD',e.cluster_id::text||':'||e.field_name,p_actor_user_id,
+    jsonb_build_object('event_id',v_event,'scope',v_scope,'field_name',e.field_name,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'canonical_after_hash',v_after_hash,'review_snapshot_hash',v_review_hash));
+
+  return jsonb_build_object('ok',true,'mode','APPLY','scope',v_scope,'field_name',e.field_name,'event_id',v_event,'target_hash',v_target_hash,'value_hash',v_value_hash,'canonical_before_hash',v_before_hash,'canonical_after_hash',v_after_hash);
+end
+$$;
+
+revoke all on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) from public,anon,authenticated;
+grant execute on function public.aos_f5_apply_enrichment_field_v2(uuid,text,uuid,timestamptz,text,text) to service_role;
+
+insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+values('FIELD_APPLY_SQL_REPAIRED','F5','REV-F5.6',jsonb_build_object(
+  'reason','LOCKED_ROW_UPDATE_REMOVES_REDUNDANT_DYNAMIC_EMPTY_PREDICATE',
+  'canonical_mutation',false,
+  'repaired_at',now()
+));

--- a/supabase/migrations/20260820003500_rev_f5_6_low_risk_batch_v2.sql
+++ b/supabase/migrations/20260820003500_rev_f5_6_low_risk_batch_v2.sql
@@ -1,0 +1,133 @@
+-- REV-F5.6 progressive expansion after mandatory canary+rollback proof.
+-- Each field is reviewed and applied sequentially so a patient with more than one
+-- fill receives a fresh optimistic snapshot for every mutation.
+
+create or replace function public.aos_f5_apply_low_risk_batch_v2(
+  p_actor_user_id uuid,
+  p_limit integer default 10,
+  p_reason text default 'Owner-authorized REV-F5.6 progressive LOW-risk fill-only batch'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  r record;
+  v_limit integer:=least(greatest(coalesce(p_limit,10),1),50);
+  v_reason text:=btrim(coalesce(p_reason,''));
+  v_review jsonb;
+  v_apply jsonb;
+  v_reviewed_at timestamptz;
+  v_processed integer:=0;
+  v_events_before bigint;
+  v_events_after bigint;
+  v_applied_before bigint;
+  v_applied_after bigint;
+  v_canon_count_before bigint;
+  v_canon_count_after bigint;
+  v_canon_fp_before text;
+  v_canon_fp_after text;
+begin
+  perform public.aos_f5_assert_active_admin_2fa_v2(p_actor_user_id);
+  if length(v_reason)<20 then raise exception 'F5_6_BATCH_REASON_REQUIRED'; end if;
+
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_count_before,v_canon_fp_before
+  from public.aos_pacientes p;
+  select count(*) into v_events_before from public.aos_f5_canonical_apply_events_v1 where rolled_back_at is null;
+  select count(*) into v_applied_before from public.aos_f5_enrichment_preview_v1 where applied_at is not null;
+
+  for r in
+    select e.cluster_id,e.field_name,e.generated_at,e.target_patient_id
+    from public.aos_f5_enrichment_preview_v1 e
+    join public.aos_f5_canonical_classification_v1 c on c.cluster_id=e.cluster_id
+    join public.aos_f5_apply_field_policy_v1 fp on fp.field_name=e.field_name
+    where e.applied_at is null
+      and e.requires_human is true
+      and e.canonical_empty is true
+      and e.source_distinct_values=1
+      and cardinality(e.source_row_ids)>0
+      and c.classification='MATCH'
+      and c.target_patient_id=e.target_patient_id
+      and not c.canonical_dni_conflict and not c.canonical_email_conflict
+      and not c.canonical_dob_conflict and not c.canonical_sex_conflict
+      and not c.target_missing and not c.target_collision and not c.source_strong_conflict
+      and fp.apply_allowed is true and fp.risk_class='LOW'
+      and e.field_name in ('Sexo','distrito','departamento','ciudad')
+    order by encode(extensions.digest(convert_to(e.target_patient_id||'|'||e.field_name,'UTF8'),'sha256'),'hex')
+    limit v_limit
+  loop
+    v_review:=public.aos_f5_review_enrichment_field_v2(
+      r.cluster_id,r.field_name,p_actor_user_id,r.generated_at,'APPROVE_FIELD',v_reason
+    );
+    select reviewed_at into v_reviewed_at
+    from public.aos_f5_enrichment_preview_v1
+    where cluster_id=r.cluster_id and field_name=r.field_name;
+    if v_reviewed_at is null then raise exception 'F5_6_BATCH_REVIEW_NOT_PERSISTED'; end if;
+
+    v_apply:=public.aos_f5_apply_enrichment_field_v2(
+      r.cluster_id,r.field_name,p_actor_user_id,v_reviewed_at,'APPLY','BATCH'
+    );
+    if coalesce((v_apply->>'ok')::boolean,false) is not true then raise exception 'F5_6_BATCH_APPLY_FAILED'; end if;
+    v_processed:=v_processed+1;
+  end loop;
+
+  select count(*) into v_events_after from public.aos_f5_canonical_apply_events_v1 where rolled_back_at is null;
+  select count(*) into v_applied_after from public.aos_f5_enrichment_preview_v1 where applied_at is not null;
+  select count(*),md5(string_agg(md5(to_jsonb(p)::text),',' order by p."ID_PACIENTE"))
+    into v_canon_count_after,v_canon_fp_after
+  from public.aos_pacientes p;
+
+  if v_canon_count_after<>v_canon_count_before then raise exception 'F5_6_BATCH_PATIENT_COUNT_CHANGED'; end if;
+  if v_events_after-v_events_before<>v_processed then raise exception 'F5_6_BATCH_EVENT_DELTA_MISMATCH'; end if;
+  if v_applied_after-v_applied_before<>v_processed then raise exception 'F5_6_BATCH_PREVIEW_DELTA_MISMATCH'; end if;
+  if exists(
+    select 1
+    from public.aos_f5_enrichment_preview_v1 e
+    join public.aos_f5_canonical_apply_events_v1 ev on ev.id=e.apply_event_id
+    where e.applied_at is not null and ev.rolled_back_at is null
+      and (e.field_name not in ('Sexo','distrito','departamento','ciudad') or not e.policy_apply_allowed or e.policy_risk_class<>'LOW')
+  ) then raise exception 'F5_6_BATCH_POLICY_BOUNDARY_BROKEN'; end if;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,actor_user_id,details)
+  values('LOW_RISK_BATCH_APPLIED','F5','REV-F5.6',p_actor_user_id,jsonb_build_object(
+    'processed',v_processed,
+    'requested_limit',v_limit,
+    'active_events_before',v_events_before,
+    'active_events_after',v_events_after,
+    'applied_preview_before',v_applied_before,
+    'applied_preview_after',v_applied_after,
+    'canonical_count',v_canon_count_after,
+    'canonical_fp_before',v_canon_fp_before,
+    'canonical_fp_after',v_canon_fp_after,
+    'policy','LOW_FILL_ONLY',
+    'at',now()
+  ));
+
+  return jsonb_build_object(
+    'ok',true,
+    'processed',v_processed,
+    'requested_limit',v_limit,
+    'active_events_before',v_events_before,
+    'active_events_after',v_events_after,
+    'applied_preview_before',v_applied_before,
+    'applied_preview_after',v_applied_after,
+    'canonical_patient_count',v_canon_count_after,
+    'canonical_fp_before',v_canon_fp_before,
+    'canonical_fp_after',v_canon_fp_after
+  );
+end
+$$;
+
+revoke all on function public.aos_f5_apply_low_risk_batch_v2(uuid,integer,text) from public,anon,authenticated;
+grant execute on function public.aos_f5_apply_low_risk_batch_v2(uuid,integer,text) to service_role;
+
+insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+values('LOW_RISK_BATCH_ENGINE_INSTALLED','F5','REV-F5.6',jsonb_build_object(
+  'max_batch',50,
+  'sequence','REVIEW_THEN_APPLY_PER_FIELD',
+  'active_admin_2fa_required',true,
+  'allowed_fields',jsonb_build_array('Sexo','distrito','departamento','ciudad'),
+  'installed_at',now()
+));

--- a/supabase/migrations/20260820004000_rev_f5_6_event_scope_uniqueness.sql
+++ b/supabase/migrations/20260820004000_rev_f5_6_event_scope_uniqueness.sql
@@ -1,0 +1,18 @@
+-- REV-F5.6 event-ledger compatibility.
+-- Legacy v1 events are cluster-scoped (field_name IS NULL): keep one active event per cluster.
+-- F5.6 v2 events are field-scoped: uniqueness is already enforced by
+-- aos_f5_one_active_field_apply_v2(cluster_id,field_name).
+
+drop index if exists public.aos_f5_apply_event_active_uq;
+
+create unique index aos_f5_apply_event_active_uq
+  on public.aos_f5_canonical_apply_events_v1(cluster_id)
+  where rolled_back_at is null and field_name is null;
+
+insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+values('APPLY_EVENT_SCOPE_UNIQUENESS_SPLIT','F5','REV-F5.6',jsonb_build_object(
+  'legacy_scope','ONE_ACTIVE_EVENT_PER_CLUSTER_WHEN_FIELD_NULL',
+  'v2_scope','ONE_ACTIVE_EVENT_PER_CLUSTER_FIELD',
+  'idempotency_weakened',false,
+  'installed_at',now()
+));


### PR DESCRIPTION
Closes REV-F5.6 governed Review & Apply. Overall REV-F5 remains IN PROGRESS and REV-F6 stays blocked.

LIVE evidence:
- external canonical movement was detected before mutation: 7,687 → 7,688 patients; F5 had 0 Apply events, so F5.3→F5.5 was revalidated before continuing
- classification remained MATCH 296 / REVIEW 6,984 / NEW 1,436
- enrichment remained 455 fields across 202 MATCH patients
- final policy: 229 APPLY_ALLOWED / 226 POLICY_BLOCKED / 0 undefined
- mutation path requires hierarchy-1 admin + active PASSWORD_2FA session + service-role transport
- field-level explicit review + optimistic snapshot hash + locked target row + before/after hashes + private audit ledger
- mandatory canary: DRY_RUN PASS → one Sexo APPLY → exact rollback; global canonical fingerprint returned exactly to pre-canary state
- two implementation defects were caught fail-closed and repaired before unsafe expansion: dynamic SQL quoting and legacy cluster-scoped event uniqueness
- progressive LOW-risk expansion completed: 10 + 50 + 50 + 50 + 50 + 19 = 229
- applied fields: Sexo 121 + distrito 108; departamento/ciudad 0 current opportunities
- blocked fields applied: 0/226
- final ledger: 230 total events / 229 active batch events / 1 rolled-back canary
- 0 current-vs-after mismatches, 0 event-preview mismatches, 0 invalid hash events, 0 policy/review violations, 0 active events outside allowlist
- canonical patients remain 7,688
- final canonical fingerprint: eee5a57717937a4f77049b3aebd8c525
- final replay processed 0 and preserved the fingerprint

REV-F5.7 Historical JOIN becomes NEXT / UNBLOCKED after this gate; REV-F5 is not yet production certified and REV-F6 remains blocked.