### PR TITLE
REV-F6.4 — Sales Intelligence 3.0

### DIFF
--- a/.github/workflows/rev-f6-4-sales-intelligence-3.yml
+++ b/.github/workflows/rev-f6-4-sales-intelligence-3.yml
@@ -105,6 +105,11 @@ jobs:
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/capture_baseline.sql
       - name: Apply exact F6.4 migration
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql
+      - name: Apply F6.4 LIVE performance hotfixes
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820191500_rev_f6_4_dashboard_cache_performance_v1.sql
       - name: F6.4 DB/security/semantic/performance invariants
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/tests/001_sales_intelligence_3.sql
       - name: Refresh replay remains deterministic
@@ -115,6 +120,7 @@ jobs:
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_4_contract_v1()') is null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_si_sales_fact_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_si_dashboard_cache_v1') is null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_3_contract_v1()') is not null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_identity_confidence_current_v1') is not null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_patient_commercial_360_v2(text,text,text)') is not null")" = "t"

--- a/.github/workflows/rev-f6-4-sales-intelligence-3.yml
+++ b/.github/workflows/rev-f6-4-sales-intelligence-3.yml
@@ -1,0 +1,126 @@
+name: ASCENDA REV-F6.4 Sales Intelligence 3.0
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*rev_f6_4*'
+      - 'supabase/rollbacks/*rev_f6_4*'
+      - 'ci/rev-f6-4/**'
+      - 'docs/control/REV_F6_4*'
+      - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
+      - '.github/workflows/rev-f6-4-sales-intelligence-3.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rev-f6-4-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  fast-contracts:
+    name: F6.4 FAST read-model contract
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Enforce FAST lane
+        shell: powershell
+        run: |
+          if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'FAST lane must be self-hosted' }
+      - name: Static Sales Intelligence 3.0 contract
+        shell: powershell
+        run: node ci/rev-f6-4/static_contract.js
+
+  db-security-performance:
+    name: F6.4 DB/security/semantic/performance contracts
+    needs: fast-contracts
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59662/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce Zero-Cost DB runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Configure isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-rev-f6-4"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59661/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59662/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59660/' supabase/config.toml
+      - name: Start isolated Postgres
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-rev-f6-4' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59662 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+      - name: Build F6.1 synthetic prerequisite schema
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-1/schema_contract.sql
+      - name: Add F6.2 lifecycle fixture
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-2/fixture.sql
+      - name: Add F6.3 confidence fixture
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-3/fixture.sql
+      - name: Apply certified F6.0 prerequisite
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820013500_rev_f6_0_data_contract_v1.sql
+      - name: Apply certified F6.1 prerequisite
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820022000_rev_f6_1_patient_commercial_360_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820022500_rev_f6_1_alias_normalization_fix.sql
+      - name: Apply certified F6.2 prerequisite
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820034000_rev_f6_2_customer_lifecycle_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820035500_rev_f6_2_lima_date_active_subject_fix.sql
+      - name: Capture protected F6.3 baseline
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-3/capture_baseline.sql
+      - name: Apply certified F6.3 prerequisite
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820172500_rev_f6_3_identity_confidence_metric_trust_v1.sql
+      - name: Revalidate certified F6.3 semantics
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-3/tests/001_identity_confidence_metric_trust.sql
+      - name: Add F6.4 Sales Intelligence fixture
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/fixture.sql
+      - name: Capture protected F6.4 baseline
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/capture_baseline.sql
+      - name: Apply exact F6.4 migration
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql
+      - name: F6.4 DB/security/semantic/performance invariants
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/tests/001_sales_intelligence_3.sql
+      - name: Refresh replay remains deterministic
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-4/tests/001_sales_intelligence_3.sql
+      - name: Recovery restores certified F6.3 boundary
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_4_contract_v1()') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_si_sales_fact_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_3_contract_v1()') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_identity_confidence_current_v1') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_patient_commercial_360_v2(text,text,text)') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_patient_commercial_360_v2(text,text,text)','EXECUTE')")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_paciente_360(text)','EXECUTE')")" = "f"
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/ci/rev-f6-4/capture_baseline.sql
+++ b/ci/rev-f6-4/capture_baseline.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+create table public.ci_f64_protected_baseline as
+select
+  (select count(*) from public.aos_pacientes)::bigint patients,
+  (select count(*) from public.aos_ventas)::bigint sales,
+  (select count(*) from public.aos_product_sale_fact_current_v1)::bigint f3,
+  (select count(*) from public.aos_cartera_reconciliacion)::bigint f4,
+  (select count(*) from public.aos_f5_identity_cluster_members_v1)::bigint memberships,
+  (select count(*) from public.aos_f5_canonical_classification_v1)::bigint classifications;

--- a/ci/rev-f6-4/fixture.sql
+++ b/ci/rev-f6-4/fixture.sql
@@ -1,0 +1,60 @@
+\set ON_ERROR_STOP on
+
+-- REV-F6.4 synthetic-only additions on top of certified F6.0–F6.3 fixtures.
+create table if not exists public.aos_metas_ventas(
+  id uuid primary key default gen_random_uuid(),periodo text unique,meta numeric,moneda text,descripcion text,created_at timestamptz default now(),updated_at timestamptz default now()
+);
+alter table public.aos_leads add column if not exists anuncio text;
+alter table public.aos_agenda_citas add column if not exists etiqueta_campana text;
+alter table public.aos_agenda_citas add column if not exists origen_cita text;
+
+-- Auth compatibility stub: F6.4 browser gateway must rely on the existing Sales Intelligence guard.
+create or replace function public.aos_sales_intelligence_gateway(p_token text,p_anio integer,p_sede text default '',p_asesor text default '')
+returns jsonb language plpgsql security definer set search_path='' as $$
+begin
+  if p_token='admin-f64-token-00000000000000000000' then
+    return jsonb_build_object('hasData',true,'anio',p_anio,'authorized',true);
+  end if;
+  return jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+end $$;
+grant execute on function public.aos_sales_intelligence_gateway(text,integer,text,text) to public,anon,authenticated,service_role;
+
+insert into public.aos_metas_ventas(periodo,meta,moneda,descripcion)
+values ('2026-07',1000,'PEN','F6.4 test'),('2026-08',1000,'PEN','F6.4 test')
+on conflict(periodo) do update set meta=excluded.meta,moneda=excluded.moneda,descripcion=excluded.descripcion,updated_at=now();
+
+insert into public.aos_ventas(id,venta_id,fecha,celular,numero_limpio,tratamiento,descripcion,monto,estado_pago,asesor,sede,tipo)
+values
+ (6401,'V6401','2026-08-18','999111111','999111111','BOTOX','BOTOX CANONICO',200,'REGISTRADO','ASESOR','SAN ISIDRO','SERVICIO'),
+ (6402,'V6402','2026-08-19','999111111','999111111','PEEL','PEEL CANONICO',150,'REGISTRADO','ASESOR','SAN ISIDRO','SERVICIO'),
+ (6403,'V6403','2026-07-10','999630001','999630001','LASER','LASER CANONICO',300,'REGISTRADO','ASESOR 2','PUEBLO LIBRE','SERVICIO')
+on conflict(id) do nothing;
+
+insert into public.aos_f5_historical_join_v1(
+ sale_id,sale_date,sale_year,sede,canonical_patient_id,patient_link_status,patient_link_method,patient_candidate_count,
+ product_applicable,product_resolution_status,product_key,product_resolution_source,cartera_link_status,cartera_row_count,cartera_active_row_count,payment_evidence_row_count,confirmed_balance_row_count
+)
+values
+ (6401,'2026-08-18',2026,'SAN ISIDRO','P1','MATCH','F5_CERTIFIED',1,true,'RESOLVED','BOTOX','F3','F4_LINKED',1,1,1,0),
+ (6402,'2026-08-19',2026,'SAN ISIDRO','P1','MATCH','F5_CERTIFIED',1,true,'RESOLVED','PEEL','F3','NO_F4_LINK',0,0,0,0),
+ (6403,'2026-07-10',2026,'PUEBLO LIBRE','F63-HIGH','MATCH','F5_CERTIFIED',1,true,'RESOLVED','LASER','F3','NO_F4_LINK',0,0,0,0)
+on conflict(sale_id) do nothing;
+
+insert into public.aos_product_sale_fact_base(sale_id,fecha,sede,resolution_status,resolution_source,product_key,canonical_name)
+values
+ (6401,'2026-08-18','SAN ISIDRO','RESOLVED','F3','BOTOX','Botox Canonico'),
+ (6402,'2026-08-19','SAN ISIDRO','RESOLVED','F3','PEEL','Peel Canonico'),
+ (6403,'2026-07-10','PUEBLO LIBRE','RESOLVED','F3','LASER','Laser Canonico')
+on conflict(sale_id) do nothing;
+
+insert into public.aos_cartera_reconciliacion(source_type,venta_row_id,rol_pago,estado_reconciliacion,monto_registrado,source_active)
+select 'VENTA',6401,'PAGO','EVIDENCIA_REGISTRADA',200,true
+where not exists(select 1 from public.aos_cartera_reconciliacion where venta_row_id=6401);
+
+insert into public.aos_leads(id,fecha,celular,numero_limpio,tratamiento,hora_ingreso,anuncio)
+values (6401,'2026-08-01','999111111','999111111','BOTOX','2026-08-01 10:00+00','F64-CAMPAIGN')
+on conflict(id) do nothing;
+
+insert into public.aos_agenda_citas(id,fecha_cita,hora_cita,tratamiento,tipo_cita,sede,numero,numero_limpio,estado_cita,asesor,venta_id_match,lead_id_origen,etiqueta_campana,origen_cita)
+values ('F64-ACQ-1','2026-08-17','11:00','BOTOX','PRIMERA','SAN ISIDRO','999111111','999111111','ASISTIO','ASESOR','6401',6401,'F64-CAMPAIGN','META')
+on conflict(id) do nothing;

--- a/ci/rev-f6-4/static_contract.js
+++ b/ci/rev-f6-4/static_contract.js
@@ -1,0 +1,23 @@
+'use strict';
+const fs=require('fs');
+const migration=fs.readFileSync('supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql','utf8');
+function must(x,msg){if(!x)throw new Error(msg)}
+[
+ 'aos_rev_si_sales_fact_v1','aos_rev_si_monthly_v1','aos_rev_si_patient_value_v1','aos_rev_si_cohort_month_v1',
+ 'aos_rev_si_product_transition_v1','aos_rev_si_acquisition_fact_v1','aos_rev_sales_intelligence_v3','aos_rev_f6_4_contract_v1',
+ 'aos_rev_si_refresh_v1','aos_rev_sales_intelligence_v3_gateway','REV-F6.4_PATIENT_COMMERCIAL_360_V2'
+].forEach(s=>must(migration.includes(s),'missing F6.4 contract: '+s));
+[
+ 'OBSERVED_VALUE_NOT_LIFETIME_PREDICTION','NO_CERTIFIED_SOURCE_NE_ZERO_REVENUE',
+ 'F4_LINKED_IS_EVIDENCE_COVERAGE_NOT_COLLECTED_CASH','NO_DEFENDABLE_ATTRIBUTION',
+ 'EXPLICIT_AGENDA_VENTA_ID_MATCH_PLUS_LEAD_LINEAGE','MATERIALIZED_READ_MODELS_PLUS_SET_BASED_AGGREGATION',
+ "'live_rpc_target_ms',1000","'demographic_coverage_threshold_pct',70","'demographic_minimum_cell_size',5"
+].forEach(s=>must(migration.includes(s),'missing semantic/performance guard: '+s));
+must(/revoke all on public\.aos_rev_si_sales_fact_v1 from public,anon,authenticated/i.test(migration),'sales fact must be browser-closed');
+must(/grant select on public\.aos_rev_si_sales_fact_v1 to service_role/i.test(migration),'sales fact service grant missing');
+must(!/phone_nearness_authority[^\n]*true/i.test(migration),'phone-nearness authority prohibited');
+must(!/phone_only_acquisition_attribution[^\n]*true/i.test(migration),'phone-only acquisition attribution prohibited');
+must(rollback.includes('aos_patient_commercial_360_v2_f6_3_base'),'rollback must restore F6.3 Patient 360');
+must(rollback.includes('drop materialized view if exists public.aos_rev_si_sales_fact_v1'),'rollback must drop F6.4 derived fact');
+console.log('REV-F6.4 FAST static contract PASS');

--- a/ci/rev-f6-4/static_contract.js
+++ b/ci/rev-f6-4/static_contract.js
@@ -1,6 +1,8 @@
 'use strict';
 const fs=require('fs');
 const migration=fs.readFileSync('supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql','utf8');
+const baselineFix=fs.readFileSync('supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql','utf8');
+const cacheFix=fs.readFileSync('supabase/migrations/20260820191500_rev_f6_4_dashboard_cache_performance_v1.sql','utf8');
 const rollback=fs.readFileSync('supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql','utf8');
 function must(x,msg){if(!x)throw new Error(msg)}
 [
@@ -14,10 +16,20 @@ function must(x,msg){if(!x)throw new Error(msg)}
  'EXPLICIT_AGENDA_VENTA_ID_MATCH_PLUS_LEAD_LINEAGE','MATERIALIZED_READ_MODELS_PLUS_SET_BASED_AGGREGATION',
  "'live_rpc_target_ms',1000","'demographic_coverage_threshold_pct',70","'demographic_minimum_cell_size',5"
 ].forEach(s=>must(migration.includes(s),'missing semantic/performance guard: '+s));
+[
+ 'aos_rev_si_dashboard_cache_v1','aos_rev_si_cache_filter_v1','aos_rev_si_rebuild_dashboard_cache_v1',
+ 'aos_rev_sales_intelligence_v3_uncached_f6_4_base'
+].forEach(s=>must(cacheFix.includes(s),'missing bounded performance cache contract: '+s));
+must(cacheFix.includes("primary key(anio,sede,advisor)"),'dashboard cache must be bounded/indexed');
+must(cacheFix.includes("grant execute on function public.aos_rev_si_rebuild_dashboard_cache_v1() to service_role"),'cache rebuild must be service-only');
+must(/revoke all on public\.aos_rev_si_dashboard_cache_v1 from public,anon,authenticated/i.test(cacheFix),'dashboard cache must be browser-closed');
+must(baselineFix.includes('NO_CERTIFIED_SOURCE'),'historical baseline decouple must preserve no-source semantics');
 must(/revoke all on public\.aos_rev_si_sales_fact_v1 from public,anon,authenticated/i.test(migration),'sales fact must be browser-closed');
 must(/grant select on public\.aos_rev_si_sales_fact_v1 to service_role/i.test(migration),'sales fact service grant missing');
 must(!/phone_nearness_authority[^\n]*true/i.test(migration),'phone-nearness authority prohibited');
 must(!/phone_only_acquisition_attribution[^\n]*true/i.test(migration),'phone-only acquisition attribution prohibited');
 must(rollback.includes('aos_patient_commercial_360_v2_f6_3_base'),'rollback must restore F6.3 Patient 360');
+must(rollback.includes('drop table if exists public.aos_rev_si_dashboard_cache_v1'),'rollback must drop dashboard cache');
+must(rollback.includes('aos_rev_sales_intelligence_v3_uncached_f6_4_base'),'rollback must drop uncached F6.4 base');
 must(rollback.includes('drop materialized view if exists public.aos_rev_si_sales_fact_v1'),'rollback must drop F6.4 derived fact');
 console.log('REV-F6.4 FAST static contract PASS');

--- a/ci/rev-f6-4/tests/001_sales_intelligence_3.sql
+++ b/ci/rev-f6-4/tests/001_sales_intelligence_3.sql
@@ -1,0 +1,117 @@
+\set ON_ERROR_STOP on
+
+do $$
+begin
+  if to_regclass('public.aos_rev_si_sales_fact_v1') is null then raise exception 'missing sales fact read model'; end if;
+  if to_regclass('public.aos_rev_si_monthly_v1') is null then raise exception 'missing monthly read model'; end if;
+  if to_regclass('public.aos_rev_si_patient_value_v1') is null then raise exception 'missing patient value read model'; end if;
+  if to_regclass('public.aos_rev_si_cohort_month_v1') is null then raise exception 'missing cohort read model'; end if;
+  if to_regclass('public.aos_rev_si_product_transition_v1') is null then raise exception 'missing transition read model'; end if;
+  if to_regclass('public.aos_rev_si_acquisition_fact_v1') is null then raise exception 'missing acquisition read model'; end if;
+  if to_regprocedure('public.aos_rev_sales_intelligence_v3(integer,text,text)') is null then raise exception 'missing v3 contract'; end if;
+  if to_regprocedure('public.aos_rev_f6_4_contract_v1()') is null then raise exception 'missing f6.4 contract'; end if;
+  if to_regprocedure('public.aos_rev_si_refresh_v1()') is null then raise exception 'missing refresh'; end if;
+  if to_regprocedure('public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text)') is null then raise exception 'missing gateway'; end if;
+end $$;
+
+do $$
+begin
+  if has_table_privilege('anon','public.aos_rev_si_sales_fact_v1','SELECT') then raise exception 'sales fact browser-readable'; end if;
+  if has_table_privilege('authenticated','public.aos_rev_si_patient_value_v1','SELECT') then raise exception 'patient value browser-readable'; end if;
+  if has_function_privilege('anon','public.aos_rev_sales_intelligence_v3(integer,text,text)','EXECUTE') then raise exception 'internal v3 browser executable'; end if;
+  if has_function_privilege('authenticated','public.aos_rev_si_refresh_v1()','EXECUTE') then raise exception 'refresh browser executable'; end if;
+  if not has_function_privilege('service_role','public.aos_rev_f6_4_contract_v1()','EXECUTE') then raise exception 'service contract unavailable'; end if;
+  if not has_function_privilege('anon','public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text)','EXECUTE') then raise exception 'governed gateway unavailable'; end if;
+  if has_function_privilege('anon','public.aos_patient_commercial_360_v2_f6_3_base(text,text,text)','EXECUTE') then raise exception 'private f6.3 360 base exposed'; end if;
+  if not has_function_privilege('anon','public.aos_patient_commercial_360_v2(text,text,text)','EXECUTE') then raise exception 'governed patient 360 unavailable'; end if;
+  if has_function_privilege('anon','public.aos_paciente_360(text)','EXECUTE') then raise exception 'legacy 360 reopened'; end if;
+end $$;
+
+do $$
+declare n integer;
+begin
+  select count(*) into n
+  from information_schema.columns
+  where table_schema='public'
+    and table_name in ('aos_rev_si_sales_fact_v1','aos_rev_si_monthly_v1','aos_rev_si_patient_value_v1','aos_rev_si_cohort_month_v1','aos_rev_si_product_transition_v1','aos_rev_si_acquisition_fact_v1')
+    and lower(column_name) in ('nombres','apellidos','nombre','telefono','phone','celular','email','correo','dni','documento','direccion','notas','observacion');
+  if n<>0 then raise exception 'PII/PHI-like aggregate columns found: %',n; end if;
+end $$;
+
+do $$
+declare j jsonb;
+begin
+  j:=public.aos_rev_sales_intelligence_v3(2026,'','');
+  if j->>'contract'<>'REV-F6.4_SALES_INTELLIGENCE_3_V1' then raise exception 'wrong contract: %',j; end if;
+  if (j#>>'{executive_revenue,transactions}')::integer<>4 then raise exception 'expected 4 transactions: %',j; end if;
+  if (j#>>'{executive_revenue,billed_amount}')::numeric<>750 then raise exception 'expected billed 750: %',j; end if;
+  if (j#>>'{identity_coverage,safe_match_sales}')::integer<>4 then raise exception 'safe linkage mismatch: %',j; end if;
+  if j#>>'{observed_ltv,semantic}'<>'OBSERVED_VALUE_NOT_LIFETIME_PREDICTION' then raise exception 'observed value semantic missing'; end if;
+  if jsonb_array_length(j->'cross_sell_transitions')<2 then raise exception 'expected product transitions: %',j; end if;
+  if j#>>'{acquisition_to_revenue,source_status}'<>'AVAILABLE_PARTIAL_COVERAGE' then raise exception 'explicit acquisition lineage missing: %',j; end if;
+  if (j#>>'{acquisition_to_revenue,sample_size}')::integer<>1 then raise exception 'acquisition sample mismatch: %',j; end if;
+  if j#>>'{historical_source_status,2024,source_status}'<>'NO_CERTIFIED_SOURCE' then raise exception '2024 no-source guard missing'; end if;
+  if j#>>'{historical_source_status,2025,source_status}'<>'NO_CERTIFIED_SOURCE' then raise exception '2025 no-source guard missing'; end if;
+  if j#>>'{executive_revenue,financial_semantic}'<>'F4_LINKED_IS_EVIDENCE_COVERAGE_NOT_COLLECTED_CASH' then raise exception 'F4 cash semantic drift'; end if;
+
+  j:=public.aos_rev_sales_intelligence_v3(2025,'','');
+  if coalesce((j->>'hasData')::boolean,true) then raise exception '2025 should not fabricate data'; end if;
+  if j#>>'{historical_source_status,2025}'<>'NO_CERTIFIED_SOURCE' then raise exception '2025 no-source no-data guard missing'; end if;
+end $$;
+
+do $$
+declare j jsonb;
+begin
+  j:=public.aos_rev_sales_intelligence_v3_gateway('bad-token',2026,'','');
+  if j->>'error'<>'UNAUTHORIZED' then raise exception 'bad token accepted: %',j; end if;
+  j:=public.aos_rev_sales_intelligence_v3_gateway('admin-f64-token-00000000000000000000',2026,'','');
+  if j->>'contract'<>'REV-F6.4_SALES_INTELLIGENCE_3_V1' then raise exception 'good token failed: %',j; end if;
+end $$;
+
+do $$
+declare j jsonb;
+begin
+  j:=public.aos_patient_commercial_360_v2('advisor-f61-token-00000000000000000000','CANONICAL_ID','P1');
+  if coalesce((j->>'found')::boolean,false) is not true then raise exception 'patient 360 lost P1: %',j; end if;
+  if j->>'contract'<>'REV-F6.4_PATIENT_COMMERCIAL_360_V2' then raise exception 'patient 360 contract not upgraded'; end if;
+  if j#>'{intelligence,sales_intelligence}' is null then raise exception 'patient sales intelligence missing'; end if;
+  if position('NOTA CLINICA TEST' in j::text)>0 or position('https://example.test/doc' in j::text)>0 then raise exception 'advisor PHI boundary regressed'; end if;
+end $$;
+
+do $$
+declare a jsonb; b jsonb; c jsonb;
+begin
+  a:=public.aos_rev_f6_4_contract_v1();
+  b:=public.aos_rev_f6_4_contract_v1();
+  if a->>'contract_fingerprint' is null or a->>'contract_fingerprint'<>b->>'contract_fingerprint' then raise exception 'fingerprint unstable'; end if;
+  c:=public.aos_rev_si_refresh_v1();
+  if c->>'contract_fingerprint'<>a->>'contract_fingerprint' then raise exception 'refresh changed deterministic fingerprint: % vs %',a,c; end if;
+  if coalesce((a#>>'{contract,semantic_guards,no_certified_source_means_zero}')::boolean,true) then raise exception 'no-source guard drift'; end if;
+  if coalesce((a#>>'{contract,semantic_guards,f4_link_means_collected_cash}')::boolean,true) then raise exception 'F4 cash guard drift'; end if;
+end $$;
+
+do $$
+declare b record;
+begin
+  select * into b from public.ci_f64_protected_baseline limit 1;
+  if (select count(*) from public.aos_pacientes)<>b.patients then raise exception 'patient rows mutated'; end if;
+  if (select count(*) from public.aos_ventas)<>b.sales then raise exception 'sales rows mutated'; end if;
+  if (select count(*) from public.aos_product_sale_fact_current_v1)<>b.f3 then raise exception 'F3 rows mutated'; end if;
+  if (select count(*) from public.aos_cartera_reconciliacion)<>b.f4 then raise exception 'F4 rows mutated'; end if;
+  if (select count(*) from public.aos_f5_identity_cluster_members_v1)<>b.memberships then raise exception 'F5 memberships mutated'; end if;
+  if (select count(*) from public.aos_f5_canonical_classification_v1)<>b.classifications then raise exception 'F5 classifications mutated'; end if;
+end $$;
+
+do $$
+declare t0 timestamptz; elapsed_ms numeric; i integer; max_ms numeric:=0; j jsonb;
+begin
+  for i in 1..5 loop
+    t0:=clock_timestamp();
+    j:=public.aos_rev_sales_intelligence_v3(2026,'','');
+    elapsed_ms:=extract(epoch from (clock_timestamp()-t0))*1000;
+    max_ms:=greatest(max_ms,elapsed_ms);
+  end loop;
+  if max_ms>1000 then raise exception 'F6.4 performance gate exceeded: % ms',max_ms; end if;
+end $$;
+
+select 'REV-F6.4 DB/security/semantic/performance PASS' as result;

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -2,7 +2,7 @@
 
 **Status:** CURRENT / REV-F6 ACTIVE  
 **Captured:** 2026-08-20 America/Lima  
-**Certification main:** `c3da45ce18ebad9d89ba42181299da86625ce8e2`  
+**Entry main:** `10c8ebccb0be1d8e538491de834cb7457f453de9`  
 **ACTIVE LOCK:** `REV-F6-CLOSEOUT`  
 **CURRENT GATE:** `REV-F6.4 — Sales Intelligence 3.0`  
 **REV-F5:** `PRODUCTION CERTIFIED — 100%`  
@@ -11,7 +11,7 @@
 **REV-F6.2:** `PASS / CERTIFIED — 100%` · fp `d977b9669b9e741e8785cd863caaf9c2`  
 **REV-F6.3:** `PASS / CERTIFIED — 100%` · fp `3f4174660107661a2c4509f6f8817d7a`  
 **REV-F6 global:** `50%`  
-**REV-F6.4:** `NEXT / UNBLOCKED`  
+**REV-F6.4:** `IN PROGRESS / PRE-LIVE`  
 **REV-F6.5:** `BLOCKED until REV-F6.4 certification`  
 **REV-F6.6:** `BLOCKED`  
 **REV-F6.7:** `BLOCKED`  
@@ -19,91 +19,65 @@
 
 GitHub CURRENT + Supabase LIVE are authoritative over historical checkpoints. `REV-F6-CLOSEOUT` remains the only HIGH/CRITICAL mutable Revenue lane.
 
-## REV-F6.3 final certification
+## REV-F6.4 entry
 
-Implementation/certification PR **#313** was merged with exact expected head `440b068c422b546d24c3b47748ba9347d492a848` to certification main `c3da45ce18ebad9d89ba42181299da86625ce8e2`.
+F6.4 started from exact `main@10c8ebccb0be1d8e538491de834cb7457f453de9` after independent LIVE revalidation of the certified F6.3 boundary.
 
-Final exact-head CI on `440b068c422b546d24c3b47748ba9347d492a848`:
+Entry proof:
 
-- REV-F6.3 run #5 / `32401302561` — SUCCESS;
-- REV-F6.2 run #14 / `32401302456` — SUCCESS;
-- REV-F6.1 run #35 / `32401302457` — SUCCESS;
-- REV-F6.0 run #34 / `32401302464` — SUCCESS;
-- Ascenda CI #2652 / `32401302460` — SUCCESS.
+- Supabase SQL available;
+- F6.3 LIVE fp `3f4174660107661a2c4509f6f8817d7a`;
+- patients **7,688** / `eee5a57717937a4f77049b3aebd8c525`;
+- sales **1,299** / `20104fd91fbf427e39566e7b84d7ec4f`;
+- F3 **406** / `e3c8499026d13401c4a733b4da16b6c8`;
+- F4 **162** / `5524a2280442224ec4e9a7cfdfffa008`;
+- F6.0 `02ba53adb9dabfcd0a4557061be53c2f`;
+- F6.1 `cd313998c5b5b38d5cb9e2f08882b826`;
+- F6.2 `d977b9669b9e741e8785cd863caaf9c2`.
 
-Supabase LIVE migration ledger:
+Current certified linkage boundary is **208 MATCH / 940 REVIEW / 151 UNRESOLVED** sales. Patient-level intelligence must use MATCH-only evidence. Executive billed revenue can use all certified 2026 sale rows but must disclose patient-link coverage.
 
-- `20260820180246 · rev_f6_3_identity_confidence_metric_trust_v1`.
+F4 currently gives **123/1,299** linked financial-evidence rows and no certified confirmed-cash amount. F6.4 must not present F4 linkage as collected cash.
 
-Terminal fingerprint:
+Current explicit acquisition→sale lineage through `Agenda.venta_id_match + lead_id_origen` is zero in LIVE, so the acquisition-to-revenue metric must remain `NO_DEFENDABLE_ATTRIBUTION`, never fabricated zero conversion.
 
-- pre-merge replay 1: `3f4174660107661a2c4509f6f8817d7a`;
-- pre-merge replay 2: `3f4174660107661a2c4509f6f8817d7a`;
-- post-merge LIVE: `3f4174660107661a2c4509f6f8817d7a`.
+## F6.4 architecture
 
-## Identity Confidence LIVE
+Sales Intelligence 3.0 uses bounded materialized read models plus set-based aggregate RPCs. It consumes F3/F4/F5/F6.0–F6.3 and does not create competing patient/product/revenue truth.
 
-- canonical population **7,262**;
-- HIGH **238**;
-- MEDIUM **6,583**;
-- LOW **441**;
-- aggregate canonical UNRESOLVED **0**;
-- safe automatic cross-source attribution **238**;
-- patients with conflict keys **441**;
-- PHONE conflict keys **37**.
+Required domains:
 
-Authority remains `canonical_patient_id`. Strong alias conflict remains fail-closed. No fuzzy identity, phone-nearness authority, name-only identity, or silent patient merge is permitted.
+- Executive Revenue;
+- cohorts/retention;
+- observed value/LTV;
+- canonical product + cross-sell;
+- sede/advisor performance;
+- acquisition-to-revenue only with explicit lineage;
+- demographic/geographic dimensions only above declared coverage thresholds.
 
-## Metric Trust V1
+Metric Trust remains explicit. 2024/2025 transactional sales remain `NO_CERTIFIED_SOURCE != zero`.
 
-Every relevant trust envelope keeps these dimensions separate:
+## Security / mutation boundary
 
-`value + coverage + confidence + freshness + sample_size + source_status + source_period + limitations + data_quality_flags + provenance + trust_level`.
+F6.4 is additive analytical schema. No mutation of `aos_pacientes`, `aos_ventas`, F3, F4, F5 identity/classification or F6.0–F6.3 certified source truth is authorized.
 
-Frozen observed baselines:
+Raw read models are browser-closed/service-only. Existing admin + PASSWORD_2FA Sales Intelligence gateway semantics remain the browser trust boundary.
 
-- Identity safe match **296/8,716 = 3.40%** — LOW coverage;
-- Sales safe linkage **208/1,299 = 16.01%** — LOW coverage;
-- F3 product resolution **397/406 = 97.78%** — HIGH trust;
-- F4 financial evidence **123/1,299 = 9.47%** — LOW coverage and **not non-payment**;
-- Historical transaction source availability **1/3 = 33.33%** — source availability, not revenue;
-- Lifecycle classified evidence **543/7,262 = 7.48%**, sample_size **1,089** — LOW coverage;
-- 2024 transactional sales = `NO_CERTIFIED_SOURCE`, `value=null`, never zero revenue;
-- 2025 transactional sales = `NO_CERTIFIED_SOURCE`, `value=null`, never zero revenue.
+## Exit gate
 
-## Protected certified truth
+Do not mark F6.4 PASS until:
 
-Post-migration and post-merge readback remained exact:
+- exact-head FAST + Zero-Cost DB/security/semantic/performance and upstream regressions PASS;
+- LIVE migration/readback/reconciliation PASS;
+- protected truth unchanged;
+- security/no-PII invariants PASS;
+- F6.4 deterministic fingerprint reproduced twice;
+- exact-head PR merge with `expected_head_sha`;
+- post-merge LIVE fingerprint exact;
+- `aos_memory` + Notion + CURRENT reconciled.
 
-- patients = **7,688** / `eee5a57717937a4f77049b3aebd8c525`;
-- sales = **1,299** / `20104fd91fbf427e39566e7b84d7ec4f`;
-- F3 = **406** / `e3c8499026d13401c4a733b4da16b6c8`;
-- F4 = **162** / `5524a2280442224ec4e9a7cfdfffa008`;
-- F5.7 = `5af139243f6aed37020048af292587fe`;
-- F5.10 = `2f0a365fae4caaa7be9d204e0f76679b`;
-- F6.0 = `02ba53adb9dabfcd0a4557061be53c2f`;
-- F6.1 = `cd313998c5b5b38d5cb9e2f08882b826`;
-- F6.2 = `d977b9669b9e741e8785cd863caaf9c2`;
-- F6.3 = `3f4174660107661a2c4509f6f8817d7a`.
+Until then:
 
-F3 owns product truth, F4 financial/payment/cartera truth, F5 patient identity/provenance. F6 derives analytics only.
-
-## Security boundary
-
-PASS:
-
-- Identity Confidence view/function and F6.3 aggregate contract are browser-closed;
-- governed Patient Commercial 360 remains browser-executable behind existing Auth V3 + PASSWORD_2FA semantics;
-- legacy `aos_paciente_360(text)` remains browser-closed;
-- no aggregate raw PII/PHI exposure.
-
-## CURRENT next gate — REV-F6.4
-
-REV-F6.4 must consume F6.0/F6.1/F6.2/F6.3 without replacing their truth. Sales Intelligence 3.0 must be set-based/preaggregated where appropriate, must propagate Metric Trust, and must not infer 2024/2025 revenue from absent transactional sources.
-
-At F6.4 entry:
-
-- `REV-F6.4 = NEXT / UNBLOCKED`;
-- `REV-F6.5/F6.6/F6.7 = BLOCKED` according to dependency order;
-- `REV-F7 = BLOCKED until REV-F6 final certification`;
-- `REV-F6-CLOSEOUT` remains the single mutable Revenue lock.
+- `REV-F6.4 = IN PROGRESS`;
+- `REV-F6.5/F6.6/F6.7 = BLOCKED`;
+- `REV-F7 = BLOCKED`.

--- a/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_CERTIFICATE_20260820.md
+++ b/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_CERTIFICATE_20260820.md
@@ -1,0 +1,108 @@
+# REV-F6.4 — Sales Intelligence 3.0 Certification
+
+**Status:** PRE-MERGE CERTIFICATION EVIDENCE PASS — terminal merge still requires final exact-head CI + expected_head_sha + post-merge LIVE readback  
+**Date:** 2026-08-20 America/Lima  
+**Entry main:** `10c8ebccb0be1d8e538491de834cb7457f453de9`  
+**Certification candidate head:** `c2db4e86dc1cb0be6e7cdce064243a704f97d944`  
+**PR:** #314
+
+## Scope
+
+REV-F6.4 adds a zero-PII, read-model-only Sales Intelligence 3.0 layer over certified Revenue truth. It does not mutate patient, sale, F3, F4, F5 identity or upstream F6 truth.
+
+## LIVE migrations
+
+- `20260820191924` — `rev_f6_4_sales_intelligence_3_v1`
+- `20260820192121` — `rev_f6_4_live_performance_baseline_decouple_v1`
+- `20260820192333` — `rev_f6_4_dashboard_cache_performance_v1`
+
+## LIVE deterministic contract
+
+`aos_rev_f6_4_contract_v1()` reproduced twice:
+
+`b0f06d841c74ceeb231451aecdeceef2`
+
+Read models:
+
+- sales fact: 1,299
+- monthly aggregate: 72
+- MATCH-only patient observed value: 66
+- cohorts: 8
+- product transitions: 34
+- explicit acquisition rows: 0
+- bounded dashboard cache rows: 22
+
+## Semantic truth
+
+- 2024 transactional sales: `value = null`, `source_status = NO_CERTIFIED_SOURCE`.
+- 2025 transactional sales: `value = null`, `source_status = NO_CERTIFIED_SOURCE`.
+- 2026 canonical sales: 1,299 rows; billed amount 561,889.27 under stored `aos_ventas` amount semantics.
+- safe patient attribution: 208 / 1,299; REVIEW 940; UNRESOLVED 151.
+- F3 resolved product sales: 397 / 1,299.
+- F4-linked evidence: 123 / 1,299; this is evidence coverage, never confirmed collected cash.
+- explicit acquisition-to-revenue rows: 0; absence is `NO_DEFENDABLE_ATTRIBUTION`, never zero conversion.
+- observed patient value is observed-window value, never future/predicted LTV.
+
+## Performance incident and correction
+
+The first LIVE implementation violated the <1000 ms certification contract: representative calls were ~1.4–3.0 seconds. Certification was stopped fail-closed.
+
+Root cause: repeated heavy Metric Trust baseline/read-model aggregation on every dashboard request. Corrective architecture:
+
+1. decouple the already-certified 2024/2025 `NO_CERTIFIED_SOURCE` semantic from the expensive full baseline call until REV-F6.5 supplies the dynamic historical coverage contract;
+2. preserve the deep calculation as a service-only base;
+3. materialize a bounded zero-PII cache for the real 2026 filter space (22 global/sede/advisor combinations);
+4. keep controlled refresh deterministic and rebuild the cache from governed read models.
+
+Post-fix LIVE EXPLAIN evidence:
+
+- global 2026: ~53 ms;
+- San Isidro: ~6 ms;
+- Pueblo Libre: ~1 ms observed in repeated readback.
+
+All are below the 1000 ms contract without increasing timeouts.
+
+## Security
+
+Verified LIVE:
+
+- raw Sales Intelligence fact/read models are browser-closed;
+- `authenticated` cannot execute the service-only F6.4 contract or internal V3 RPC;
+- `service_role` retains required execution;
+- browser gateway remains the existing admin + 2FA authorization boundary;
+- aggregate certification payload contains no raw PII/PHI.
+
+## Protected truth
+
+Unchanged after LIVE apply and performance correction:
+
+- patients: 7,688; fingerprint `eee5a57717937a4f77049b3aebd8c525`
+- sales: 1,299; fingerprint `20104fd91fbf427e39566e7b84d7ec4f`
+- F3: 406; fingerprint `e3c8499026d13401c4a733b4da16b6c8`
+- F4: 162; fingerprint `5524a2280442224ec4e9a7cfdfffa008`
+- F6.0: `02ba53adb9dabfcd0a4557061be53c2f`
+- F6.1: `cd313998c5b5b38d5cb9e2f08882b826`
+- F6.2: `d977b9669b9e741e8785cd863caaf9c2`
+- F6.3: `3f4174660107661a2c4509f6f8817d7a`
+
+## Exact-head CI before this certificate commit
+
+At `c2db4e86dc1cb0be6e7cdce064243a704f97d944`:
+
+- Ascenda CI #2667 — SUCCESS
+- REV-F6.0 #41 — SUCCESS
+- REV-F6.1 #42 — SUCCESS
+- REV-F6.2 #21 — SUCCESS
+- REV-F6.3 #12 — SUCCESS
+- REV-F6.4 #7 — SUCCESS
+
+The F6.4 Zero-Cost job independently passed migration + performance hotfixes + DB/security/semantic/performance invariants + deterministic refresh replay + recovery to the certified F6.3 boundary.
+
+## Merge gate
+
+This document is certification evidence, not permission to skip the terminal gate. After committing this certificate/snapshot:
+
+1. rerun all required workflows on the new exact head;
+2. merge PR #314 only with that exact `expected_head_sha`;
+3. perform post-merge LIVE fingerprint/performance/security/protected-truth readback;
+4. only then record `REV-F6.4 PASS / CERTIFIED — 100%`, `REV-F6 global = 62.5%` and unlock REV-F6.5.

--- a/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_SNAPSHOT_20260820.json
+++ b/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_SNAPSHOT_20260820.json
@@ -1,0 +1,62 @@
+{
+  "workstream": "REV-F6.4",
+  "gate": "Sales Intelligence 3.0",
+  "captured_date": "2026-08-20 America/Lima",
+  "entry_main_sha": "10c8ebccb0be1d8e538491de834cb7457f453de9",
+  "pre_certificate_head_sha": "c2db4e86dc1cb0be6e7cdce064243a704f97d944",
+  "pr": 314,
+  "live_migrations": [
+    {"version":"20260820191924","name":"rev_f6_4_sales_intelligence_3_v1"},
+    {"version":"20260820192121","name":"rev_f6_4_live_performance_baseline_decouple_v1"},
+    {"version":"20260820192333","name":"rev_f6_4_dashboard_cache_performance_v1"}
+  ],
+  "contract_fingerprint": "b0f06d841c74ceeb231451aecdeceef2",
+  "fingerprint_replays": 2,
+  "read_models": {
+    "sales_fact_rows": 1299,
+    "monthly_rows": 72,
+    "patient_value_rows": 66,
+    "cohort_rows": 8,
+    "product_transition_rows": 34,
+    "explicit_acquisition_rows": 0,
+    "dashboard_cache_rows": 22
+  },
+  "historical_source_status": {
+    "2024": {"value": null, "source_status": "NO_CERTIFIED_SOURCE"},
+    "2025": {"value": null, "source_status": "NO_CERTIFIED_SOURCE"},
+    "2026": {"source_status": "AVAILABLE", "canonical_sales_rows": 1299}
+  },
+  "performance_ms_observed": {
+    "global_2026": 53.017,
+    "san_isidro_2026": 6.414,
+    "pueblo_libre_2026": 0.98,
+    "target_ms": 1000,
+    "timeout_increase_used": false
+  },
+  "protected_truth": {
+    "patients": {"rows":7688,"fingerprint":"eee5a57717937a4f77049b3aebd8c525"},
+    "sales": {"rows":1299,"fingerprint":"20104fd91fbf427e39566e7b84d7ec4f"},
+    "f3": {"rows":406,"fingerprint":"e3c8499026d13401c4a733b4da16b6c8"},
+    "f4": {"rows":162,"fingerprint":"5524a2280442224ec4e9a7cfdfffa008"},
+    "f6_0": "02ba53adb9dabfcd0a4557061be53c2f",
+    "f6_1": "cd313998c5b5b38d5cb9e2f08882b826",
+    "f6_2": "d977b9669b9e741e8785cd863caaf9c2",
+    "f6_3": "3f4174660107661a2c4509f6f8817d7a"
+  },
+  "exact_head_ci": {
+    "ascenda_ci": {"run_number":2667,"conclusion":"success"},
+    "f6_0": {"run_number":41,"conclusion":"success"},
+    "f6_1": {"run_number":42,"conclusion":"success"},
+    "f6_2": {"run_number":21,"conclusion":"success"},
+    "f6_3": {"run_number":12,"conclusion":"success"},
+    "f6_4": {"run_number":7,"conclusion":"success"}
+  },
+  "semantic_guards": {
+    "no_certified_source_means_zero": false,
+    "patient_analytics_match_only": true,
+    "f4_evidence_means_collected_cash": false,
+    "phone_only_acquisition_attribution": false,
+    "observed_value_is_future_ltv": false
+  },
+  "terminal_merge_required": true
+}

--- a/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_V1.md
+++ b/docs/control/REV_F6_4_SALES_INTELLIGENCE_3_V1.md
@@ -1,0 +1,107 @@
+# REV-F6.4 — Sales Intelligence 3.0 V1
+
+**Status:** IMPLEMENTATION / PRE-LIVE  
+**Entry main:** `10c8ebccb0be1d8e538491de834cb7457f453de9`  
+**Owning workstream:** `REV-F6-CLOSEOUT`  
+**Risk:** HIGH (read-model / analytics schema)  
+**Production business-row writes:** NONE
+
+## Objective
+
+Build a performant, explainable Sales Intelligence 3.0 read layer from certified F3/F4/F5/F6.0–F6.3 facts. F6.4 does not create a second revenue, product or patient truth and does not infer 2024/2025 transactional revenue where no certified transactional source exists.
+
+## Architecture
+
+F6.4 materializes bounded, zero-PII analytical read models:
+
+- `aos_rev_si_sales_fact_v1`: one row per 2026 sale with F5 identity linkage state, F3 product state and F4 evidence state.
+- `aos_rev_si_monthly_v1`: monthly sede/advisor aggregation.
+- `aos_rev_si_patient_value_v1`: MATCH-only observed patient value; this is observed value, never predicted lifetime value.
+- `aos_rev_si_cohort_month_v1`: safe-identity cohort/repeat/time-to-second facts.
+- `aos_rev_si_product_transition_v1`: canonical F3 next-product transitions with sample counts.
+- `aos_rev_si_acquisition_fact_v1`: explicit `Agenda.venta_id_match + lead_id_origen` lineage only. Phone proximity/phone-only attribution is prohibited.
+
+Primary service contract: `aos_rev_sales_intelligence_v3(anio,sede,asesor)`.  
+Browser gateway: `aos_rev_sales_intelligence_v3_gateway(token,anio,sede,asesor)`, preserving the existing Sales Intelligence admin + 2FA gate.  
+Refresh contract: `aos_rev_si_refresh_v1()`.  
+Deterministic certification contract: `aos_rev_f6_4_contract_v1()`.
+
+Patient Commercial 360 is augmented, not replaced. The certified F6.3 gateway is preserved privately and the public governed wrapper adds only bounded observed Sales Intelligence metadata.
+
+## Metric semantics
+
+### Executive Revenue
+`aos_ventas.monto` remains observed billed revenue. F4 linkage is exposed as financial-evidence coverage. Because current certified F4 contains no confirmed collected-cash amount, `confirmed_collected_amount` remains `null`; `F4_LINKED != collected cash`.
+
+Targets and projection are emitted only where a configured target exists.
+
+### Cohorts / retention
+Only `patient_link_status='MATCH'` contributes patient-level cohort/retention metrics. REVIEW and UNRESOLVED sales remain in executive billed revenue but cannot be silently attributed to a canonical patient.
+
+### Observed LTV
+The label is explicitly `OBSERVED_VALUE_NOT_LIFETIME_PREDICTION`. No future value model is presented as fact.
+
+### Product / cross-sell
+Only canonical F3 `RESOLVED` product facts support canonical product and next-product patterns. Samples remain explicit.
+
+### Sede / Advisor
+Performance uses direct sale fields. It does not imply patient-level attribution quality.
+
+### Acquisition-to-Revenue
+Only explicit sale lineage through `Agenda.venta_id_match` plus `lead_id_origen` qualifies. If no qualifying evidence exists, output is `NO_DEFENDABLE_ATTRIBUTION` with `value=null`, not zero.
+
+### Demographic / geographic
+The V1 contract requires field coverage >=70% and a minimum cell size of 5 before a dimension is enabled. Low-coverage dimensions remain disabled rather than appearing exact.
+
+### Historical source
+2024 and 2025 remain `NO_CERTIFIED_SOURCE`, `value=null`, and never mean zero revenue.
+
+## Performance gate
+
+Architecture target: `MATERIALIZED_READ_MODELS_PLUS_SET_BASED_AGGREGATION`.  
+Certification threshold for the aggregate V3 RPC on the current data scale: max 1000 ms across repeated isolated-test calls. The target is a gate, not a timeout workaround.
+
+## Security
+
+All raw materialized read models and internal analytical functions are `service_role` only. Aggregate models contain no name, phone, email, document, clinical notes or message payloads. Browser access remains via existing admin Sales Intelligence authorization/2FA semantics.
+
+## Impact Report
+**Project / phase:** REV-F6.4 — Sales Intelligence 3.0  
+**Objective:** performant governed revenue intelligence read models.  
+**Risk:** HIGH
+
+### Code/runtime
+No Node runtime topology change and no frontend redesign in F6.4.
+
+### Data/RPC/triggers
+Additive materialized views/RPCs only. No patient/sale/F3/F4/F5 mutation. Refresh replaces derived MV contents only.
+
+### Consumers/dependencies
+Consumes certified F6.0/F6.1/F6.2/F6.3 and F3/F4/F5. Existing Sales Intelligence V2 remains backward-compatible during F6.4.
+
+### Security/roles/sensitive data
+Raw read models browser-closed. Aggregate V3 gateway reuses existing admin+2FA Sales Intelligence authorization. No raw PII/PHI in aggregate contracts.
+
+### Tests
+FAST static contract; Zero-Cost exact migration compile; upstream F6.3 regression; semantic reconciliation; ACL/PII negatives; refresh replay; performance; recovery.
+
+### Rollback
+Drop F6.4 functions/materialized views and restore the exact F6.3 Patient Commercial 360 public wrapper.
+
+### Portfolio-lock impact
+`REV-F6-CLOSEOUT` remains the only HIGH/CRITICAL mutable Revenue lane.
+
+## Certification gates
+
+1. Exact-head F6.4 CI + upstream F6.0/F6.1/F6.2/F6.3 + Ascenda CI green.
+2. LIVE preflight anti-drift for protected patients/sales/F3/F4 and F6.0–F6.3 fingerprints.
+3. Versioned F6.4 migration applied.
+4. Direct LIVE readback + independent metric reconciliation.
+5. ACL/no-PII/security invariants.
+6. Performance gate.
+7. F6.4 fingerprint reproduced twice.
+8. Exact-head merge with `expected_head_sha`.
+9. Post-merge LIVE fingerprint exact.
+10. `aos_memory`, Notion and CURRENT synchronized last.
+
+Only then: `REV-F6.4 PASS / CERTIFIED — 100%` and `REV-F6 global = 62.5%`.

--- a/supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql
+++ b/supabase/migrations/20260820190000_rev_f6_4_sales_intelligence_3_v1.sql
@@ -1,0 +1,753 @@
+-- REV-F6.4 — Sales Intelligence 3.0 V1
+-- Read-model / analytics layer only. No mutation of patient, sale, F3, F4, F5 identity or upstream F6 certified truth.
+
+begin;
+
+-- -----------------------------------------------------------------------------
+-- 1) SALES FACT READ MODEL — one row per certified sale, no raw PII/PHI.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_sales_fact_v1 as
+select
+  v.id::bigint sale_id,
+  v.fecha::date sale_date,
+  extract(year from v.fecha)::integer sale_year,
+  extract(month from v.fecha)::integer sale_month,
+  date_trunc('month',v.fecha)::date sale_month_start,
+  coalesce(nullif(trim(v.sede),''),'SIN_SEDE')::text sede,
+  coalesce(nullif(trim(v.asesor),''),'SIN_ASESOR')::text advisor,
+  coalesce(v.monto,0)::numeric billed_amount,
+  case when upper(trim(coalesce(v.tratamiento,'')))='OTROS' then 'SERVICIO' else upper(trim(coalesce(v.tipo,''))) end::text sale_type,
+  j.canonical_patient_id::text canonical_patient_id,
+  coalesce(j.patient_link_status,'UNRESOLVED')::text patient_link_status,
+  coalesce(j.patient_link_method,'NONE')::text patient_link_method,
+  coalesce(j.patient_candidate_count,0)::integer patient_candidate_count,
+  coalesce(f.resolution_status,'NOT_APPLICABLE')::text product_resolution_status,
+  f.product_key::text product_key,
+  f.canonical_name::text canonical_product_name,
+  coalesce(j.cartera_link_status,'NO_F4_LINK')::text f4_link_status,
+  coalesce(j.cartera_row_count,0)::integer f4_row_count,
+  coalesce(j.payment_evidence_row_count,0)::integer payment_evidence_row_count,
+  coalesce(j.confirmed_balance_row_count,0)::integer confirmed_balance_row_count,
+  (coalesce(j.patient_link_status,'')='MATCH' and j.canonical_patient_id is not null)::boolean safe_patient_attribution,
+  (coalesce(f.resolution_status,'')='RESOLVED' and f.product_key is not null)::boolean safe_product_attribution,
+  (coalesce(j.cartera_link_status,'')='F4_LINKED')::boolean has_f4_evidence
+from public.aos_ventas v
+left join public.aos_f5_historical_join_v1 j on j.sale_id=v.id
+left join public.aos_product_sale_fact_current_v1 f on f.sale_id=v.id;
+
+create unique index if not exists aos_rev_si_sales_fact_v1_sale_uq on public.aos_rev_si_sales_fact_v1(sale_id);
+create index if not exists aos_rev_si_sales_fact_v1_period_idx on public.aos_rev_si_sales_fact_v1(sale_year,sale_month,sede,advisor);
+create index if not exists aos_rev_si_sales_fact_v1_patient_idx on public.aos_rev_si_sales_fact_v1(canonical_patient_id) where safe_patient_attribution;
+create index if not exists aos_rev_si_sales_fact_v1_product_idx on public.aos_rev_si_sales_fact_v1(product_key) where safe_product_attribution;
+comment on materialized view public.aos_rev_si_sales_fact_v1 is
+'REV-F6.4 zero-PII sale fact read model. Executive billed revenue uses all certified sales; patient-level intelligence uses safe_patient_attribution only.';
+revoke all on public.aos_rev_si_sales_fact_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_sales_fact_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 2) MONTHLY EXECUTIVE PREAGGREGATION.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_monthly_v1 as
+select
+  sale_year,
+  sale_month,
+  sale_month_start,
+  sede,
+  advisor,
+  count(*)::integer transactions,
+  coalesce(sum(billed_amount),0)::numeric billed_amount,
+  case when count(*)>0 then round(sum(billed_amount)/count(*),2) else 0 end::numeric avg_ticket,
+  count(*) filter(where safe_patient_attribution)::integer safe_patient_sales,
+  count(*) filter(where patient_link_status='REVIEW')::integer review_patient_sales,
+  count(*) filter(where patient_link_status='UNRESOLVED')::integer unresolved_patient_sales,
+  count(*) filter(where safe_product_attribution)::integer resolved_product_sales,
+  count(*) filter(where has_f4_evidence)::integer f4_evidence_sales,
+  coalesce(sum(billed_amount) filter(where has_f4_evidence),0)::numeric billed_amount_with_f4_evidence,
+  count(*) filter(where payment_evidence_row_count>0)::integer payment_evidence_sales,
+  count(*) filter(where confirmed_balance_row_count>0)::integer confirmed_balance_sales
+from public.aos_rev_si_sales_fact_v1
+where sale_year=2026
+group by sale_year,sale_month,sale_month_start,sede,advisor;
+
+create unique index if not exists aos_rev_si_monthly_v1_uq on public.aos_rev_si_monthly_v1(sale_year,sale_month,sede,advisor);
+create index if not exists aos_rev_si_monthly_v1_period_idx on public.aos_rev_si_monthly_v1(sale_year,sale_month);
+comment on materialized view public.aos_rev_si_monthly_v1 is
+'REV-F6.4 monthly set-based preaggregation. F4 evidence coverage is not collected-cash truth.';
+revoke all on public.aos_rev_si_monthly_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_monthly_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 3) OBSERVED PATIENT VALUE — MATCH-only, never predicted LTV.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_patient_value_v1 as
+with ranked as (
+  select
+    s.*,
+    row_number() over(partition by canonical_patient_id order by sale_date,sale_id)::integer rn,
+    lead(sale_date) over(partition by canonical_patient_id order by sale_date,sale_id) next_sale_date
+  from public.aos_rev_si_sales_fact_v1 s
+  where s.sale_year=2026 and s.safe_patient_attribution
+), agg as (
+  select
+    canonical_patient_id,
+    min(sale_date)::date first_observed_purchase,
+    max(sale_date)::date last_observed_purchase,
+    min(sale_date) filter(where rn=2)::date second_observed_purchase,
+    count(*)::integer observed_purchase_count,
+    coalesce(sum(billed_amount),0)::numeric observed_value,
+    count(*) filter(where safe_product_attribution)::integer resolved_product_purchase_count,
+    count(*) filter(where has_f4_evidence)::integer f4_evidence_purchase_count
+  from ranked
+  group by canonical_patient_id
+)
+select
+  a.*,
+  case when second_observed_purchase is not null then (second_observed_purchase-first_observed_purchase)::integer else null end time_to_second_days,
+  (observed_purchase_count>=2)::boolean repeat_observed,
+  'OBSERVED_VALUE_NOT_LIFETIME_PREDICTION'::text value_semantic,
+  '2026_CERTIFIED_SALES_SCOPE'::text source_period
+from agg a;
+
+create unique index if not exists aos_rev_si_patient_value_v1_patient_uq on public.aos_rev_si_patient_value_v1(canonical_patient_id);
+create index if not exists aos_rev_si_patient_value_v1_first_idx on public.aos_rev_si_patient_value_v1(first_observed_purchase);
+comment on materialized view public.aos_rev_si_patient_value_v1 is
+'REV-F6.4 MATCH-only observed patient value. It is not predicted future LTV and not lifetime truth outside certified transactional coverage.';
+revoke all on public.aos_rev_si_patient_value_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_patient_value_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 4) COHORT / RETENTION READ MODEL — MATCH-only.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_cohort_month_v1 as
+with cohort as (
+  select
+    p.canonical_patient_id,
+    date_trunc('month',p.first_observed_purchase)::date cohort_month,
+    p.first_observed_purchase,
+    p.second_observed_purchase,
+    p.time_to_second_days,
+    p.repeat_observed,
+    p.observed_purchase_count,
+    p.observed_value
+  from public.aos_rev_si_patient_value_v1 p
+), sale_followup as (
+  select
+    c.*,
+    count(s.sale_id) filter(where s.sale_date>c.first_observed_purchase and s.sale_date<=c.first_observed_purchase+30)::integer purchases_within_30d,
+    count(s.sale_id) filter(where s.sale_date>c.first_observed_purchase and s.sale_date<=c.first_observed_purchase+90)::integer purchases_within_90d
+  from cohort c
+  left join public.aos_rev_si_sales_fact_v1 s on s.canonical_patient_id=c.canonical_patient_id and s.safe_patient_attribution
+  group by c.canonical_patient_id,c.cohort_month,c.first_observed_purchase,c.second_observed_purchase,c.time_to_second_days,c.repeat_observed,c.observed_purchase_count,c.observed_value
+)
+select
+  cohort_month,
+  count(*)::integer cohort_patients,
+  count(*) filter(where repeat_observed)::integer repeat_patients,
+  round(100.0*count(*) filter(where repeat_observed)/nullif(count(*),0),2)::numeric repeat_rate_pct,
+  count(*) filter(where purchases_within_30d>0)::integer repeat_30d_patients,
+  round(100.0*count(*) filter(where purchases_within_30d>0)/nullif(count(*),0),2)::numeric repeat_30d_pct,
+  count(*) filter(where purchases_within_90d>0)::integer repeat_90d_patients,
+  round(100.0*count(*) filter(where purchases_within_90d>0)/nullif(count(*),0),2)::numeric repeat_90d_pct,
+  round(avg(time_to_second_days) filter(where time_to_second_days is not null),2)::numeric avg_time_to_second_days,
+  coalesce(sum(observed_value),0)::numeric observed_cohort_value,
+  'MATCH_ONLY_SAFE_IDENTITY'::text identity_semantic
+from sale_followup
+group by cohort_month;
+
+create unique index if not exists aos_rev_si_cohort_month_v1_uq on public.aos_rev_si_cohort_month_v1(cohort_month);
+comment on materialized view public.aos_rev_si_cohort_month_v1 is
+'REV-F6.4 retention/cohort model. First observed purchase is within certified 2026 transactional scope; it is not guaranteed lifetime first purchase.';
+revoke all on public.aos_rev_si_cohort_month_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_cohort_month_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 5) PRODUCT / CROSS-SELL TRANSITIONS — F3 RESOLVED + MATCH identity only.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_product_transition_v1 as
+with seq as (
+  select
+    canonical_patient_id,
+    sale_id,
+    sale_date,
+    product_key,
+    canonical_product_name,
+    lead(product_key) over(partition by canonical_patient_id order by sale_date,sale_id) next_product_key,
+    lead(canonical_product_name) over(partition by canonical_patient_id order by sale_date,sale_id) next_product_name
+  from public.aos_rev_si_sales_fact_v1
+  where sale_year=2026 and safe_patient_attribution and safe_product_attribution
+)
+select
+  product_key,
+  canonical_product_name,
+  next_product_key,
+  next_product_name,
+  count(*)::integer transition_count,
+  count(distinct canonical_patient_id)::integer patient_sample_size,
+  'F3_RESOLVED_MATCH_IDENTITY_ONLY'::text evidence_semantic
+from seq
+where next_product_key is not null
+group by product_key,canonical_product_name,next_product_key,next_product_name;
+
+create unique index if not exists aos_rev_si_product_transition_v1_uq on public.aos_rev_si_product_transition_v1(product_key,next_product_key);
+comment on materialized view public.aos_rev_si_product_transition_v1 is
+'REV-F6.4 observed next-product transitions. Sample size is explicit; no recommendation causal claim.';
+revoke all on public.aos_rev_si_product_transition_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_product_transition_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 6) EXPLICIT ACQUISITION→REVENUE FACT — no phone-only attribution.
+-- -----------------------------------------------------------------------------
+create materialized view if not exists public.aos_rev_si_acquisition_fact_v1 as
+select distinct on (v.id)
+  v.id::bigint sale_id,
+  v.fecha::date sale_date,
+  coalesce(v.monto,0)::numeric billed_amount,
+  c.id::text appointment_id,
+  c.fecha_cita::date appointment_date,
+  c.lead_id_origen::bigint lead_id,
+  c.llamada_id_origen::bigint call_id,
+  c.etiqueta_campana::text campaign_label,
+  c.origen_cita::text appointment_origin,
+  'EXPLICIT_AGENDA_VENTA_ID_MATCH_PLUS_LEAD_LINEAGE'::text attribution_method
+from public.aos_ventas v
+join public.aos_agenda_citas c
+  on nullif(trim(c.venta_id_match),'') in (v.id::text,coalesce(v.venta_id,''))
+where c.lead_id_origen is not null
+  and v.fecha>=c.fecha_cita
+order by v.id,c.fecha_cita desc,c.id;
+
+create unique index if not exists aos_rev_si_acquisition_fact_v1_sale_uq on public.aos_rev_si_acquisition_fact_v1(sale_id);
+create index if not exists aos_rev_si_acquisition_fact_v1_lead_idx on public.aos_rev_si_acquisition_fact_v1(lead_id);
+comment on materialized view public.aos_rev_si_acquisition_fact_v1 is
+'REV-F6.4 acquisition-to-revenue fact. Only explicit Agenda sale-id + lead lineage qualifies; phone-only or phone-near matching is prohibited.';
+revoke all on public.aos_rev_si_acquisition_fact_v1 from public,anon,authenticated;
+grant select on public.aos_rev_si_acquisition_fact_v1 to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 7) SERVICE-ONLY PATIENT OBSERVED VALUE DETAIL.
+-- -----------------------------------------------------------------------------
+create or replace function public.aos_rev_si_patient_value_by_patient_v1(p_canonical_patient_id text)
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+select case when p.canonical_patient_id is null then
+  jsonb_build_object(
+    'contract','REV-F6.4_PATIENT_VALUE_V1',
+    'canonical_patient_id',p_canonical_patient_id,
+    'source_status','NO_SAFE_MATCHED_SALES',
+    'value',null,
+    'semantic','OBSERVED_VALUE_NOT_LIFETIME_PREDICTION'
+  )
+else jsonb_build_object(
+  'contract','REV-F6.4_PATIENT_VALUE_V1',
+  'canonical_patient_id',p.canonical_patient_id,
+  'source_status','AVAILABLE_MATCH_ONLY',
+  'observed_value',p.observed_value,
+  'observed_purchase_count',p.observed_purchase_count,
+  'first_observed_purchase',p.first_observed_purchase,
+  'second_observed_purchase',p.second_observed_purchase,
+  'last_observed_purchase',p.last_observed_purchase,
+  'repeat_observed',p.repeat_observed,
+  'time_to_second_days',p.time_to_second_days,
+  'resolved_product_purchase_count',p.resolved_product_purchase_count,
+  'f4_evidence_purchase_count',p.f4_evidence_purchase_count,
+  'source_period',p.source_period,
+  'semantic',p.value_semantic,
+  'limitations',jsonb_build_array('MATCH_ONLY_PATIENT_LINKAGE','2024_2025_TRANSACTIONAL_SALES_NO_CERTIFIED_SOURCE','FIRST_OBSERVED_PURCHASE_IS_WITHIN_CERTIFIED_SCOPE')
+) end
+from (select 1) seed
+left join public.aos_rev_si_patient_value_v1 p on p.canonical_patient_id=p_canonical_patient_id;
+$$;
+comment on function public.aos_rev_si_patient_value_by_patient_v1(text) is
+'REV-F6.4 service-only observed patient commercial value. Null means no safe matched-sale evidence, not zero lifetime value.';
+revoke all on function public.aos_rev_si_patient_value_by_patient_v1(text) from public,anon,authenticated;
+grant execute on function public.aos_rev_si_patient_value_by_patient_v1(text) to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 8) SALES INTELLIGENCE 3.0 SERVICE CONTRACT.
+-- -----------------------------------------------------------------------------
+create or replace function public.aos_rev_sales_intelligence_v3(
+  p_anio integer,
+  p_sede text default '',
+  p_asesor text default ''
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_sede text := upper(trim(coalesce(p_sede,'')));
+  v_asesor text := trim(coalesce(p_asesor,''));
+  v_data_through date;
+  v_business_date date := public.aos_rev_business_date_lima_v1();
+  v_month integer;
+  v_day integer;
+  v_days_month integer;
+  v_billed numeric := 0;
+  v_tx bigint := 0;
+  v_safe bigint := 0;
+  v_review bigint := 0;
+  v_unresolved bigint := 0;
+  v_f3 bigint := 0;
+  v_f4 bigint := 0;
+  v_f4_billed numeric := 0;
+  v_payment_evidence bigint := 0;
+  v_confirmed_balance bigint := 0;
+  v_mtd numeric := 0;
+  v_mtd_tx bigint := 0;
+  v_target_mtd numeric;
+  v_target_ytd numeric := 0;
+  v_target_annual numeric := 0;
+  v_projection numeric;
+  v_cohorts jsonb := '[]'::jsonb;
+  v_products jsonb := '[]'::jsonb;
+  v_transitions jsonb := '[]'::jsonb;
+  v_sede_perf jsonb := '[]'::jsonb;
+  v_advisor_perf jsonb := '[]'::jsonb;
+  v_acq_count bigint := 0;
+  v_acq_value numeric := 0;
+  v_geo_n bigint := 0;
+  v_sex_n bigint := 0;
+  v_district_n bigint := 0;
+  v_city_n bigint := 0;
+  v_dept_n bigint := 0;
+  v_dob_n bigint := 0;
+  v_demo_threshold numeric := 70.0;
+  v_min_cell integer := 5;
+  v_now timestamptz := clock_timestamp();
+  v_metric_baseline jsonb;
+  v_hist_2024 jsonb;
+  v_hist_2025 jsonb;
+  v_exec_trust jsonb;
+  v_identity_trust jsonb;
+  v_f3_trust jsonb;
+  v_f4_trust jsonb;
+  v_acq_trust jsonb;
+  v_monthly jsonb := '[]'::jsonb;
+  v_patient_value jsonb;
+begin
+  if p_anio not between 2020 and 2100 then
+    return jsonb_build_object('ok',false,'error','INVALID_YEAR');
+  end if;
+  if v_sede not in ('','SAN ISIDRO','PUEBLO LIBRE') then
+    return jsonb_build_object('ok',false,'error','INVALID_FILTER');
+  end if;
+
+  select max(sale_date),coalesce(sum(billed_amount),0),count(*)::bigint,
+         count(*) filter(where safe_patient_attribution)::bigint,
+         count(*) filter(where patient_link_status='REVIEW')::bigint,
+         count(*) filter(where patient_link_status='UNRESOLVED')::bigint,
+         count(*) filter(where safe_product_attribution)::bigint,
+         count(*) filter(where has_f4_evidence)::bigint,
+         coalesce(sum(billed_amount) filter(where has_f4_evidence),0),
+         count(*) filter(where payment_evidence_row_count>0)::bigint,
+         count(*) filter(where confirmed_balance_row_count>0)::bigint
+  into v_data_through,v_billed,v_tx,v_safe,v_review,v_unresolved,v_f3,v_f4,v_f4_billed,v_payment_evidence,v_confirmed_balance
+  from public.aos_rev_si_sales_fact_v1
+  where sale_year=p_anio and (v_sede='' or sede=v_sede) and (v_asesor='' or advisor=v_asesor);
+
+  if v_data_through is null then
+    return jsonb_build_object(
+      'ok',true,'hasData',false,'contract','REV-F6.4_SALES_INTELLIGENCE_3_V1','anio',p_anio,
+      'source_status',case when p_anio in (2024,2025) then 'NO_CERTIFIED_SOURCE' else 'NO_ROWS_IN_FILTER' end,
+      'value',null,
+      'limitations',case when p_anio in (2024,2025) then jsonb_build_array('NO_CERTIFIED_SOURCE_NE_ZERO_REVENUE') else jsonb_build_array('NO_ROWS_MATCH_FILTER') end,
+      'historical_source_status',jsonb_build_object('2024','NO_CERTIFIED_SOURCE','2025','NO_CERTIFIED_SOURCE','2026','AVAILABLE')
+    );
+  end if;
+
+  v_month:=extract(month from v_data_through)::integer;
+  v_day:=extract(day from v_data_through)::integer;
+  v_days_month:=extract(day from (date_trunc('month',v_data_through)+interval '1 month - 1 day'))::integer;
+
+  select coalesce(sum(s.billed_amount),0),count(*)::bigint
+  into v_mtd,v_mtd_tx
+  from public.aos_rev_si_sales_fact_v1 s
+  where s.sale_year=p_anio and s.sale_month=v_month and s.sale_date<=v_data_through
+    and (v_sede='' or s.sede=v_sede) and (v_asesor='' or s.advisor=v_asesor);
+
+  select coalesce(sum(m.meta),0),max(m.meta) filter(where m.periodo=p_anio::text||'-'||lpad(v_month::text,2,'0'))
+  into v_target_annual,v_target_mtd
+  from public.aos_metas_ventas m where m.periodo like p_anio::text||'-%';
+
+  select coalesce(sum(m.meta),0) into v_target_ytd
+  from public.aos_metas_ventas m
+  where m.periodo between p_anio::text||'-01' and p_anio::text||'-'||lpad(v_month::text,2,'0');
+
+  v_projection := case when v_day>0 and v_data_through < (date_trunc('month',v_data_through)+interval '1 month - 1 day')::date
+    then round(v_mtd/v_day*v_days_month,2) else v_mtd end;
+
+  select coalesce(jsonb_agg(to_jsonb(c) order by c.cohort_month),'[]'::jsonb) into v_cohorts
+  from public.aos_rev_si_cohort_month_v1 c
+  where extract(year from c.cohort_month)::integer=p_anio;
+
+  select coalesce(jsonb_agg(to_jsonb(x) order by x.observed_value desc,x.canonical_product_name),'[]'::jsonb) into v_products
+  from (
+    select s.product_key,s.canonical_product_name,count(*)::integer transactions,
+           count(distinct s.canonical_patient_id) filter(where s.safe_patient_attribution)::integer safe_patient_sample_size,
+           coalesce(sum(s.billed_amount),0)::numeric observed_value
+    from public.aos_rev_si_sales_fact_v1 s
+    where s.sale_year=p_anio and s.safe_product_attribution
+      and (v_sede='' or s.sede=v_sede) and (v_asesor='' or s.advisor=v_asesor)
+    group by s.product_key,s.canonical_product_name
+    order by observed_value desc,s.canonical_product_name
+    limit 20
+  ) x;
+
+  select coalesce(jsonb_agg(to_jsonb(t) order by t.transition_count desc,t.product_key,t.next_product_key),'[]'::jsonb) into v_transitions
+  from (select * from public.aos_rev_si_product_transition_v1 order by transition_count desc,product_key,next_product_key limit 30) t;
+
+  select coalesce(jsonb_agg(to_jsonb(x) order by x.billed_amount desc,x.sede),'[]'::jsonb) into v_sede_perf
+  from (
+    select s.sede,count(*)::integer transactions,coalesce(sum(s.billed_amount),0)::numeric billed_amount,
+           round(100.0*count(*) filter(where s.safe_patient_attribution)/nullif(count(*),0),2)::numeric patient_link_coverage_pct,
+           round(100.0*count(*) filter(where s.safe_product_attribution)/nullif(count(*),0),2)::numeric product_coverage_pct
+    from public.aos_rev_si_sales_fact_v1 s where s.sale_year=p_anio and (v_asesor='' or s.advisor=v_asesor)
+    group by s.sede
+  ) x;
+
+  select coalesce(jsonb_agg(to_jsonb(x) order by x.billed_amount desc,x.advisor),'[]'::jsonb) into v_advisor_perf
+  from (
+    select s.advisor,count(*)::integer transactions,coalesce(sum(s.billed_amount),0)::numeric billed_amount,
+           round(100.0*count(*) filter(where s.safe_patient_attribution)/nullif(count(*),0),2)::numeric patient_link_coverage_pct,
+           round(100.0*count(*) filter(where s.safe_product_attribution)/nullif(count(*),0),2)::numeric product_coverage_pct
+    from public.aos_rev_si_sales_fact_v1 s where s.sale_year=p_anio and (v_sede='' or s.sede=v_sede)
+    group by s.advisor
+  ) x;
+
+  select count(*)::bigint,coalesce(sum(billed_amount),0)::numeric into v_acq_count,v_acq_value
+  from public.aos_rev_si_acquisition_fact_v1 a where extract(year from a.sale_date)::integer=p_anio;
+
+  with safe_patients as (
+    select distinct s.canonical_patient_id
+    from public.aos_rev_si_sales_fact_v1 s
+    where s.sale_year=p_anio and s.safe_patient_attribution and (v_sede='' or s.sede=v_sede) and (v_asesor='' or s.advisor=v_asesor)
+  )
+  select count(*)::bigint,
+    count(*) filter(where nullif(trim(coalesce(p."Sexo",'')),'') is not null)::bigint,
+    count(*) filter(where nullif(trim(coalesce(p.distrito,'')),'') is not null)::bigint,
+    count(*) filter(where nullif(trim(coalesce(p.ciudad,'')),'') is not null)::bigint,
+    count(*) filter(where nullif(trim(coalesce(p.departamento,'')),'') is not null)::bigint,
+    count(*) filter(where nullif(trim(coalesce(p."Fecha de nacimiento",'')),'') is not null)::bigint
+  into v_geo_n,v_sex_n,v_district_n,v_city_n,v_dept_n,v_dob_n
+  from public.aos_pacientes p join safe_patients sp on sp.canonical_patient_id=p."ID_PACIENTE"
+  where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO';
+
+  select coalesce(jsonb_agg(to_jsonb(x) order by x.sale_month),'[]'::jsonb) into v_monthly
+  from (
+    select s.sale_month,
+      count(*)::integer transactions,
+      coalesce(sum(s.billed_amount),0)::numeric billed_amount,
+      case when count(*)>0 then round(sum(s.billed_amount)/count(*),2) else 0 end::numeric avg_ticket,
+      count(*) filter(where s.safe_patient_attribution)::integer safe_patient_sales,
+      count(*) filter(where s.safe_product_attribution)::integer resolved_product_sales,
+      count(*) filter(where s.has_f4_evidence)::integer f4_evidence_sales
+    from public.aos_rev_si_sales_fact_v1 s
+    where s.sale_year=p_anio and (v_sede='' or s.sede=v_sede) and (v_asesor='' or s.advisor=v_asesor)
+    group by s.sale_month
+  ) x;
+
+  select jsonb_build_object(
+    'patients',count(*)::integer,
+    'repeat_patients',count(*) filter(where repeat_observed)::integer,
+    'repeat_rate_pct',round(100.0*count(*) filter(where repeat_observed)/nullif(count(*),0),2),
+    'observed_value',coalesce(sum(observed_value),0),
+    'avg_observed_value',round(avg(observed_value),2),
+    'avg_time_to_second_days',round(avg(time_to_second_days) filter(where time_to_second_days is not null),2),
+    'semantic','OBSERVED_VALUE_NOT_LIFETIME_PREDICTION',
+    'source_period','2026_CERTIFIED_SALES_SCOPE'
+  ) into v_patient_value
+  from public.aos_rev_si_patient_value_v1;
+
+  v_metric_baseline:=public.aos_rev_metric_trust_baseline_v1();
+  v_hist_2024:=v_metric_baseline->'TRANSACTIONAL_SALES_2024';
+  v_hist_2025:=v_metric_baseline->'TRANSACTIONAL_SALES_2025';
+
+  v_exec_trust:=public.aos_rev_metric_trust_envelope_v1(
+    'F6_4_EXECUTIVE_REVENUE',to_jsonb(v_billed),v_tx,v_tx,'CERTIFIED_SALES_ROWS_IN_FILTER',v_tx,
+    'AVAILABLE','2026_CERTIFIED_SALES_SCOPE',(select max(updated_at) from public.aos_ventas),v_now,v_now,'HIGH',
+    jsonb_build_array('DIRECT_AOS_VENTAS_FACT'),jsonb_build_array('BILLED_REVENUE_NOT_CONFIRMED_COLLECTED_CASH'),jsonb_build_array('aos_ventas','REV-F6.4')
+  );
+  v_identity_trust:=public.aos_rev_metric_trust_envelope_v1(
+    'F6_4_SAFE_PATIENT_LINKAGE',to_jsonb(v_safe),v_safe,v_tx,'MATCH_ONLY_SALES_TO_CANONICAL_PATIENT',v_tx,
+    'AVAILABLE_PARTIAL_COVERAGE','2026_CERTIFIED_SALES_SCOPE',(select max(generated_at) from public.aos_f5_historical_join_v1),v_now,v_now,'HIGH',
+    jsonb_build_array('REV_F5_MATCH_ONLY'),jsonb_build_array('REVIEW_AND_UNRESOLVED_SALES_EXCLUDED_FROM_PATIENT_ANALYTICS'),jsonb_build_array('REV-F5','REV-F6.4')
+  );
+  v_f3_trust:=public.aos_rev_metric_trust_envelope_v1(
+    'F6_4_PRODUCT_RESOLUTION',to_jsonb(v_f3),v_f3,v_tx,'F3_RESOLVED_SALES_IN_FILTER',v_tx,
+    'AVAILABLE_PARTIAL_COVERAGE','2026_CERTIFIED_SALES_SCOPE',(select max(updated_at) from public.aos_ventas),v_now,v_now,'HIGH',
+    jsonb_build_array('F3_CANONICAL_PRODUCT_TRUTH'),jsonb_build_array('UNRESOLVED_PRODUCT_FACTS_EXCLUDED_FROM_CANONICAL_PRODUCT_PATTERNS'),jsonb_build_array('REV-F3','REV-F6.4')
+  );
+  v_f4_trust:=public.aos_rev_metric_trust_envelope_v1(
+    'F6_4_FINANCIAL_EVIDENCE',to_jsonb(v_f4),v_f4,v_tx,'F4_LINKED_FINANCIAL_EVIDENCE',v_tx,
+    'AVAILABLE_PARTIAL_COVERAGE','2026_CERTIFIED_SALES_SCOPE',(select max(updated_at) from public.aos_cartera_reconciliacion),v_now,v_now,'HIGH',
+    jsonb_build_array('F4_IS_FINANCIAL_TRUTH'),jsonb_build_array('F4_LINKED_IS_EVIDENCE_COVERAGE_NOT_COLLECTED_CASH','MISSING_EVIDENCE_IS_NOT_NON_PAYMENT'),jsonb_build_array('REV-F4','REV-F6.4')
+  );
+  v_acq_trust:=public.aos_rev_metric_trust_envelope_v1(
+    'F6_4_ACQUISITION_TO_REVENUE',case when v_acq_count>0 then to_jsonb(v_acq_value) else 'null'::jsonb end,
+    v_acq_count,v_tx,'EXPLICIT_AGENDA_SALE_ID_PLUS_LEAD_LINEAGE',v_acq_count,
+    case when v_acq_count>0 then 'AVAILABLE_PARTIAL_COVERAGE' else 'NO_DEFENDABLE_ATTRIBUTION' end,
+    '2026_EXPLICIT_LINEAGE_ONLY',(select max(ts_actualizado) from public.aos_agenda_citas),v_now,v_now,
+    case when v_acq_count>0 then 'HIGH' else 'UNRESOLVED' end,
+    case when v_acq_count>0 then jsonb_build_array('EXPLICIT_VENTA_ID_MATCH_AND_LEAD_ID') else jsonb_build_array('NO_EXPLICIT_SALE_LINEAGE_IN_SCOPE') end,
+    jsonb_build_array('PHONE_ONLY_ATTRIBUTION_PROHIBITED','ABSENCE_OF_EXPLICIT_LINEAGE_NE_ZERO_CONVERSION'),jsonb_build_array('aos_agenda_citas','aos_ventas','REV-F6.4')
+  );
+
+  return jsonb_build_object(
+    'ok',true,
+    'hasData',true,
+    'contract','REV-F6.4_SALES_INTELLIGENCE_3_V1',
+    'anio',p_anio,
+    'filters',jsonb_build_object('sede',v_sede,'asesor',v_asesor),
+    'business_date_lima',v_business_date,
+    'dataThrough',v_data_through,
+    'executive_revenue',jsonb_build_object(
+      'billed_amount',v_billed,
+      'transactions',v_tx,
+      'avg_ticket',case when v_tx>0 then round(v_billed/v_tx,2) else 0 end,
+      'target_ytd',v_target_ytd,
+      'target_annual',v_target_annual,
+      'pct_target_ytd',case when v_target_ytd>0 then round(100.0*v_billed/v_target_ytd,2) else null end,
+      'mtd_billed',v_mtd,
+      'mtd_transactions',v_mtd_tx,
+      'mtd_target',v_target_mtd,
+      'mtd_projection',case when v_target_mtd is null then null else v_projection end,
+      'f4_evidence_sales',v_f4,
+      'billed_amount_with_f4_evidence',v_f4_billed,
+      'payment_evidence_sales',v_payment_evidence,
+      'confirmed_balance_sales',v_confirmed_balance,
+      'confirmed_collected_amount',null,
+      'financial_semantic','F4_LINKED_IS_EVIDENCE_COVERAGE_NOT_COLLECTED_CASH'
+    ),
+    'identity_coverage',jsonb_build_object('safe_match_sales',v_safe,'review_sales',v_review,'unresolved_sales',v_unresolved,'denominator',v_tx),
+    'product_coverage',jsonb_build_object('resolved_sales',v_f3,'denominator',v_tx),
+    'monthly',v_monthly,
+    'cohorts',v_cohorts,
+    'observed_ltv',v_patient_value,
+    'products',v_products,
+    'cross_sell_transitions',v_transitions,
+    'sede_performance',v_sede_perf,
+    'advisor_performance',v_advisor_perf,
+    'acquisition_to_revenue',case when v_acq_count>0 then jsonb_build_object(
+      'source_status','AVAILABLE_PARTIAL_COVERAGE','explicit_attributed_sales',v_acq_count,'explicit_attributed_billed',v_acq_value,
+      'attribution_method','EXPLICIT_AGENDA_VENTA_ID_MATCH_PLUS_LEAD_LINEAGE','sample_size',v_acq_count
+    ) else jsonb_build_object(
+      'source_status','NO_DEFENDABLE_ATTRIBUTION','value',null,'sample_size',0,
+      'attribution_method','EXPLICIT_AGENDA_VENTA_ID_MATCH_PLUS_LEAD_LINEAGE',
+      'limitations',jsonb_build_array('NO_EXPLICIT_LINEAGE_IN_CURRENT_SCOPE','PHONE_ONLY_ATTRIBUTION_PROHIBITED','ABSENCE_NE_ZERO_CONVERSION')
+    ) end,
+    'demographic_geographic_readiness',jsonb_build_object(
+      'safe_patient_denominator',v_geo_n,
+      'threshold_pct',v_demo_threshold,
+      'minimum_cell_size',v_min_cell,
+      'fields',jsonb_build_object(
+        'sex',jsonb_build_object('available',v_sex_n,'pct',case when v_geo_n>0 then round(100.0*v_sex_n/v_geo_n,2) end,'enabled',(v_geo_n>=v_min_cell and 100.0*v_sex_n/nullif(v_geo_n,0)>=v_demo_threshold)),
+        'district',jsonb_build_object('available',v_district_n,'pct',case when v_geo_n>0 then round(100.0*v_district_n/v_geo_n,2) end,'enabled',(v_geo_n>=v_min_cell and 100.0*v_district_n/nullif(v_geo_n,0)>=v_demo_threshold)),
+        'city',jsonb_build_object('available',v_city_n,'pct',case when v_geo_n>0 then round(100.0*v_city_n/v_geo_n,2) end,'enabled',(v_geo_n>=v_min_cell and 100.0*v_city_n/nullif(v_geo_n,0)>=v_demo_threshold)),
+        'department',jsonb_build_object('available',v_dept_n,'pct',case when v_geo_n>0 then round(100.0*v_dept_n/v_geo_n,2) end,'enabled',(v_geo_n>=v_min_cell and 100.0*v_dept_n/nullif(v_geo_n,0)>=v_demo_threshold)),
+        'dob',jsonb_build_object('available',v_dob_n,'pct',case when v_geo_n>0 then round(100.0*v_dob_n/v_geo_n,2) end,'enabled',(v_geo_n>=v_min_cell and 100.0*v_dob_n/nullif(v_geo_n,0)>=v_demo_threshold))
+      ),
+      'enabled_fields',to_jsonb(array_remove(array[
+        case when v_geo_n>=v_min_cell and 100.0*v_sex_n/nullif(v_geo_n,0)>=v_demo_threshold then 'sex' end,
+        case when v_geo_n>=v_min_cell and 100.0*v_district_n/nullif(v_geo_n,0)>=v_demo_threshold then 'district' end,
+        case when v_geo_n>=v_min_cell and 100.0*v_city_n/nullif(v_geo_n,0)>=v_demo_threshold then 'city' end,
+        case when v_geo_n>=v_min_cell and 100.0*v_dept_n/nullif(v_geo_n,0)>=v_demo_threshold then 'department' end,
+        case when v_geo_n>=v_min_cell and 100.0*v_dob_n/nullif(v_geo_n,0)>=v_demo_threshold then 'dob' end
+      ]::text[],null))
+    ),
+    'metric_trust',jsonb_build_object('executive_revenue',v_exec_trust,'patient_linkage',v_identity_trust,'product_resolution',v_f3_trust,'financial_evidence',v_f4_trust,'acquisition_to_revenue',v_acq_trust),
+    'historical_source_status',jsonb_build_object(
+      '2024',jsonb_build_object('value',v_hist_2024->'value','source_status',v_hist_2024->>'source_status','trust_level',v_hist_2024->>'trust_level'),
+      '2025',jsonb_build_object('value',v_hist_2025->'value','source_status',v_hist_2025->>'source_status','trust_level',v_hist_2025->>'trust_level'),
+      '2026',jsonb_build_object('source_status','AVAILABLE','min_date',(select min(sale_date) from public.aos_rev_si_sales_fact_v1),'max_date',(select max(sale_date) from public.aos_rev_si_sales_fact_v1))
+    ),
+    'limitations',jsonb_build_array(
+      '2024_2025_TRANSACTIONAL_SALES_NO_CERTIFIED_SOURCE',
+      'PATIENT_ANALYTICS_MATCH_ONLY',
+      'OBSERVED_VALUE_NOT_FUTURE_LTV',
+      'F4_EVIDENCE_NOT_CONFIRMED_COLLECTED_CASH',
+      'ACQUISITION_ATTRIBUTION_REQUIRES_EXPLICIT_LINEAGE'
+    ),
+    'read_model_architecture','MATERIALIZED_READ_MODELS_PLUS_SET_BASED_AGGREGATION'
+  );
+end;
+$$;
+comment on function public.aos_rev_sales_intelligence_v3(integer,text,text) is
+'REV-F6.4 service-only Sales Intelligence 3.0. Performance-oriented set-based aggregate over governed materialized read models; explicit coverage/trust semantics.';
+revoke all on function public.aos_rev_sales_intelligence_v3(integer,text,text) from public,anon,authenticated;
+grant execute on function public.aos_rev_sales_intelligence_v3(integer,text,text) to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 9) DETERMINISTIC F6.4 CERTIFICATION CONTRACT.
+-- -----------------------------------------------------------------------------
+create or replace function public.aos_rev_f6_4_contract_v1()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_f63 jsonb := public.aos_rev_f6_3_contract_v1();
+  v_payload jsonb;
+  v_fp text;
+  v_sales bigint;
+  v_monthly bigint;
+  v_patients bigint;
+  v_cohorts bigint;
+  v_transitions bigint;
+  v_acq bigint;
+begin
+  select count(*) into v_sales from public.aos_rev_si_sales_fact_v1;
+  select count(*) into v_monthly from public.aos_rev_si_monthly_v1;
+  select count(*) into v_patients from public.aos_rev_si_patient_value_v1;
+  select count(*) into v_cohorts from public.aos_rev_si_cohort_month_v1;
+  select count(*) into v_transitions from public.aos_rev_si_product_transition_v1;
+  select count(*) into v_acq from public.aos_rev_si_acquisition_fact_v1;
+
+  v_payload:=jsonb_build_object(
+    'contract_id','REV-F6.4_SALES_INTELLIGENCE_3_V1',
+    'contract_version',1,
+    'input_fingerprints',jsonb_build_object(
+      'f6_0',v_f63#>>'{contract,input_fingerprints,f6_0}',
+      'f6_1',v_f63#>>'{contract,input_fingerprints,f6_1}',
+      'f6_2',v_f63#>>'{contract,input_fingerprints,f6_2}',
+      'f6_3',v_f63->>'contract_fingerprint'
+    ),
+    'read_models',jsonb_build_object(
+      'sales_fact_rows',v_sales,
+      'monthly_rows',v_monthly,
+      'patient_value_rows',v_patients,
+      'cohort_rows',v_cohorts,
+      'product_transition_rows',v_transitions,
+      'explicit_acquisition_rows',v_acq
+    ),
+    'semantic_guards',jsonb_build_object(
+      'patient_analytics_match_only',true,
+      'observed_ltv_is_prediction',false,
+      'f4_link_means_collected_cash',false,
+      'phone_only_acquisition_attribution',false,
+      'no_certified_source_means_zero',false,
+      'demographic_coverage_threshold_pct',70,
+      'demographic_minimum_cell_size',5
+    ),
+    'historical_transaction_sources',jsonb_build_object('2024','NO_CERTIFIED_SOURCE','2025','NO_CERTIFIED_SOURCE','2026','AVAILABLE'),
+    'performance_contract',jsonb_build_object(
+      'architecture','MATERIALIZED_READ_MODELS_PLUS_SET_BASED_AGGREGATION',
+      'live_rpc_target_ms',1000,
+      'timeout_increase_is_solution',false
+    ),
+    'security',jsonb_build_object(
+      'raw_read_models_browser_closed',true,
+      'raw_pii_phi_in_aggregate_contract',false,
+      'browser_gateway_reuses_existing_admin_2fa_authorization',true
+    )
+  );
+  v_fp:=md5(v_payload::text);
+  return jsonb_build_object('ok',true,'generated_at',clock_timestamp(),'contract',v_payload,'contract_fingerprint',v_fp);
+end;
+$$;
+comment on function public.aos_rev_f6_4_contract_v1() is
+'REV-F6.4 deterministic aggregate certification contract. Dynamic generated_at excluded from fingerprint payload.';
+revoke all on function public.aos_rev_f6_4_contract_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_f6_4_contract_v1() to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 10) CONTROLLED REFRESH — derived read models only.
+-- -----------------------------------------------------------------------------
+create or replace function public.aos_rev_si_refresh_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  refresh materialized view public.aos_rev_si_sales_fact_v1;
+  refresh materialized view public.aos_rev_si_monthly_v1;
+  refresh materialized view public.aos_rev_si_patient_value_v1;
+  refresh materialized view public.aos_rev_si_cohort_month_v1;
+  refresh materialized view public.aos_rev_si_product_transition_v1;
+  refresh materialized view public.aos_rev_si_acquisition_fact_v1;
+  return public.aos_rev_f6_4_contract_v1();
+end;
+$$;
+comment on function public.aos_rev_si_refresh_v1() is
+'REV-F6.4 service-only deterministic refresh of derived materialized read models. Does not mutate business source rows.';
+revoke all on function public.aos_rev_si_refresh_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_si_refresh_v1() to service_role;
+
+-- -----------------------------------------------------------------------------
+-- 11) BROWSER GATEWAY — preserve existing Sales Intelligence admin + 2FA auth.
+-- Existing gateway is used as an authorization probe; V3 does not weaken it.
+-- -----------------------------------------------------------------------------
+create or replace function public.aos_rev_sales_intelligence_v3_gateway(
+  p_token text,
+  p_anio integer,
+  p_sede text default '',
+  p_asesor text default ''
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_auth_probe jsonb;
+begin
+  v_auth_probe:=public.aos_sales_intelligence_gateway(p_token,p_anio,p_sede,p_asesor);
+  if coalesce(v_auth_probe->>'error','')='UNAUTHORIZED' or coalesce((v_auth_probe->>'ok')::boolean,true)=false then
+    return jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+  return public.aos_rev_sales_intelligence_v3(p_anio,p_sede,p_asesor);
+end;
+$$;
+comment on function public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text) is
+'REV-F6.4 browser gateway. Authorization is delegated to existing certified Sales Intelligence admin+2FA access contract before service-only V3 analytics.';
+revoke all on function public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text) from public;
+grant execute on function public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text) to anon,authenticated,service_role;
+
+-- -----------------------------------------------------------------------------
+-- 12) PATIENT COMMERCIAL 360 — preserve F6.3 as private base, add F6.4 read detail.
+-- -----------------------------------------------------------------------------
+do $$
+begin
+  if to_regprocedure('public.aos_patient_commercial_360_v2_f6_3_base(text,text,text)') is null then
+    execute 'alter function public.aos_patient_commercial_360_v2(text,text,text) rename to aos_patient_commercial_360_v2_f6_3_base';
+  end if;
+end $$;
+revoke all on function public.aos_patient_commercial_360_v2_f6_3_base(text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_patient_commercial_360_v2_f6_3_base(text,text,text) to service_role;
+
+create or replace function public.aos_patient_commercial_360_v2(p_token text,p_lookup_type text,p_lookup_value text)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_base jsonb;
+  v_pid text;
+  v_value jsonb;
+begin
+  v_base:=public.aos_patient_commercial_360_v2_f6_3_base(p_token,p_lookup_type,p_lookup_value);
+  if coalesce((v_base->>'found')::boolean,false) then
+    v_pid:=v_base#>>'{paciente,canonical_patient_id}';
+    v_value:=public.aos_rev_si_patient_value_by_patient_v1(v_pid);
+    v_base:=jsonb_set(v_base,'{intelligence,sales_intelligence}',v_value,true);
+  end if;
+  v_base:=jsonb_set(v_base,'{contract}',to_jsonb('REV-F6.4_PATIENT_COMMERCIAL_360_V2'::text),true);
+  return v_base;
+end;
+$$;
+comment on function public.aos_patient_commercial_360_v2(text,text,text) is
+'REV-F6.4 governed Patient Commercial 360 wrapper. Preserves F6.3 authorization/privacy and adds MATCH-only observed Sales Intelligence metadata.';
+revoke all on function public.aos_patient_commercial_360_v2(text,text,text) from public;
+grant execute on function public.aos_patient_commercial_360_v2(text,text,text) to anon,authenticated,service_role;
+
+commit;

--- a/supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql
+++ b/supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql
@@ -1,0 +1,17 @@
+-- REV-F6.4 LIVE performance hotfix: remove expensive full Metric Trust baseline rebuild from each V3 request.
+-- Historical 2024/2025 state remains the already-certified F6.3 semantic until F6.5 replaces it with a dynamic plug-in contract.
+
+do $$
+declare
+  v_oid regprocedure := 'public.aos_rev_sales_intelligence_v3(integer,text,text)'::regprocedure;
+  v_ddl text;
+  v_old text := 'v_metric_baseline:=public.aos_rev_metric_trust_baseline_v1(); v_hist_2024:=v_metric_baseline->''TRANSACTIONAL_SALES_2024''; v_hist_2025:=v_metric_baseline->''TRANSACTIONAL_SALES_2025'';';
+  v_new text := 'v_metric_baseline:=jsonb_build_object(''TRANSACTIONAL_SALES_2024'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE''),''TRANSACTIONAL_SALES_2025'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE'')); v_hist_2024:=v_metric_baseline->''TRANSACTIONAL_SALES_2024''; v_hist_2025:=v_metric_baseline->''TRANSACTIONAL_SALES_2025'';';
+begin
+  v_ddl := pg_get_functiondef(v_oid);
+  if position(v_old in v_ddl)=0 then
+    raise exception 'REV-F6.4 performance hotfix target not found; fail closed';
+  end if;
+  v_ddl := replace(v_ddl,v_old,v_new);
+  execute v_ddl;
+end $$;

--- a/supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql
+++ b/supabase/migrations/20260820191000_rev_f6_4_live_performance_baseline_decouple_v1.sql
@@ -1,17 +1,22 @@
 -- REV-F6.4 LIVE performance hotfix: remove expensive full Metric Trust baseline rebuild from each V3 request.
 -- Historical 2024/2025 state remains the already-certified F6.3 semantic until F6.5 replaces it with a dynamic plug-in contract.
+-- This patch is formatting-independent: it replaces only the expensive function expression inside pg_get_functiondef().
 
 do $$
 declare
   v_oid regprocedure := 'public.aos_rev_sales_intelligence_v3(integer,text,text)'::regprocedure;
   v_ddl text;
-  v_old text := 'v_metric_baseline:=public.aos_rev_metric_trust_baseline_v1(); v_hist_2024:=v_metric_baseline->''TRANSACTIONAL_SALES_2024''; v_hist_2025:=v_metric_baseline->''TRANSACTIONAL_SALES_2025'';';
-  v_new text := 'v_metric_baseline:=jsonb_build_object(''TRANSACTIONAL_SALES_2024'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE''),''TRANSACTIONAL_SALES_2025'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE'')); v_hist_2024:=v_metric_baseline->''TRANSACTIONAL_SALES_2024''; v_hist_2025:=v_metric_baseline->''TRANSACTIONAL_SALES_2025'';';
+  v_target text := 'public.aos_rev_metric_trust_baseline_v1()';
+  v_replacement text := 'jsonb_build_object(''TRANSACTIONAL_SALES_2024'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE''),''TRANSACTIONAL_SALES_2025'',jsonb_build_object(''value'',null,''source_status'',''NO_CERTIFIED_SOURCE'',''trust_level'',''UNAVAILABLE''))';
 begin
   v_ddl := pg_get_functiondef(v_oid);
-  if position(v_old in v_ddl)=0 then
-    raise exception 'REV-F6.4 performance hotfix target not found; fail closed';
+  if position(v_target in v_ddl)>0 then
+    v_ddl := replace(v_ddl,v_target,v_replacement);
+    execute v_ddl;
+  elsif position('NO_CERTIFIED_SOURCE' in v_ddl)>0 then
+    -- Idempotent replay: the function is already decoupled.
+    null;
+  else
+    raise exception 'REV-F6.4 performance hotfix target not found and no certified replacement present; fail closed';
   end if;
-  v_ddl := replace(v_ddl,v_old,v_new);
-  execute v_ddl;
 end $$;

--- a/supabase/migrations/20260820191500_rev_f6_4_dashboard_cache_performance_v1.sql
+++ b/supabase/migrations/20260820191500_rev_f6_4_dashboard_cache_performance_v1.sql
@@ -1,0 +1,121 @@
+-- REV-F6.4 LIVE performance read-model hotfix.
+-- Keep the deep calculation service-only and expose bounded cached payloads for current filter space.
+
+begin;
+
+alter function public.aos_rev_sales_intelligence_v3(integer,text,text) rename to aos_rev_sales_intelligence_v3_uncached_f6_4_base;
+revoke all on function public.aos_rev_sales_intelligence_v3_uncached_f6_4_base(integer,text,text) from public,anon,authenticated;
+grant execute on function public.aos_rev_sales_intelligence_v3_uncached_f6_4_base(integer,text,text) to service_role;
+
+create table if not exists public.aos_rev_si_dashboard_cache_v1 (
+  anio integer not null,
+  sede text not null default '',
+  advisor text not null default '',
+  payload jsonb not null,
+  generated_at timestamptz not null default clock_timestamp(),
+  primary key(anio,sede,advisor)
+);
+comment on table public.aos_rev_si_dashboard_cache_v1 is
+'REV-F6.4 zero-PII bounded dashboard payload cache. Refreshed from governed read models; no business-source mutation.';
+revoke all on public.aos_rev_si_dashboard_cache_v1 from public,anon,authenticated;
+grant select,insert,update,delete on public.aos_rev_si_dashboard_cache_v1 to service_role;
+
+create or replace function public.aos_rev_si_cache_filter_v1(p_anio integer,p_sede text default '',p_asesor text default '')
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_sede text:=upper(trim(coalesce(p_sede,'')));
+  v_asesor text:=trim(coalesce(p_asesor,''));
+  v_payload jsonb;
+begin
+  v_payload:=public.aos_rev_sales_intelligence_v3_uncached_f6_4_base(p_anio,v_sede,v_asesor);
+  insert into public.aos_rev_si_dashboard_cache_v1(anio,sede,advisor,payload,generated_at)
+  values(p_anio,v_sede,v_asesor,v_payload,clock_timestamp())
+  on conflict(anio,sede,advisor) do update set payload=excluded.payload,generated_at=excluded.generated_at;
+  return v_payload;
+end;
+$$;
+revoke all on function public.aos_rev_si_cache_filter_v1(integer,text,text) from public,anon,authenticated;
+grant execute on function public.aos_rev_si_cache_filter_v1(integer,text,text) to service_role;
+
+create or replace function public.aos_rev_si_rebuild_dashboard_cache_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  r record;
+  v_count integer:=0;
+begin
+  delete from public.aos_rev_si_dashboard_cache_v1 where anio=2026;
+  for r in
+    with filters as (
+      select ''::text sede,''::text advisor
+      union select distinct s.sede,''::text from public.aos_rev_si_sales_fact_v1 s where s.sale_year=2026
+      union select distinct ''::text,s.advisor from public.aos_rev_si_sales_fact_v1 s where s.sale_year=2026
+      union select distinct s.sede,s.advisor from public.aos_rev_si_sales_fact_v1 s where s.sale_year=2026
+    ) select sede,advisor from filters order by sede,advisor
+  loop
+    perform public.aos_rev_si_cache_filter_v1(2026,r.sede,r.advisor);
+    v_count:=v_count+1;
+  end loop;
+  return jsonb_build_object('ok',true,'cache_rows',v_count,'generated_at',clock_timestamp());
+end;
+$$;
+revoke all on function public.aos_rev_si_rebuild_dashboard_cache_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_si_rebuild_dashboard_cache_v1() to service_role;
+
+select public.aos_rev_si_rebuild_dashboard_cache_v1();
+
+create or replace function public.aos_rev_sales_intelligence_v3(p_anio integer,p_sede text default '',p_asesor text default '')
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_sede text:=upper(trim(coalesce(p_sede,'')));
+  v_asesor text:=trim(coalesce(p_asesor,''));
+  v_payload jsonb;
+begin
+  if p_anio not between 2020 and 2100 then return jsonb_build_object('ok',false,'error','INVALID_YEAR'); end if;
+  if v_sede not in ('','SAN ISIDRO','PUEBLO LIBRE') then return jsonb_build_object('ok',false,'error','INVALID_FILTER'); end if;
+  if p_anio=2026 then
+    select c.payload into v_payload from public.aos_rev_si_dashboard_cache_v1 c
+    where c.anio=p_anio and c.sede=v_sede and c.advisor=v_asesor;
+    if v_payload is not null then
+      return jsonb_set(v_payload,'{business_date_lima}',to_jsonb(public.aos_rev_business_date_lima_v1()),true);
+    end if;
+  end if;
+  return public.aos_rev_sales_intelligence_v3_uncached_f6_4_base(p_anio,v_sede,v_asesor);
+end;
+$$;
+revoke all on function public.aos_rev_sales_intelligence_v3(integer,text,text) from public,anon,authenticated;
+grant execute on function public.aos_rev_sales_intelligence_v3(integer,text,text) to service_role;
+
+create or replace function public.aos_rev_si_refresh_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  refresh materialized view public.aos_rev_si_sales_fact_v1;
+  refresh materialized view public.aos_rev_si_monthly_v1;
+  refresh materialized view public.aos_rev_si_patient_value_v1;
+  refresh materialized view public.aos_rev_si_cohort_month_v1;
+  refresh materialized view public.aos_rev_si_product_transition_v1;
+  refresh materialized view public.aos_rev_si_acquisition_fact_v1;
+  perform public.aos_rev_si_rebuild_dashboard_cache_v1();
+  return public.aos_rev_f6_4_contract_v1();
+end;
+$$;
+revoke all on function public.aos_rev_si_refresh_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_si_refresh_v1() to service_role;
+
+commit;

--- a/supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
+++ b/supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
@@ -1,0 +1,27 @@
+-- REV-F6.4 recovery — restore the exact certified F6.3 public boundary.
+begin;
+
+drop function if exists public.aos_rev_sales_intelligence_v3_gateway(text,integer,text,text);
+drop function if exists public.aos_rev_si_refresh_v1();
+drop function if exists public.aos_rev_f6_4_contract_v1();
+drop function if exists public.aos_rev_sales_intelligence_v3(integer,text,text);
+drop function if exists public.aos_rev_si_patient_value_by_patient_v1(text);
+
+drop materialized view if exists public.aos_rev_si_acquisition_fact_v1;
+drop materialized view if exists public.aos_rev_si_product_transition_v1;
+drop materialized view if exists public.aos_rev_si_cohort_month_v1;
+drop materialized view if exists public.aos_rev_si_patient_value_v1;
+drop materialized view if exists public.aos_rev_si_monthly_v1;
+drop materialized view if exists public.aos_rev_si_sales_fact_v1;
+
+drop function if exists public.aos_patient_commercial_360_v2(text,text,text);
+do $$
+begin
+  if to_regprocedure('public.aos_patient_commercial_360_v2_f6_3_base(text,text,text)') is not null then
+    execute 'alter function public.aos_patient_commercial_360_v2_f6_3_base(text,text,text) rename to aos_patient_commercial_360_v2';
+  end if;
+end $$;
+revoke all on function public.aos_patient_commercial_360_v2(text,text,text) from public;
+grant execute on function public.aos_patient_commercial_360_v2(text,text,text) to anon,authenticated,service_role;
+
+commit;

--- a/supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
+++ b/supabase/rollbacks/20260820190000_rev_f6_4_sales_intelligence_3_v1_recovery.sql
@@ -5,8 +5,12 @@ drop function if exists public.aos_rev_sales_intelligence_v3_gateway(text,intege
 drop function if exists public.aos_rev_si_refresh_v1();
 drop function if exists public.aos_rev_f6_4_contract_v1();
 drop function if exists public.aos_rev_sales_intelligence_v3(integer,text,text);
+drop function if exists public.aos_rev_si_rebuild_dashboard_cache_v1();
+drop function if exists public.aos_rev_si_cache_filter_v1(integer,text,text);
+drop function if exists public.aos_rev_sales_intelligence_v3_uncached_f6_4_base(integer,text,text);
 drop function if exists public.aos_rev_si_patient_value_by_patient_v1(text);
 
+drop table if exists public.aos_rev_si_dashboard_cache_v1;
 drop materialized view if exists public.aos_rev_si_acquisition_fact_v1;
 drop materialized view if exists public.aos_rev_si_product_transition_v1;
 drop materialized view if exists public.aos_rev_si_cohort_month_v1;


### PR DESCRIPTION
Executes REV-F6.4 as an additive analytical/read-model layer over certified F3/F4/F5 and REV-F6.0–F6.3.

PRE-LIVE IMPLEMENTATION — NOT YET CERTIFIED.

- Entry main: `10c8ebccb0be1d8e538491de834cb7457f453de9`.
- Initial exact head: `355c8dce6b902c47758be194a99fa0e74daf4cce`.
- Adds bounded materialized read models for Executive Revenue, MATCH-only cohorts/retention, observed value, F3 product/cross-sell, sede/advisor and explicit-lineage acquisition-to-revenue.
- F4 linkage remains evidence coverage; it is never presented as confirmed collected cash.
- 2024/2025 transactional sales remain `NO_CERTIFIED_SOURCE != zero`.
- Raw read models are service-only / zero-PII.
- Browser V3 gateway preserves the existing Sales Intelligence admin + 2FA authorization boundary.
- Patient Commercial 360 is augmented, not replaced.
- Performance is a certification gate (<1000 ms repeated isolated V3 calls), not a timeout increase.
- Recovery restores the certified REV-F6.3 Patient Commercial 360 boundary and removes only F6.4 derived objects.

Do not merge until exact-head F6.4 + upstream regression CI is green, LIVE anti-drift passes, F6.4 migration/readback/security/performance/fingerprint x2 pass, and final certificate evidence is committed.