### PR TITLE
F4 hotfix — preserve real advisor/attendant values in Sales editor

### DIFF
--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -1,4 +1,4 @@
-// ASCENDA OS — F4 production canary P0/P0.5/P0.6 browser recovery.
+// ASCENDA OS — F4 production canary P0/P0.5/P0.6/P0.7 browser recovery.
 (function(){
 'use strict';
 if(window.__AOS_F4_PRODUCTION_CANARY_P0__)return;
@@ -117,7 +117,25 @@ window.fetch=function(input,init){
   return previousFetch(input,init);
 };
 
-function run(){cleanCajaClosedState();}
+// P0.7: the legacy Sales editor hard-codes a short list of advisor/attendant names.
+// If production contains a valid value outside that list, a native <select> silently
+// falls back to its first option (for example DRA. CAROLINA -> MIREYA). Preserve the
+// exact current truth as a selectable option instead of fabricating a different value.
+function patchSalesEditorTruth(){
+  if(typeof window.evCampoSel!=='function'||window.evCampoSel.__f4TruthSafe)return;
+  var original=window.evCampoSel;
+  function safe(id,label,val,opts){
+    var current=String(val==null?'':val);
+    var list=(opts||[]).map(function(x){return String(x);});
+    if(list.indexOf(current)<0)list.unshift(current);
+    return original(id,label,current,list);
+  }
+  safe.__f4TruthSafe=true;
+  safe.__original=original;
+  window.evCampoSel=safe;
+}
+
+function run(){cleanCajaClosedState();patchSalesEditorTruth();}
 run();
 syncCanonicalAppToken();
 setTimeout(syncCanonicalAppToken,700);

--- a/ci/phase4-revenue/ui_contract.py
+++ b/ci/phase4-revenue/ui_contract.py
@@ -64,6 +64,14 @@ assert 'window.__AOS_F4_REVENUE_OPS__' in canary, 'legacy confirmation suppressi
 assert 'return nativeConfirm(message)' in canary, 'native confirmations outside F4 import must remain untouched'
 assert 'Validación previa · Importar ventas' in bridge, 'V4 preview must remain the single authoritative import approval UI'
 
+# P0.7 editor truth regression: values stored in production must never be silently
+# replaced by the first hard-coded <select> option when the legacy list is incomplete.
+assert "typeof window.evCampoSel!=='function'||window.evCampoSel.__f4TruthSafe" in canary, 'sales editor select wrapper must be idempotent'
+assert "var current=String(val==null?'':val)" in canary, 'sales editor must preserve the exact current production value including empty values'
+assert 'if(list.indexOf(current)<0)list.unshift(current)' in canary, 'unknown current sales values must be injected into the editor options instead of falling back'
+assert 'window.evCampoSel=safe' in canary, 'truth-safe sales editor selector must replace the incomplete legacy selector'
+assert 'safe.__f4TruthSafe=true' in canary, 'sales editor truth wrapper must publish an idempotency marker'
+
 direct_f4 = 'node server-f4.js' in railway
 wa2_wrapped_f4 = 'node server-wa2.js' in railway and "['server-f4.js']" in wa2 and 'proxy(req,res)' in wa2
 wa3_wrapped_chain = (


### PR DESCRIPTION
## Incident
Owner opened sale #2111 for RUTH DE LAS MERCEDES. The Sales table showed advisor DRA. CAROLINA, while the edit modal silently displayed MIREYA.

## Root cause
`admin-sales.html` uses a hard-coded `<select>` option list. Production stores legitimate values not present in that list (for example `DRA. CAROLINA`, `CESAR`, `DRA YESSICA`). When the current value is absent, the browser silently selects the first option, fabricating a different visible value.

Production truth for sale #2111 remains unchanged:
- advisor `DRA. CAROLINA`
- attended by `WILMER`
- product `HYDRAINTENSIVE`
- amount S/189
- sede PUEBLO LIBRE

## Fix
Extend the existing F4 runtime integrity layer so every Sales editor select preserves the exact current production value. If the current value is not in the legacy suggested list, inject it as the selected option instead of falling back. Empty values are preserved too.

## Scope
- 2 files only: runtime integrity layer + F4 UI contract.
- No SQL/DDL.
- No sales mutation.
- No patient mutation.
- No normalization/merge of staff names.
- No change to commissions logic.

## Acceptance
- Sale #2111 opens with Asesor = DRA. CAROLINA and Atendió = WILMER.
- Unknown/historical current values never silently become the first select option.
- Existing F4/WA/Ascenda gates remain green.