### PR TITLE
REV hotfix — canonical patient selection with safe identity fallback

### DIFF
--- a/app/public/patients-f6-v2.js
+++ b/app/public/patients-f6-v2.js
@@ -4,7 +4,7 @@
 if(window.__AOS_PATIENTS_F6_V2__==='installed'||window.__AOS_PATIENTS_F6_V2__==='waiting')return;
 window.__AOS_PATIENTS_F6_V2__='waiting';
 var installed=false,timer=null;
-function esc(v){return typeof window.h==='function'?window.h(v):String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
+function esc(v){return typeof window.h==='function'?window.h(v):String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c];});}
 function pct(o){return o&&o.pct!=null?Number(o.pct).toFixed(2)+'%':'—';}
 function schedule(){if(!installed)timer=setTimeout(install,1000);}
 function install(){
@@ -21,21 +21,41 @@ function install(){
       var rows=d&&d.results||[],warn=d&&d.lookup_status==='IDENTITY_CONFLICT';
       if(!rows.length){r.innerHTML=(warn?'<div style="padding:8px;margin:6px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:10px;font-weight:700;">IDENTITY_CONFLICT · el identificador pertenece a más de un candidato y no se asignó automáticamente.</div>':'')+'<div class="ld">Sin resultados</div>';return;}
       var html=warn?'<div style="padding:8px;margin:6px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:10px;font-weight:700;">IDENTITY_CONFLICT · selecciona explícitamente el paciente correcto; no hubo auto-merge.</div>':'';
-      html+=rows.map(function(p){var n=((p.nombres||'')+' '+(p.apellidos||'')).trim(),cid=p.canonical_patient_id||'',e=(p.estado||'PROSPECTO').toUpperCase(),bc=e==='PACIENTE'||e==='ACTIVO'?'bg-pac':e==='PROSPECTO'||e==='NUEVO'?'bg-pros':'bg-inact';return '<div class="pt-c" data-cid="'+esc(cid)+'" onclick="ptSelV2(\'CANONICAL_ID\',\''+esc(cid)+'\')"><div class="pt-cn">'+esc(n||'Sin nombre')+'</div><div class="pt-cm">'+esc(p.telefono||'')+(p.dni?' · '+esc(p.dni):'')+'</div><div class="pt-cb"><span class="pt-bg '+bc+'">'+esc(e)+'</span><span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">'+esc(p.identity_status||'CANONICAL')+'</span>'+(p.alias_match?'<span class="pt-bg" style="background:#ECFDF5;color:#047857;">Alias V2</span>':'')+(p.sede?'<span class="pt-bg" style="background:#EBF2FF;color:#0A4FBF;">'+esc(p.sede)+'</span>':'')+'</div></div>';}).join('');r.innerHTML=html;
+      html+=rows.map(function(p){
+        var n=((p.nombres||'')+' '+(p.apellidos||'')).trim(),cid=p.canonical_patient_id||'',phone=p.telefono||'',dni=p.dni||'',e=(p.estado||'PROSPECTO').toUpperCase(),bc=e==='PACIENTE'||e==='ACTIVO'?'bg-pac':e==='PROSPECTO'||e==='NUEVO'?'bg-pros':'bg-inact';
+        var identityBadges=p.identity_status==='REVIEW_REQUIRED'
+          ? '<span class="pt-bg" style="background:#ECFDF5;color:#047857;">ACTUAL RESOLVED</span><span class="pt-bg" style="background:#FFF7ED;color:#C2410C;">HISTÓRICO REVIEW</span>'
+          : '<span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">'+esc(p.identity_status||'CANONICAL')+'</span>';
+        return '<div class="pt-c" data-cid="'+esc(cid)+'" data-phone="'+esc(phone)+'" data-dni="'+esc(dni)+'" onclick="ptSelV2(\'CANONICAL_ID\',\''+esc(cid)+'\',\''+esc(phone)+'\',\''+esc(dni)+'\')"><div class="pt-cn">'+esc(n||'Sin nombre')+'</div><div class="pt-cm">'+esc(phone)+(dni?' · '+esc(dni):'')+'</div><div class="pt-cb"><span class="pt-bg '+bc+'">'+esc(e)+'</span>'+identityBadges+(p.alias_match?'<span class="pt-bg" style="background:#ECFDF5;color:#047857;">Alias V2</span>':'')+(p.sede?'<span class="pt-bg" style="background:#EBF2FF;color:#0A4FBF;">'+esc(p.sede)+'</span>':'')+'</div></div>';
+      }).join('');r.innerHTML=html;
     },function(){r.innerHTML='<div class="ld">Error de búsqueda</div>';});},250);
   };
 
-  window.ptSelV2=function(type,value){
-    document.querySelectorAll('.pt-c').forEach(function(c){c.classList.toggle('act',type==='CANONICAL_ID'&&c.getAttribute('data-cid')===value);});
+  window.ptSelV2=function(type,value,phone,dni){
+    var selected=null;
+    document.querySelectorAll('.pt-c').forEach(function(c){var active=type==='CANONICAL_ID'&&c.getAttribute('data-cid')===value;c.classList.toggle('act',active);if(active)selected=c;});
+    if(selected){phone=phone||selected.getAttribute('data-phone')||'';dni=dni||selected.getAttribute('data-dni')||'';}
     var f=document.getElementById('pt-ficha');document.getElementById('pt-empty').style.display='none';f.style.display='block';f.innerHTML='<div class="ld"><span class="sp"></span>Cargando Patient Commercial 360 V2...</div>';
-    window._rpc('aos_patient_commercial_360_v2',{p_lookup_type:type,p_lookup_value:value},function(d){
-      if(!d||!d.found){var st=d&&d.identity_resolution&&d.identity_resolution.status||'UNRESOLVED';f.innerHTML='<div style="padding:16px;background:#FEF2F2;border:1px solid #FECACA;border-radius:10px;color:#B91C1C;font-size:11px;font-weight:700;">'+esc(st)+' · no se asignó una identidad automáticamente.</div>';return;}
-      window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';baseRender360(d);augment360(d);
-      var rt=document.getElementById('pt-right');if(rt){rt.classList.toggle('hidden',!d.clinical_access);}
-      if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);
-    });
+    var attempts=[];
+    function addAttempt(t,v){v=String(v||'').trim();if(!v)return;for(var i=0;i<attempts.length;i++){if(attempts[i].type===t&&attempts[i].value===v)return;}attempts.push({type:t,value:v});}
+    addAttempt(type,value);
+    if(type==='CANONICAL_ID'){addAttempt('PHONE',phone);addAttempt('DOCUMENT',dni);}
+    else if(type==='PHONE'){addAttempt('DOCUMENT',dni);}
+    var idx=0,last=null;
+    function success(d){window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';window.render360(d);var rt=document.getElementById('pt-right');if(rt){rt.classList.toggle('hidden',!d.clinical_access);}if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);}
+    function fail(){var st=last&&last.identity_resolution&&last.identity_resolution.status||'UNRESOLVED';f.innerHTML='<div style="padding:16px;background:#FEF2F2;border:1px solid #FECACA;border-radius:10px;color:#B91C1C;font-size:11px;font-weight:700;">'+esc(st)+' · no se pudo resolver la ficha por ninguna identidad actual unívoca. No se modificó ni fusionó ningún dato.</div>';}
+    function next(){
+      if(idx>=attempts.length){fail();return;}
+      var a=attempts[idx++];
+      window._rpc('aos_patient_commercial_360_v2',{p_lookup_type:a.type,p_lookup_value:a.value},function(d){
+        if(d&&d.found){success(d);return;}
+        last=d||last;
+        next();
+      },function(){next();});
+    }
+    next();
   };
-  window.ptSel=function(num){window.ptSelV2('PHONE',num);};
+  window.ptSel=function(num){window.ptSelV2('PHONE',num,num,'');};
 
   window.render360=function(d){baseRender360(d);augment360(d);};
   window.renderTab=function(){
@@ -45,8 +65,8 @@ function install(){
 
   function augment360(d){
     var root=document.getElementById('pt-ficha');if(!root||root.querySelector('[data-f61="identity"]'))return;
-    var id=d.identity||{},mt=d.metric_trust||{},cov=mt.coverage||{},cs=d.commercial_summary||{};
-    var fh=root.querySelector('.fh');if(fh){fh.insertAdjacentHTML('afterend','<div data-f61="identity" style="margin-bottom:10px;padding:10px 12px;background:#F8FAFF;border:1px solid #DDE4F5;border-radius:10px;"><div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;"><span style="font-family:\'Exo 2\',sans-serif;font-weight:800;font-size:11px;color:#0D1B3E;">Identidad canónica V2</span><span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">'+esc(id.status||'—')+'</span><span class="pt-bg" style="background:'+(id.confidence_band==='CONFLICT'?'#FEF2F2;color:#B91C1C':'#ECFDF5;color:#047857')+';">Confianza '+esc(id.confidence_band||'—')+'</span><span class="pt-bg" style="background:#F8FAFC;color:#475569;">'+esc(id.duplicate_evidence_class||'—')+'</span></div><div style="margin-top:6px;font-size:9px;color:#64748B;">Aliases: '+Number(id.alias_count||0)+' · teléfonos '+Number(id.phone_alias_count||0)+' · históricos '+Number(id.historical_phone_alias_count||0)+' · conflictos '+Number(id.alias_conflicts||0)+(id.historical_contact_indicator?' · historial multi-contacto':'')+'</div></div>');}
+    var id=d.identity||{},ir=d.identity_resolution||{},mt=d.metric_trust||{},cov=mt.coverage||{},cs=d.commercial_summary||{};
+    var fh=root.querySelector('.fh');if(fh){fh.insertAdjacentHTML('afterend','<div data-f61="identity" style="margin-bottom:10px;padding:10px 12px;background:#F8FAFF;border:1px solid #DDE4F5;border-radius:10px;"><div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;"><span style="font-family:\'Exo 2\',sans-serif;font-weight:800;font-size:11px;color:#0D1B3E;">Identidad canónica V2</span><span class="pt-bg" style="background:#ECFDF5;color:#047857;">Actual '+esc(ir.status||'MATCH')+'</span><span class="pt-bg" style="background:'+(id.status==='REVIEW_REQUIRED'?'#FFF7ED;color:#C2410C':'#EEF2FF;color:#4338CA')+';">Histórico '+esc(id.status||'—')+'</span><span class="pt-bg" style="background:'+(id.confidence_band==='CONFLICT'?'#FEF2F2;color:#B91C1C':'#ECFDF5;color:#047857')+';">Confianza '+esc(id.confidence_band||'—')+'</span><span class="pt-bg" style="background:#F8FAFC;color:#475569;">'+esc(id.duplicate_evidence_class||'—')+'</span></div><div style="margin-top:6px;font-size:9px;color:#64748B;">Aliases: '+Number(id.alias_count||0)+' · teléfonos '+Number(id.phone_alias_count||0)+' · históricos '+Number(id.historical_phone_alias_count||0)+' · conflictos '+Number(id.alias_conflicts||0)+(id.historical_contact_indicator?' · historial multi-contacto':'')+'</div></div>');}
     var fkr=root.querySelector('.fkr');if(fkr){fkr.insertAdjacentHTML('afterend','<div data-f61="trust" style="margin:0 0 10px;padding:10px 12px;background:#0F172A;color:#E2E8F0;border-radius:10px;font-size:9px;line-height:1.55;"><div style="font-family:\'Exo 2\',sans-serif;font-size:11px;font-weight:800;color:white;margin-bottom:4px;">Metric Trust · REV-F6.0/F6.1</div><div>Identity '+pct(cov.identity)+' · Sales linkage '+pct(cov.sales_linkage)+' · F3 producto '+pct(cov.f3_product)+' · F4 evidencia '+pct(cov.f4_financial_evidence)+' · Histórico transaccional '+pct(cov.historical_transaction_source_availability)+'</div><div style="color:#FBBF24;margin-top:3px;">2024/2025 = NO_CERTIFIED_SOURCE, no ventas cero. Total observado no equivale a lifetime.</div><div style="margin-top:3px;color:#94A3B8;">Lifecycle: '+esc(cs.lifecycle_state||'PENDING_REV_F6_2')+' · F4 linked sales: '+Number(cs.f4_linked_sales||0)+' · payment evidence: '+Number(cs.payment_evidence_rows||0)+'</div></div>');}
     var tabs=root.querySelector('.ftabs');if(tabs&&!tabs.querySelector('[data-tab="timeline"]')){tabs.insertAdjacentHTML('beforeend','<div class="ftab" data-tab="timeline" onclick="ptTab(\'timeline\')">Timeline V2 ('+((d.timeline||[]).length)+')</div>');}
   }

--- a/ci/rev-f6-1/ui_contract.js
+++ b/ci/rev-f6-1/ui_contract.js
@@ -16,7 +16,12 @@ ok(ui.includes("window.__AOS_PATIENTS_F6_V2__='waiting'"),'Patient bridge must p
 ok(ui.includes("window.__AOS_PATIENTS_F6_V2__='installed'"),'Patient bridge must publish installed state');
 ok(!ui.includes('tries>240'),'Patient bridge must not expire after 60 seconds in long-lived sessions');
 ok(ui.includes('schedule();return;'),'Patient bridge must retry when the Patients panel is loaded later');
-ok(ui.includes('p_lookup_type:type'),'UI selection must support canonical lookup type');
+ok(ui.includes('p_lookup_type:a.type'),'Patient selection must execute the explicit governed lookup attempt');
+ok(ui.includes("addAttempt('PHONE',phone)"),'Canonical selection must safely fall back to the current unique phone alias');
+ok(ui.includes("addAttempt('DOCUMENT',dni)"),'Canonical selection must safely fall back to the current unique document alias');
+ok(ui.includes('data-phone=')&&ui.includes('data-dni='),'Search result cards must preserve current identifiers for safe fallback');
+ok(ui.includes('ACTUAL RESOLVED'),'UI must distinguish resolved current patient identity');
+ok(ui.includes('HISTÓRICO REVIEW'),'UI must distinguish historical linkage review from current identity resolution');
 // Search cards are HTML strings, so their inline JS quotes are escaped in source.
 ok(/ptSelV2\(\\?'CANONICAL_ID\\?'\s*,/.test(ui),'search results must select canonical_patient_id explicitly');
 ok(ui.includes('canonical_patient_id'),'search result payload must use canonical_patient_id');

--- a/docs/control/REV_PATIENT_CANONICAL_SELECTION_HOTFIX_20260820.md
+++ b/docs/control/REV_PATIENT_CANONICAL_SELECTION_HOTFIX_20260820.md
@@ -1,0 +1,36 @@
+# REV Patient Canonical Selection Hotfix — 2026-08-20
+
+## Incident
+After PR #320 restored the Patient V2 runtime bridge, a current canonical patient could still display `UNRESOLVED` on selection when the patient also had an unrelated historical F5 cluster pending human review.
+
+Observed owner case:
+- canonical patient: `P-5549`
+- current phone alias: `986293339`
+- current document alias: `22892747`
+- all three current aliases resolve uniquely to `P-5549`
+- one 2024 historical cluster remains `AUTO_CANDIDATE / requires_human=true`
+- identity confidence remains `MEDIUM` because historical linkage is not reviewed
+
+## Root cause
+The UI exposed `REVIEW_REQUIRED` without distinguishing current canonical identity from historical linkage review. In addition, the browser selection path could return `UNRESOLVED` for the canonical-id lookup even though the underlying Identity Bridge resolver returns `MATCH` for `P-5549`.
+
+## Hotfix
+- Preserve explicit canonical selection as the first attempt.
+- If that browser call returns no patient, retry only through governed Identity Bridge V2 using current identifiers already present on the selected card:
+  1. `CANONICAL_ID`
+  2. `PHONE`
+  3. `DOCUMENT`
+- Each attempt remains fail-closed and must independently resolve to exactly one canonical patient.
+- No auto-merge, F5 review decision, historical attribution, or source mutation is introduced.
+- UI separates `ACTUAL RESOLVED` from `HISTÓRICO REVIEW` so historical review cannot be mistaken for an unresolved current patient.
+
+## Safety
+- No SQL/DDL in this hotfix.
+- No production data mutation.
+- Existing Auth V3 + PASSWORD_2FA gate remains authoritative.
+- `IDENTITY_CONFLICT` remains visible and cannot be auto-assigned.
+
+## Acceptance
+- Jacquelina / `P-5549` opens the current Patient 360.
+- Historical 2024 linkage remains review-required and is not silently attributed.
+- Existing F6.1/F6.7 and cross-workstream CI remain green.


### PR DESCRIPTION
## Incident
Owner smoke after PR #320 still showed `UNRESOLVED` when selecting a current patient whose historical F5 linkage remains pending review.

## Root cause
Current identity and historical-linkage review were conflated in the UI. Production evidence for the reported patient shows current `CANONICAL_ID`, `PHONE`, and `DOCUMENT` aliases all uniquely resolve to the same canonical patient, while one 2024 historical cluster remains `AUTO_CANDIDATE / requires_human=true`.

## Fix
- Keep `CANONICAL_ID` as the first governed selection attempt.
- If that browser call returns no patient, retry only via Identity Bridge V2 using current identifiers already present on the selected card: `PHONE`, then `DOCUMENT`.
- Every attempt remains fail-closed and must independently resolve to exactly one canonical patient.
- UI now separates `ACTUAL RESOLVED` from `HISTÓRICO REVIEW`.
- No auto-merge, historical attribution, F5 review decision, SQL/DDL, or business-data mutation.

## Acceptance
- Current patient `P-5549` opens Patient 360.
- Historical 2024 linkage remains review-required.
- Existing F6.1/F6.7 and cross-workstream CI remain green.

Do not merge with any red or ambiguous exact-head gate.