### PR TITLE
REV hotfix — canonical service-worker token for Patient 360 V3

### DIFF
--- a/app/public/phase2-service-worker.js
+++ b/app/public/phase2-service-worker.js
@@ -159,7 +159,9 @@ self.addEventListener('fetch',function(event){
       return rpcFrom(req,'aos_patient_commercial_360_v2',{p_token:t,p_lookup_type:'PHONE',p_lookup_value:p.p_numero||''});
     })());return;
   }
-  if(rm&&(rm[1]==='aos_patient_search_v2'||rm[1]==='aos_patient_commercial_360_v2')){
+  // Governed patient reads must all use the canonical worker token. The browser/sessionStorage
+  // token is never authoritative; overwrite it before calling PostgREST.
+  if(rm&&(rm[1]==='aos_patient_search_v2'||rm[1]==='aos_patient_commercial_360_v2'||rm[1]==='aos_patient_360_current_v3')){
     event.respondWith((async function(){
       var p=await requestJson(req),t=String(await getToken()).trim();
       if(t.length<32)return json({ok:false,error:'PATIENT_360_APP_SESSION_REQUIRED'},401);
@@ -175,6 +177,6 @@ self.addEventListener('fetch',function(event){
   }
   var tm=u.pathname.match(/\/rest\/v1\/([^/]+)$/),table=tm&&tm[1],method=req.method.toUpperCase();
   if(table&&PROTECTED[table]&&(method==='POST'||method==='PATCH'||method==='DELETE')){
-    event.respondWith((async function(){var match;try{match=parseMatch(u);}catch(e){return json({ok:false,error:'FILTER_NOT_ALLOWED'},403);}var payload={p_token:await getToken(),p_table:table,p_action:method==='POST'?'INSERT':method,p_match:match,p_data:method==='DELETE'?{}:await requestJson(req)};var r=await rpcFrom(req,'aos_secure_write_v2',payload);if(isMissing(r))return fetch(req);var d;try{d=await r.json();}catch(e){return json({ok:false,error:'WRITE_REJECTED'},500);}if(!d||d.ok===false)return json(d||{ok:false,error:'WRITE_REJECTED'},403);return json(d.rows||[],200);})());
+    event.respondWith((async function(){var match;try{match=parseMatch(u);}catch(e){return json({ok:false,error:'FILTER_NOT_ALLOWED'},403);}var payload={p_token:await getToken(),p_table:table,p_action:method==='POST'?'INSERT':method,p_match:match,p_data:method==='DELETE'?{}:await requestJson(req)};var r=await rpcFrom(req,'aos_secure_write_v2',payload);if(isMissing(r))return fetch(req);var d;try{d=await r.json();}catch(e){return json(d||{ok:false,error:'WRITE_REJECTED'},500);}if(!d||d.ok===false)return json(d||{ok:false,error:'WRITE_REJECTED'},403);return json(d.rows||[],200);})());
   }
 });

--- a/ci/rev-f6-1/ui_contract.js
+++ b/ci/rev-f6-1/ui_contract.js
@@ -15,13 +15,18 @@ ok(ui.includes("window.__AOS_PATIENTS_360_V3__='waiting'"),'V3 runtime must wait
 ok(ui.includes("window.__AOS_PATIENTS_360_V3__='installed'"),'V3 runtime must publish installed state');
 ok(ui.includes('schedule();return;'),'V3 runtime must support long-lived sessions without expiry');
 ok(ui.includes("'aos_patient_search_v2'"),'Search must keep governed canonical patient discovery');
-ok(ui.includes('p_token:token()'),'Patient search must carry the current Auth V3 application token explicitly');
+ok(ui.includes('p_token:token()'),'Patient search may carry the browser token, but worker authority must overwrite it');
 ok(ui.includes('onclick="ptSelCurrent'),'Search cards must open the returned canonical patient directly');
 ok(ui.includes("'aos_patient_360_current_v3'"),'Selection must call the rebuilt canonical-current Patient 360 RPC');
 ok(ui.includes('p_canonical_patient_id:cid'),'Selection must pass canonical_patient_id directly');
 ok(!ui.includes("'aos_patient_commercial_360_v2'"),'Current selection must not use the failed V2 re-resolution chain');
 ok(!ui.includes("addAttempt('PHONE'"),'Current canonical selection must not fall back through phone resolution');
 ok(!ui.includes("addAttempt('DOCUMENT'"),'Current canonical selection must not fall back through document resolution');
+
+// Browser-path authentication: every governed patient read must use the canonical service-worker token.
+ok(sw.includes("rm[1]==='aos_patient_search_v2'||rm[1]==='aos_patient_commercial_360_v2'||rm[1]==='aos_patient_360_current_v3'"),'Patient 360 Current V3 must share the governed worker token bridge');
+ok(sw.includes('p.p_token=t'),'Governed patient bridge must overwrite browser p_token with the canonical worker token');
+ok(sw.includes('browser/sessionStorage'),'Worker contract must explicitly reject browser/sessionStorage as token authority');
 
 // F5/F6 enrich current truth; historical review remains visible but non-blocking.
 ok(ui.includes('ACTUAL RESOLVED'),'UI must distinguish resolved current patient identity');
@@ -33,4 +38,4 @@ ok(ui.includes('NO_CERTIFIED_SOURCE'),'Historical transaction coverage warning m
 ok(ui.includes('Compatibility for old buttons'),'Legacy UI compatibility must be explicit');
 ok(ui.includes('Selecciona la ficha por nombre'),'Shared phone compatibility must fail closed instead of auto-merging');
 
-console.log('REV-F6.1 UI contract PASS — canonical current Patient 360 V3');
+console.log('REV-F6.1 UI contract PASS — canonical current Patient 360 V3 + worker token bridge');

--- a/docs/control/REV_PATIENT_360_V3_BROWSER_TOKEN_FIX_20260820.md
+++ b/docs/control/REV_PATIENT_360_V3_BROWSER_TOKEN_FIX_20260820.md
@@ -1,0 +1,13 @@
+# REV Patient 360 V3 — Browser Token Bridge Fix
+
+## Incident
+Owner UI reached canonical patient `P-5549` but `aos_patient_360_current_v3` returned no usable record.
+
+## Root cause
+`patients-f6-v2.js` calls `aos_patient_360_current_v3` from the browser. The canonical Auth V3 token used by governed runtime flows lives in the Phase 2 service-worker cache (`aos-phase2-auth`). The service worker injected/overrode that token for `aos_patient_search_v2` and `aos_patient_commercial_360_v2`, but the new `aos_patient_360_current_v3` RPC was omitted from the governed bridge. Therefore search could succeed with the current 2FA token while selection reached V3 with the browser/sessionStorage token instead of the canonical worker token.
+
+## Fix
+Route `aos_patient_360_current_v3` through the same governed patient RPC bridge and always overwrite `p_token` with `getToken()` from the controlled service-worker cache.
+
+## Security invariant
+Browser-provided token values are not trusted as authority. The service worker owns token injection for governed patient RPCs.


### PR DESCRIPTION
## Incident
Owner UI can search and resolve canonical patient `P-5549`, but selection returns `No se pudo cargar el registro canónico actual P-5549`.

## Root cause
Search V2 and Commercial 360 V2 are routed through the Phase 2 service worker, which overwrites `p_token` with the canonical token stored in `aos-phase2-auth`. The new `aos_patient_360_current_v3` RPC was omitted from that governed bridge. Therefore search succeeded with the active 2FA token while V3 selection used the browser/sessionStorage token instead of the worker-authoritative token.

## Fix
- Add `aos_patient_360_current_v3` to the governed patient RPC bridge.
- Always overwrite `p_token` with the canonical worker token before calling PostgREST.
- Add UI-contract assertions so future V3 changes cannot bypass the worker token bridge.

## Scope
No SQL, no patient mutation, no sales mutation, no identity merge/review decision.
