### PR TITLE
MKT Loop 6 V2.2 — block legacy bypass + repair Ruben canary

### DIFF
--- a/.github/workflows/loop6-runtime-loader-patch.yml
+++ b/.github/workflows/loop6-runtime-loader-patch.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'app/public/calls-loop6.js'
       - 'app/public/calls.html'
+      - 'app/public/calls.js'
       - 'scripts/ci/loop6_patch_calls_html.mjs'
       - '.github/workflows/loop6-runtime-loader-patch.yml'
       - 'supabase/migrations/*mkt_integrity_loop6*'
@@ -41,34 +42,38 @@ jobs:
         shell: powershell
         run: |
           if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'Loop 6 loader patch must use self-hosted runner' }
-          Write-Host "Runner: $env:RUNNER_NAME"
-          Write-Host "OS: $env:RUNNER_OS"
       - id: patch
-        name: Apply deterministic loader patch
+        name: Apply deterministic V2.2 runtime patch
         shell: powershell
         run: |
           node scripts/ci/loop6_patch_calls_html.mjs
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $changed = git status --porcelain -- app/public/calls.html
+          $changed = git status --porcelain -- app/public/calls.html app/public/calls.js app/public/calls-loop6.js
           if ($changed) {
             "changed=true" >> $env:GITHUB_OUTPUT
             git config user.name 'ASCENDA Zero-Cost CI'
             git config user.email 'actions@users.noreply.github.com'
-            git add app/public/calls.html
-            git commit -m 'LOOP 6 — load atomic Call Center runtime override'
+            git add app/public/calls.html app/public/calls.js app/public/calls-loop6.js
+            git commit -m 'LOOP 6 V2.2 — rearm runtime and block legacy frontend fallback'
             git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
           } else {
             "changed=false" >> $env:GITHUB_OUTPUT
           }
-      - name: Validate runtime loader
+      - name: Validate V2.2 runtime
         if: steps.patch.outputs.changed == 'false'
         shell: powershell
         run: |
           node --check app/public/calls-loop6.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $text = Get-Content -Raw app/public/calls.html
-          $marker = '<script src="/calls-loop6.js?v=20260821-loop6"></script>'
-          $count = ([regex]::Matches($text, [regex]::Escape($marker))).Count
-          if ($count -ne 1) { throw "Expected exactly one Loop 6 loader, found $count" }
+          $html = Get-Content -Raw app/public/calls.html
+          $callsjs = Get-Content -Raw app/public/calls.js
+          $runtime = Get-Content -Raw app/public/calls-loop6.js
+          $marker = '<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>'
+          if (([regex]::Matches($html,[regex]::Escape($marker))).Count -ne 1) { throw 'Expected exactly one V2.2 loader' }
+          if ($html.Contains('calls-loop6.js?v=20260821-loop6"></script>')) { throw 'Old Loop6 cache key remains' }
+          if (([regex]::Matches($html,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.2'"))).Count -lt 2) { throw 'Legacy guards missing in calls.html' }
+          if (([regex]::Matches($callsjs,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.2'"))).Count -lt 2) { throw 'Legacy guards missing in calls.js' }
+          if (-not $runtime.Contains("window.__AOS_CC_LOOP6_V2__='v2.2';")) { throw 'V2.2 runtime build marker missing' }
+          if ($runtime.Contains('if(window.__AOS_CC_LOOP6_V2__) return;')) { throw 'Unsafe SPA early-return remains' }
           git diff --check
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/app/public/calls-loop6.js
+++ b/app/public/calls-loop6.js
@@ -3,8 +3,7 @@
  */
 (function(){
 'use strict';
-if(window.__AOS_CC_LOOP6_V2__) return;
-window.__AOS_CC_LOOP6_V2__='v2';
+window.__AOS_CC_LOOP6_V2__='v2.2';
 
 function cc6Token(){return (window.AOS_getToken&&window.AOS_getToken())||sessionStorage.getItem('aos_app_token')||(window.CC&&CC.token)||'';}
 function cc6Rpc(fn,p){return new Promise(function(resolve,reject){if(typeof window._rpc!=='function'){reject(new Error('RPC_UNAVAILABLE'));return;}window._rpc(fn,p,function(d){resolve(d);},function(e){reject(e||new Error('RPC_FAILED'));});});}

--- a/app/public/calls.html
+++ b/app/public/calls.html
@@ -713,6 +713,7 @@ function ccGuardar(){
 }
 
 function ccConfirmarCita(){
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   if(CC.guardando)return;CC.guardando=true;
   var tipoCita='';document.querySelectorAll('#cc-tipo-cita-grp .tb').forEach(function(t){if(t.classList.contains('act'))tipoCita=t.getAttribute('data-val');});
   if(!document.getElementById('cc-c-fecha').value){if(window.AOS_showToast)AOS_showToast('⚠️ Falta fecha','Seleccioná la fecha.','');else alert('Falta la fecha');return;}
@@ -1381,6 +1382,7 @@ function buscarPacCitaManual(q){
 }
 
 function guardarCitaManual(){
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var num=(document.getElementById('cm-num').value||'').trim().replace(/\D/g,'');
   if(!num||num.length<7){alert('Ingresa un número válido.');return;}
   var fecha=document.getElementById('cm-fecha').value;
@@ -1505,6 +1507,6 @@ function buscarRepo(){
 }
 
 </script>
-<script src="/calls-loop6.js?v=20260821-loop6"></script>
 
+<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>
 <!-- KronIA Chat — en app.html (persistente entre paneles) -->

--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -212,6 +212,7 @@ function ccGuardar(){
 }
 
 function ccConfirmarCita(){
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var tipoCita='';document.querySelectorAll('#cc-tipo-cita-grp .tb').forEach(function(t){if(t.classList.contains('act'))tipoCita=t.getAttribute('data-val');});
   if(!document.getElementById('cc-c-fecha').value){if(window.AOS_showToast)AOS_showToast('⚠️ Falta fecha','Seleccioná la fecha.','');else alert('Falta la fecha');return;}
   var p={numero:CC.lead?CC.lead.num:'',estado:'CITA CONFIRMADA',nombre:document.getElementById('cc-c-nombre').value.trim(),apellido:document.getElementById('cc-c-apellido').value.trim(),dni:document.getElementById('cc-c-dni').value.trim(),correo:document.getElementById('cc-c-correo').value.trim(),tipoAtencion:document.getElementById('cc-c-tipo-at').value,sede:document.getElementById('cc-c-sede').value,fechaCita:document.getElementById('cc-c-fecha').value,horaCita:document.getElementById('cc-c-hora').value,tratamiento:document.getElementById('cc-c-trat').value,tipoCita:tipoCita||'CONSULTA NUEVA',obs:document.getElementById('cc-c-obs').value.trim(),rowNum:CC.lead?(CC.lead.rowNum||0):0};
@@ -838,6 +839,7 @@ function buscarPacCitaManual(q){
 }
 
 function guardarCitaManual(){
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var num=(document.getElementById('cm-num').value||'').trim().replace(/\D/g,'');
   if(!num||num.length<7){alert('Ingresa un número válido.');return;}
   var fecha=document.getElementById('cm-fecha').value;

--- a/docs/control/MKT_INTEGRITY_V3_LOOP6_V22_EXACT_HEAD_TRIGGER_20260821.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP6_V22_EXACT_HEAD_TRIGGER_20260821.md
@@ -1,0 +1,3 @@
+# Loop 6 V2.2 exact-head trigger
+
+The FAST self-hosted runner materialized the deterministic frontend patch after PR #340 creation. This owner commit exists only to force all required PR checks to run against the final materialized head. No runtime or database semantics are changed by this file.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP6_V22_RUBEN_CANARY_HOTFIX_20260821.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP6_V22_RUBEN_CANARY_HOTFIX_20260821.md
@@ -1,0 +1,45 @@
+# MKT-INTEGRITY-V3 · Loop 6 V2.2 — first real canary hotfix
+
+## Incident
+First genuine post-baseline operation failed the governed runtime path.
+
+Ruben Carlos Dominguez Munoz / `997883711`:
+- Marketing lead `5884`, CAPILAR, unique prior touchpoint;
+- Mireya SEGUIMIENTO call `38301` at 18:23:41 Lima;
+- Agenda `2c581c52-89e9-465f-89be-0e3818eda309` created 19:35:06 Lima for 2026-08-25 18:00;
+- legacy `CITA_MANUAL`, initially `lead_id_origen=NULL`, `llamada_id_origen=NULL`;
+- no Loop6 journal/policy row at incident time.
+
+Strong evidence: no prior sale, clinical attention or ASISTIO/EFECTIVA. Correct semantic = `FOLLOWUP_CONVERSION / MARKETING / lead 5884 / +1 call +1 cita / MIREYA`.
+
+Three additional legacy-unlinked Agenda rows were found after the old baseline:
+- `7d530a24-fe05-43bc-b7ab-a83428050532` / 928017492 / WILMER — converted patient; no contemporary call evidence, no automatic credit granted;
+- `dc99e863-1e97-49e3-8000-cc420b71bc8a` / 995558890 / WILMER — converted patient; no contemporary call evidence, no automatic credit granted;
+- `92949454-4c1e-4273-bb7c-9b2b9288e0b2` / 980749071 / WILMER — converted patient with qualifying activity 17/08 (<15d), no new commercial credit permitted.
+
+## Root cause / containment
+Production retained legacy Call Center save functions and the loader cache key remained `calls-loop6.js?v=20260821-loop6`. In an SPA/stale-runtime condition a legacy function could persist directly outside `aos_callcenter_commit_action_v1`. The runtime also had an early-return build guard that could prevent re-arming overrides after panel reinjection.
+
+V2.2 containment:
+1. DB BEFORE INSERT guards reject non-governed `CITA CONFIRMADA` call writes.
+2. DB BEFORE INSERT guards reject non-governed `CITA_MANUAL` and `CALL_CENTER*` Agenda writes.
+3. canonical core sets transaction-local `aos.loop6_governed_write=1` before calling V2 implementation.
+4. frontend loader cache key becomes `calls-loop6.js?v=20260821-loop6-v2.2`.
+5. runtime build marker becomes `v2.2` and unsafe SPA early-return is removed.
+6. legacy `ccConfirmarCita()` and `guardarCitaManual()` are fail-closed unless exact runtime v2.2 is active.
+
+Rollback canary after LIVE DB apply:
+- direct legacy commercial Call rows = 0;
+- direct legacy CITA_MANUAL Agenda rows = 0;
+- governed core = journal 1 / Call 1 / Agenda 1.
+All synthetic rows rolled back.
+
+## Ruben repair
+Deterministic repair applied after exact precondition checks:
+- Call `38384` = `CITA CONFIRMADA / FOLLOWUP_CONVERSION / MARKETING / lead 5884 / MIREYA`;
+- Agenda `2c581c52-89e9-465f-89be-0e3818eda309` now links `lead_id_origen=5884`, `llamada_id_origen=38384`, `origen_cita=CALL_CENTER`;
+- Seguimiento `SEG-1787354621097-4zle` = COMPLETADO and linked to lead 5884;
+- journal key `repair-ruben-997883711-20260821-193506` = COMPLETE, creditedAdvisor MIREYA;
+- post-repair panel snapshot: Mireya 151 calls / 3 citas (call total is dynamic due concurrent advisor activity; cita delta is the repaired business invariant).
+
+Loop 6 remains BLOCKED until V2.2 frontend deploy is exact-commit SUCCESS, stale-client canary passes, invariants are re-read, and a fresh genuine-operation baseline is captured. Loop 7 NOT STARTED.

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -1,28 +1,58 @@
 import fs from 'node:fs';
 
-const path = 'app/public/calls.html';
-const marker = '<script src="/calls-loop6.js?v=20260821-loop6"></script>';
-const obsoletePolicyMarker = '<script src="/calls-loop6-policy-v2.js?v=20260821-loop6-policy-v2"></script>';
-const anchor = '<!-- KronIA Chat — en app.html (persistente entre paneles) -->';
-let text = fs.readFileSync(path, 'utf8');
-let changed = false;
+const htmlPath='app/public/calls.html';
+const jsPath='app/public/calls-loop6.js';
+const callsJsPath='app/public/calls.js';
+const marker='<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>';
+const oldMarkers=[
+  '<script src="/calls-loop6.js?v=20260821-loop6"></script>',
+  '<script src="/calls-loop6-policy-v2.js?v=20260821-loop6-policy-v2"></script>'
+];
+const anchor='<!-- KronIA Chat — en app.html (persistente entre paneles) -->';
+const guard="if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}";
 
-if (text.includes(obsoletePolicyMarker)) {
-  text = text.split(obsoletePolicyMarker + '\n').join('');
-  text = text.split(obsoletePolicyMarker).join('');
-  changed = true;
-  console.log('LOOP6_OBSOLETE_POLICY_LOADER=REMOVED');
+function patchLegacy(path){
+  let text=fs.readFileSync(path,'utf8');
+  let changed=false;
+  for(const sig of ['function ccConfirmarCita(){','function guardarCitaManual(){']){
+    const guarded=`${sig}\n  ${guard}`;
+    if(text.includes(guarded)) continue;
+    if(!text.includes(sig)) throw new Error(`Loop6 legacy function not found in ${path}: ${sig}`);
+    text=text.replace(sig,guarded);
+    changed=true;
+  }
+  if(changed) fs.writeFileSync(path,text,'utf8');
+  return changed;
 }
 
-const count = text.split(marker).length - 1;
-if (count > 1) throw new Error(`LOOP6 loader duplicated: ${count}`);
-if (count === 0) {
-  if (!text.includes(anchor)) throw new Error('LOOP6 loader anchor not found');
-  text = text.replace(anchor, `${marker}\n${anchor}`);
-  changed = true;
-  console.log('LOOP6_LOADER_PATCH=APPLIED');
-} else {
-  console.log('LOOP6_LOADER_PATCH=ALREADY_PRESENT');
+let html=fs.readFileSync(htmlPath,'utf8');
+let htmlChanged=false;
+for(const old of oldMarkers){
+  if(html.includes(old)){
+    html=html.split(old+'\n').join('').split(old).join('');
+    htmlChanged=true;
+  }
+}
+const count=html.split(marker).length-1;
+if(count>1) throw new Error(`LOOP6 v2.2 loader duplicated: ${count}`);
+if(count===0){
+  if(!html.includes(anchor)) throw new Error('LOOP6 loader anchor not found');
+  html=html.replace(anchor,`${marker}\n${anchor}`);
+  htmlChanged=true;
+}
+if(htmlChanged) fs.writeFileSync(htmlPath,html,'utf8');
+
+patchLegacy(htmlPath);
+patchLegacy(callsJsPath);
+
+let runtime=fs.readFileSync(jsPath,'utf8');
+const oldBoot="if(window.__AOS_CC_LOOP6_V2__) return;\nwindow.__AOS_CC_LOOP6_V2__='v2';";
+const newBoot="window.__AOS_CC_LOOP6_V2__='v2.2';";
+if(runtime.includes(oldBoot)){
+  runtime=runtime.replace(oldBoot,newBoot);
+  fs.writeFileSync(jsPath,runtime,'utf8');
+}else if(!runtime.includes(newBoot)){
+  throw new Error('Loop6 runtime bootstrap signature not found');
 }
 
-if (changed) fs.writeFileSync(path, text, 'utf8');
+console.log('LOOP6_V22_PATCH=OK');

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -16,20 +16,20 @@ function patchLegacy(path){
   let changed=false;
   for(const sig of ['function ccConfirmarCita(){','function guardarCitaManual(){']){
     const guarded=`${sig}\n  ${guard}`;
-    if(text.includes(guarded)) continue;
+    const guardedCr=`${sig}\r\n  ${guard}`;
+    if(text.includes(guarded)||text.includes(guardedCr)) continue;
     if(!text.includes(sig)) throw new Error(`Loop6 legacy function not found in ${path}: ${sig}`);
-    text=text.replace(sig,guarded);
+    text=text.replace(sig,`${sig}\n  ${guard}`);
     changed=true;
   }
   if(changed) fs.writeFileSync(path,text,'utf8');
-  return changed;
 }
 
 let html=fs.readFileSync(htmlPath,'utf8');
 let htmlChanged=false;
 for(const old of oldMarkers){
   if(html.includes(old)){
-    html=html.split(old+'\n').join('').split(old).join('');
+    html=html.split(old+'\n').join('').split(old+'\r\n').join('').split(old).join('');
     htmlChanged=true;
   }
 }
@@ -46,12 +46,11 @@ patchLegacy(htmlPath);
 patchLegacy(callsJsPath);
 
 let runtime=fs.readFileSync(jsPath,'utf8');
-const oldBoot="if(window.__AOS_CC_LOOP6_V2__) return;\nwindow.__AOS_CC_LOOP6_V2__='v2';";
-const newBoot="window.__AOS_CC_LOOP6_V2__='v2.2';";
-if(runtime.includes(oldBoot)){
-  runtime=runtime.replace(oldBoot,newBoot);
+const bootRe=/if\(window\.__AOS_CC_LOOP6_V2__\) return;\r?\nwindow\.__AOS_CC_LOOP6_V2__='v2';/;
+if(bootRe.test(runtime)){
+  runtime=runtime.replace(bootRe,"window.__AOS_CC_LOOP6_V2__='v2.2';");
   fs.writeFileSync(jsPath,runtime,'utf8');
-}else if(!runtime.includes(newBoot)){
+}else if(!runtime.includes("window.__AOS_CC_LOOP6_V2__='v2.2';")){
   throw new Error('Loop6 runtime bootstrap signature not found');
 }
 

--- a/scripts/data/20260821_loop6_repair_ruben_997883711.sql
+++ b/scripts/data/20260821_loop6_repair_ruben_997883711.sql
@@ -1,0 +1,79 @@
+-- Deterministic repair for first real Loop 6 V2 canary: Ruben Carlos Dominguez Munoz / 997883711.
+-- Preconditions are intentionally strict. Run only once in production.
+
+do $repair$
+declare
+  v_call_id bigint;
+  v_key text:='repair-ruben-997883711-20260821-193506';
+  v_actor uuid:='ddfefe34-a598-4262-8d99-3f55a43a1afb';
+  v_agenda text:='2c581c52-89e9-465f-89be-0e3818eda309';
+  v_follow text:='SEG-1787354621097-4zle';
+  v_event timestamptz:='2026-08-22T00:35:06.586+00:00';
+  v_result jsonb;
+begin
+  if exists(select 1 from public.aos_callcenter_actions_v1 where idempotency_key=v_key) then
+    raise exception 'RUBEN_REPAIR_ALREADY_APPLIED';
+  end if;
+  if (select count(*) from public.aos_leads where id=5884 and numero_limpio='997883711' and tratamiento='CAPILAR')<>1 then
+    raise exception 'RUBEN_LEAD_PRECONDITION_FAILED';
+  end if;
+  if (select count(*) from public.aos_llamadas where numero_limpio='997883711' and fecha='2026-08-21' and upper(coalesce(estado,''))='CITA CONFIRMADA')<>0 then
+    raise exception 'RUBEN_ALREADY_HAS_COMMERCIAL_CITA_CALL';
+  end if;
+  if not exists(select 1 from public.aos_agenda_citas where id=v_agenda and numero_limpio='997883711' and upper(coalesce(asesor,''))='MIREYA' and lead_id_origen is null and llamada_id_origen is null) then
+    raise exception 'RUBEN_AGENDA_PRECONDITION_FAILED';
+  end if;
+  if not exists(select 1 from public.aos_seguimientos where "ID"=v_follow and upper(coalesce("ASESOR",''))='MIREYA' and upper(coalesce("ESTADO",''))='PENDIENTE') then
+    raise exception 'RUBEN_FOLLOWUP_PRECONDITION_FAILED';
+  end if;
+
+  perform pg_catalog.set_config('aos.loop6_governed_write','1',true);
+
+  insert into public.aos_llamadas(
+    fecha,numero,numero_limpio,tratamiento,estado,sub_estado,observacion,hora_llamada,
+    asesor,id_asesor,anuncio,origen,intento,created_at,duracion_seg,tipo_gestion,desde_dispositivo,lead_id_origen
+  ) values(
+    '2026-08-21','997883711','997883711','CAPILAR','CITA CONFIRMADA','FOLLOWUP_CONVERSION',
+    'RUBEN | Reparacion Loop6 V2: lead 5884 + seguimiento Mireya + cita real 25/08 18:00',
+    '19:35:06','MIREYA','ZIV-003','CAPILAR- INJERTO REEL4','MARKETING',2,v_event,0,'FOLLOWUP_CONVERSION','web',5884
+  ) returning id into v_call_id;
+
+  update public.aos_agenda_citas
+  set lead_id_origen=5884,
+      llamada_id_origen=v_call_id,
+      origen_cita='CALL_CENTER',
+      ts_actualizado=pg_catalog.now()
+  where id=v_agenda;
+
+  update public.aos_seguimientos
+  set "ESTADO"='COMPLETADO',
+      "TS_ACTUALIZADO"='2026-08-22T00:35:06.586Z',
+      lead_id_origen=5884
+  where "ID"=v_follow;
+
+  v_result:=pg_catalog.jsonb_build_object(
+    'ok',true,'idempotent',false,'requestedAction','CALLBACK_INBOUND_APPOINTMENT',
+    'effectiveAction','CALLBACK_INBOUND_APPOINTMENT','patientState','HISTORICAL_PROSPECT',
+    'identityStatus','MATCH','canonicalPatientId','5a0bc038-7dd4-4fab-9aac-b9d5d2a23e05','converted',false,
+    'callId',v_call_id,'agendaId',v_agenda,'leadId',5884,'origin','MARKETING',
+    'callState','CITA CONFIRMADA','tipoGestion','FOLLOWUP_CONVERSION','businessDate','2026-08-21',
+    'executedBy','MIREYA','executedById','ZIV-003','creditedAdvisor','MIREYA','creditedAdvisorId','ZIV-003',
+    'commercialOwner','MIREYA','commercialOwnerId','ZIV-003','beneficiaryScope','ADVISOR',
+    'eligibilityStatus','ALLOW','eligibilityReason','LEGACY_FOLLOWUP_CONVERSION_REPAIR',
+    'ownershipTransfer',false,'priorAgendaId',null,'priorAdvisor',''
+  );
+
+  insert into public.aos_callcenter_actions_v1(
+    idempotency_key,request_hash,actor_user_id,asesor,id_asesor,numero_limpio,action_type,source_mode,
+    patient_state,identity_status,canonical_patient_id,lead_id_origen,origen,llamada_id,agenda_id,status,result,
+    created_at,updated_at,credited_advisor,credited_advisor_id,commercial_owner,commercial_owner_id,beneficiary_scope,
+    eligibility_status,eligibility_reason,prior_agenda_id,prior_advisor,prior_advisor_id,ownership_transfer,rule_context
+  ) values(
+    v_key,pg_catalog.md5('RUBEN|5884|FOLLOWUP_CONVERSION|2026-08-21T19:35:06'),v_actor,'MIREYA','ZIV-003','997883711',
+    'CALLBACK_INBOUND_APPOINTMENT','FOLLOWUP','HISTORICAL_PROSPECT','MATCH','5a0bc038-7dd4-4fab-9aac-b9d5d2a23e05',
+    5884,'MARKETING',v_call_id,v_agenda,'COMPLETE',v_result,v_event,pg_catalog.now(),
+    'MIREYA','ZIV-003','MIREYA','ZIV-003','ADVISOR','ALLOW','LEGACY_FOLLOWUP_CONVERSION_REPAIR',null,null,null,false,
+    pg_catalog.jsonb_build_object('repair',true,'reason','FIRST_REAL_CANARY_LEGACY_BYPASS','leadId',5884,'followupId',v_follow)
+  );
+end
+$repair$;

--- a/scripts/data/20260821_loop6_repair_ruben_997883711_rollback.sql
+++ b/scripts/data/20260821_loop6_repair_ruben_997883711_rollback.sql
@@ -1,0 +1,27 @@
+do $rollback$
+declare
+  v_key text:='repair-ruben-997883711-20260821-193506';
+  v_call bigint;
+begin
+  select llamada_id into v_call from public.aos_callcenter_actions_v1 where idempotency_key=v_key;
+  if v_call is null then raise exception 'RUBEN_REPAIR_JOURNAL_NOT_FOUND'; end if;
+
+  update public.aos_agenda_citas
+  set lead_id_origen=null,
+      llamada_id_origen=null,
+      origen_cita='CITA_MANUAL',
+      ts_actualizado='2026-08-22T00:35:07.336729+00:00'
+  where id='2c581c52-89e9-465f-89be-0e3818eda309' and llamada_id_origen=v_call and lead_id_origen=5884;
+
+  update public.aos_seguimientos
+  set "ESTADO"='PENDIENTE',
+      "TS_ACTUALIZADO"='2026-08-21T23:23:41.097Z',
+      lead_id_origen=null
+  where "ID"='SEG-1787354621097-4zle' and lead_id_origen=5884;
+
+  delete from public.aos_callcenter_actions_v1 where idempotency_key=v_key and llamada_id=v_call;
+  delete from public.aos_llamadas
+  where id=v_call and numero_limpio='997883711' and upper(coalesce(asesor,''))='MIREYA'
+    and tipo_gestion='FOLLOWUP_CONVERSION' and lead_id_origen=5884;
+end
+$rollback$;

--- a/supabase/migrations/20260822011500_mkt_loop6_legacy_bypass_guard_v22.sql
+++ b/supabase/migrations/20260822011500_mkt_loop6_legacy_bypass_guard_v22.sql
@@ -1,0 +1,92 @@
+-- Loop 6 V2.2: fail closed legacy Call Center writes and mark governed transactions.
+
+insert into public.aos_loop6_function_backups_v1(backup_key,function_name,function_args,definition)
+select '20260821_legacy_bypass_guard_v22',p.proname,pg_get_function_identity_arguments(p.oid),pg_get_functiondef(p.oid)
+from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+where n.nspname='public' and p.prokind='f' and p.proname='aos_callcenter_commit_action_core_v1'
+on conflict do nothing;
+
+create or replace function public.aos_loop6_require_governed_call_v22()
+returns trigger
+language plpgsql security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+begin
+  if upper(coalesce(new.estado,''))='CITA CONFIRMADA'
+     and upper(coalesce(new.tipo_gestion,'LLAMADA')) <> 'INFERIDA_HISTORICA'
+     and coalesce(pg_catalog.current_setting('aos.loop6_governed_write',true),'') <> '1' then
+    raise exception using errcode='P0001',
+      message='AOS_LOOP6_RUNTIME_REQUIRED',
+      detail='Call Center actualizado requerido. Recarga ASCENDA antes de registrar una cita comercial.';
+  end if;
+  return new;
+end
+$function$;
+
+create or replace function public.aos_loop6_require_governed_agenda_v22()
+returns trigger
+language plpgsql security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+declare v_origin text:=upper(coalesce(new.origen_cita,''));
+begin
+  if (v_origin='CITA_MANUAL' or v_origin like 'CALL_CENTER%')
+     and coalesce(pg_catalog.current_setting('aos.loop6_governed_write',true),'') <> '1' then
+    raise exception using errcode='P0001',
+      message='AOS_LOOP6_RUNTIME_REQUIRED',
+      detail='Call Center actualizado requerido. Recarga ASCENDA antes de registrar una cita desde este panel.';
+  end if;
+  return new;
+end
+$function$;
+
+revoke all on function public.aos_loop6_require_governed_call_v22() from public,anon,authenticated;
+revoke all on function public.aos_loop6_require_governed_agenda_v22() from public,anon,authenticated;
+
+drop trigger if exists trg_000_aos_loop6_governed_call_v22 on public.aos_llamadas;
+create trigger trg_000_aos_loop6_governed_call_v22
+before insert on public.aos_llamadas
+for each row execute function public.aos_loop6_require_governed_call_v22();
+
+drop trigger if exists trg_000_aos_loop6_governed_agenda_v22 on public.aos_agenda_citas;
+create trigger trg_000_aos_loop6_governed_agenda_v22
+before insert on public.aos_agenda_citas
+for each row execute function public.aos_loop6_require_governed_agenda_v22();
+
+create or replace function public.aos_callcenter_commit_action_core_v1(
+  p_actor uuid,p_idempotency_key text,p_action_type text,p_payload jsonb,p_test_fail_stage text default null
+) returns jsonb
+language plpgsql security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+declare
+  v_key text:=pg_catalog.btrim(coalesce(p_idempotency_key,''));
+  v_action text:=upper(pg_catalog.btrim(coalesce(p_action_type,'')));
+  v_payload jsonb:=coalesce(p_payload,'{}'::jsonb);
+  v_source_mode text:=upper(pg_catalog.btrim(coalesce(v_payload->>'source_mode','QUEUE')));
+  v_num text:=pg_catalog.regexp_replace(coalesce(v_payload->>'numero',''),'[^0-9]','','g');
+  v_hash text;
+  v_existing record;
+begin
+  if p_actor is null then return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if pg_catalog.length(v_key)<16 or pg_catalog.length(v_key)>160 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_IDEMPOTENCY_KEY'); end if;
+  if v_action not in ('COMMERCIAL_CALL_APPOINTMENT','CALLBACK_INBOUND_APPOINTMENT','REACTIVATION','PATIENT_FOLLOWUP','AGENDA_ONLY') then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_ACTION'); end if;
+  if v_source_mode not in ('QUEUE','MANUAL','CALLBACK','FOLLOWUP') then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_SOURCE_MODE'); end if;
+  if pg_catalog.length(v_num)<7 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_PHONE'); end if;
+
+  v_hash:=pg_catalog.encode(extensions.digest(v_action||'|'||(v_payload-'event_ts'-'business_date')::text,'sha256'),'hex');
+  select * into v_existing from public.aos_callcenter_actions_v1 a where a.idempotency_key=v_key;
+  if found then
+    if v_existing.actor_user_id<>p_actor then return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_ACTOR_CONFLICT'); end if;
+    if v_existing.request_hash<>v_hash then return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_CONFLICT'); end if;
+    if v_existing.status='COMPLETE' and v_existing.result is not null then return v_existing.result||pg_catalog.jsonb_build_object('idempotent',true); end if;
+    return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_IN_PROGRESS');
+  end if;
+
+  perform pg_catalog.set_config('aos.loop6_governed_write','1',true);
+  return public.aos_callcenter_commit_action_core_impl_v2(p_actor,p_idempotency_key,p_action_type,p_payload,p_test_fail_stage);
+end
+$function$;
+
+revoke all on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text) from public,anon,authenticated;
+grant execute on function public.aos_callcenter_commit_action_core_v1(uuid,text,text,jsonb,text) to service_role;

--- a/supabase/rollbacks/20260822011500_mkt_loop6_legacy_bypass_guard_v22_rollback.sql
+++ b/supabase/rollbacks/20260822011500_mkt_loop6_legacy_bypass_guard_v22_rollback.sql
@@ -1,0 +1,17 @@
+drop trigger if exists trg_000_aos_loop6_governed_call_v22 on public.aos_llamadas;
+drop trigger if exists trg_000_aos_loop6_governed_agenda_v22 on public.aos_agenda_citas;
+drop function if exists public.aos_loop6_require_governed_call_v22();
+drop function if exists public.aos_loop6_require_governed_agenda_v22();
+
+do $rollback$
+declare v_def text;
+begin
+  select definition into v_def
+  from public.aos_loop6_function_backups_v1
+  where backup_key='20260821_legacy_bypass_guard_v22'
+    and function_name='aos_callcenter_commit_action_core_v1'
+  order by captured_at desc limit 1;
+  if v_def is null then raise exception 'Missing Loop6 core backup'; end if;
+  execute v_def;
+end
+$rollback$;


### PR DESCRIPTION
Fixes the first genuine Loop 6 V2 production canary failure. Scope: server-side fail-closed guards for non-governed commercial Call/Agenda writes; canonical core transaction marker; deterministic Ruben repair + rollback; cache-busted v2.2 runtime loader; removal of SPA early-return; legacy save guards in calls.html/calls.js; exact evidence. LIVE DB guard and Ruben repair were applied only after rollback canary and strict preconditions. Merge only after runner materializes frontend patch and exact-head CI is green. Loop 6 remains blocked/not certified; Loop 7 not started.