### PR TITLE
F4 incident hotfix — single sales import approval + canonical write session

### DIFF
--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -1,10 +1,12 @@
-// ASCENDA OS — F4 production canary P0/P0.5 browser recovery.
+// ASCENDA OS — F4 production canary P0/P0.5/P0.6 browser recovery.
 (function(){
 'use strict';
 if(window.__AOS_F4_PRODUCTION_CANARY_P0__)return;
 window.__AOS_F4_PRODUCTION_CANARY_P0__=true;
 
 var previousFetch=window.fetch.bind(window);
+var nativeConfirm=window.confirm.bind(window);
+var tokenSyncPromise=null;
 
 function cleanCajaClosedState(){
   var box=document.getElementById('no-sesion-msg');
@@ -37,6 +39,17 @@ function rememberToken(t){
   // Sales Intelligence owns its own finance token and must remain untouched.
   try{sessionStorage.setItem('aos_app_token',t);}catch(e){}
   try{caches.open('aos-phase2-auth').then(function(c){return c.put('/__aos_app_token',new Response(t));}).catch(function(){});}catch(e){}
+}
+function syncCanonicalAppToken(){
+  // F4 bridge is synchronous and reads sessionStorage. Before every governed write,
+  // synchronize it from the same canonical cache used by the Phase 2 service worker.
+  if(tokenSyncPromise)return tokenSyncPromise;
+  tokenSyncPromise=cacheToken().then(function(t){
+    t=String(t||'').trim();
+    if(t.length>=32)try{sessionStorage.setItem('aos_app_token',t);}catch(e){}
+    return t;
+  }).catch(function(){return '';}).then(function(t){tokenSyncPromise=null;return t;},function(){tokenSyncPromise=null;return '';});
+  return tokenSyncPromise;
 }
 function salesErrorBanner(msg){
   var host=document.querySelector('.vs');if(!host)return;
@@ -76,21 +89,41 @@ function strongSalesRead(url,init,name,body){
   });
 }
 
-// P0.5: intercept Sales reads before the older F4 bridge. The older bridge used
-// only sessionStorage synchronously; after some app/PWA navigation cycles the
-// app token can be absent while the same strong app token remains in the service
-// worker cache written at login. Trying both app-token sources prevents a valid
-// dataset from being rendered as an all-zero dashboard on an UNAUTHORIZED envelope.
+// The V4 preview is the authoritative import approval. The old app shell still has a
+// native CONFIRMAR IMPORTACIÓN DE VENTAS dialog; suppress only that exact legacy dialog
+// when the F4 bridge is active, retaining native confirm as a fallback if F4 is absent.
+window.confirm=function(message){
+  var text=String(message||'');
+  if(window.__AOS_F4_REVENUE_OPS__&&text.indexOf('CONFIRMAR IMPORTACIÓN DE VENTAS')===0)return true;
+  return nativeConfirm(message);
+};
+
+// P0.5/P0.6: reads try both strong token sources. Governed writes first synchronize the
+// canonical cache token into sessionStorage, then hand control to the existing F4 bridge.
+// This keeps one Auth V3 session authority for edit/import/caja without duplicating F4 logic.
 window.fetch=function(input,init){
   var url=urlOf(input),rm=url.match(/\/rest\/v1\/rpc\/([^?]+)/),name=rm&&rm[1];
   if(name==='aos_ventas_admin'||name==='aos_ventas_admin_anio'){
     return strongSalesRead(url,init,name,parseBody(init));
+  }
+  if(name==='aos_editar_venta'||name==='aos_importar_ventas'||name==='aos_grabar_venta_caja'){
+    return syncCanonicalAppToken().then(function(t){
+      if(String(t||'').trim().length<32){
+        salesErrorBanner('Sesión 2FA de Ventas no disponible. Vuelve a iniciar sesión; no se realizó ninguna escritura.');
+      }
+      return previousFetch(input,init);
+    });
   }
   return previousFetch(input,init);
 };
 
 function run(){cleanCajaClosedState();}
 run();
+syncCanonicalAppToken();
+setTimeout(syncCanonicalAppToken,700);
+setTimeout(syncCanonicalAppToken,2500);
+try{window.addEventListener('focus',syncCanonicalAppToken);}catch(e){}
+try{document.addEventListener('visibilitychange',function(){if(!document.hidden)syncCanonicalAppToken();});}catch(e){}
 
 try{
   var obs=new MutationObserver(function(){run();});

--- a/ci/phase4-revenue/ui_contract.py
+++ b/ci/phase4-revenue/ui_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 root = Path(__file__).resolve().parents[2]
 bridge = (root / 'app/public/f4-revenue-ops.js').read_text(encoding='utf-8')
 kronia = (root / 'app/public/f4-kronia-revenue-bridge.js').read_text(encoding='utf-8')
+canary = (root / 'app/public/f4-production-canary-hotfix.js').read_text(encoding='utf-8')
 sw = (root / 'app/public/phase2-service-worker.js').read_text(encoding='utf-8')
 app_shell = (root / 'app/public/app.html').read_text(encoding='utf-8')
 proxy = (root / 'app/server-f4.js').read_text(encoding='utf-8')
@@ -51,6 +52,17 @@ assert 'F4_STRONG_SESSION_REQUIRED' in proxy
 assert 'aos_sales_admin_sale_v4' in proxy and 'aos_editar_venta_v4' in proxy
 assert "pathname==='/api/f4/cartera-candidates'" in proxy
 assert 'aos_cartera_candidates_v2' in proxy
+
+# P0.6 incident regression: all F4 writes must recover the same Auth V3 app token
+# already cached by the Phase 2 login flow before the synchronous F4 bridge reads it.
+assert "caches.open('aos-phase2-auth')" in canary, 'F4 canary must read the canonical Phase 2 app-token cache'
+assert "sessionStorage.setItem('aos_app_token',t)" in canary, 'F4 canary must synchronize canonical app token into legacy synchronous bridge storage'
+assert "name==='aos_editar_venta'||name==='aos_importar_ventas'||name==='aos_grabar_venta_caja'" in canary, 'governed F4 writes must synchronize canonical token before delegation'
+assert 'return syncCanonicalAppToken().then' in canary, 'F4 write delegation must await canonical token synchronization'
+assert "text.indexOf('CONFIRMAR IMPORTACIÓN DE VENTAS')===0" in canary, 'legacy importer confirmation must be identified exactly'
+assert 'window.__AOS_F4_REVENUE_OPS__' in canary, 'legacy confirmation suppression must only happen when F4 V4 bridge is active'
+assert 'return nativeConfirm(message)' in canary, 'native confirmations outside F4 import must remain untouched'
+assert 'Validación previa · Importar ventas' in bridge, 'V4 preview must remain the single authoritative import approval UI'
 
 direct_f4 = 'node server-f4.js' in railway
 wa2_wrapped_f4 = 'node server-wa2.js' in railway and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2


### PR DESCRIPTION
## Production incident
Owner reported three concurrent symptoms after Revenue/Patient work:
- Sales import displayed duplicate approval dialogs.
- Editing sale #2360 failed while correcting a malformed imported name.
- Multiple users temporarily could not enter ASCENDA and the system became extremely slow.

## Read-only diagnosis
- `aos_ventas` now contains 1,312 rows, so 13 imports did persist; the owner's S/259 smoke row for 20/08 did not persist.
- Sale #2360 still has `nombres='"'`, confirming the failed edit did not mutate it.
- The duplicate import approval is deterministic: the legacy `window.confirm('CONFIRMAR IMPORTACIÓN DE VENTAS...')` runs before F4 opens its governed V4 preview.
- F4 write bridge reads `sessionStorage.aos_app_token` synchronously while the canonical active token can remain in Cache Storage `aos-phase2-auth`, the same divergence already proven in Patient 360.
- Supabase had a real service interruption/restart during the owner test: mass statement timeouts, administrator-terminated DB connections, REST 503/520/521, followed by recovery. Current DB health is normal (0 blocked, 0 waiting, 0 idle-in-transaction).

## Fix
Consolidate behavior in the existing `f4-production-canary-hotfix.js` recovery layer — no new runtime patch file:
1. Before governed F4 writes (`aos_editar_venta`, `aos_importar_ventas`, `aos_grabar_venta_caja`), synchronize the canonical `aos-phase2-auth` token into `sessionStorage.aos_app_token`, then delegate to the existing F4 V4 bridge.
2. Suppress only the exact legacy `CONFIRMAR IMPORTACIÓN DE VENTAS` native dialog when F4 V4 is active. The governed `Validación previa · Importar ventas` preview remains the single authoritative approval.
3. Preserve native confirmations everywhere else and preserve the existing strong-token sales-read recovery.
4. Add Phase 4 UI/runtime gates for canonical write-token synchronization and single import approval.

## Scope
- No SQL/DDL.
- No patient mutation.
- No sales mutation.
- No automatic correction of sale #2360.
- No identity merge/review decision.
- No change to Revenue truth models.
