### PR TITLE
REV rebuild — restore proven Patient 360 and enrich canonical current record

### DIFF
--- a/app/public/patients-f6-v2.js
+++ b/app/public/patients-f6-v2.js
@@ -1,77 +1,69 @@
-// REV-F6.1 — Patient Commercial 360 V2 UI bridge.
-// Upgrades the existing patients.html/patients.js surface; does not create a second patient panel.
+// REV Patient 360 Current V3 — rebuild over the proven pre-F6 patient flow.
+// Search resolves a canonical current patient once. Selection then reads that canonical
+// patient directly; F5/F6 enrich the payload but never gate visibility of the current record.
 (function(){'use strict';
-if(window.__AOS_PATIENTS_F6_V2__==='installed'||window.__AOS_PATIENTS_F6_V2__==='waiting')return;
-window.__AOS_PATIENTS_F6_V2__='waiting';
-var installed=false,timer=null;
-function esc(v){return typeof window.h==='function'?window.h(v):String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c];});}
-function pct(o){return o&&o.pct!=null?Number(o.pct).toFixed(2)+'%':'—';}
-function schedule(){if(!installed)timer=setTimeout(install,1000);}
+if(window.__AOS_PATIENTS_360_V3__==='installed'||window.__AOS_PATIENTS_360_V3__==='waiting')return;
+window.__AOS_PATIENTS_360_V3__='waiting';
+var installed=false,timer=null,cards={};
+function esc(v){return typeof window.h==='function'?window.h(v):String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
+function token(){try{return sessionStorage.getItem('aos_app_token')||'';}catch(_){return '';}}
+function schedule(){if(!installed)timer=setTimeout(install,800);}
+function showError(msg){var f=document.getElementById('pt-ficha');if(!f)return;f.innerHTML='<div style="padding:16px;background:#FEF2F2;border:1px solid #FECACA;border-radius:10px;color:#B91C1C;font-size:11px;font-weight:700;">'+esc(msg)+'</div>';}
 function install(){
   if(installed)return;
-  if(typeof window._rpc!=='function'||typeof window.render360!=='function'||typeof window.renderTab!=='function'||!window.PT){schedule();return;}
-  installed=true;if(timer)clearTimeout(timer);window.__AOS_PATIENTS_F6_V2__='installed';
-  var baseRender360=window.render360,baseRenderTab=window.renderTab;
+  if(typeof window._rpc!=='function'||typeof window.render360!=='function'||!window.PT){schedule();return;}
+  installed=true;if(timer)clearTimeout(timer);window.__AOS_PATIENTS_360_V3__='installed';
+  var baseRender360=window.render360;
 
   window.ptSearch=function(q){
     clearTimeout(window._ptT);var r=document.getElementById('pt-res');
     if(!q||q.length<2){r.innerHTML='<div class="ld">Min. 2 caracteres</div>';return;}
-    r.innerHTML='<div class="ld"><span class="sp"></span>Buscando identidad canónica...</div>';
-    window._ptT=setTimeout(function(){window._rpc('aos_patient_search_v2',{p_query:q,p_limit:20},function(d){
-      var rows=d&&d.results||[],warn=d&&d.lookup_status==='IDENTITY_CONFLICT';
-      if(!rows.length){r.innerHTML=(warn?'<div style="padding:8px;margin:6px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:10px;font-weight:700;">IDENTITY_CONFLICT · el identificador pertenece a más de un candidato y no se asignó automáticamente.</div>':'')+'<div class="ld">Sin resultados</div>';return;}
-      var html=warn?'<div style="padding:8px;margin:6px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:10px;font-weight:700;">IDENTITY_CONFLICT · selecciona explícitamente el paciente correcto; no hubo auto-merge.</div>':'';
-      html+=rows.map(function(p){
-        var n=((p.nombres||'')+' '+(p.apellidos||'')).trim(),cid=p.canonical_patient_id||'',phone=p.telefono||'',dni=p.dni||'',e=(p.estado||'PROSPECTO').toUpperCase(),bc=e==='PACIENTE'||e==='ACTIVO'?'bg-pac':e==='PROSPECTO'||e==='NUEVO'?'bg-pros':'bg-inact';
-        var identityBadges=p.identity_status==='REVIEW_REQUIRED'
-          ? '<span class="pt-bg" style="background:#ECFDF5;color:#047857;">ACTUAL RESOLVED</span><span class="pt-bg" style="background:#FFF7ED;color:#C2410C;">HISTÓRICO REVIEW</span>'
-          : '<span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">'+esc(p.identity_status||'CANONICAL')+'</span>';
-        return '<div class="pt-c" data-cid="'+esc(cid)+'" data-phone="'+esc(phone)+'" data-dni="'+esc(dni)+'" onclick="ptSelV2(\'CANONICAL_ID\',\''+esc(cid)+'\',\''+esc(phone)+'\',\''+esc(dni)+'\')"><div class="pt-cn">'+esc(n||'Sin nombre')+'</div><div class="pt-cm">'+esc(phone)+(dni?' · '+esc(dni):'')+'</div><div class="pt-cb"><span class="pt-bg '+bc+'">'+esc(e)+'</span>'+identityBadges+(p.alias_match?'<span class="pt-bg" style="background:#ECFDF5;color:#047857;">Alias V2</span>':'')+(p.sede?'<span class="pt-bg" style="background:#EBF2FF;color:#0A4FBF;">'+esc(p.sede)+'</span>':'')+'</div></div>';
-      }).join('');r.innerHTML=html;
-    },function(){r.innerHTML='<div class="ld">Error de búsqueda</div>';});},250);
+    r.innerHTML='<div class="ld"><span class="sp"></span>Buscando paciente actual...</div>';
+    window._ptT=setTimeout(function(){
+      window._rpc('aos_patient_search_v2',{p_token:token(),p_query:q,p_limit:20},function(d){
+        var rows=d&&d.results||[],warn=d&&d.lookup_status==='IDENTITY_CONFLICT';cards={};
+        if(!rows.length){r.innerHTML=(warn?'<div style="padding:8px;margin:6px;background:#FEF2F2;border:1px solid #FECACA;border-radius:8px;color:#B91C1C;font-size:10px;font-weight:700;">IDENTITY_CONFLICT · revisa el identificador compartido.</div>':'')+'<div class="ld">Sin resultados</div>';return;}
+        var html=warn?'<div style="padding:8px;margin:6px;background:#FFF7ED;border:1px solid #FED7AA;border-radius:8px;color:#C2410C;font-size:10px;font-weight:700;">Hay un identificador compartido. La ficha actual se abrirá únicamente por su ID canónico.</div>':'';
+        html+=rows.map(function(p){
+          var cid=p.canonical_patient_id||'',n=((p.nombres||'')+' '+(p.apellidos||'')).trim(),e=(p.estado||'PROSPECTO').toUpperCase(),bc=e==='PACIENTE'||e==='ACTIVO'?'bg-pac':e==='PROSPECTO'||e==='NUEVO'?'bg-pros':'bg-inact';cards[cid]=p;
+          var hist=p.identity_status==='REVIEW_REQUIRED'?'<span class="pt-bg" style="background:#FFF7ED;color:#C2410C;">HISTÓRICO REVIEW</span>':'<span class="pt-bg" style="background:#F8FAFC;color:#475569;">HISTÓRICO '+esc(p.identity_status||'SIN REVIEW')+'</span>';
+          return '<div class="pt-c" data-cid="'+esc(cid)+'" onclick="ptSelCurrent(\''+esc(cid)+'\')"><div class="pt-cn">'+esc(n||'Sin nombre')+'</div><div class="pt-cm">'+esc(p.telefono||'')+(p.dni?' · '+esc(p.dni):'')+'</div><div class="pt-cb"><span class="pt-bg '+bc+'">'+esc(e)+'</span><span class="pt-bg" style="background:#ECFDF5;color:#047857;">ACTUAL RESOLVED</span>'+hist+(p.sede?'<span class="pt-bg" style="background:#EBF2FF;color:#0A4FBF;">'+esc(p.sede)+'</span>':'')+'</div></div>';
+        }).join('');r.innerHTML=html;
+      },function(){r.innerHTML='<div class="ld">Error de búsqueda</div>';});
+    },250);
   };
 
-  window.ptSelV2=function(type,value,phone,dni){
-    var selected=null;
-    document.querySelectorAll('.pt-c').forEach(function(c){var active=type==='CANONICAL_ID'&&c.getAttribute('data-cid')===value;c.classList.toggle('act',active);if(active)selected=c;});
-    if(selected){phone=phone||selected.getAttribute('data-phone')||'';dni=dni||selected.getAttribute('data-dni')||'';}
-    var f=document.getElementById('pt-ficha');document.getElementById('pt-empty').style.display='none';f.style.display='block';f.innerHTML='<div class="ld"><span class="sp"></span>Cargando Patient Commercial 360 V2...</div>';
-    var attempts=[];
-    function addAttempt(t,v){v=String(v||'').trim();if(!v)return;for(var i=0;i<attempts.length;i++){if(attempts[i].type===t&&attempts[i].value===v)return;}attempts.push({type:t,value:v});}
-    addAttempt(type,value);
-    if(type==='CANONICAL_ID'){addAttempt('PHONE',phone);addAttempt('DOCUMENT',dni);}
-    else if(type==='PHONE'){addAttempt('DOCUMENT',dni);}
-    var idx=0,last=null;
-    function success(d){window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';window.render360(d);var rt=document.getElementById('pt-right');if(rt){rt.classList.toggle('hidden',!d.clinical_access);}if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);}
-    function fail(){var st=last&&last.identity_resolution&&last.identity_resolution.status||'UNRESOLVED';f.innerHTML='<div style="padding:16px;background:#FEF2F2;border:1px solid #FECACA;border-radius:10px;color:#B91C1C;font-size:11px;font-weight:700;">'+esc(st)+' · no se pudo resolver la ficha por ninguna identidad actual unívoca. No se modificó ni fusionó ningún dato.</div>';}
-    function next(){
-      if(idx>=attempts.length){fail();return;}
-      var a=attempts[idx++];
-      window._rpc('aos_patient_commercial_360_v2',{p_lookup_type:a.type,p_lookup_value:a.value},function(d){
-        if(d&&d.found){success(d);return;}
-        last=d||last;
-        next();
-      },function(){next();});
-    }
-    next();
-  };
-  window.ptSel=function(num){window.ptSelV2('PHONE',num,num,'');};
-
-  window.render360=function(d){baseRender360(d);augment360(d);};
-  window.renderTab=function(){
-    if(window.PT&&window.PT.tab==='timeline')return renderTimeline(window.PT.data&&window.PT.data.timeline||[]);
-    return baseRenderTab();
+  window.ptSelCurrent=function(cid){
+    cid=String(cid||'').trim();if(!cid){showError('Paciente canónico inválido.');return;}
+    document.querySelectorAll('.pt-c').forEach(function(c){c.classList.toggle('act',c.getAttribute('data-cid')===cid);});
+    var f=document.getElementById('pt-ficha'),empty=document.getElementById('pt-empty');if(empty)empty.style.display='none';if(!f)return;f.style.display='block';f.innerHTML='<div class="ld"><span class="sp"></span>Cargando Pacientes 360...</div>';
+    var t=token();if(t.length<32){showError('Sesión segura no disponible. Vuelve a iniciar sesión.');return;}
+    window._rpc('aos_patient_360_current_v3',{p_token:t,p_canonical_patient_id:cid},function(d){
+      if(!d||!d.found){showError('No se pudo cargar el registro canónico actual '+cid+'.');return;}
+      window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';baseRender360(d);augment(d);
+      var rt=document.getElementById('pt-right');if(rt)rt.classList.toggle('hidden',!d.clinical_access);
+      if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);
+    },function(){showError('Error al cargar Pacientes 360. El registro actual no fue modificado.');});
   };
 
-  function augment360(d){
-    var root=document.getElementById('pt-ficha');if(!root||root.querySelector('[data-f61="identity"]'))return;
-    var id=d.identity||{},ir=d.identity_resolution||{},mt=d.metric_trust||{},cov=mt.coverage||{},cs=d.commercial_summary||{};
-    var fh=root.querySelector('.fh');if(fh){fh.insertAdjacentHTML('afterend','<div data-f61="identity" style="margin-bottom:10px;padding:10px 12px;background:#F8FAFF;border:1px solid #DDE4F5;border-radius:10px;"><div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;"><span style="font-family:\'Exo 2\',sans-serif;font-weight:800;font-size:11px;color:#0D1B3E;">Identidad canónica V2</span><span class="pt-bg" style="background:#ECFDF5;color:#047857;">Actual '+esc(ir.status||'MATCH')+'</span><span class="pt-bg" style="background:'+(id.status==='REVIEW_REQUIRED'?'#FFF7ED;color:#C2410C':'#EEF2FF;color:#4338CA')+';">Histórico '+esc(id.status||'—')+'</span><span class="pt-bg" style="background:'+(id.confidence_band==='CONFLICT'?'#FEF2F2;color:#B91C1C':'#ECFDF5;color:#047857')+';">Confianza '+esc(id.confidence_band||'—')+'</span><span class="pt-bg" style="background:#F8FAFC;color:#475569;">'+esc(id.duplicate_evidence_class||'—')+'</span></div><div style="margin-top:6px;font-size:9px;color:#64748B;">Aliases: '+Number(id.alias_count||0)+' · teléfonos '+Number(id.phone_alias_count||0)+' · históricos '+Number(id.historical_phone_alias_count||0)+' · conflictos '+Number(id.alias_conflicts||0)+(id.historical_contact_indicator?' · historial multi-contacto':'')+'</div></div>');}
-    var fkr=root.querySelector('.fkr');if(fkr){fkr.insertAdjacentHTML('afterend','<div data-f61="trust" style="margin:0 0 10px;padding:10px 12px;background:#0F172A;color:#E2E8F0;border-radius:10px;font-size:9px;line-height:1.55;"><div style="font-family:\'Exo 2\',sans-serif;font-size:11px;font-weight:800;color:white;margin-bottom:4px;">Metric Trust · REV-F6.0/F6.1</div><div>Identity '+pct(cov.identity)+' · Sales linkage '+pct(cov.sales_linkage)+' · F3 producto '+pct(cov.f3_product)+' · F4 evidencia '+pct(cov.f4_financial_evidence)+' · Histórico transaccional '+pct(cov.historical_transaction_source_availability)+'</div><div style="color:#FBBF24;margin-top:3px;">2024/2025 = NO_CERTIFIED_SOURCE, no ventas cero. Total observado no equivale a lifetime.</div><div style="margin-top:3px;color:#94A3B8;">Lifecycle: '+esc(cs.lifecycle_state||'PENDING_REV_F6_2')+' · F4 linked sales: '+Number(cs.f4_linked_sales||0)+' · payment evidence: '+Number(cs.payment_evidence_rows||0)+'</div></div>');}
-    var tabs=root.querySelector('.ftabs');if(tabs&&!tabs.querySelector('[data-tab="timeline"]')){tabs.insertAdjacentHTML('beforeend','<div class="ftab" data-tab="timeline" onclick="ptTab(\'timeline\')">Timeline V2 ('+((d.timeline||[]).length)+')</div>');}
+  // Compatibility for old buttons that still pass a phone number. Resolve once through
+  // governed search, then open the returned canonical current ID. Never auto-merge.
+  window.ptSel=function(value){
+    value=String(value||'').trim();if(/^P-/i.test(value)){window.ptSelCurrent(value);return;}
+    window._rpc('aos_patient_search_v2',{p_token:token(),p_query:value,p_limit:10},function(d){
+      var rows=d&&d.results||[];
+      if(rows.length===1&&rows[0].canonical_patient_id){window.ptSelCurrent(rows[0].canonical_patient_id);return;}
+      showError(rows.length>1?'El teléfono corresponde a más de un paciente actual. Selecciona la ficha por nombre.':'No se encontró un paciente actual para ese identificador.');
+    },function(){showError('No se pudo resolver el botón legado hacia un paciente actual.');});
+  };
+
+  window.render360=function(d){baseRender360(d);augment(d);};
+  function augment(d){
+    var root=document.getElementById('pt-ficha');if(!root||root.querySelector('[data-p360v3="identity"]'))return;
+    var id=d.identity||{},conf=d.identity_confidence||{},life=d.lifecycle||{},link=d.legacy_link_status||'UNKNOWN';
+    var fh=root.querySelector('.fh');if(fh){fh.insertAdjacentHTML('afterend','<div data-p360v3="identity" style="margin-bottom:10px;padding:10px 12px;background:#F8FAFF;border:1px solid #DDE4F5;border-radius:10px;"><div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;"><span style="font-family:\'Exo 2\',sans-serif;font-weight:800;font-size:11px;color:#0D1B3E;">Paciente actual · '+esc(id.canonical_patient_id||'')+'</span><span class="pt-bg" style="background:#ECFDF5;color:#047857;">ACTUAL '+esc(id.current_status||'RESOLVED')+'</span><span class="pt-bg" style="background:'+(id.historical_review_required?'#FFF7ED;color:#C2410C':'#F8FAFC;color:#475569')+';">HISTÓRICO '+esc(id.historical_status||'—')+'</span><span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">Confianza '+esc(conf.confidence_level||'—')+'</span></div><div style="margin-top:6px;font-size:9px;color:#64748B;">360 core: '+esc(link)+' · lifecycle: '+esc(life.lifecycle_state||life.classification_status||'—')+' · el histórico pendiente no bloquea esta ficha.</div></div>');}
+    var fkr=root.querySelector('.fkr');if(fkr){fkr.insertAdjacentHTML('afterend','<div data-p360v3="trust" style="margin:0 0 10px;padding:9px 12px;background:#0F172A;color:#E2E8F0;border-radius:10px;font-size:9px;line-height:1.5;"><b style="color:white;">Revenue enrichment</b> · F5/F6 se muestra como contexto gobernado. 2024/2025 transaccional sigue siendo NO_CERTIFIED_SOURCE hasta que exista fuente certificada.</div>');}
   }
-
-  function renderTimeline(rows){var b=document.getElementById('pt-tc');if(!b)return;if(!rows.length){b.innerHTML='<div class="ld">Sin eventos canónicos observados</div>';return;}b.innerHTML='<table class="tt"><thead><tr><th>Fecha</th><th>Tipo</th><th>Evento</th><th>Estado</th><th>Provenance</th></tr></thead><tbody>'+rows.map(function(e){return '<tr><td>'+esc(e.event_date||'')+'</td><td><span class="pt-bg" style="background:#EEF2FF;color:#4338CA;">'+esc(e.event_type||'')+'</span></td><td>'+esc(e.label||'')+(e.amount!=null?' · S/'+Number(e.amount||0).toFixed(2):'')+'</td><td>'+esc(e.status||'')+'</td><td style="font-size:8px;color:#64748B;">'+esc(e.provenance||'')+'</td></tr>';}).join('')+'</tbody></table>';}
 }
 install();
 })();

--- a/ci/rev-f6-1/ui_contract.js
+++ b/ci/rev-f6-1/ui_contract.js
@@ -3,30 +3,34 @@ const sw=fs.readFileSync('app/public/phase2-service-worker.js','utf8');
 const app=fs.readFileSync('app/public/app.html','utf8');
 const ui=fs.readFileSync('app/public/patients-f6-v2.js','utf8');
 function ok(cond,msg){if(!cond){console.error('F6.1 UI CONTRACT FAIL:',msg);process.exit(1);}}
-ok(sw.includes('/patients-f6-v2.js'),'Service worker must preserve Patient 360 V2 compatibility injection');
-ok(sw.includes('20260820-rev-f6-runtime-hotfix-v1'),'Patient 360 bridge cache-buster must advance for runtime hotfix');
+
+// Runtime availability remains deterministic through the existing critical bridge slot.
+ok(sw.includes('/patients-f6-v2.js'),'Service worker must preserve Patient 360 runtime compatibility injection');
 ok(app.includes('ASCENDA_CRITICAL_RUNTIME_BRIDGES_20260820'),'App shell must contain deterministic critical-runtime marker');
-ok(app.includes('/patients-f6-v2.js?v=20260820-rev-f6-runtime-hotfix-v1'),'Patient V2 bridge must load directly from app shell, not only from service worker');
-ok(sw.includes("rpcFrom(req,'aos_patient_commercial_360_v2'"),'legacy Patient 360 must route to canonical V2');
-ok(sw.includes("rm[1]==='aos_patient_search_v2'"),'search V2 must receive governed token injection');
-ok(sw.includes('p.p_token=t'),'V2 browser RPCs must receive app token from controlled cache');
-ok(!sw.includes("rpcFrom(req,'aos_patient_history_summary_v1',{p_token:t,p_numero:p.p_numero||''})"),'legacy Patient 360 must not route to F6.0 minimum summary');
-ok(ui.includes('window.__AOS_PATIENTS_F6_V2__'),'Patient bridge must be globally idempotent across shell/panel reloads');
-ok(ui.includes("window.__AOS_PATIENTS_F6_V2__='waiting'"),'Patient bridge must preserve a waiting state until patients.js exists');
-ok(ui.includes("window.__AOS_PATIENTS_F6_V2__='installed'"),'Patient bridge must publish installed state');
-ok(!ui.includes('tries>240'),'Patient bridge must not expire after 60 seconds in long-lived sessions');
-ok(ui.includes('schedule();return;'),'Patient bridge must retry when the Patients panel is loaded later');
-ok(ui.includes('p_lookup_type:a.type'),'Patient selection must execute the explicit governed lookup attempt');
-ok(ui.includes("addAttempt('PHONE',phone)"),'Canonical selection must safely fall back to the current unique phone alias');
-ok(ui.includes("addAttempt('DOCUMENT',dni)"),'Canonical selection must safely fall back to the current unique document alias');
-ok(ui.includes('data-phone=')&&ui.includes('data-dni='),'Search result cards must preserve current identifiers for safe fallback');
+ok(app.includes('/patients-f6-v2.js?v=20260820-rev-f6-runtime-hotfix-v1'),'Patient runtime must load directly from app shell');
+
+// Rebuild semantics: search resolves current canonical identity once; selection never re-resolves it.
+ok(ui.includes('window.__AOS_PATIENTS_360_V3__'),'Rebuilt Patient 360 runtime must publish a V3 idempotency marker');
+ok(ui.includes("window.__AOS_PATIENTS_360_V3__='waiting'"),'V3 runtime must wait until base patients.js exists');
+ok(ui.includes("window.__AOS_PATIENTS_360_V3__='installed'"),'V3 runtime must publish installed state');
+ok(ui.includes('schedule();return;'),'V3 runtime must support long-lived sessions without expiry');
+ok(ui.includes("'aos_patient_search_v2'"),'Search must keep governed canonical patient discovery');
+ok(ui.includes('p_token:token()'),'Patient search must carry the current Auth V3 application token explicitly');
+ok(ui.includes('onclick="ptSelCurrent'),'Search cards must open the returned canonical patient directly');
+ok(ui.includes("'aos_patient_360_current_v3'"),'Selection must call the rebuilt canonical-current Patient 360 RPC');
+ok(ui.includes('p_canonical_patient_id:cid'),'Selection must pass canonical_patient_id directly');
+ok(!ui.includes("'aos_patient_commercial_360_v2'"),'Current selection must not use the failed V2 re-resolution chain');
+ok(!ui.includes("addAttempt('PHONE'"),'Current canonical selection must not fall back through phone resolution');
+ok(!ui.includes("addAttempt('DOCUMENT'"),'Current canonical selection must not fall back through document resolution');
+
+// F5/F6 enrich current truth; historical review remains visible but non-blocking.
 ok(ui.includes('ACTUAL RESOLVED'),'UI must distinguish resolved current patient identity');
-ok(ui.includes('HISTÓRICO REVIEW'),'UI must distinguish historical linkage review from current identity resolution');
-// Search cards are HTML strings, so their inline JS quotes are escaped in source.
-ok(/ptSelV2\(\\?'CANONICAL_ID\\?'\s*,/.test(ui),'search results must select canonical_patient_id explicitly');
-ok(ui.includes('canonical_patient_id'),'search result payload must use canonical_patient_id');
-ok(ui.includes('IDENTITY_CONFLICT'),'shared-identifier conflicts must be visible');
-ok(ui.includes('Timeline V2'),'existing panel must expose unified timeline');
-ok(ui.includes('NO_CERTIFIED_SOURCE'),'historical coverage warning must be visible');
-ok(ui.includes('Metric Trust'),'trust metadata must be visible');
-console.log('REV-F6.1 UI contract PASS');
+ok(ui.includes('HISTÓRICO REVIEW'),'UI must distinguish historical linkage review from current identity');
+ok(ui.includes('el histórico pendiente no bloquea esta ficha'),'UI must state that historical review does not gate current visibility');
+ok(ui.includes('NO_CERTIFIED_SOURCE'),'Historical transaction coverage warning must remain explicit');
+
+// Legacy phone buttons may resolve once through governed search, but never auto-merge.
+ok(ui.includes('Compatibility for old buttons'),'Legacy UI compatibility must be explicit');
+ok(ui.includes('Selecciona la ficha por nombre'),'Shared phone compatibility must fail closed instead of auto-merging');
+
+console.log('REV-F6.1 UI contract PASS — canonical current Patient 360 V3');

--- a/supabase/migrations/20260821032000_rev_f6_1_patient_360_current_v3.sql
+++ b/supabase/migrations/20260821032000_rev_f6_1_patient_360_current_v3.sql
@@ -1,0 +1,179 @@
+-- REV patient rebuild — restore the proven Patient 360 reader as a private core
+-- and expose a governed canonical-current read that F5/F6 enriches instead of blocks.
+
+alter function public.aos_paciente_360(text)
+  set search_path = pg_catalog, public;
+
+revoke all on function public.aos_paciente_360(text) from public, anon, authenticated;
+grant execute on function public.aos_paciente_360(text) to service_role;
+
+create or replace function public.aos_patient_360_current_v3(
+  p_token text,
+  p_canonical_patient_id text
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid;
+  v_admin uuid;
+  v_pid text := trim(coalesce(p_canonical_patient_id,''));
+  v_phone text;
+  v_patient jsonb;
+  v_core jsonb;
+  v_identity jsonb := '{}'::jsonb;
+  v_lifecycle jsonb := '{}'::jsonb;
+  v_sales_intelligence jsonb := '{}'::jsonb;
+  v_review_clusters integer := 0;
+  v_match_clusters integer := 0;
+  v_strong_conflicts integer := 0;
+begin
+  v_actor := public.aos_app_actor_v3(p_token,'advisor-patients',true);
+  if v_actor is null then
+    v_actor := public.aos_app_actor_v3(p_token,'admin-patients',true);
+  end if;
+  if v_actor is null then
+    raise exception 'UNAUTHORIZED';
+  end if;
+
+  v_admin := public.aos_app_actor_v3(p_token,'admin-patients',true);
+
+  if v_pid = '' then
+    return jsonb_build_object(
+      'ok',true,'found',false,'contract','REV-PATIENT-360-CURRENT-V3',
+      'identity_resolution',jsonb_build_object('status','INVALID_CANONICAL_ID')
+    );
+  end if;
+
+  select
+    jsonb_build_object(
+      'id',p."ID_PACIENTE",
+      'canonical_patient_id',p."ID_PACIENTE",
+      'nombres',p."Nombres",
+      'apellidos',p."Apellidos",
+      'telefono',coalesce(nullif(p.numero_limpio,''),regexp_replace(coalesce(p."Teléfono",''),'[^0-9]','','g')),
+      'dni',p."N° documento",
+      'correo',p."Email",
+      'sexo',p."Sexo",
+      'fecha_nac',p."Fecha de nacimiento",
+      'direccion',p."Dirección",
+      'ocupacion',p."Ocupación",
+      'sede',p."SEDE_PRINCIPAL",
+      'fuente',p."FUENTE",
+      'fecha_registro',p."FECHA_REGISTRO",
+      'estado',p."ESTADO_PACIENTE",
+      'notas',p."NOTAS",
+      'etiqueta',p."ETIQUETA_BASE",
+      'score',p."SCORE_ESTADO",
+      'trat_principal',p.tratamiento_principal,
+      'pais',p.pais,
+      'departamento',p.departamento,
+      'ciudad',p.ciudad,
+      'distrito',p.distrito,
+      'contacto_emergencia',case when v_admin is not null then p.contacto_emergencia else null end,
+      'estado_civil',p.estado_civil,
+      'etiqueta_vip',coalesce(p.etiqueta_vip,'NORMAL'),
+      'dias_ultima_visita',p."DIAS_ULTIMA_VISITA"
+    ),
+    coalesce(nullif(p.numero_limpio,''),regexp_replace(coalesce(p."Teléfono",''),'[^0-9]','','g'))
+  into v_patient,v_phone
+  from public.aos_pacientes p
+  where p."ID_PACIENTE"=v_pid
+    and coalesce(p."ESTADO_PACIENTE",'') <> 'FUSIONADO'
+  limit 1;
+
+  if v_patient is null then
+    return jsonb_build_object(
+      'ok',true,'found',false,'contract','REV-PATIENT-360-CURRENT-V3',
+      'identity_resolution',jsonb_build_object('status','CANONICAL_TARGET_MISSING','canonical_patient_id',v_pid)
+    );
+  end if;
+
+  -- Preserve the proven pre-F6 Patient 360 aggregation. It remains browser-closed;
+  -- only this Auth V3 wrapper can expose its payload.
+  v_core := public.aos_paciente_360(v_phone);
+
+  -- Never allow a phone collision inside the legacy core to substitute another patient.
+  -- The current canonical record remains visible; ambiguous cross-source sections fail closed.
+  if not coalesce((v_core->>'found')::boolean,false)
+     or coalesce(v_core#>>'{paciente,id}','') <> v_pid then
+    v_core := jsonb_build_object(
+      'found',true,
+      'paciente',v_patient,
+      'compras','[]'::jsonb,
+      'totalFacturado',null,
+      'totalCompras',null,
+      'citas','[]'::jsonb,
+      'llamadas','[]'::jsonb,
+      'seguimientos','[]'::jsonb,
+      'duplicados','[]'::jsonb,
+      'notas','[]'::jsonb,
+      'documentos','[]'::jsonb,
+      'completitud',jsonb_build_object('pct',null,'faltantes','[]'::jsonb),
+      'legacy_link_status','AMBIGUOUS_OR_UNAVAILABLE'
+    );
+  else
+    -- Canonical row is authority for current demographic fields after F5 enrichment.
+    v_core := jsonb_set(v_core,'{paciente}',v_patient,true);
+    v_core := v_core || jsonb_build_object('legacy_link_status','MATCH');
+  end if;
+
+  select
+    count(*) filter(where c.classification='REVIEW')::integer,
+    count(*) filter(where c.classification='MATCH')::integer,
+    count(*) filter(where c.source_strong_conflict)::integer
+  into v_review_clusters,v_match_clusters,v_strong_conflicts
+  from public.aos_f5_canonical_classification_v1 c
+  where c.target_patient_id=v_pid;
+
+  begin
+    v_identity := coalesce(public.aos_rev_identity_confidence_by_patient_v1(v_pid),'{}'::jsonb);
+  exception when others then
+    v_identity := jsonb_build_object('confidence_level','UNKNOWN','limitations',jsonb_build_array('IDENTITY_ENRICHMENT_UNAVAILABLE'));
+  end;
+
+  begin
+    v_lifecycle := coalesce(public.aos_rev_customer_lifecycle_by_patient_v1(v_pid,public.aos_rev_business_date_lima_v1()),'{}'::jsonb);
+  exception when others then
+    v_lifecycle := jsonb_build_object('classification_status','UNKNOWN','limitations',jsonb_build_array('LIFECYCLE_ENRICHMENT_UNAVAILABLE'));
+  end;
+
+  begin
+    v_sales_intelligence := coalesce(public.aos_rev_si_patient_value_by_patient_v1(v_pid),'{}'::jsonb);
+  exception when others then
+    v_sales_intelligence := jsonb_build_object('source_status','UNKNOWN','limitations',jsonb_build_array('SALES_INTELLIGENCE_ENRICHMENT_UNAVAILABLE'));
+  end;
+
+  if v_admin is null then
+    v_core := jsonb_set(v_core,'{notas}','[]'::jsonb,true);
+    v_core := jsonb_set(v_core,'{documentos}','[]'::jsonb,true);
+  end if;
+
+  return v_core || jsonb_build_object(
+    'ok',true,
+    'found',true,
+    'contract','REV-PATIENT-360-CURRENT-V3',
+    'readOnly',true,
+    'clinical_access',(v_admin is not null),
+    'identity',jsonb_build_object(
+      'canonical_patient_id',v_pid,
+      'current_status','RESOLVED',
+      'historical_status',case when v_review_clusters>0 then 'REVIEW_REQUIRED' else 'NO_PENDING_REVIEW' end,
+      'historical_review_required',(v_review_clusters>0),
+      'review_clusters',v_review_clusters,
+      'reviewed_match_clusters',v_match_clusters,
+      'strong_conflicts',v_strong_conflicts
+    ),
+    'identity_confidence',v_identity,
+    'lifecycle',v_lifecycle,
+    'sales_intelligence',v_sales_intelligence,
+    'provenance',jsonb_build_array('LEGACY_PATIENT_360_RESTORED','CANONICAL_CURRENT','REV-F5','REV-F6')
+  );
+end;
+$$;
+
+revoke all on function public.aos_patient_360_current_v3(text,text) from public;
+grant execute on function public.aos_patient_360_current_v3(text,text) to anon, authenticated, service_role;

--- a/supabase/rollbacks/20260821032000_rev_f6_1_patient_360_current_v3_recovery.sql
+++ b/supabase/rollbacks/20260821032000_rev_f6_1_patient_360_current_v3_recovery.sql
@@ -1,0 +1,10 @@
+-- Recovery for REV Patient 360 Current V3 hotfix.
+-- Restore the pre-hotfix fail-closed state without reopening browser access.
+
+drop function if exists public.aos_patient_360_current_v3(text,text);
+
+alter function public.aos_paciente_360(text)
+  set search_path = '';
+
+revoke all on function public.aos_paciente_360(text) from public, anon, authenticated;
+grant execute on function public.aos_paciente_360(text) to service_role;


### PR DESCRIPTION
## Why this replaces the previous patches
Owner smoke after PR #320/#321 still failed to open the current patient record. Historical GitHub evidence showed the pre-F6 flow was known-good: `buscar -> seleccionar -> aos_paciente_360 -> render360`.

LIVE read-only diagnosis found the actual regression: `aos_paciente_360(text)` was hardened to `SET search_path=''` while still referencing unqualified tables such as `aos_pacientes`. The RPC therefore fails internally with `relation "aos_pacientes" does not exist` even for backend execution.

## Proof before change
A transaction-only test (`BEGIN -> ALTER search_path -> call legacy 360 -> ROLLBACK`) restored the reported patient without persisting any change:
- `found=true`
- patient `P-5549`
- phone `986293339`
- 87 purchases
- 62 appointments
- 20 calls
- observed facturado S/ 37,316

## Rebuild
1. Restore the proven legacy 360 core with `search_path = pg_catalog, public`; browser execute stays revoked.
2. Add governed `aos_patient_360_current_v3(token, canonical_patient_id)`.
3. Current canonical row is opened directly by `canonical_patient_id`; it is not re-resolved through historical identity.
4. The old 360 payload remains the compatibility/read surface for purchases, appointments, calls, notes, docs, etc.
5. F5/F6 identity confidence, lifecycle and Sales Intelligence are appended as enrichment/provenance.
6. Historical `REVIEW_REQUIRED` remains visible but cannot block the current clinical record.
7. Replace the previous browser resolver chain with `search -> canonical id -> Patient 360 Current V3`.

## Security
- Legacy `aos_paciente_360(text)` remains closed to `public/anon/authenticated` and executable only by service role/internal definer flow.
- `public`, `anon`, and `authenticated` have no CREATE privilege on schema `public`.
- New V3 wrapper requires Auth V3 + PASSWORD_2FA + `advisor-patients` or `admin-patients`.
- Non-admin callers receive notes/documents redacted.
- No patient merge, identity review decision, source-row mutation, sales mutation, or canonical patient mutation.

## Acceptance
- Exact-head JS/UI gates green.
- LIVE migration compiles.
- Restored private core returns the same patient and data.
- New V3 wrapper privileges stay governed.
- Owner can open Jacquelina from Patients and see the original 360 information plus F5/F6 enrichment.
