### PR TITLE
MKT Loop 6 V2 — idempotency precheck hotfix

### DIFF
--- a/docs/control/MKT_INTEGRITY_V3_LOOP6_V2_IDEMPOTENCY_HOTFIX_20260821.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP6_V2_IDEMPOTENCY_HOTFIX_20260821.md
@@ -1,0 +1,57 @@
+# MKT-INTEGRITY-HOTFIX-V3 — Loop 6 V2 idempotency precheck hotfix — 2026-08-21
+
+## Trigger
+Dedicated V2 canary 8 discovered that a retry with the same idempotency key was being re-evaluated against the active-appointment rule before the existing journal result was returned. The first request correctly created one Call + one Agenda + one action journal row, but the second identical request returned `ACTIVE_APPOINTMENT_EXISTS` instead of the original result with `idempotent=true`.
+
+No duplicate data was created, but this violated the retry-after-timeout contract.
+
+## Fix
+The existing V2 policy implementation is preserved as `aos_callcenter_commit_action_core_impl_v2`. A narrow `aos_callcenter_commit_action_core_v1` wrapper now:
+1. validates actor/key/action/source/phone shape;
+2. computes the same request hash used by V2;
+3. checks `aos_callcenter_actions_v1` before F6/patient-state/active-appointment/ownership re-evaluation;
+4. returns `IDEMPOTENCY_ACTOR_CONFLICT` for actor mismatch;
+5. returns `IDEMPOTENCY_CONFLICT` for request-hash mismatch;
+6. returns the stored COMPLETE result with `idempotent=true` for an identical retry;
+7. delegates only first-seen actions to the unchanged V2 implementation.
+
+F6 remains private; browser grants are unchanged.
+
+## LIVE gate before apply
+- action journal = 0;
+- policy events = 0;
+- canonical core existed;
+- implementation alias did not yet exist.
+
+The wrapper migration was then applied to Supabase LIVE. It changes no customer rows, Calls, Agenda, sales, leads or F5/F6 data.
+
+## Canary PASS after fix
+Rollback canary used a synthetic new prospect with one identical action invoked twice.
+
+Observed inside the transaction:
+- journal_count = 1;
+- call_count = 1;
+- agenda_count = 1;
+- second result `ok=true`;
+- second result `idempotent=true`;
+- same `callId` and `agendaId` as the first action.
+
+Transaction ended in ROLLBACK.
+
+## Downstream readback after all V2 canaries
+- action journal = 0;
+- policy events = 0;
+- synthetic Calls = 0;
+- synthetic Agenda rows = 0;
+- repaired Calls intact: 36701, 37185, 37813, 38012, 38168, 38186;
+- five repaired direct links intact;
+- removed Alberto/Alan duplicate Agenda rows remain absent;
+- REV-F5 = 6 batches / 15,498 source rows / 8,716 clusters / 15,498 members / 8,716 previews / 230 apply events;
+- F6 Identity/Lifecycle remain service-role-only;
+- Acquisition = V2 56 / V3 57 / V2-only 0 / sole V3-only 973438607 -> lead 2135;
+- August Attribution snapshot after canaries: V2 22 rows / S/6,538; V3 35 rows / S/13,747. Canaries were rollback-only and could not create attribution rows.
+
+## Governance note
+PR #337 was merged externally at `main@521c013209702a7c26ddafed23799f9c36236481` while the final canary sequence was still running. The idempotency defect was found after that merge. This hotfix PR exists solely to restore Git↔Supabase parity and must be merged from exact current main with `expected_head_sha` after exact-head CI passes.
+
+Loop 6 remains production-canary / NOT YET CERTIFIED. Loop 7 remains NOT STARTED.

--- a/supabase/migrations/20260822001500_mkt_loop6_idempotency_precheck_v2.sql
+++ b/supabase/migrations/20260822001500_mkt_loop6_idempotency_precheck_v2.sql
@@ -1,0 +1,74 @@
+-- ASCENDA OS · MKT-INTEGRITY-HOTFIX-V3 · LOOP 6 V2
+-- Retry/idempotency hardening: resolve an existing action journal entry before
+-- re-evaluating patient state, active appointment or ownership policy.
+
+alter function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text)
+  rename to aos_callcenter_commit_action_core_impl_v2;
+
+revoke all on function public.aos_callcenter_commit_action_core_impl_v2(uuid,text,text,jsonb,text)
+  from public,anon,authenticated;
+grant execute on function public.aos_callcenter_commit_action_core_impl_v2(uuid,text,text,jsonb,text)
+  to service_role;
+
+create or replace function public.aos_callcenter_commit_action_core_v1(
+  p_actor uuid,
+  p_idempotency_key text,
+  p_action_type text,
+  p_payload jsonb,
+  p_test_fail_stage text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+declare
+  v_key text:=pg_catalog.btrim(coalesce(p_idempotency_key,''));
+  v_action text:=upper(pg_catalog.btrim(coalesce(p_action_type,'')));
+  v_payload jsonb:=coalesce(p_payload,'{}'::jsonb);
+  v_source_mode text:=upper(pg_catalog.btrim(coalesce(v_payload->>'source_mode','QUEUE')));
+  v_num text:=pg_catalog.regexp_replace(coalesce(v_payload->>'numero',''),'[^0-9]','','g');
+  v_hash text;
+  v_existing record;
+begin
+  if p_actor is null then return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if pg_catalog.length(v_key)<16 or pg_catalog.length(v_key)>160 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_IDEMPOTENCY_KEY'); end if;
+  if v_action not in ('COMMERCIAL_CALL_APPOINTMENT','CALLBACK_INBOUND_APPOINTMENT','REACTIVATION','PATIENT_FOLLOWUP','AGENDA_ONLY') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_ACTION');
+  end if;
+  if v_source_mode not in ('QUEUE','MANUAL','CALLBACK','FOLLOWUP') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_SOURCE_MODE');
+  end if;
+  if pg_catalog.length(v_num)<7 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_PHONE'); end if;
+
+  v_hash:=pg_catalog.encode(
+    extensions.digest(v_action||'|'||(v_payload-'event_ts'-'business_date')::text,'sha256'),
+    'hex'
+  );
+
+  select * into v_existing
+  from public.aos_callcenter_actions_v1 a
+  where a.idempotency_key=v_key;
+
+  if found then
+    if v_existing.actor_user_id<>p_actor then
+      return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_ACTOR_CONFLICT');
+    end if;
+    if v_existing.request_hash<>v_hash then
+      return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_CONFLICT');
+    end if;
+    if v_existing.status='COMPLETE' and v_existing.result is not null then
+      return v_existing.result||pg_catalog.jsonb_build_object('idempotent',true);
+    end if;
+    return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_IN_PROGRESS');
+  end if;
+
+  return public.aos_callcenter_commit_action_core_impl_v2(
+    p_actor,p_idempotency_key,p_action_type,p_payload,p_test_fail_stage
+  );
+end
+$function$;
+
+revoke all on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text)
+  from public,anon,authenticated;
+grant execute on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text)
+  to service_role;

--- a/supabase/rollbacks/20260822001500_mkt_loop6_idempotency_precheck_v2_recovery.sql
+++ b/supabase/rollbacks/20260822001500_mkt_loop6_idempotency_precheck_v2_recovery.sql
@@ -1,0 +1,12 @@
+-- Roll back only the Loop 6 V2 idempotency precheck wrapper.
+-- Restores the policy implementation to the canonical core function name.
+
+drop function if exists public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text);
+
+alter function public.aos_callcenter_commit_action_core_impl_v2(uuid,text,text,jsonb,text)
+  rename to aos_callcenter_commit_action_core_v1;
+
+revoke all on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text)
+  from public,anon,authenticated;
+grant execute on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text)
+  to service_role;


### PR DESCRIPTION
Restores Git↔Supabase parity after canary 8 found that identical retries were reaching ACTIVE_APPOINTMENT_EXISTS before the existing action journal was consulted.

Scope is intentionally narrow:
- rename the current V2 core implementation to an internal service-role-only implementation;
- add a thin canonical wrapper that resolves identical retries from `aos_callcenter_actions_v1` before re-evaluating F6/patient state/active appointment/ownership;
- preserve actor/hash conflict handling;
- rollback script restores the implementation name directly;
- control evidence records the failed canary, LIVE apply gate, fixed canary PASS and downstream invariants.

LIVE wrapper is already applied after journal=0/policy=0 gate and rollback canary PASS. No customer/Call/Agenda/sales/lead/F5 data was mutated by the fix itself.

Merge only after exact-head CI passes. Loop 6 remains production-canary / NOT CERTIFIED. Loop 7 NOT STARTED.