### PR TITLE
REV-PRC1 hotfix — fix Product Resolution modal HTTP 401

### DIFF
--- a/.github/workflows/rev-prc1-product-resolution-center.yml
+++ b/.github/workflows/rev-prc1-product-resolution-center.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'supabase/migrations/*prc1*'
       - 'app/public/rev-prc1-product-resolution-center.js'
+      - 'app/public/rev-prc1-auth-bridge.js'
       - 'app/public/f4-production-canary-hotfix.js'
+      - 'app/server-phase-s-f17.js'
       - 'ci/rev-prc1/**'
       - 'ci/phase4-revenue/schema_contract.sql'
       - '.github/workflows/rev-prc1-product-resolution-center.yml'
@@ -15,7 +17,9 @@ on:
     paths:
       - 'supabase/migrations/*prc1*'
       - 'app/public/rev-prc1-product-resolution-center.js'
+      - 'app/public/rev-prc1-auth-bridge.js'
       - 'app/public/f4-production-canary-hotfix.js'
+      - 'app/server-phase-s-f17.js'
       - 'ci/rev-prc1/**'
       - 'ci/phase4-revenue/schema_contract.sql'
       - '.github/workflows/rev-prc1-product-resolution-center.yml'
@@ -54,9 +58,13 @@ jobs:
         run: |
           set -euo pipefail
           node --check app/public/rev-prc1-product-resolution-center.js
+          node --check app/public/rev-prc1-auth-bridge.js
           node --check app/public/f4-production-canary-hotfix.js
+          node --check app/server-phase-s-f17.js
           node --check ci/rev-prc1/ui_contract.js
+          node --check ci/rev-prc1/auth_bridge_contract.js
           node ci/rev-prc1/ui_contract.js
+          node ci/rev-prc1/auth_bridge_contract.js
 
       - name: Configure isolated Supabase ports
         working-directory: ci/zero-cost-staging

--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -113,12 +113,24 @@ function patchSalesEditorTruth(){
   window.evCampoSel=safe;
 }
 function loadProductResolutionCenter(){
+  function loadCenterRuntime(){
+    if(window.__AOS_REV_PRC1__||document.getElementById('rev-prc1-runtime'))return;
+    var s=document.createElement('script');
+    s.id='rev-prc1-runtime';
+    s.src='/rev-prc1-product-resolution-center.js?v=20260821-prc1-v3-authbridge';
+    s.async=false;
+    (document.head||document.documentElement).appendChild(s);
+  }
   if(window.__AOS_REV_PRC1__||document.getElementById('rev-prc1-runtime'))return;
-  var s=document.createElement('script');
-  s.id='rev-prc1-runtime';
-  s.src='/rev-prc1-product-resolution-center.js?v=20260821-prc1-v2';
-  s.async=false;
-  (document.head||document.documentElement).appendChild(s);
+  if(window.__AOS_REV_PRC1_AUTH_BRIDGE__){loadCenterRuntime();return;}
+  if(document.getElementById('rev-prc1-auth-bridge'))return;
+  var b=document.createElement('script');
+  b.id='rev-prc1-auth-bridge';
+  b.src='/rev-prc1-auth-bridge.js?v=20260821-prc1-auth-v1';
+  b.async=false;
+  b.onload=loadCenterRuntime;
+  b.onerror=function(){console.error('[REV-PRC1] auth bridge failed to load');};
+  (document.head||document.documentElement).appendChild(b);
 }
 function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();}
 run();

--- a/app/public/rev-prc1-auth-bridge.js
+++ b/app/public/rev-prc1-auth-bridge.js
@@ -1,0 +1,89 @@
+// ASCENDA OS — REV-PRC1 Auth Bridge v1
+// Keeps Product Resolution Center inside the existing Auth V3/2FA boundary.
+(function(){
+'use strict';
+if(window.__AOS_REV_PRC1_AUTH_BRIDGE__)return;
+window.__AOS_REV_PRC1_AUTH_BRIDGE__=true;
+
+var downstreamFetch=window.fetch.bind(window);
+var ALLOWED={
+  aos_product_review_admin_v1:1,
+  aos_product_review_admin_v2:1,
+  aos_product_review_resolve_v2:1,
+  aos_product_review_reopen_v1:1,
+  aos_product_batch_review_v1:1
+};
+
+function rpcName(input){
+  var u=typeof input==='string'?input:(input&&input.url)||'';
+  var m=u.match(/\/rest\/v1\/rpc\/([^?]+)/);
+  return m&&m[1]||'';
+}
+function parseBody(init){
+  try{return JSON.parse((init&&init.body)||'{}');}catch(e){return {};}
+}
+function unique(xs){
+  var out=[];
+  (xs||[]).forEach(function(x){x=String(x||'').trim();if(x&&out.indexOf(x)<0)out.push(x);});
+  return out;
+}
+function sessionToken(){
+  try{return String(sessionStorage.getItem('aos_app_token')||'').trim();}catch(e){return '';}
+}
+function cacheToken(){
+  if(!('caches' in window))return Promise.resolve('');
+  return caches.open('aos-phase2-auth').then(function(c){return c.match('/__aos_app_token');}).then(function(r){return r?r.text():'';}).then(function(t){return String(t||'').trim();}).catch(function(){return '';});
+}
+function tokenCandidates(){
+  var first=sessionToken();
+  return cacheToken().then(function(cached){return unique([first,cached]);});
+}
+function rememberToken(t){
+  t=String(t||'').trim();if(!t)return;
+  try{sessionStorage.setItem('aos_app_token',t);}catch(e){}
+  if('caches' in window){
+    try{caches.open('aos-phase2-auth').then(function(c){return c.put('/__aos_app_token',new Response(t));}).catch(function(){});}catch(e){}
+  }
+}
+function authError(d,status){
+  var e=String(d&&d.error||d&&d.message||'').toUpperCase();
+  return status===401||status===403||e==='UNAUTHORIZED'||e==='F4_STRONG_SESSION_REQUIRED'||e==='APP_SESSION_REQUIRED';
+}
+function synthetic(obj,status){
+  return new Response(JSON.stringify(obj),{status:status||200,headers:{'Content-Type':'application/json','Cache-Control':'no-store','X-Ascenda-PRC1-Bridge':'browser-v1'}});
+}
+function proxy(name,payload,token){
+  return downstreamFetch('/api/prc1/rpc',{
+    method:'POST',
+    headers:{'Content-Type':'application/json','Accept':'application/json','X-AOS-App-Token':token},
+    body:JSON.stringify({name:name,payload:payload||{}}),
+    cache:'no-store',credentials:'same-origin'
+  });
+}
+function bridgedRpc(name,payload){
+  delete payload.p_token;
+  return tokenCandidates().then(function(tokens){
+    if(!tokens.length)return synthetic({ok:false,error:'F4_STRONG_SESSION_REQUIRED'},401);
+    var i=0,last=null;
+    function attempt(){
+      if(i>=tokens.length)return last||synthetic({ok:false,error:'F4_STRONG_SESSION_REQUIRED'},401);
+      var token=tokens[i++];
+      return proxy(name,payload,token).then(function(r){
+        last=r;
+        return r.clone().json().catch(function(){return null;}).then(function(d){
+          if(authError(d,r.status)&&i<tokens.length)return attempt();
+          if(r.ok&&d&&d.ok===true)rememberToken(token);
+          return r;
+        });
+      });
+    }
+    return attempt();
+  });
+}
+
+window.fetch=function(input,init){
+  var name=rpcName(input);
+  if(!ALLOWED[name])return downstreamFetch(input,init);
+  return bridgedRpc(name,parseBody(init));
+};
+})();

--- a/app/server-phase-s-f17.js
+++ b/app/server-phase-s-f17.js
@@ -1,9 +1,21 @@
 'use strict'
 // ASCENDA S15.2 — production bootstrap that preserves Phase S intact while
 // inserting the certified F17 boundary before F5.
-// Effective chain: Phase S -> F17 -> F5 -> WA4 -> WA3 -> WA2 -> F4.
+// REV-PRC1 hotfix: also installs a narrow same-origin Auth V3/2FA bridge for
+// governed Product Resolution Center RPCs before the production HTTP server starts.
 const childProcess=require('child_process')
+const http=require('http')
+const https=require('https')
 const originalSpawn=childProcess.spawn
+const originalCreateServer=http.createServer
+
+const PRC1_ALLOWED=new Set([
+  'aos_product_review_admin_v1',
+  'aos_product_review_admin_v2',
+  'aos_product_review_resolve_v2',
+  'aos_product_review_reopen_v1',
+  'aos_product_batch_review_v1'
+])
 
 function rewriteChildArgs(command,args){
   const a=Array.isArray(args)?args.slice():args
@@ -26,9 +38,124 @@ function installF17Boundary(){
   childProcess.spawn=aosSpawn
 }
 
+function writePrc1Json(res,status,obj){
+  if(res.headersSent)return
+  res.writeHead(status,{
+    'Content-Type':'application/json; charset=utf-8',
+    'Cache-Control':'no-store',
+    'X-Ascenda-PRC1-Bridge':'server-v1'
+  })
+  res.end(JSON.stringify(obj))
+}
+
+function readPrc1Json(req,maxBytes){
+  maxBytes=maxBytes||262144
+  return new Promise(function(resolve,reject){
+    let raw='',overflow=false
+    req.on('data',function(c){
+      if(overflow)return
+      raw+=c
+      if(Buffer.byteLength(raw)>maxBytes)overflow=true
+    })
+    req.on('end',function(){
+      if(overflow){const e=new Error('PAYLOAD_TOO_LARGE');e.status=413;reject(e);return}
+      try{resolve(JSON.parse(raw||'{}'))}catch(_){const e=new Error('INVALID_JSON');e.status=400;reject(e)}
+    })
+    req.on('error',reject)
+  })
+}
+
+function prc1DbKey(){
+  return String(process.env.SUPABASE_ANON_KEY||process.env.SUPABASE_PUBLISHABLE_KEY||'').trim()
+}
+
+function prc1Rpc(name,payload){
+  return new Promise(function(resolve,reject){
+    const key=prc1DbKey()
+    if(!key){reject(Object.assign(new Error('SUPABASE_ANON_KEY_NOT_CONFIGURED'),{status:503}));return}
+    let sb
+    try{sb=new URL(process.env.SUPABASE_URL||'https://ituyqwstonmhnfshnaqz.supabase.co')}catch(e){reject(e);return}
+    const data=JSON.stringify(payload||{})
+    const headers={
+      apikey:key,
+      'Content-Type':'application/json',
+      'Content-Length':Buffer.byteLength(data),
+      'User-Agent':'AscendaOS-REV-PRC1-Bridge/1.0'
+    }
+    // Legacy anon JWTs are valid Bearer tokens. New publishable keys are API keys,
+    // not JWTs, so they must not be forced into Authorization.
+    if(!/^sb_publishable_/i.test(key))headers.Authorization='Bearer '+key
+    const q=https.request({
+      hostname:sb.hostname,
+      port:sb.port||443,
+      path:'/rest/v1/rpc/'+encodeURIComponent(name),
+      method:'POST',headers:headers,timeout:12000
+    },function(r){
+      let body=''
+      r.on('data',function(c){body+=c})
+      r.on('end',function(){
+        let parsed=null
+        try{parsed=body?JSON.parse(body):null}catch(_){}
+        resolve({status:r.statusCode||502,data:parsed,raw:body})
+      })
+    })
+    q.on('timeout',function(){q.destroy(Object.assign(new Error('PRC1_DB_TIMEOUT'),{status:504}))})
+    q.on('error',reject)
+    q.write(data);q.end()
+  })
+}
+
+async function handlePrc1(req,res){
+  if(req.method==='OPTIONS'){
+    res.writeHead(204,{
+      'Access-Control-Allow-Methods':'POST,OPTIONS',
+      'Access-Control-Allow-Headers':'Content-Type,X-AOS-App-Token',
+      'Cache-Control':'no-store',
+      'X-Ascenda-PRC1-Bridge':'server-v1'
+    })
+    res.end();return
+  }
+  if(req.method!=='POST'){writePrc1Json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'});return}
+  const token=String(req.headers['x-aos-app-token']||'').trim()
+  if(token.length<32){writePrc1Json(res,401,{ok:false,error:'F4_STRONG_SESSION_REQUIRED'});return}
+  try{
+    const body=await readPrc1Json(req)
+    const name=String(body&&body.name||'').trim()
+    if(!PRC1_ALLOWED.has(name)){writePrc1Json(res,403,{ok:false,error:'PRC1_RPC_NOT_ALLOWED'});return}
+    const payload=body&&body.payload&&typeof body.payload==='object'&&!Array.isArray(body.payload)?Object.assign({},body.payload):{}
+    payload.p_token=token
+    const out=await prc1Rpc(name,payload)
+    if(out.data!==null){writePrc1Json(res,out.status,out.data);return}
+    writePrc1Json(res,out.status||502,{ok:false,error:'PRC1_UPSTREAM_INVALID_JSON'})
+  }catch(e){
+    console.error('[REV-PRC1-BRIDGE]',e&&e.message||e)
+    writePrc1Json(res,e&&e.status||502,{ok:false,error:e&&e.message||'PRC1_BRIDGE_UNAVAILABLE'})
+  }
+}
+
+function installPrc1HttpBoundary(){
+  if(http.createServer&&http.createServer.__aosPrc1)return
+  function wrap(listener){
+    return function(req,res){
+      let pathname=''
+      try{pathname=new URL(req.url||'/','http://localhost').pathname}catch(_){}
+      if(pathname==='/api/prc1/rpc'){handlePrc1(req,res);return}
+      return listener.call(this,req,res)
+    }
+  }
+  function aosCreateServer(options,listener){
+    if(typeof options==='function')return originalCreateServer.call(http,wrap(options))
+    if(typeof listener==='function')return originalCreateServer.call(http,options,wrap(listener))
+    return originalCreateServer.call(http,options)
+  }
+  aosCreateServer.__aosPrc1=true
+  http.createServer=aosCreateServer
+}
+
 if(require.main===module){
+  installPrc1HttpBoundary()
   installF17Boundary()
   require('./server-phase-s.js')
 }
 
-module.exports={rewriteChildArgs,installF17Boundary}
+module.exports={rewriteChildArgs,installF17Boundary,installPrc1HttpBoundary,handlePrc1}

--- a/ci/phase4-revenue/ui_contract.js
+++ b/ci/phase4-revenue/ui_contract.js
@@ -6,6 +6,7 @@ const bridge = read('app/public/f4-revenue-ops.js');
 const kronia = read('app/public/f4-kronia-revenue-bridge.js');
 const canary = read('app/public/f4-production-canary-hotfix.js');
 const prc1 = read('app/public/rev-prc1-product-resolution-center.js');
+const prc1Auth = read('app/public/rev-prc1-auth-bridge.js');
 const prc1Sql = read('supabase/migrations/20260821122500_f4_revenue_prc1_product_resolution_center_v1.sql');
 const prc1SqlV2 = read('supabase/migrations/20260821130000_f4_revenue_prc1_product_resolution_center_v2.sql');
 const sw = read('app/public/phase2-service-worker.js');
@@ -36,14 +37,18 @@ ok(proxy.includes('aos_sales_admin_sale_v4') && proxy.includes('aos_editar_venta
 ok(proxy.includes("pathname==='/api/f4/cartera-candidates'"), 'cartera candidates route missing');
 ok(proxy.includes('aos_cartera_candidates_v2'), 'cartera candidates RPC missing');
 
-// REV-PRC1 v2: deterministic runtime + modal + historical human-in-the-loop contracts.
+// REV-PRC1 v3 auth bridge: deterministic runtime + modal + historical human-in-the-loop contracts.
 new Function(prc1);
-ok(canary.includes("/rev-prc1-product-resolution-center.js?v=20260821-prc1-v2"), 'PRC1 v2 must load through deterministic F4 runtime');
+new Function(prc1Auth);
+ok(canary.includes("/rev-prc1-auth-bridge.js?v=20260821-prc1-auth-v1"), 'PRC1 auth bridge must load through deterministic F4 runtime');
+ok(canary.includes("/rev-prc1-product-resolution-center.js?v=20260821-prc1-v3-authbridge"), 'PRC1 v3 auth bridge runtime must load through deterministic F4 runtime');
+ok(canary.includes('b.onload=loadCenterRuntime'), 'PRC1 runtime must wait for auth bridge load');
+ok(prc1Auth.includes("downstreamFetch('/api/prc1/rpc'") && prc1Auth.includes("'X-AOS-App-Token':token"), 'PRC1 must use same-origin Auth V3 transport');
 for(const marker of ['prc1-products-review-btn','Centro de validación de productos','aos_product_review_admin_v2','aos_product_review_resolve_v2','aos_product_review_reopen_v1','aos_product_batch_review_v1','LINK_EXISTING','CREATE_NEW','EXCLUDE_NOT_PRODUCT','REVIEW_REQUIRED','Todos los años','Todos los meses','Todas las sedes','Vista previa del impacto','Editar venta','Reabrir para corregir']) ok(prc1.includes(marker), `missing PRC1 v2 UI marker: ${marker}`);
 ok(prc1.includes('la descripción original de cada venta NO será modificada'), 'PRC1 impact preview must disclose raw-sale preservation');
 ok(prc1.includes('p_expected_count'), 'PRC1 resolution must carry optimistic review count');
 ok(prc1.includes('p_default_qty') && prc1.includes('p_default_is_pack'), 'PRC1 physical quantity controls missing');
-ok(!prc1.toLowerCase().includes('service_role'), 'PRC1 browser runtime must not contain service_role');
+ok(!prc1.toLowerCase().includes('service_role') && !prc1Auth.toLowerCase().includes('service_role'), 'PRC1 browser runtime must not contain service_role');
 for(const marker of ['aos_product_review_admin_v1','aos_product_batch_review_v1','aos_product_review_resolve_v1','OWNER_REVIEW_CENTER','OWNER_CONFIRMED','STALE_REVIEW','ALIAS_CONFLICT','CANONICAL_ALREADY_EXISTS']) ok(prc1Sql.includes(marker), `missing PRC1 v1 SQL marker: ${marker}`);
 for(const marker of ['aos_product_review_admin_v2','aos_product_review_resolve_v2','aos_product_review_reopen_v1','OWNER_REOPENED','REV_PRC1_PRODUCT_REOPEN',"r.treatment<>'OTROS'"]) ok(prc1SqlV2.includes(marker), `missing PRC1 v2 SQL marker: ${marker}`);
 ok(prc1Sql.includes("v_actor:=public.aos_f4_actor(p_token,'admin-sales')"), 'PRC1 admin resolution must require F4 Auth V3/2FA actor');

--- a/ci/rev-prc1/auth_bridge_contract.js
+++ b/ci/rev-prc1/auth_bridge_contract.js
@@ -26,6 +26,7 @@ must(bootstrap,"PRC1_RPC_NOT_ALLOWED",'server must fail closed outside allowlist
 must(bootstrap,"F4_STRONG_SESSION_REQUIRED",'server must require strong app session');
 must(hotfix,"/rev-prc1-auth-bridge.js?v=20260821-prc1-auth-v1",'hotfix must load auth bridge');
 must(hotfix,"/rev-prc1-product-resolution-center.js?v=20260821-prc1-v3-authbridge",'hotfix must cache-bust PRC1 runtime');
-if(hotfix.indexOf('rev-prc1-auth-bridge.js')>hotfix.indexOf('rev-prc1-product-resolution-center.js'))throw new Error('REV_PRC1_AUTH_BRIDGE_CONTRACT: bridge must be declared before PRC1 runtime');
+must(hotfix,'b.onload=loadCenterRuntime','PRC1 runtime must load only after bridge onload');
+must(hotfix,'if(window.__AOS_REV_PRC1_AUTH_BRIDGE__){loadCenterRuntime();return;}','already-loaded bridge path missing');
 
 console.log('REV_PRC1_AUTH_BRIDGE_CONTRACT PASS');

--- a/ci/rev-prc1/auth_bridge_contract.js
+++ b/ci/rev-prc1/auth_bridge_contract.js
@@ -1,0 +1,31 @@
+'use strict';
+const fs=require('fs');
+
+function read(p){return fs.readFileSync(p,'utf8');}
+function must(hay,needle,label){if(!hay.includes(needle))throw new Error('REV_PRC1_AUTH_BRIDGE_CONTRACT: '+label);}
+
+const bridge=read('app/public/rev-prc1-auth-bridge.js');
+const bootstrap=read('app/server-phase-s-f17.js');
+const hotfix=read('app/public/f4-production-canary-hotfix.js');
+
+[
+  'aos_product_review_admin_v1',
+  'aos_product_review_admin_v2',
+  'aos_product_review_resolve_v2',
+  'aos_product_review_reopen_v1',
+  'aos_product_batch_review_v1'
+].forEach(function(name){must(bridge,name,'browser allowlist missing '+name);must(bootstrap,name,'server allowlist missing '+name);});
+
+must(bridge,"downstreamFetch('/api/prc1/rpc'",'browser must use same-origin PRC1 endpoint');
+must(bridge,"'X-AOS-App-Token':token",'browser must bind Auth V3 token in header');
+must(bridge,"delete payload.p_token",'browser must not trust body token');
+must(bridge,'tokenCandidates()','browser must try strong token candidates');
+must(bootstrap,"pathname==='/api/prc1/rpc'",'server route missing');
+must(bootstrap,"payload.p_token=token",'server must overwrite RPC token from verified boundary header');
+must(bootstrap,"PRC1_RPC_NOT_ALLOWED",'server must fail closed outside allowlist');
+must(bootstrap,"F4_STRONG_SESSION_REQUIRED",'server must require strong app session');
+must(hotfix,"/rev-prc1-auth-bridge.js?v=20260821-prc1-auth-v1",'hotfix must load auth bridge');
+must(hotfix,"/rev-prc1-product-resolution-center.js?v=20260821-prc1-v3-authbridge",'hotfix must cache-bust PRC1 runtime');
+if(hotfix.indexOf('rev-prc1-auth-bridge.js')>hotfix.indexOf('rev-prc1-product-resolution-center.js'))throw new Error('REV_PRC1_AUTH_BRIDGE_CONTRACT: bridge must be declared before PRC1 runtime');
+
+console.log('REV_PRC1_AUTH_BRIDGE_CONTRACT PASS');

--- a/ci/rev-prc1/ui_contract.js
+++ b/ci/rev-prc1/ui_contract.js
@@ -17,6 +17,6 @@ ok(v2.includes("r.treatment<>'OTROS'")&&v2.includes("OTROS is always SERVICIO"),
 ok(v2.includes('aos_product_review_admin_v2')&&v2.includes('p_year integer')&&v2.includes('p_month integer')&&v2.includes('p_sede text')&&v2.includes('p_search text'),'historical filter SQL contract missing');
 ok(v2.includes('OWNER_REOPENED')&&v2.includes('REV_PRC1_PRODUCT_REOPEN'),'audited correction/reopen contract missing');
 ok(!v1.toLowerCase().includes('update public.aos_ventas')&&!v2.toLowerCase().includes('update public.aos_ventas'),'PRC migrations must never mutate raw sales');
-ok(canary.includes('20260821-prc1-v2'),'deterministic PRC1 v2 runtime version missing');
+ok(canary.includes('20260821-prc1-v3-authbridge'),'deterministic PRC1 v3 auth-bridge runtime version missing');
 ok(!ui.toLowerCase().includes('service_role'),'browser PRC must not contain service_role');
 console.log('REV-PRC1 UI/governance contract PASS');


### PR DESCRIPTION
## Incident
Owner visual smoke in production showed `No se pudo cargar la validación de productos: HTTP_401` even though the PRC1 button rendered and the LIVE RPC contracts/migrations were healthy.

## Root boundary
The Product Resolution runtime was calling the new Supabase RPCs directly from the browser. That path did not reuse the hardened same-origin Auth V3/2FA boundary already used by F4, so transport/auth could fail before the PRC1 function returned its governed `UNAUTHORIZED` result.

## Fix
- Add `rev-prc1-auth-bridge.js` before PRC1 runtime.
- Intercept only 5 explicit PRC1 RPC names.
- Send them to same-origin `/api/prc1/rpc` with `X-AOS-App-Token`.
- Prefer sessionStorage strong token, retry Cache Storage token if needed, and synchronize the successful token.
- Add a narrow production bootstrap HTTP boundary that:
  - requires the app token,
  - allowlists exactly the 5 PRC1 RPCs,
  - overwrites `p_token` server-side,
  - calls Supabase with server-side anon/publishable key,
  - never uses service-role and never opens generic RPC proxying.
- Cache-bust PRC1 runtime to `prc1-v3-authbridge`.
- Add CI static contract for the auth bridge and server fail-closed allowlist.

## Data safety
No schema/data migration. No mutation to `aos_ventas`, `aos_pacientes`, canonical products, aliases, or review facts occurs on deploy. Owner decisions remain inside existing Auth V3 + 2FA + admin-sales database guards.

## Acceptance
1. Existing PRC1 DB/pgTAP contract remains green.
2. Browser/server bridge syntax + allowlist contract green.
3. Merge/deploy exact SHA.
4. Owner reload → `Validar productos · 8` → modal opens with 8 lines / 7 groups.
5. Then perform one owner-confirmed resolution as the final visual write smoke.
