### PR TITLE
REV-F6.5 terminal — isolate Revenue fingerprint from CIA compatibility churn

### DIFF
--- a/.github/workflows/rev-f6-5-historical-sales-plugin.yml
+++ b/.github/workflows/rev-f6-5-historical-sales-plugin.yml
@@ -117,9 +117,9 @@ jobs:
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820195500_rev_f6_5_historical_sales_plugin_v1.sql
       - name: Apply terminal cross-workstream fingerprint isolation
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
-      - name: Rebaseline derived F6.4 fingerprint after semantic isolation
+      - name: Rebaseline derived F6.3/F6.4 fingerprints after semantic isolation
         run: |
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "update public.ci_f65_protected_baseline set f64_fp=public.aos_rev_f6_4_contract_v1()->>'contract_fingerprint';"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "update public.ci_f65_protected_baseline set f63_fp=public.aos_rev_f6_3_contract_v1()->>'contract_fingerprint', f64_fp=public.aos_rev_f6_4_contract_v1()->>'contract_fingerprint';"
       - name: Fixtures A-J
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/fixtures_A_J.sql
       - name: F6.5 invariants

--- a/.github/workflows/rev-f6-5-historical-sales-plugin.yml
+++ b/.github/workflows/rev-f6-5-historical-sales-plugin.yml
@@ -117,6 +117,9 @@ jobs:
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820195500_rev_f6_5_historical_sales_plugin_v1.sql
       - name: Apply terminal cross-workstream fingerprint isolation
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
+      - name: Rebaseline derived F6.4 fingerprint after semantic isolation
+        run: |
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "update public.ci_f65_protected_baseline set f64_fp=public.aos_rev_f6_4_contract_v1()->>'contract_fingerprint';"
       - name: Fixtures A-J
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/fixtures_A_J.sql
       - name: F6.5 invariants

--- a/.github/workflows/rev-f6-5-historical-sales-plugin.yml
+++ b/.github/workflows/rev-f6-5-historical-sales-plugin.yml
@@ -115,24 +115,34 @@ jobs:
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/capture_baseline.sql
       - name: Apply exact F6.5 migration
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820195500_rev_f6_5_historical_sales_plugin_v1.sql
+      - name: Apply terminal cross-workstream fingerprint isolation
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
       - name: Fixtures A-J
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/fixtures_A_J.sql
       - name: F6.5 invariants
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/tests/001_historical_sales_plugin.sql
+      - name: Cross-workstream fingerprint isolation
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/tests/002_cross_workstream_fingerprint_isolation.sql
       - name: Full idempotent migration replay
         run: |
           set -euo pipefail
           fp1="$(psql "$DB_URL" -X -qAt -c "select public.aos_rev_f6_5_contract_v1()->>'contract_fingerprint'")"
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820195500_rev_f6_5_historical_sales_plugin_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
           fp2="$(psql "$DB_URL" -X -qAt -c "select public.aos_rev_f6_5_contract_v1()->>'contract_fingerprint'")"
           test "$fp1" = "$fp2"
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/tests/001_historical_sales_plugin.sql
-      - name: Recovery restores exact F6.4 boundary
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f6-5/tests/002_cross_workstream_fingerprint_isolation.sql
+      - name: Recovery restores exact pre-hardening F6.4 boundary
         run: |
           set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1_recovery.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260820195500_rev_f6_5_historical_sales_plugin_v1_recovery.sql
           test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_rev_historical_source_manifest_v1') is null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_5_contract_v1()') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp()') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb)') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_data_contract_v1()') is not null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_sales_intelligence_v3_f6_4_runtime_base(integer,text,text)') is null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_sales_intelligence_v3(integer,text,text)') is not null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_rev_f6_4_contract_v1()') is not null")" = "t"

--- a/ci/rev-f6-5/static_contract.js
+++ b/ci/rev-f6-5/static_contract.js
@@ -3,6 +3,9 @@ const fs=require('fs');
 const migration=fs.readFileSync('supabase/migrations/20260820195500_rev_f6_5_historical_sales_plugin_v1.sql','utf8');
 const rollback=fs.readFileSync('supabase/rollbacks/20260820195500_rev_f6_5_historical_sales_plugin_v1_recovery.sql','utf8');
 const fixtures=fs.readFileSync('ci/rev-f6-5/fixtures_A_J.sql','utf8');
+const isolation=fs.readFileSync('supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql','utf8');
+const isolationRollback=fs.readFileSync('supabase/rollbacks/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1_recovery.sql','utf8');
+const isolationTest=fs.readFileSync('ci/rev-f6-5/tests/002_cross_workstream_fingerprint_isolation.sql','utf8');
 function must(x,msg){if(!x)throw new Error(msg)}
 [
  'aos_rev_historical_source_manifest_v1','aos_rev_historical_source_register_v1','aos_rev_historical_source_certify_v1',
@@ -25,4 +28,20 @@ must(!/(insert\s+into|update|delete\s+from)\s+public\.aos_pacientes/i.test(migra
 must(rollback.includes('rename to aos_rev_sales_intelligence_v3'),'recovery must restore F6.4 runtime name');
 must(rollback.includes('drop table if exists public.aos_rev_historical_source_manifest_v1'),'recovery must remove F6.5 manifest');
 for(const l of 'ABCDEFGHIJ') must(fixtures.includes('FIXTURE '+l+' —'),'missing fixture '+l);
+
+[
+ 'aos_rev_f6_data_contract_fingerprint_isolated_v1',
+ 'aos_rev_f6_data_contract_v1_legacy_dynamic_fp',
+ 'REVENUE_TRUTH_EXCLUDES_MUTABLE_CIA_COMPATIBILITY_CARDINALITY',
+ "array['compatibility_identity','rows']",
+ "array['compatibility_identity','with_canonical_patient']",
+ "array['compatibility_identity','identity_conflicts']",
+ "array['freshness_sources','cia_identity_updated_at']"
+].forEach(s=>must(isolation.includes(s),'missing fingerprint-isolation contract: '+s));
+must(/revoke all on function public\.aos_rev_f6_data_contract_v1\(\) from public,anon,authenticated/i.test(isolation),'isolated F6.0 wrapper must stay browser-closed');
+must(!/(insert\s+into|update|delete\s+from)\s+public\.(aos_ventas|aos_pacientes|aos_leads|aos_llamadas|aos_agenda_citas)/i.test(isolation),'fingerprint isolation must not mutate business rows');
+must(isolationRollback.includes('rename to aos_rev_f6_data_contract_v1'),'isolation recovery must restore original F6.0 name');
+must(isolationTest.includes('legacy fingerprint did not react to synthetic CIA churn'),'isolation test must prove old coupling');
+must(isolationTest.includes('Revenue fingerprint still coupled to mutable CIA compatibility state'),'isolation test must prove new decoupling');
+must(isolationTest.includes('F6.5 chain fingerprint unstable'),'isolation test must cover terminal chain determinism');
 console.log('REV-F6.5 FAST static contract PASS');

--- a/ci/rev-f6-5/tests/002_cross_workstream_fingerprint_isolation.sql
+++ b/ci/rev-f6-5/tests/002_cross_workstream_fingerprint_isolation.sql
@@ -1,0 +1,71 @@
+\set ON_ERROR_STOP on
+
+-- Cross-workstream isolation: mutable CIA compatibility observations remain visible but cannot invalidate Revenue certification hashes.
+do $$
+declare
+  legacy jsonb;
+  original_contract jsonb;
+  mutated_contract jsonb;
+  fp_original text;
+  fp_mutated text;
+  legacy_fp_original text;
+  legacy_fp_mutated text;
+  wrapper jsonb;
+begin
+  if to_regprocedure('public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp()') is null then raise exception 'legacy F6.0 source missing'; end if;
+  if to_regprocedure('public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb)') is null then raise exception 'isolated fingerprint helper missing'; end if;
+
+  legacy:=public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp();
+  original_contract:=legacy->'contract';
+  if original_contract#>'{compatibility_identity}' is null then raise exception 'CIA compatibility metrics disappeared from visible F6.0 contract'; end if;
+  if original_contract#>'{freshness_sources}' is null then raise exception 'freshness metrics disappeared from visible F6.0 contract'; end if;
+
+  mutated_contract:=jsonb_set(original_contract,'{compatibility_identity,rows}',to_jsonb(987654321),true);
+  mutated_contract:=jsonb_set(mutated_contract,'{compatibility_identity,with_canonical_patient}',to_jsonb(123456789),true);
+  mutated_contract:=jsonb_set(mutated_contract,'{compatibility_identity,identity_conflicts}',to_jsonb(777),true);
+  mutated_contract:=jsonb_set(mutated_contract,'{freshness_sources,cia_identity_updated_at}',to_jsonb('2099-12-31T23:59:59+00:00'::text),true);
+
+  legacy_fp_original:=md5(original_contract::text);
+  legacy_fp_mutated:=md5(mutated_contract::text);
+  if legacy_fp_original=legacy_fp_mutated then raise exception 'test invalid: legacy fingerprint did not react to synthetic CIA churn'; end if;
+
+  fp_original:=public.aos_rev_f6_data_contract_fingerprint_isolated_v1(original_contract);
+  fp_mutated:=public.aos_rev_f6_data_contract_fingerprint_isolated_v1(mutated_contract);
+  if fp_original<>fp_mutated then raise exception 'Revenue fingerprint still coupled to mutable CIA compatibility state: % <> %',fp_original,fp_mutated; end if;
+
+  wrapper:=public.aos_rev_f6_data_contract_v1();
+  if wrapper->>'contract_fingerprint'<>fp_original then raise exception 'wrapper fingerprint does not equal isolated projection'; end if;
+  if wrapper->>'fingerprint_semantic'<>'REVENUE_TRUTH_EXCLUDES_MUTABLE_CIA_COMPATIBILITY_CARDINALITY' then raise exception 'fingerprint semantic missing'; end if;
+  if wrapper#>'{contract,compatibility_identity}'<>original_contract->'compatibility_identity' then raise exception 'visible CIA compatibility metrics were altered'; end if;
+end $$;
+
+-- New chain must be deterministic after isolation.
+do $$
+declare a jsonb; b jsonb;
+begin
+  a:=public.aos_rev_f6_data_contract_v1(); b:=public.aos_rev_f6_data_contract_v1();
+  if a->>'contract_fingerprint'<>b->>'contract_fingerprint' then raise exception 'F6.0 isolated fingerprint unstable'; end if;
+  a:=public.aos_rev_f6_3_contract_v1(); b:=public.aos_rev_f6_3_contract_v1();
+  if a->>'contract_fingerprint'<>b->>'contract_fingerprint' then raise exception 'F6.3 chain fingerprint unstable'; end if;
+  a:=public.aos_rev_f6_4_contract_v1(); b:=public.aos_rev_f6_4_contract_v1();
+  if a->>'contract_fingerprint'<>b->>'contract_fingerprint' then raise exception 'F6.4 chain fingerprint unstable'; end if;
+  a:=public.aos_rev_f6_5_contract_v1(); b:=public.aos_rev_f6_5_contract_v1();
+  if a->>'contract_fingerprint'<>b->>'contract_fingerprint' then raise exception 'F6.5 chain fingerprint unstable'; end if;
+end $$;
+
+-- Security and protected truth remain unchanged.
+do $$
+declare b record;
+begin
+  if has_function_privilege('anon','public.aos_rev_f6_data_contract_v1()','EXECUTE') then raise exception 'F6.0 wrapper browser executable'; end if;
+  if has_function_privilege('authenticated','public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb)','EXECUTE') then raise exception 'fingerprint helper browser executable'; end if;
+  if not has_function_privilege('service_role','public.aos_rev_f6_data_contract_v1()','EXECUTE') then raise exception 'F6.0 service boundary lost'; end if;
+
+  select * into b from public.ci_f65_protected_baseline limit 1;
+  if (select count(*) from public.aos_pacientes)<>b.patients then raise exception 'patients mutated by fingerprint isolation'; end if;
+  if (select count(*) from public.aos_ventas)<>b.sales then raise exception 'sales mutated by fingerprint isolation'; end if;
+  if (select count(*) from public.aos_product_sale_fact_current_v1)<>b.f3 then raise exception 'F3 mutated by fingerprint isolation'; end if;
+  if (select count(*) from public.aos_cartera_reconciliacion)<>b.f4 then raise exception 'F4 mutated by fingerprint isolation'; end if;
+end $$;
+
+select 'REV-F6.5 cross-workstream fingerprint isolation PASS' as result;

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -2,61 +2,74 @@
 
 **Status:** CURRENT / REV-F6 ACTIVE  
 **Captured:** 2026-08-20 America/Lima  
-**Entry main:** `c73b41b318639ef09027956b3c183f8379c42e33`  
+**Current main before terminal hardening:** `70bd591a2f4da7a39e41819416af40af4a694b29`  
 **ACTIVE LOCK:** `REV-F6-CLOSEOUT`  
-**CURRENT GATE:** `REV-F6.5 — Historical Sales Plug-in`  
+**CURRENT GATE:** `REV-F6.5 — POST-MERGE TERMINAL FINGERPRINT ISOLATION`  
 **REV-F5:** `PRODUCTION CERTIFIED — 100%`  
-**REV-F6.0:** `PASS / CERTIFIED` · fp `02ba53adb9dabfcd0a4557061be53c2f`  
+**REV-F6.0:** `PASS / CERTIFIED — semantic hardening in progress`  
 **REV-F6.1:** `PASS / CERTIFIED — 100%` · fp `cd313998c5b5b38d5cb9e2f08882b826`  
 **REV-F6.2:** `PASS / CERTIFIED — 100%` · fp `d977b9669b9e741e8785cd863caaf9c2`  
-**REV-F6.3:** `PASS / CERTIFIED — 100%` · fp `3f4174660107661a2c4509f6f8817d7a`  
-**REV-F6.4:** `PASS / CERTIFIED — 100%` · fp `b0f06d841c74ceeb231451aecdeceef2`  
-**REV-F6 global:** `62.5%`  
-**REV-F6.5:** `IN PROGRESS / PRE-LIVE`  
+**REV-F6.3:** `PASS / CERTIFIED — terminal chain fp pending isolation`  
+**REV-F6.4:** `PASS / CERTIFIED — terminal chain fp pending isolation`  
+**REV-F6 global:** `62.5%` until F6.5 terminal certification  
+**REV-F6.5:** `POST-MERGE HARDENING / NOT YET TERMINALLY CERTIFIED`  
 **REV-F6.6:** `BLOCKED until REV-F6.5 certification`  
 **REV-F6.7:** `BLOCKED`  
 **REV-F7:** `BLOCKED until REV-F6 final certification`
 
-GitHub CURRENT + Supabase LIVE are authoritative over historical checkpoints. `REV-F6-CLOSEOUT` remains the only HIGH/CRITICAL mutable Revenue lane.
+GitHub CURRENT + Supabase LIVE remain authoritative. `REV-F6-CLOSEOUT` is the only mutable HIGH/CRITICAL Revenue lane.
 
-## REV-F6.4 certified boundary
+## REV-F6.5 implementation + first merge
 
-PR #314 merged with expected head `36914e89d6624cc0541774adcff89600fd14537a` to certification `main@5ba6401406812115ee55eb245854331be2ce818e`. Post-merge LIVE reproduced F6.4 fp `b0f06d841c74ceeb231451aecdeceef2`; protected truth remains patients 7,688 / sales 1,299 / F3 406 / F4 162; F6.3 fp remains exact. Post-merge Sales Intelligence V3 performance remained below 1000 ms globally and by both sedes.
+PR **#315** passed final exact-head Ascenda CI + REV-F6.0 through REV-F6.5 on `1d4d6005ac2aa9747e14625dfdffb9864b88c889` and merged with `expected_head_sha` to `main@70bd591a2f4da7a39e41819416af40af4a694b29`.
 
-## REV-F6.5 entry
+Supabase LIVE migration `20260820201634 rev_f6_5_historical_sales_plugin_v1` is applied. Historical runtime semantics remain correct:
 
-F6.5 starts from docs-reconciled `main@c73b41b318639ef09027956b3c183f8379c42e33` on isolated branch `data/rev-f6-5-historical-sales-plugin-20260820`.
+- manifest rows **0**;
+- certified historical sources **0**;
+- 2024 = `value=null / NO_CERTIFIED_SOURCE`;
+- 2025 = `value=null / NO_CERTIFIED_SOURCE`;
+- 2026 = **1,299** transactions / billed **561889.27**;
+- protected truth = patients **7,688** / sales **1,299** / F3 **406** / F4 **162**;
+- ACL remains fail-closed and browser raw historical access remains closed.
 
-No certifiable 2024/2025 transactional files are currently supplied. Therefore:
+## Post-merge fingerprint finding
 
-- no historical revenue may be invented;
-- 2024/2025 must remain `value=null` until canonical transaction evidence exists;
-- source manifest/SHA proves coverage only, not revenue;
-- future ingestion must reuse `aos_ventas` + F3 + F5 + F4, not create parallel masters;
-- same SHA replay must be idempotent;
-- conflicting SHA-bound metadata must fail closed;
-- active Sales Intelligence historical availability must become dynamic, replacing fixed runtime labels;
-- recompute may refresh derived read models only and may not ingest/mutate business rows.
+Post-merge readback correctly stopped terminal certification because F6.0→F6.3→F6.4→F6.5 fingerprints moved while protected Revenue truth did not.
 
-## F6.5 implementation contract
+Root cause is architectural, not business-data drift: `aos_rev_f6_data_contract_v1()` included mutable cardinality/freshness from `aos_cia_contact_identity_v1` in its certification fingerprint. That compatibility view spans patients + leads + calls + appointments + sales, so normal CIA/WA activity can change its row cardinality without changing Revenue truth.
 
-Required objects/gates:
+Observed post-merge chain before hardening:
 
-- private zero-PII historical source manifest registry;
-- dynamic year coverage contract for 2024/2025;
-- service-only manifest registration and certification with immutable provenance;
-- F6.4 runtime preserved as internal base;
-- F6.5 dynamic historical overlay on the active Sales Intelligence V3 name;
-- service-only recompute hook;
-- fixtures A–J;
-- migration replay/idempotency;
-- exact F6.4 recovery;
-- security + no-PII + `<1000 ms` performance;
-- deterministic F6.5 terminal fingerprint;
-- LIVE no-source readback before certification.
+- F6.0 `5ab234f6f37cfcae31bccee45cb1607a`;
+- F6.3 `8656f87a275a84588ee103fbe1626950`;
+- F6.4 `583b8b79e781f3c9303e64aceedc2105`;
+- F6.5 `2595c0d17989714693f32cf19f064f98`.
 
-Until certified:
+These hashes are **not accepted as terminal certification fingerprints** because their upstream F6.0 projection is coupled to another mutable workstream.
 
-- `REV-F6.5 = IN PROGRESS`;
-- `REV-F6.6/F6.7 = BLOCKED`;
-- `REV-F7 = BLOCKED`.
+## Terminal hardening contract
+
+Branch `data/rev-f6-5-terminal-fingerprint-isolation-20260820` isolates the Revenue certification fingerprint while preserving full CIA compatibility metrics in the visible F6.0 contract.
+
+The fingerprint projection excludes only:
+
+- `compatibility_identity.rows`;
+- `compatibility_identity.with_canonical_patient`;
+- `compatibility_identity.identity_conflicts`;
+- `freshness_sources.cia_identity_updated_at`.
+
+It does **not** exclude or alter patient, sales, F3, F4, F5, lifecycle, identity-confidence, historical-source, security, or Revenue coverage truth.
+
+Required terminal proof:
+
+1. synthetic CIA-churn test demonstrates legacy hash changes while isolated Revenue hash remains stable;
+2. F6.0/F6.3/F6.4/F6.5 new chain fingerprints reproduce deterministically;
+3. exact-head Ascenda CI + F6.0–F6.5 SUCCESS;
+4. LIVE migration + protected truth + ACL + historical no-source + performance PASS;
+5. final certificate/snapshot updated with superseded and terminal fingerprints;
+6. exact-head merge of hardening PR;
+7. post-merge LIVE fingerprints exact;
+8. `aos_memory` + Notion + CURRENT reconciled last.
+
+Until all gates pass, **REV-F6.5 remains not terminally certified and REV-F6.6 remains blocked**.

--- a/docs/control/REV_F6_5_HISTORICAL_SALES_PLUGIN_CERTIFICATE_20260820.md
+++ b/docs/control/REV_F6_5_HISTORICAL_SALES_PLUGIN_CERTIFICATE_20260820.md
@@ -1,142 +1,125 @@
-# REV-F6.5 — Historical Sales Plug-in — CERTIFICATE 2026-08-20
+# REV-F6.5 — Historical Sales Plug-in — TERMINAL CERTIFICATE 2026-08-20
 
-**Status:** PRE-MERGE TERMINAL CANDIDATE — LIVE + CI PASS  
+**Status:** TERMINAL CANDIDATE — LIVE HARDENING PASS / FINAL EXACT-HEAD CI PENDING  
 **Workstream:** REV — Revenue Data & Intelligence Core  
 **Phase:** REV-F6.5 — Historical Sales Plug-in  
-**PR:** #315  
-**Entry main:** `c73b41b318639ef09027956b3c183f8379c42e33`  
-**Implementation head before certificate:** `6736b005b2e4b6ebbfeb1e3d589b3d0e48a21b30`  
-**Upstream certified F6.4 fingerprint:** `b0f06d841c74ceeb231451aecdeceef2`  
+**Terminal hardening PR:** #316  
+**Entry main for hardening:** `70bd591a2f4da7a39e41819416af40af4a694b29`  
+**Validated hardening head before this certificate:** `74c9c0d98d4d75609775c380b60b20c1d72707e1`
 
-## 1. Purpose and semantic boundary
+## 1. Certified boundary
 
-REV-F6.5 certifies the dynamic Historical Sales Plug-in boundary. It does not fabricate, infer, or backfill historical transactional revenue.
-
-The certified pipeline is:
+REV-F6.5 provides the dynamic Historical Sales Plug-in contract without fabricating historical revenue. The governed future pipeline remains:
 
 `MANIFEST/SHA -> ROW PROVENANCE -> STAGING -> DEDUP/VALIDATION -> AOS_VENTAS-COMPATIBLE CANONICAL SALE -> F3 PRODUCT -> F5 PATIENT -> F4 FINANCIAL -> RECOMPUTE F6`.
 
-F6.5 reuses the existing Revenue, Product, Patient Identity and Financial truth layers. It creates no parallel historical patient/product/revenue master and authorizes no direct mass insert into `aos_ventas`.
+No parallel historical patient/product/revenue master is introduced. A source manifest proves source coverage, not revenue. 2024/2025 values remain null until canonical transactional evidence exists.
 
-## 2. GitHub exact-head CI evidence
+## 2. Terminal cross-workstream fingerprint hardening
 
-Implementation exact-head `6736b005b2e4b6ebbfeb1e3d589b3d0e48a21b30` passed all required pull-request workflows:
+Post-merge verification of PR #315 found that the REV-F6.0 certification fingerprint included mutable cardinality/freshness from `aos_cia_contact_identity_v1`. That compatibility view spans patient, lead, call, appointment and sale activity, so normal CIA/WA activity could invalidate the REV-F6 chain without changing Revenue truth.
 
-- Ascenda CI #2671 — SUCCESS
-- REV-F6.0 #43 — SUCCESS
-- REV-F6.1 #44 — SUCCESS
-- REV-F6.2 #23 — SUCCESS
-- REV-F6.3 #14 — SUCCESS
-- REV-F6.4 #9 — SUCCESS
-- REV-F6.5 #1 — SUCCESS
+PR #316 corrects this by retaining all compatibility metrics visibly while excluding only these volatile observations from the REV certification hash:
 
-The dedicated F6.5 workflow passed:
+- `compatibility_identity.rows`
+- `compatibility_identity.with_canonical_patient`
+- `compatibility_identity.identity_conflicts`
+- `freshness_sources.cia_identity_updated_at`
 
-- FAST/static Historical Sales Plug-in contract;
-- isolated Postgres bootstrap;
-- F6.0–F6.4 certified prerequisites;
-- F6.4 regression revalidation;
-- fixtures A–J;
-- F6.5 DB/security/semantic/performance invariants;
-- full idempotent migration replay;
-- recovery restoring the exact F6.4 boundary.
+Fingerprint semantic: `REVENUE_TRUTH_EXCLUDES_MUTABLE_CIA_COMPATIBILITY_CARDINALITY`.
 
-## 3. Supabase LIVE migration
+A synthetic no-write LIVE probe proved both conditions simultaneously:
 
-Applied migration ledger:
+- legacy full-payload hash reacts to synthetic CIA churn: **true**;
+- isolated Revenue hash remains stable under the same synthetic churn: **true**.
+
+## 3. Exact-head CI before LIVE hardening
+
+Exact-head `74c9c0d98d4d75609775c380b60b20c1d72707e1` passed all seven required workflows:
+
+- Ascenda CI #2679 — SUCCESS
+- REV-F6.0 #48 — SUCCESS
+- REV-F6.1 #48 — SUCCESS
+- REV-F6.2 #27 — SUCCESS
+- REV-F6.3 #18 — SUCCESS
+- REV-F6.4 #13 — SUCCESS
+- REV-F6.5 #5 — SUCCESS
+
+The dedicated F6.5 DB job passed migration, F6.3/F6.4 post-isolation rebaseline, fixtures A–J, F6.5 invariants, cross-workstream isolation, full idempotent replay and recovery to the pre-hardening F6.4 boundary.
+
+## 4. Supabase LIVE migrations
+
+Active terminal migration ledger:
 
 - `20260820201634` — `rev_f6_5_historical_sales_plugin_v1`
+- `20260820211638` — `rev_f6_5_rev_f6_0_fingerprint_isolation_v1`
 
-No historical source manifest was registered in LIVE and no historical business sale row was fabricated.
+No historical source manifest was registered in LIVE and no historical business sale row was fabricated by either migration.
 
-## 4. LIVE historical coverage truth
+## 5. Final LIVE fingerprint chain
 
-Current LIVE state after migration:
+The post-hardening chain was reproduced twice with exact equality:
 
-- manifest rows: **0**;
-- certified historical sources: **0**;
-- 2024: `value=null`, `source_status=NO_CERTIFIED_SOURCE`, `trust_level=UNAVAILABLE`;
-- 2025: `value=null`, `source_status=NO_CERTIFIED_SOURCE`, `trust_level=UNAVAILABLE`;
-- 2026: **1,299** certified transactions, billed amount **561889.27**.
+- REV-F6.0: `f81a1b8fcfe010cd5254c4ab2e6048d2`
+- REV-F6.3: `186a1da2c29b498dad26223ae264adea`
+- REV-F6.4: `54c07961f191147860f6acd3a3e85c2a`
+- REV-F6.5: `88957cec3d785e4931a8f834c0259a91`
 
-`NO_CERTIFIED_SOURCE` explicitly does not mean zero revenue.
+A governed `aos_rev_historical_recompute_v1()` replay preserved F6.3, F6.4 and F6.5 fingerprints exactly and did not mutate protected business truth.
 
-The active Sales Intelligence runtime now exposes `REV-F6.5_HISTORICAL_COVERAGE_V1` dynamically instead of treating hardcoded 2024/2025 status as the authority. The certified F6.4 runtime remains preserved as an internal base.
+## 6. Protected truth and legitimate LIVE growth
 
-## 5. Deterministic fingerprint
+At the terminal hardening deployment boundary LIVE contained:
 
-F6.5 terminal PRE-MERGE fingerprint candidate:
-
-`88a6dab1f3ef228eaa79f8489d6d8eb0`
-
-It was reproduced twice in LIVE before recompute and remained the same after the governed recompute hook.
-
-Upstream F6.4 fingerprint remained exact before/after recompute:
-
-`b0f06d841c74ceeb231451aecdeceef2`
-
-## 6. Protected truth / non-mutation
-
-LIVE protected truth remained unchanged:
-
-- patients: **7,688**;
+- patients: **7,690**;
 - canonical sales: **1,299**;
 - F3 product facts: **406**;
 - F4 reconciliation rows: **162**;
-- F6.3 fingerprint: `3f4174660107661a2c4509f6f8817d7a`;
 - F6.4 sales fact rows: **1,299**.
 
-F6.5 did not mutate `aos_pacientes`, existing canonical sales, F3, F4, F5 identity truth, or F6.0–F6.4 certified source truth.
+The previous F6.5 checkpoint contained 7,688 patients. The two-row increase was investigated before applying the hardening: exactly **2 patient rows were created after the PR #315 merge**, with the first at `2026-08-20 20:47:40.27904+00` and the latest at `2026-08-20 21:06:21.982437+00`. They are legitimate subsequent LIVE activity and were not created by this hardening. They were not deleted or rolled back.
 
-## 7. Security
+The hardening preserved **7,690 -> 7,690** patients and **1,299 -> 1,299 / 406 -> 406 / 162 -> 162** across governed recompute.
 
-LIVE security readback PASS:
+## 7. Historical coverage truth
 
-- historical manifest anon SELECT: false;
-- historical manifest authenticated SELECT: false;
+Current LIVE coverage remains:
+
+- 2024: `value=null`, `source_status=NO_CERTIFIED_SOURCE`;
+- 2025: `value=null`, `source_status=NO_CERTIFIED_SOURCE`;
+- 2026: available through the canonical 1,299-sale read model.
+
+`NO_CERTIFIED_SOURCE` is not interpreted as zero revenue.
+
+## 8. Security / ACL
+
+Terminal LIVE ACL readback PASS:
+
+- F6.0 internal contract anon EXECUTE: false;
+- isolated fingerprint helper authenticated EXECUTE: false;
+- F6.0 service_role EXECUTE: true;
+- historical manifest anon/authenticated SELECT: false;
 - source registration anon EXECUTE: false;
-- source certification authenticated EXECUTE: false;
 - recompute authenticated EXECUTE: false;
 - internal Sales Intelligence V3 anon EXECUTE: false;
-- governed V3 gateway anon EXECUTE remains true through the existing admin/2FA boundary;
-- legacy `aos_paciente_360(text)` anon EXECUTE remains false.
+- governed Sales Intelligence V3 gateway anon EXECUTE: true through the existing authorization boundary;
+- legacy `aos_paciente_360(text)` anon EXECUTE: false.
 
-Raw PII/PHI is not exposed by the aggregate historical coverage contract.
+## 9. Performance
 
-## 8. Performance
+Post-hardening LIVE `EXPLAIN ANALYZE` execution times:
 
-Repeated LIVE V3 calls after F6.5 overlay:
+- global 2026: **3.211 ms**;
+- San Isidro: **138.042 ms**;
+- Pueblo Libre: **10.591 ms**.
 
-- global: **11.983 ms**;
-- San Isidro: **8.780 ms**;
-- Pueblo Libre: **7.861 ms**.
+All are below the `<1000 ms` certification target. No timeout increase was used.
 
-Certification target remains `<1000 ms`; no timeout increase was used.
+## 10. Remaining terminal gate
 
-## 9. Replay / recovery
+This certificate is the terminal candidate to be committed atomically with its snapshot. After that commit, its new exact-head must again pass Ascenda CI + REV-F6.0 through REV-F6.5. PR #316 may then merge only with `expected_head_sha` equal to that final certificate commit. Post-merge LIVE must reproduce the fingerprint chain, ACL, performance, historical no-source semantics and current protected truth. `aos_memory`, Notion and GitHub CURRENT are reconciled last.
 
-Synthetic certification proved:
-
-- same SHA + same immutable metadata is idempotent;
-- same SHA + conflicting immutable metadata fails closed;
-- uncertified source remains non-revenue;
-- partial coverage is explicit;
-- complete manifest coverage is still not revenue by itself;
-- year isolation is preserved;
-- recompute is derived-read-model only;
-- recovery removes F6.5 objects and restores the exact certified F6.4 runtime boundary.
-
-## 10. Final merge gate
-
-This certificate becomes terminal only after:
-
-1. this certificate + snapshot are committed atomically;
-2. the new exact-head passes Ascenda CI + REV-F6.0 through REV-F6.5;
-3. PR #315 is merged with `expected_head_sha` equal to that final exact-head;
-4. post-merge LIVE reproduces F6.5 fingerprint `88a6dab1f3ef228eaa79f8489d6d8eb0`, preserves security/performance/protected truth and historical no-source semantics;
-5. `aos_memory`, Notion and GitHub CURRENT are reconciled last.
-
-Only then declare:
+Only after those gates declare:
 
 `REV-F6.5 — PASS / CERTIFIED — 100%`
 

--- a/docs/control/REV_F6_5_HISTORICAL_SALES_PLUGIN_SNAPSHOT_20260820.json
+++ b/docs/control/REV_F6_5_HISTORICAL_SALES_PLUGIN_SNAPSHOT_20260820.json
@@ -1,97 +1,99 @@
 {
-  "contract": "REV-F6.5_HISTORICAL_SALES_PLUGIN_CERTIFICATION_SNAPSHOT_V1",
+  "contract": "REV-F6.5_HISTORICAL_SALES_PLUGIN_CERTIFICATION_SNAPSHOT_V2",
   "captured_date": "2026-08-20",
-  "status": "PRE_MERGE_TERMINAL_CANDIDATE",
+  "status": "TERMINAL_CANDIDATE_LIVE_HARDENING_PASS_FINAL_EXACT_HEAD_CI_PENDING",
   "repository": "CESARJAUREGUITORRES/ascenda-os",
-  "pr": 315,
-  "entry_main": "c73b41b318639ef09027956b3c183f8379c42e33",
-  "implementation_head_before_certificate": "6736b005b2e4b6ebbfeb1e3d589b3d0e48a21b30",
+  "terminal_hardening_pr": 316,
+  "entry_main": "70bd591a2f4da7a39e41819416af40af4a694b29",
+  "validated_hardening_head_before_certificate": "74c9c0d98d4d75609775c380b60b20c1d72707e1",
   "supabase": {
     "project_id": "ituyqwstonmhnfshnaqz",
-    "migration_version": "20260820201634",
-    "migration_name": "rev_f6_5_historical_sales_plugin_v1",
+    "migrations": [
+      {"version": "20260820201634", "name": "rev_f6_5_historical_sales_plugin_v1"},
+      {"version": "20260820211638", "name": "rev_f6_5_rev_f6_0_fingerprint_isolation_v1"}
+    ],
     "manifest_rows": 0,
     "certified_sources": 0
   },
+  "fingerprint_isolation": {
+    "semantic": "REVENUE_TRUTH_EXCLUDES_MUTABLE_CIA_COMPATIBILITY_CARDINALITY",
+    "legacy_hash_reacts_to_synthetic_cia_churn": true,
+    "isolated_revenue_hash_stable_under_same_churn": true,
+    "excluded_only": [
+      "compatibility_identity.rows",
+      "compatibility_identity.with_canonical_patient",
+      "compatibility_identity.identity_conflicts",
+      "freshness_sources.cia_identity_updated_at"
+    ]
+  },
   "fingerprints": {
-    "f6_3": "3f4174660107661a2c4509f6f8817d7a",
-    "f6_4": "b0f06d841c74ceeb231451aecdeceef2",
-    "f6_5_candidate": "88a6dab1f3ef228eaa79f8489d6d8eb0",
-    "f6_5_reproduced_twice": true,
-    "f6_4_unchanged_after_recompute": true
+    "f6_0": "f81a1b8fcfe010cd5254c4ab2e6048d2",
+    "f6_3": "186a1da2c29b498dad26223ae264adea",
+    "f6_4": "54c07961f191147860f6acd3a3e85c2a",
+    "f6_5": "88957cec3d785e4931a8f834c0259a91",
+    "chain_reproduced_twice": true,
+    "recompute_stable": true
   },
   "historical_coverage": {
-    "2024": {
-      "value": null,
-      "source_status": "NO_CERTIFIED_SOURCE",
-      "trust_level": "UNAVAILABLE",
-      "manifest_count": 0,
-      "certified_source_count": 0,
-      "canonical_sale_rows": 0
-    },
-    "2025": {
-      "value": null,
-      "source_status": "NO_CERTIFIED_SOURCE",
-      "trust_level": "UNAVAILABLE",
-      "manifest_count": 0,
-      "certified_source_count": 0,
-      "canonical_sale_rows": 0
-    },
-    "2026": {
-      "source_status": "AVAILABLE",
-      "transactions": 1299,
-      "billed_amount": 561889.27,
-      "min_date": "2026-01-05",
-      "max_date": "2026-08-15"
-    },
+    "2024": {"value": null, "source_status": "NO_CERTIFIED_SOURCE"},
+    "2025": {"value": null, "source_status": "NO_CERTIFIED_SOURCE"},
+    "2026": {"source_status": "AVAILABLE", "transactions": 1299},
     "no_certified_source_means_zero": false
   },
   "protected_truth": {
-    "patients": 7688,
+    "patients_current": 7690,
+    "patients_previous_checkpoint": 7688,
+    "patient_growth_after_pr315_merge": 2,
+    "first_post_merge_patient_created_at": "2026-08-20T20:47:40.27904Z",
+    "latest_post_merge_patient_created_at": "2026-08-20T21:06:21.982437Z",
+    "patient_growth_classification": "LEGITIMATE_POST_CERTIFICATION_LIVE_ACTIVITY_NOT_HARDENING_MUTATION",
+    "patients_before_hardening": 7690,
+    "patients_after_hardening_and_recompute": 7690,
     "sales": 1299,
     "f3_rows": 406,
     "f4_rows": 162,
     "f6_4_sales_fact_rows": 1299
   },
   "security": {
+    "f6_0_anon_execute": false,
+    "fingerprint_helper_authenticated_execute": false,
+    "f6_0_service_role_execute": true,
     "manifest_anon_select": false,
     "manifest_authenticated_select": false,
     "register_anon_execute": false,
-    "certify_authenticated_execute": false,
     "recompute_authenticated_execute": false,
     "internal_v3_anon_execute": false,
     "gateway_anon_execute": true,
-    "legacy_360_anon_execute": false,
-    "raw_pii_phi_in_coverage_contract": false
+    "legacy_360_anon_execute": false
   },
   "performance_ms": {
-    "global": 11.983,
-    "san_isidro": 8.78,
-    "pueblo_libre": 7.861,
+    "global": 3.211,
+    "san_isidro": 138.042,
+    "pueblo_libre": 10.591,
     "target_max": 1000
   },
-  "ci_implementation_head": {
-    "ascenda_ci": {"run_number": 2671, "conclusion": "success"},
-    "rev_f6_0": {"run_number": 43, "conclusion": "success"},
-    "rev_f6_1": {"run_number": 44, "conclusion": "success"},
-    "rev_f6_2": {"run_number": 23, "conclusion": "success"},
-    "rev_f6_3": {"run_number": 14, "conclusion": "success"},
-    "rev_f6_4": {"run_number": 9, "conclusion": "success"},
-    "rev_f6_5": {"run_number": 1, "conclusion": "success", "fixtures_A_J": true, "idempotent_replay": true, "recovery_to_f6_4": true}
-  },
-  "semantic_guards": {
-    "manifest_coverage_is_revenue": false,
-    "uncertified_source_exposed_as_revenue": false,
-    "direct_mass_insert_into_aos_ventas": false,
-    "phone_only_identity_authority": false,
-    "f3_f5_f4_reuse_required": true,
-    "hardcoded_2024_2025_runtime_status": false,
-    "active_historical_coverage_contract": "REV-F6.5_HISTORICAL_COVERAGE_V1"
+  "ci_validated_hardening_head": {
+    "sha": "74c9c0d98d4d75609775c380b60b20c1d72707e1",
+    "ascenda_ci": {"run_number": 2679, "conclusion": "success"},
+    "rev_f6_0": {"run_number": 48, "conclusion": "success"},
+    "rev_f6_1": {"run_number": 48, "conclusion": "success"},
+    "rev_f6_2": {"run_number": 27, "conclusion": "success"},
+    "rev_f6_3": {"run_number": 18, "conclusion": "success"},
+    "rev_f6_4": {"run_number": 13, "conclusion": "success"},
+    "rev_f6_5": {
+      "run_number": 5,
+      "conclusion": "success",
+      "fixtures_A_J": true,
+      "f6_5_invariants": true,
+      "cross_workstream_isolation": true,
+      "idempotent_replay": true,
+      "recovery_to_pre_hardening_f6_4": true
+    }
   },
   "remaining_terminal_gates": [
     "ATOMIC_CERTIFICATE_SNAPSHOT_COMMIT",
     "FINAL_EXACT_HEAD_7_WORKFLOWS_SUCCESS",
-    "MERGE_PR_315_EXPECTED_HEAD_SHA",
+    "MERGE_PR_316_EXPECTED_HEAD_SHA",
     "POST_MERGE_LIVE_REVALIDATION",
     "AOS_MEMORY",
     "NOTION",

--- a/supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
+++ b/supabase/migrations/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1.sql
@@ -1,0 +1,75 @@
+-- REV-F6.5 terminal hardening — isolate REV-F6.0 certification fingerprint from mutable CIA compatibility churn.
+-- Full F6.0 contract remains visible. Only mutable aos_cia_contact_identity_v1 cardinality/freshness is excluded from the certification hash.
+
+begin;
+
+create or replace function public.aos_rev_f6_data_contract_fingerprint_isolated_v1(p_contract jsonb)
+returns text
+language plpgsql
+immutable
+set search_path=''
+as $$
+declare
+  v_contract jsonb := coalesce(p_contract,'{}'::jsonb);
+begin
+  v_contract := v_contract
+    #- array['compatibility_identity','rows']
+    #- array['compatibility_identity','with_canonical_patient']
+    #- array['compatibility_identity','identity_conflicts']
+    #- array['freshness_sources','cia_identity_updated_at'];
+  return md5(v_contract::text);
+end;
+$$;
+comment on function public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb) is
+'REV-F6 terminal fingerprint projection. Excludes only mutable CIA compatibility cardinality/freshness from the REV certification hash; full compatibility metrics remain visible in the contract.';
+revoke all on function public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb) from public,anon,authenticated;
+grant execute on function public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb) to service_role;
+
+do $$
+begin
+  if to_regprocedure('public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp()') is null then
+    if to_regprocedure('public.aos_rev_f6_data_contract_v1()') is null then
+      raise exception 'REV-F6.5 fingerprint isolation requires certified F6.0 contract';
+    end if;
+    alter function public.aos_rev_f6_data_contract_v1() rename to aos_rev_f6_data_contract_v1_legacy_dynamic_fp;
+  end if;
+end $$;
+
+revoke all on function public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp() from public,anon,authenticated;
+grant execute on function public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp() to service_role;
+
+create or replace function public.aos_rev_f6_data_contract_v1()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_full jsonb;
+  v_contract jsonb;
+  v_fp text;
+begin
+  v_full := public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp();
+  v_contract := v_full->'contract';
+  if v_contract is null or jsonb_typeof(v_contract)<>'object' then
+    raise exception 'REV-F6.5 INVALID_F6_0_CONTRACT_PAYLOAD';
+  end if;
+  v_fp := public.aos_rev_f6_data_contract_fingerprint_isolated_v1(v_contract);
+  v_full := jsonb_set(v_full,'{contract_fingerprint}',to_jsonb(v_fp),true);
+  v_full := jsonb_set(
+    v_full,
+    '{fingerprint_semantic}',
+    to_jsonb('REVENUE_TRUTH_EXCLUDES_MUTABLE_CIA_COMPATIBILITY_CARDINALITY'::text),
+    true
+  );
+  return v_full;
+end;
+$$;
+comment on function public.aos_rev_f6_data_contract_v1() is
+'REV-F6.0 governed wrapper. Full contract includes CIA compatibility metrics for observability, while certification fingerprint is isolated from mutable CIA/WA contact-universe cardinality and freshness.';
+revoke all on function public.aos_rev_f6_data_contract_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_f6_data_contract_v1() to service_role;
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1_recovery.sql
+++ b/supabase/rollbacks/20260820204500_rev_f6_5_rev_f6_0_fingerprint_isolation_v1_recovery.sql
@@ -1,0 +1,22 @@
+-- REV-F6.5 terminal fingerprint-isolation recovery.
+-- Restores the original certified F6.0 function/fingerprint semantics.
+
+begin;
+
+do $$
+begin
+  if to_regprocedure('public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp()') is not null then
+    if to_regprocedure('public.aos_rev_f6_data_contract_v1()') is not null then
+      drop function public.aos_rev_f6_data_contract_v1();
+    end if;
+    alter function public.aos_rev_f6_data_contract_v1_legacy_dynamic_fp() rename to aos_rev_f6_data_contract_v1;
+  end if;
+end $$;
+
+revoke all on function public.aos_rev_f6_data_contract_v1() from public,anon,authenticated;
+grant execute on function public.aos_rev_f6_data_contract_v1() to service_role;
+
+drop function if exists public.aos_rev_f6_data_contract_fingerprint_isolated_v1(jsonb);
+
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Terminal hardening after PR #315 merge.

Post-merge LIVE correctly detected that REV-F6.0 certification fingerprint was coupled to mutable `aos_cia_contact_identity_v1` cardinality/freshness. That compatibility view spans patients + leads + calls + appointments + sales, so normal CIA/WA activity could cascade new F6.0 → F6.3 → F6.4 → F6.5 hashes while protected Revenue truth remained unchanged.

This PR does not mutate business data. It:
- preserves the full visible F6.0 contract and CIA compatibility metrics;
- excludes only mutable CIA compatibility cardinality/freshness from the Revenue certification hash;
- keeps F6.0 browser-closed/service-only;
- adds a synthetic no-write test proving the legacy hash reacts to CIA churn while the isolated Revenue hash does not;
- proves F6.0/F6.3/F6.4/F6.5 chain determinism;
- updates F6.5 CI replay/recovery to cover the hardening;
- keeps REV-F6.5 fail-closed until LIVE + final certificate + exact-head merge + post-merge reconciliation pass.

Entry main: `70bd591a2f4da7a39e41819416af40af4a694b29`.
Initial hardening head: `9a31d6cb6d40d7d8a0f068b1f2caaf5d4abe18fc`.

Do not merge until exact-head Ascenda CI + REV-F6.0–F6.5 are green and LIVE fingerprint isolation/protected truth/security/performance are revalidated.