### PR TITLE
MKT Loop 6 V2.3 — automatic queue conversion + Carlos repair

### DIFF
--- a/.github/workflows/loop6-runtime-loader-patch.yml
+++ b/.github/workflows/loop6-runtime-loader-patch.yml
@@ -13,6 +13,7 @@ on:
       - 'supabase/migrations/*mkt_loop6*'
       - 'supabase/rollbacks/*mkt_integrity_loop6*'
       - 'supabase/rollbacks/*mkt_loop6*'
+      - 'supabase/backfills/*mkt_loop6*'
       - 'docs/control/MKT_INTEGRITY_V3_LOOP6*'
   workflow_dispatch:
 
@@ -43,7 +44,7 @@ jobs:
         run: |
           if ('${{ runner.environment }}' -ne 'self-hosted') { throw 'Loop 6 loader patch must use self-hosted runner' }
       - id: patch
-        name: Apply deterministic V2.2 runtime patch
+        name: Apply deterministic V2.3 runtime patch
         shell: powershell
         run: |
           node scripts/ci/loop6_patch_calls_html.mjs
@@ -54,12 +55,12 @@ jobs:
             git config user.name 'ASCENDA Zero-Cost CI'
             git config user.email 'actions@users.noreply.github.com'
             git add app/public/calls.html app/public/calls.js app/public/calls-loop6.js
-            git commit -m 'LOOP 6 V2.2 — rearm runtime and block legacy frontend fallback'
+            git commit -m 'LOOP 6 V2.3 — automatic queue confirmation and manual-only selector'
             git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
           } else {
             "changed=false" >> $env:GITHUB_OUTPUT
           }
-      - name: Validate V2.2 runtime
+      - name: Validate V2.3 runtime
         if: steps.patch.outputs.changed == 'false'
         shell: powershell
         run: |
@@ -68,12 +69,16 @@ jobs:
           $html = Get-Content -Raw app/public/calls.html
           $callsjs = Get-Content -Raw app/public/calls.js
           $runtime = Get-Content -Raw app/public/calls-loop6.js
-          $marker = '<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>'
-          if (([regex]::Matches($html,[regex]::Escape($marker))).Count -ne 1) { throw 'Expected exactly one V2.2 loader' }
-          if ($html.Contains('calls-loop6.js?v=20260821-loop6"></script>')) { throw 'Old Loop6 cache key remains' }
-          if (([regex]::Matches($html,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.2'"))).Count -lt 2) { throw 'Legacy guards missing in calls.html' }
-          if (([regex]::Matches($callsjs,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.2'"))).Count -lt 2) { throw 'Legacy guards missing in calls.js' }
-          if (-not $runtime.Contains("window.__AOS_CC_LOOP6_V2__='v2.2';")) { throw 'V2.2 runtime build marker missing' }
+          $marker = '<script src="/calls-loop6.js?v=20260821-loop6-v2.3"></script>'
+          if (([regex]::Matches($html,[regex]::Escape($marker))).Count -ne 1) { throw 'Expected exactly one V2.3 loader' }
+          if ($html.Contains('calls-loop6.js?v=20260821-loop6-v2.2')) { throw 'V2.2 cache key remains' }
+          if (([regex]::Matches($html,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.3'"))).Count -lt 2) { throw 'V2.3 legacy guards missing in calls.html' }
+          if (([regex]::Matches($callsjs,[regex]::Escape("__AOS_CC_LOOP6_V2__!=='v2.3'"))).Count -lt 2) { throw 'V2.3 legacy guards missing in calls.js' }
+          if (-not $runtime.Contains("window.__AOS_CC_LOOP6_V2__='v2.3';")) { throw 'V2.3 runtime marker missing' }
+          if ($runtime.Contains('id="cc6-contact-mode"')) { throw 'Queue selector markup must be absent' }
+          if (([regex]::Matches($runtime,[regex]::Escape('id="cc6-manual-mode"'))).Count -ne 1) { throw 'Expected exactly one Agenda Manual selector' }
+          if (-not $runtime.Contains('aos_callcenter_confirm_queue_appointment_v1')) { throw 'Automatic queue RPC missing' }
+          if (-not $runtime.Contains('CITA AGENDADA CON ÉXITO')) { throw 'Success modal missing' }
           if ($runtime.Contains('if(window.__AOS_CC_LOOP6_V2__) return;')) { throw 'Unsafe SPA early-return remains' }
           git diff --check
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/loop6-runtime-loader-patch.yml
+++ b/.github/workflows/loop6-runtime-loader-patch.yml
@@ -80,5 +80,14 @@ jobs:
           if (-not $runtime.Contains('aos_callcenter_confirm_queue_appointment_v1')) { throw 'Automatic queue RPC missing' }
           if (-not $runtime.Contains('CITA AGENDADA CON ÉXITO')) { throw 'Success modal missing' }
           if ($runtime.Contains('if(window.__AOS_CC_LOOP6_V2__) return;')) { throw 'Unsafe SPA early-return remains' }
+          $finishStart = $runtime.IndexOf('function cc6QueueFinishModal(')
+          $commitStart = $runtime.IndexOf('function cc6QueueCommit(', $finishStart)
+          $overrideStart = $runtime.IndexOf('window.ccConfirmarCita=function(){', $commitStart)
+          if ($finishStart -lt 0 -or $commitStart -lt 0 -or $overrideStart -lt 0) { throw 'Queue function boundaries missing' }
+          $finishBlock = $runtime.Substring($finishStart, $commitStart-$finishStart)
+          $commitBlock = $runtime.Substring($commitStart, $overrideStart-$commitStart)
+          if ($finishBlock.Contains('data-cancel') -or $finishBlock.Contains('cc6InfoModal(')) { throw 'Success modal must expose only CONTINUAR LLAMADAS' }
+          if (-not $finishBlock.Contains('data-ok') -or -not $finishBlock.Contains('CONTINUAR LLAMADAS') -or -not $finishBlock.Contains('loadLead()')) { throw 'Success modal continue contract incomplete' }
+          if ($commitBlock.Contains('loadLead()')) { throw 'Next lead may not load before post-commit confirmation' }
           git diff --check
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/app/public/calls-loop6.js
+++ b/app/public/calls-loop6.js
@@ -54,7 +54,8 @@ function cc6QueueFinishModal(res,payload){
   var title=commercial?'✅ CITA AGENDADA CON ÉXITO':'Gestión registrada';
   var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
   var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
-  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
+  var rule=commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial');
+  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+rule+'</div>';
   var m=document.createElement('div');
   m.id='cc6-queue-success-modal';m.className='mov open';m.style.zIndex='1250';
   m.innerHTML='<div class="modal" style="max-width:520px"><div class="mhd"><span style="font-size:22px">'+(commercial?'✅':'ℹ️')+'</span><div><div class="mtit">'+cc6Esc(title)+'</div></div></div>'+detail+'<div class="mfoot"><button class="mconf gr" data-ok>CONTINUAR LLAMADAS</button></div></div>';

--- a/app/public/calls-loop6.js
+++ b/app/public/calls-loop6.js
@@ -55,13 +55,19 @@ function cc6QueueFinishModal(res,payload){
   var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
   var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
   var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
-  cc6InfoModal('cc6-queue-success-modal',title,detail,'CONTINUAR LLAMADAS',function(){
+  var m=document.createElement('div');
+  m.id='cc6-queue-success-modal';m.className='mov open';m.style.zIndex='1250';
+  m.innerHTML='<div class="modal" style="max-width:520px"><div class="mhd"><span style="font-size:22px">'+(commercial?'✅':'ℹ️')+'</span><div><div class="mtit">'+cc6Esc(title)+'</div></div></div>'+detail+'<div class="mfoot"><button class="mconf gr" data-ok>CONTINUAR LLAMADAS</button></div></div>';
+  document.body.appendChild(m);
+  var ok=m.querySelector('[data-ok]');
+  if(ok)ok.onclick=function(){
+    m.remove();
     if(typeof window.loadMetrics==='function')loadMetrics();
     if(typeof window.loadHistorial==='function')loadHistorial();
     if(typeof window.recargarCalendario==='function')recargarCalendario();
     if(window.AOS_pollNow)AOS_pollNow();
     if(typeof window.loadLead==='function')loadLead();
-  });
+  };
 }
 function cc6QueueCommit(payload,sourceModal){
   var pending=cc6PendingKey('QUEUE_AUTO_APPOINTMENT',payload);

--- a/app/public/calls-loop6.js
+++ b/app/public/calls-loop6.js
@@ -3,7 +3,7 @@
  */
 (function(){
 'use strict';
-window.__AOS_CC_LOOP6_V2__='v2.2';
+window.__AOS_CC_LOOP6_V2__='v2.3';
 
 function cc6Token(){return (window.AOS_getToken&&window.AOS_getToken())||sessionStorage.getItem('aos_app_token')||(window.CC&&CC.token)||'';}
 function cc6Rpc(fn,p){return new Promise(function(resolve,reject){if(typeof window._rpc!=='function'){reject(new Error('RPC_UNAVAILABLE'));return;}window._rpc(fn,p,function(d){resolve(d);},function(e){reject(e||new Error('RPC_FAILED'));});});}
@@ -26,7 +26,16 @@ if(typeof window._rpc==='function'&&!window._rpc.__cc6wrapped){var _rpc0=window.
 
 function cc6ClassifyCurrentLead(){if(!window.CC||!CC.lead||!CC.lead.num)return;var num=CC.lead.num;cc6Prepare(num).then(function(prep){if(!CC.lead||String(CC.lead.num)!==String(num))return;CC.loop6Patient=prep;CC.loop6Blocked=!!(prep&&prep.error==='IDENTITY_CONFLICT');var tier=document.getElementById('cc-tier'),ctx=document.getElementById('cc-contexto'),p=cc6Policy(prep);if(CC.loop6Blocked){if(tier)tier.textContent='REVIEW · IDENTIDAD';if(ctx){ctx.style.display='block';ctx.innerHTML='<div class="ctx-bloque" style="border-left-color:#DC2626;background:#FEF2F2"><div class="ctx-tit" style="color:#DC2626">⚠️ Identidad ambigua</div><div class="ctx-row"><span class="ctx-val">No registrar conversión automática. Revisar identidad.</span></div></div>';}return;}if(prep.patientState==='CONVERTED_PATIENT'){if(tier)tier.textContent='PACIENTE EXISTENTE';if(ctx){var current=ctx.innerHTML||'',elig=p.reactivationEligible?'Reactivación elegible':'Reactivación elegible desde '+cc6Local(p.reactivationEligibleFrom);var note='<div class="ctx-bloque" id="cc6-patient-context" style="border-left-color:#D97706;background:#FFF7ED"><div class="ctx-tit" style="color:#D97706">♻️ Paciente convertido</div><div class="ctx-row"><span class="ctx-val">'+cc6Esc(cc6EvidenceLabel(prep))+' · '+cc6Esc(elig)+'</span></div></div>';if(current.indexOf('cc6-patient-context')<0){ctx.style.display='block';ctx.innerHTML=current+note;}}}else if(p.lastNoShow&&ctx){var ns=p.lastNoShow,txt='NO ASISTIO '+ns.date+' '+(ns.time||'')+' · Propietario: '+(ns.advisor||'—')+' · protección hasta '+cc6Local(ns.protectedUntil);var cur=ctx.innerHTML||'';if(cur.indexOf('cc6-noshow-context')<0){ctx.style.display='block';ctx.innerHTML=cur+'<div class="ctx-bloque" id="cc6-noshow-context" style="border-left-color:#2563EB;background:#EFF6FF"><div class="ctx-tit" style="color:#2563EB">↩️ Oportunidad con NO ASISTIO</div><div class="ctx-row"><span class="ctx-val">'+cc6Esc(txt)+'</span></div></div>';}}}).catch(function(e){console.warn('[CC6V2] patient state unavailable',e);});}
 
-function cc6EnsureSelectors(){var cita=document.querySelector('#cc-m-cita .mg');if(cita&&!document.getElementById('cc6-contact-mode')){var wrap=document.createElement('div');wrap.className='mf full';wrap.innerHTML='<div class="ml">Origen de esta conversación</div><select class="ms2" id="cc6-contact-mode"><option value="COMMERCIAL">📞 Llamada comercial</option><option value="CALLBACK">↩️ Seguimiento / callback / entrante</option></select>';cita.insertBefore(wrap,cita.firstChild);}var manual=document.querySelector('#cc-m-cita-manual .mg');if(manual&&!document.getElementById('cc6-manual-mode')){var mw=document.createElement('div');mw.className='mf full';mw.innerHTML='<div class="ml">Qué gestión realizó</div><select class="ms2" id="cc6-manual-mode"><option value="COMMERCIAL">📞 Llamada comercial</option><option value="CALLBACK">↩️ Seguimiento / callback / entrante</option><option value="AGENDA_ONLY">📅 Solo agendar</option></select>';manual.insertBefore(mw,manual.firstChild);}}
+function cc6EnsureSelectors(){
+  var obsolete=document.getElementById('cc6-contact-mode');
+  if(obsolete){var ow=obsolete.closest('.mf');if(ow)ow.remove();else obsolete.remove();}
+  var manual=document.querySelector('#cc-m-cita-manual .mg');
+  if(manual&&!document.getElementById('cc6-manual-mode')){
+    var mw=document.createElement('div');mw.className='mf full';
+    mw.innerHTML='<div class="ml">Qué gestión realizó</div><select class="ms2" id="cc6-manual-mode"><option value="COMMERCIAL">📞 Llamada comercial</option><option value="CALLBACK">↩️ Seguimiento / callback / entrante</option><option value="AGENDA_ONLY">📅 Solo agendar</option></select>';
+    manual.insertBefore(mw,manual.firstChild);
+  }
+}
 function cc6PayloadFromCita(){var tipo='CONSULTA NUEVA';document.querySelectorAll('#cc-tipo-cita-grp .tb').forEach(function(t){if(t.classList.contains('act'))tipo=t.getAttribute('data-val')||tipo;});var num=window.CC&&CC.lead?String(CC.lead.num||'').replace(/\D/g,''):'';return{numero:num,lead_id:(CC.lead&&CC.lead.leadId)||null,tratamiento:(document.getElementById('cc-c-trat')||{}).value||((CC.lead&&CC.lead.trat)||''),anuncio:(CC.lead&&CC.lead.anuncio)||'',source_mode:(CC.lead&&CC.lead.fromSeg)?'FOLLOWUP':((CC.lead&&CC.lead.manual)?'MANUAL':'QUEUE'),nombre:(document.getElementById('cc-c-nombre')||{}).value||'',apellido:(document.getElementById('cc-c-apellido')||{}).value||'',dni:(document.getElementById('cc-c-dni')||{}).value||'',correo:(document.getElementById('cc-c-correo')||{}).value||'',tipo_atencion:(document.getElementById('cc-c-tipo-at')||{}).value||'',sede:(document.getElementById('cc-c-sede')||{}).value||'',fecha_cita:(document.getElementById('cc-c-fecha')||{}).value||'',hora_cita:(document.getElementById('cc-c-hora')||{}).value||'',tipo_cita:tipo,doctora:(document.getElementById('cc-c-doctora')||{}).value||'',obs:(document.getElementById('cc-c-obs')||{}).value||'',duracion_seg:(CC.leadStartTs?Math.max(0,Math.round((Date.now()-CC.leadStartTs)/1000)):0),desde_dispositivo:/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)?'movil':'web',followup_id:(CC.lead&&CC.lead.fromSeg&&CC.lead.segId)?CC.lead.segId:null};}
 function cc6PayloadFromManual(){var tipo='CONSULTA NUEVA',grp=document.getElementById('cm-tipo-cita-grp');if(grp)grp.querySelectorAll('.tb').forEach(function(t){if(t.classList.contains('act'))tipo=t.getAttribute('data-val')||tipo;});return{numero:String((document.getElementById('cm-num')||{}).value||'').replace(/\D/g,''),lead_id:null,tratamiento:(document.getElementById('cm-trat')||{}).value||'',anuncio:'',source_mode:'MANUAL',nombre:(document.getElementById('cm-nombre')||{}).value||'',apellido:(document.getElementById('cm-apellido')||{}).value||'',dni:(document.getElementById('cm-dni')||{}).value||'',correo:(document.getElementById('cm-correo')||{}).value||'',tipo_atencion:(document.getElementById('cm-tipo-at')||{}).value||'',sede:(document.getElementById('cm-sede')||{}).value||'',fecha_cita:(document.getElementById('cm-fecha')||{}).value||'',hora_cita:(document.getElementById('cm-hora')||{}).value||'',tipo_cita:tipo,doctora:(document.getElementById('cm-doctora')||{}).value||'',obs:(document.getElementById('cm-obs')||{}).value||'',duracion_seg:0,desde_dispositivo:/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)?'movil':'web'};}
 function cc6ValidatePayload(p){if(!p.numero||p.numero.length<7)return'Número inválido';if(!p.fecha_cita)return'Falta fecha de cita';if(!p.hora_cita)return'Falta hora de cita';return'';}
@@ -38,7 +47,63 @@ function cc6ManualChoice(payload,done){var mode=((document.getElementById('cc6-m
 function cc6Outcome(res){var reason=res&&res.eligibilityReason;if(res&&res.eligibilityStatus==='DOWNGRADE'){var txt=reason==='REACTIVATION_BEFORE_15D'?'Paciente reciente: la gestión y Agenda quedaron registradas, pero aún no genera nueva cita comercial. Beneficiario: Clínica.':reason==='NO_SHOW_PROTECTED_72H'?'La oportunidad sigue protegida para '+(res.commercialOwner||res.priorAdvisor||'el asesor anterior')+'. Tu gestión quedó registrada como ayuda; no se creó una segunda cita comercial.':reason==='ORIGINAL_OWNER_FOLLOWUP_EXISTS'?'El asesor anterior tiene seguimiento registrado. La oportunidad mantiene su propietario; tu gestión quedó como apoyo.':reason==='ORIGINAL_OWNER_REBOOK'?'Reagendamiento del mismo propietario: conserva la oportunidad, pero no crea una segunda conversión.':'La gestión fue registrada sin nuevo crédito comercial.';cc6InfoModal('cc6-outcome-modal','Gestión registrada con regla de crédito','<div style="padding:10px;background:#FFF7ED;border:1px solid #FED7AA;border-radius:9px">'+cc6Esc(txt)+'</div>','Cerrar',function(){});return;}if(res&&res.ownershipTransfer)cc6Toast('✓ Recuperación acreditada',res.executedBy+' recuperó la oportunidad','toast-venta');}
 function cc6Commit(action,payload,sourceModal){if(action==='CALLBACK_INBOUND_APPOINTMENT')payload.source_mode=payload.followup_id?'FOLLOWUP':'CALLBACK';if(action==='AGENDA_ONLY'&&payload.source_mode==='QUEUE')payload.source_mode='MANUAL';var pending=cc6PendingKey(action,payload);return cc6Rpc('aos_callcenter_commit_action_v1',{p_token:cc6Token(),p_idempotency_key:pending.key,p_action_type:action,p_payload:payload}).then(function(res){if(!res||res.ok!==true){var er=new Error((res&&res.error)||'CALLCENTER_ACTION_FAILED');er.payload=res;throw er;}cc6ClearPending(pending.fp);if(sourceModal&&typeof window.closeCCModal==='function')closeCCModal(sourceModal);var isCommercial=res.callState==='CITA CONFIRMADA',label=action==='AGENDA_ONLY'?'Cita agendada · no suma conversión':res.eligibilityReason==='REACTIVATION_15D_ELIGIBLE'?'Reactivación válida + cita comercial':action==='REACTIVATION'?'Reactivación registrada':action==='PATIENT_FOLLOWUP'?'Seguimiento guardado':action==='CALLBACK_INBOUND_APPOINTMENT'?'Seguimiento/callback guardado':'Cita confirmada';if(window.AOS_playSound)AOS_playSound(isCommercial?'venta':'notif');cc6Toast(label,res.origin||'Guardado',isCommercial?'toast-venta':'');cc6Outcome(res);if(payload.correo&&typeof window.enviarEmailConfirmacionCita==='function')enviarEmailConfirmacionCita({correo:payload.correo,nombre:payload.nombre,apellido:payload.apellido,fecha_cita:payload.fecha_cita,hora_cita:payload.hora_cita,tratamiento:payload.tratamiento,sede:payload.sede,dni:payload.dni,numero_limpio:payload.numero});if(typeof window.loadHistorial==='function')loadHistorial();if(typeof window.loadMetrics==='function')loadMetrics();if(typeof window.recargarCalendario==='function')recargarCalendario();if(window.AOS_pollNow)AOS_pollNow();if(typeof window.loadLead==='function'&&action!=='AGENDA_ONLY')loadLead();return res;}).catch(function(err){console.error('[CC6V2] commit',action,err,err&&err.payload);var ep=err&&err.payload||{},msg=ep.error||(err&&err.message)||'Error al guardar';if(msg==='PATIENT_ACTION_REQUIRED')msg='Paciente existente: selecciona Reactivación, Seguimiento o Solo agendar.';if(msg==='IDENTITY_CONFLICT')msg='Identidad ambigua: requiere revisión antes de guardar.';if(msg==='ACTIVE_APPOINTMENT_EXISTS'){var a=ep.activeAppointment||{};cc6InfoModal('cc6-active-error','Ya existe una cita activa','<b>Asesor:</b> '+cc6Esc(a.advisor||'—')+'<br><b>Fecha:</b> '+cc6Esc(a.date||'—')+' · '+cc6Esc(a.time||'—')+'<br>No se creó una segunda cita.',null);throw err;}cc6Toast('No se guardó',msg,'toast-alerta');throw err;});}
 function cc6RunPrepared(prep,p,sourceModal,chooser){if(cc6ActiveBlock(prep)){cc6SetBusy(false);return;}if(prep.patientState==='CONVERTED_PATIENT'){cc6ExistingPatientModal(prep,p,function(action){cc6Commit(action,p,sourceModal).finally(function(){cc6SetBusy(false);});});return;}cc6NoShowGate(prep,function(){chooser(function(action){cc6Commit(action,p,sourceModal).finally(function(){cc6SetBusy(false);});});});}
-window.ccConfirmarCita=function(){if(window.CC&&CC.guardando)return;cc6EnsureSelectors();var p=cc6PayloadFromCita(),bad=cc6ValidatePayload(p);if(bad){cc6Toast('⚠️ '+bad,'','toast-alerta');return;}cc6SetBusy(true);cc6Prepare(p.numero).then(function(prep){if(!prep||prep.ok!==true)throw Object.assign(new Error((prep&&prep.error)||'PATIENT_STATE_FAILED'),{payload:prep});CC.loop6Patient=prep;cc6RunPrepared(prep,p,'cc-m-cita',function(done){var mode=((document.getElementById('cc6-contact-mode')||{}).value||'COMMERCIAL');done(mode==='CALLBACK'?'CALLBACK_INBOUND_APPOINTMENT':'COMMERCIAL_CALL_APPOINTMENT');});}).catch(function(e){cc6SetBusy(false);var msg=(e&&e.payload&&e.payload.error)||(e&&e.message)||'No se pudo clasificar';cc6Toast('No se guardó',msg,'toast-alerta');});};
+/* LOOP6_V23_AUTO_QUEUE */
+function cc6QueueFinishModal(res,payload){
+  cc6RemoveModal('cc6-queue-success-modal');
+  var commercial=res&&res.callState==='CITA CONFIRMADA'&&res.eligibilityStatus==='ALLOW';
+  var title=commercial?'✅ CITA AGENDADA CON ÉXITO':'Gestión registrada';
+  var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
+  var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
+  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
+  cc6InfoModal('cc6-queue-success-modal',title,detail,'CONTINUAR LLAMADAS',function(){
+    if(typeof window.loadMetrics==='function')loadMetrics();
+    if(typeof window.loadHistorial==='function')loadHistorial();
+    if(typeof window.recargarCalendario==='function')recargarCalendario();
+    if(window.AOS_pollNow)AOS_pollNow();
+    if(typeof window.loadLead==='function')loadLead();
+  });
+}
+function cc6QueueCommit(payload,sourceModal){
+  var pending=cc6PendingKey('QUEUE_AUTO_APPOINTMENT',payload);
+  return cc6Rpc('aos_callcenter_confirm_queue_appointment_v1',{p_token:cc6Token(),p_idempotency_key:pending.key,p_payload:payload}).then(function(res){
+    if(!res||res.ok!==true){var er=new Error((res&&res.error)||'QUEUE_CONFIRM_FAILED');er.payload=res;throw er;}
+    cc6ClearPending(pending.fp);
+    if(sourceModal&&typeof window.closeCCModal==='function')closeCCModal(sourceModal);
+    if(window.AOS_playSound)AOS_playSound(res.callState==='CITA CONFIRMADA'?'venta':'notif');
+    if(payload.correo&&typeof window.enviarEmailConfirmacionCita==='function')enviarEmailConfirmacionCita({correo:payload.correo,nombre:payload.nombre,apellido:payload.apellido,fecha_cita:payload.fecha_cita,hora_cita:payload.hora_cita,tratamiento:payload.tratamiento,sede:payload.sede,dni:payload.dni,numero_limpio:payload.numero});
+    cc6QueueFinishModal(res,payload);
+    return res;
+  }).catch(function(err){
+    console.error('[CC6V23] queue commit',err,err&&err.payload);
+    var ep=err&&err.payload||{},msg=ep.error||(err&&err.message)||'No se pudo guardar la cita';
+    if(msg==='ACTIVE_APPOINTMENT_EXISTS'){var a=ep.activeAppointment||{};cc6InfoModal('cc6-active-error','Ya existe una cita activa','<b>Asesor:</b> '+cc6Esc(a.advisor||'—')+'<br><b>Fecha:</b> '+cc6Esc(a.date||'—')+' · '+cc6Esc(a.time||'—')+'<br>No se creó una segunda cita.',null);throw err;}
+    if(msg==='IDENTITY_CONFLICT')cc6InfoModal('cc6-identity-error','Identidad requiere revisión','Este número está vinculado a más de una identidad. No se creó Call ni Agenda.',null);
+    else if(msg==='PATIENT_ACTION_REQUIRED')cc6InfoModal('cc6-patient-error','Paciente existente detectado','El servidor detectó un paciente convertido. Reabre la cita y selecciona Reactivación, Seguimiento o Solo agendar desde el modal de excepción.',null);
+    else cc6Toast('No se guardó',msg,'toast-alerta');
+    throw err;
+  });
+}
+window.ccConfirmarCita=function(){
+  if(window.CC&&CC.guardando)return;
+  cc6EnsureSelectors();
+  var p=cc6PayloadFromCita(),bad=cc6ValidatePayload(p);
+  if(bad){cc6Toast('⚠️ '+bad,'','toast-alerta');return;}
+  cc6SetBusy(true);
+  cc6Prepare(p.numero).then(function(prep){
+    if(!prep||prep.ok!==true)throw Object.assign(new Error((prep&&prep.error)||'PATIENT_STATE_FAILED'),{payload:prep});
+    CC.loop6Patient=prep;
+    if(cc6ActiveBlock(prep)){cc6SetBusy(false);return;}
+    if(prep.patientState==='CONVERTED_PATIENT'){
+      cc6ExistingPatientModal(prep,p,function(action){cc6Commit(action,p,'cc-m-cita').finally(function(){cc6SetBusy(false);});});
+      return;
+    }
+    cc6NoShowGate(prep,function(){cc6QueueCommit(p,'cc-m-cita').finally(function(){cc6SetBusy(false);});});
+  }).catch(function(e){
+    cc6SetBusy(false);
+    var msg=(e&&e.payload&&e.payload.error)||(e&&e.message)||'No se pudo clasificar';
+    if(msg!=='ACTIVE_APPOINTMENT_EXISTS'&&msg!=='IDENTITY_CONFLICT'&&msg!=='PATIENT_ACTION_REQUIRED')cc6Toast('No se guardó',msg,'toast-alerta');
+  });
+};
 window.guardarCitaManual=function(){if(window.CC&&CC.guardando)return;cc6EnsureSelectors();var p=cc6PayloadFromManual(),bad=cc6ValidatePayload(p);if(bad){cc6Toast('⚠️ '+bad,'','toast-alerta');return;}cc6SetBusy(true);cc6Prepare(p.numero).then(function(prep){if(!prep||prep.ok!==true)throw Object.assign(new Error((prep&&prep.error)||'PATIENT_STATE_FAILED'),{payload:prep});cc6RunPrepared(prep,p,'cc-m-cita-manual',function(done){cc6ManualChoice(p,done);});}).catch(function(e){cc6SetBusy(false);var msg=(e&&e.payload&&e.payload.error)||(e&&e.message)||'No se pudo clasificar';cc6Toast('No se guardó',msg,'toast-alerta');});};
 cc6EnsureSelectors();setTimeout(function(){if(typeof window.loadLead==='function')loadLead();},80);console.log('[ASCENDA][CC6V2] credit/ownership policy ready');
 })();

--- a/app/public/calls.html
+++ b/app/public/calls.html
@@ -713,7 +713,7 @@ function ccGuardar(){
 }
 
 function ccConfirmarCita(){
-  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.3'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   if(CC.guardando)return;CC.guardando=true;
   var tipoCita='';document.querySelectorAll('#cc-tipo-cita-grp .tb').forEach(function(t){if(t.classList.contains('act'))tipoCita=t.getAttribute('data-val');});
   if(!document.getElementById('cc-c-fecha').value){if(window.AOS_showToast)AOS_showToast('⚠️ Falta fecha','Seleccioná la fecha.','');else alert('Falta la fecha');return;}
@@ -1382,7 +1382,7 @@ function buscarPacCitaManual(q){
 }
 
 function guardarCitaManual(){
-  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.3'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var num=(document.getElementById('cm-num').value||'').trim().replace(/\D/g,'');
   if(!num||num.length<7){alert('Ingresa un número válido.');return;}
   var fecha=document.getElementById('cm-fecha').value;
@@ -1508,5 +1508,5 @@ function buscarRepo(){
 
 </script>
 
-<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>
+<script src="/calls-loop6.js?v=20260821-loop6-v2.3"></script>
 <!-- KronIA Chat — en app.html (persistente entre paneles) -->

--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -212,7 +212,7 @@ function ccGuardar(){
 }
 
 function ccConfirmarCita(){
-  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.3'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var tipoCita='';document.querySelectorAll('#cc-tipo-cita-grp .tb').forEach(function(t){if(t.classList.contains('act'))tipoCita=t.getAttribute('data-val');});
   if(!document.getElementById('cc-c-fecha').value){if(window.AOS_showToast)AOS_showToast('⚠️ Falta fecha','Seleccioná la fecha.','');else alert('Falta la fecha');return;}
   var p={numero:CC.lead?CC.lead.num:'',estado:'CITA CONFIRMADA',nombre:document.getElementById('cc-c-nombre').value.trim(),apellido:document.getElementById('cc-c-apellido').value.trim(),dni:document.getElementById('cc-c-dni').value.trim(),correo:document.getElementById('cc-c-correo').value.trim(),tipoAtencion:document.getElementById('cc-c-tipo-at').value,sede:document.getElementById('cc-c-sede').value,fechaCita:document.getElementById('cc-c-fecha').value,horaCita:document.getElementById('cc-c-hora').value,tratamiento:document.getElementById('cc-c-trat').value,tipoCita:tipoCita||'CONSULTA NUEVA',obs:document.getElementById('cc-c-obs').value.trim(),rowNum:CC.lead?(CC.lead.rowNum||0):0};
@@ -839,7 +839,7 @@ function buscarPacCitaManual(q){
 }
 
 function guardarCitaManual(){
-  if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
+  if(window.__AOS_CC_LOOP6_V2__!=='v2.3'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}
   var num=(document.getElementById('cm-num').value||'').trim().replace(/\D/g,'');
   if(!num||num.length<7){alert('Ingresa un número válido.');return;}
   var fecha=document.getElementById('cm-fecha').value;

--- a/docs/control/MKT_INTEGRITY_V3_LOOP6_V23_CI_REARM_20260821.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP6_V23_CI_REARM_20260821.md
@@ -1,0 +1,25 @@
+# ASCENDA OS — MKT Integrity V3 · Loop 6 V2.3 · CI Rearm
+
+Date (Lima): 2026-08-21
+Workstream: MKT-INTEGRITY-HOTFIX-V3
+PR: #342
+
+## Purpose
+
+Re-arm all pull-request CI gates after the self-hosted runtime patcher materialized the final V2.3 frontend. GitHub Actions-generated commits do not recursively execute the full PR workflow graph, so the bot-materialized head showed `action_required` with zero jobs rather than test failures.
+
+## Materialized runtime verified before this rearm
+
+- Previous materialized head: `5dc7ad31c5bb0334bc4739653e5539ee34fbf12d`.
+- `app/public/calls-loop6.js` parses with the corrected success-modal expression.
+- Queue runtime marker: `v2.3`.
+- Normal queue selector removed.
+- Agenda Manual selector retained with COMMERCIAL / CALLBACK / AGENDA_ONLY.
+- Queue confirmation uses `aos_callcenter_confirm_queue_appointment_v1`.
+- Success modal exposes only `CONTINUAR LLAMADAS`.
+- `loadLead()` is not invoked inside the queue commit block; it is invoked only from the post-commit success confirmation.
+- Loop 7 remains NOT STARTED.
+
+## Gate
+
+This commit intentionally changes documentation only. Its sole purpose is to trigger the complete CI graph against the already materialized V2.3 runtime. Do not merge PR #342 unless the new exact head is green and production invariants are revalidated.

--- a/docs/control/MKT_INTEGRITY_V3_LOOP6_V23_IMPACT_ADDENDUM_20260821.md
+++ b/docs/control/MKT_INTEGRITY_V3_LOOP6_V23_IMPACT_ADDENDUM_20260821.md
@@ -1,0 +1,71 @@
+# MKT-INTEGRITY-HOTFIX-V3 — Loop 6 V2.3 Impact Addendum
+
+Date: 2026-08-21 America/Lima
+Base main: `5e364a626256a2146cf42b8270999cacafadd49f`
+Active lane: `MKT-INTEGRITY-HOTFIX-V3`
+Loop 7: NOT STARTED
+
+## Objective
+Close the remaining production usability gap in Loop 6 by separating queue-confirmation from manual scheduling semantics.
+
+### Queue / Call Center happy path
+A lead already delivered by Call Center and tipified as `CITA CONFIRMADA` must not ask the advisor to choose commercial semantics. The server already has lead, advisor, phone, source, treatment and identity context and must decide automatically. Only exceptions may interrupt with a modal.
+
+### Agenda Manual
+Retain the three explicit choices because the server cannot infer why the advisor manually entered the number:
+- commercial call;
+- follow-up/callback/inbound;
+- agenda only.
+Server policy remains authoritative and may BLOCK/DOWNGRADE.
+
+## Confirmed incidents in scope
+### Ruben — regression canary only
+`997883711`, lead 5884, repair Call 38384 + linked Agenda `2c581c52-89e9-465f-89be-0e3818eda309`, repair journal COMPLETE. Must remain unchanged.
+
+### Carlos Alonso Aguilar Uceda — deterministic repair required
+`941764266`, lead 5894 CAPILAR, advisor MIREYA. Existing Call 38396 = SIN CONTACTO / `SE ENVIA AUDIO`. No Agenda, no journal, no CITA CONFIRMADA. Evidence shows no prior conversion. Repair must preserve Call 38396 and add exactly one governed commercial conversion + linked Agenda for 2026-08-22 14:30 San Isidro. Repair must be idempotent and excluded from the future 5-genuine-operation gate.
+
+### Wilmer legacy rows — review only
+- `928017492`: >=15d reactivation eligibility, but no contemporaneous registered commercial call proven yet.
+- `995558890`: >=15d reactivation eligibility, but no contemporaneous registered commercial call proven yet.
+- `980749071`: <15d, not eligible for commercial reactivation.
+No blind retroactive KPI credit.
+
+## Proposed V2.3 architecture
+1. Add a dedicated governed queue-confirmation contract (`aos_callcenter_confirm_queue_appointment_v1` or equivalent) that does not accept a browser-selected commercial action type.
+2. Reuse the existing V2.2 prepare/policy/core path internally.
+3. Validate that the supplied lead belongs to the phone and is a valid prior/current lead before committing.
+4. For a normal unconverted lead, derive the action automatically:
+   - FOLLOWUP source / followup_id -> `CALLBACK_INBOUND_APPOINTMENT` routed as `FOLLOWUP_CONVERSION` by the existing core;
+   - otherwise queue lead -> `COMMERCIAL_CALL_APPOINTMENT`.
+5. Converted patient / active appointment / NO ASISTIO / identity conflict remain server-authoritative exception paths.
+6. Preserve V2.2 idempotency precheck and legacy fail-closed triggers.
+7. Frontend build marker -> `v2.3`; one loader only; remove `cc6-contact-mode` from `#cc-m-cita`; keep one `cc6-manual-mode` in `#cc-m-cita-manual`.
+8. After a successful normal queue commit, show a green confirmation modal only after Call + Agenda + direct links + journal exist, then let the advisor explicitly continue to the next lead.
+
+## Blast radius
+Expected functional changes only in:
+- governed Call Center RPC/migration;
+- `app/public/calls-loop6.js` and loader cache key;
+- CI assertions / control documentation;
+- deterministic Carlos repair and rollback.
+
+No change to REV-F5/F6 source truth, Marketing acquisition rules, sales tables or unrelated workstreams.
+
+## Protected invariants
+- REV-F5 = 6 / 15,498 / 8,716 / 15,498 / 8,716 / 230.
+- F6 Identity/Lifecycle service-role-only.
+- Protected calls 36701/37185/37813/38012/38168/38186 unchanged.
+- Removed Alan/Alberto duplicate Agenda rows remain absent.
+- Ruben repair remains exact.
+- Acquisition V2/V3 baseline 56/57 with V2-only 0.
+
+## Rollback requirements
+Before any LIVE functional mutation version:
+- queue RPC rollback;
+- frontend revert path;
+- Carlos exact repair rollback.
+All synthetic canaries must run inside rollback and leave zero residue.
+
+## STOP
+Stop on incompatible main advance, active competing HIGH/CRITICAL lane, Carlos unexpected new commercial Call/Agenda, Ruben regression, F5/F6 drift, unexplained Acquisition delta, legacy bypass persistence, CI failure or Railway non-success.

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -3,17 +3,19 @@ import fs from 'node:fs';
 const htmlPath='app/public/calls.html';
 const jsPath='app/public/calls-loop6.js';
 const callsJsPath='app/public/calls.js';
-const marker='<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>';
+const marker='<script src="/calls-loop6.js?v=20260821-loop6-v2.3"></script>';
 const oldMarkers=[
+  '<script src="/calls-loop6.js?v=20260821-loop6-v2.2"></script>',
   '<script src="/calls-loop6.js?v=20260821-loop6"></script>',
   '<script src="/calls-loop6-policy-v2.js?v=20260821-loop6-policy-v2"></script>'
 ];
 const anchor='<!-- KronIA Chat — en app.html (persistente entre paneles) -->';
-const guard="if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}";
+const guard="if(window.__AOS_CC_LOOP6_V2__!=='v2.3'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}";
 
 function patchLegacy(path){
   let text=fs.readFileSync(path,'utf8');
   let changed=false;
+  text=text.replaceAll("if(window.__AOS_CC_LOOP6_V2__!=='v2.2'){alert('ASCENDA Call Center se actualizó. Recarga esta pantalla antes de registrar una cita.');return;}",guard);
   for(const sig of ['function ccConfirmarCita(){','function guardarCitaManual(){']){
     const guarded=`${sig}\n  ${guard}`;
     const guardedCr=`${sig}\r\n  ${guard}`;
@@ -22,7 +24,7 @@ function patchLegacy(path){
     text=text.replace(sig,`${sig}\n  ${guard}`);
     changed=true;
   }
-  if(changed) fs.writeFileSync(path,text,'utf8');
+  if(changed||!text.includes("__AOS_CC_LOOP6_V2__!=='v2.2'")) fs.writeFileSync(path,text,'utf8');
 }
 
 let html=fs.readFileSync(htmlPath,'utf8');
@@ -34,7 +36,7 @@ for(const old of oldMarkers){
   }
 }
 const count=html.split(marker).length-1;
-if(count>1) throw new Error(`LOOP6 v2.2 loader duplicated: ${count}`);
+if(count>1) throw new Error(`LOOP6 v2.3 loader duplicated: ${count}`);
 if(count===0){
   if(!html.includes(anchor)) throw new Error('LOOP6 loader anchor not found');
   html=html.replace(anchor,`${marker}\n${anchor}`);
@@ -46,12 +48,93 @@ patchLegacy(htmlPath);
 patchLegacy(callsJsPath);
 
 let runtime=fs.readFileSync(jsPath,'utf8');
-const bootRe=/if\(window\.__AOS_CC_LOOP6_V2__\) return;\r?\nwindow\.__AOS_CC_LOOP6_V2__='v2';/;
-if(bootRe.test(runtime)){
-  runtime=runtime.replace(bootRe,"window.__AOS_CC_LOOP6_V2__='v2.2';");
-  fs.writeFileSync(jsPath,runtime,'utf8');
-}else if(!runtime.includes("window.__AOS_CC_LOOP6_V2__='v2.2';")){
-  throw new Error('Loop6 runtime bootstrap signature not found');
-}
+runtime=runtime.replace("window.__AOS_CC_LOOP6_V2__='v2.2';","window.__AOS_CC_LOOP6_V2__='v2.3';");
+if(!runtime.includes("window.__AOS_CC_LOOP6_V2__='v2.3';")) throw new Error('Loop6 v2.3 runtime marker not found');
 
-console.log('LOOP6_V22_PATCH=OK');
+const ensureStart=runtime.indexOf('function cc6EnsureSelectors(){');
+const ensureEnd=runtime.indexOf('function cc6PayloadFromCita()',ensureStart);
+if(ensureStart<0||ensureEnd<0) throw new Error('cc6EnsureSelectors boundaries not found');
+const ensureFn=`function cc6EnsureSelectors(){
+  var obsolete=document.getElementById('cc6-contact-mode');
+  if(obsolete){var ow=obsolete.closest('.mf');if(ow)ow.remove();else obsolete.remove();}
+  var manual=document.querySelector('#cc-m-cita-manual .mg');
+  if(manual&&!document.getElementById('cc6-manual-mode')){
+    var mw=document.createElement('div');mw.className='mf full';
+    mw.innerHTML='<div class="ml">Qué gestión realizó</div><select class="ms2" id="cc6-manual-mode"><option value="COMMERCIAL">📞 Llamada comercial</option><option value="CALLBACK">↩️ Seguimiento / callback / entrante</option><option value="AGENDA_ONLY">📅 Solo agendar</option></select>';
+    manual.insertBefore(mw,manual.firstChild);
+  }
+}
+`;
+runtime=runtime.slice(0,ensureStart)+ensureFn+runtime.slice(ensureEnd);
+
+const queueStart=runtime.indexOf('window.ccConfirmarCita=function(){');
+const queueEnd=runtime.indexOf('\nwindow.guardarCitaManual=function(){',queueStart);
+if(queueStart<0||queueEnd<0) throw new Error('ccConfirmarCita override boundaries not found');
+const queuePatch=`/* LOOP6_V23_AUTO_QUEUE */
+function cc6QueueFinishModal(res,payload){
+  cc6RemoveModal('cc6-queue-success-modal');
+  var commercial=res&&res.callState==='CITA CONFIRMADA'&&res.eligibilityStatus==='ALLOW';
+  var title=commercial?'✅ CITA AGENDADA CON ÉXITO':'Gestión registrada';
+  var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
+  var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
+  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
+  cc6InfoModal('cc6-queue-success-modal',title,detail,'CONTINUAR LLAMADAS',function(){
+    if(typeof window.loadMetrics==='function')loadMetrics();
+    if(typeof window.loadHistorial==='function')loadHistorial();
+    if(typeof window.recargarCalendario==='function')recargarCalendario();
+    if(window.AOS_pollNow)AOS_pollNow();
+    if(typeof window.loadLead==='function')loadLead();
+  });
+}
+function cc6QueueCommit(payload,sourceModal){
+  var pending=cc6PendingKey('QUEUE_AUTO_APPOINTMENT',payload);
+  return cc6Rpc('aos_callcenter_confirm_queue_appointment_v1',{p_token:cc6Token(),p_idempotency_key:pending.key,p_payload:payload}).then(function(res){
+    if(!res||res.ok!==true){var er=new Error((res&&res.error)||'QUEUE_CONFIRM_FAILED');er.payload=res;throw er;}
+    cc6ClearPending(pending.fp);
+    if(sourceModal&&typeof window.closeCCModal==='function')closeCCModal(sourceModal);
+    if(window.AOS_playSound)AOS_playSound(res.callState==='CITA CONFIRMADA'?'venta':'notif');
+    if(payload.correo&&typeof window.enviarEmailConfirmacionCita==='function')enviarEmailConfirmacionCita({correo:payload.correo,nombre:payload.nombre,apellido:payload.apellido,fecha_cita:payload.fecha_cita,hora_cita:payload.hora_cita,tratamiento:payload.tratamiento,sede:payload.sede,dni:payload.dni,numero_limpio:payload.numero});
+    cc6QueueFinishModal(res,payload);
+    return res;
+  }).catch(function(err){
+    console.error('[CC6V23] queue commit',err,err&&err.payload);
+    var ep=err&&err.payload||{},msg=ep.error||(err&&err.message)||'No se pudo guardar la cita';
+    if(msg==='ACTIVE_APPOINTMENT_EXISTS'){var a=ep.activeAppointment||{};cc6InfoModal('cc6-active-error','Ya existe una cita activa','<b>Asesor:</b> '+cc6Esc(a.advisor||'—')+'<br><b>Fecha:</b> '+cc6Esc(a.date||'—')+' · '+cc6Esc(a.time||'—')+'<br>No se creó una segunda cita.',null);throw err;}
+    if(msg==='IDENTITY_CONFLICT')cc6InfoModal('cc6-identity-error','Identidad requiere revisión','Este número está vinculado a más de una identidad. No se creó Call ni Agenda.',null);
+    else if(msg==='PATIENT_ACTION_REQUIRED')cc6InfoModal('cc6-patient-error','Paciente existente detectado','El servidor detectó un paciente convertido. Reabre la cita y selecciona Reactivación, Seguimiento o Solo agendar desde el modal de excepción.',null);
+    else cc6Toast('No se guardó',msg,'toast-alerta');
+    throw err;
+  });
+}
+window.ccConfirmarCita=function(){
+  if(window.CC&&CC.guardando)return;
+  cc6EnsureSelectors();
+  var p=cc6PayloadFromCita(),bad=cc6ValidatePayload(p);
+  if(bad){cc6Toast('⚠️ '+bad,'','toast-alerta');return;}
+  cc6SetBusy(true);
+  cc6Prepare(p.numero).then(function(prep){
+    if(!prep||prep.ok!==true)throw Object.assign(new Error((prep&&prep.error)||'PATIENT_STATE_FAILED'),{payload:prep});
+    CC.loop6Patient=prep;
+    if(cc6ActiveBlock(prep)){cc6SetBusy(false);return;}
+    if(prep.patientState==='CONVERTED_PATIENT'){
+      cc6ExistingPatientModal(prep,p,function(action){cc6Commit(action,p,'cc-m-cita').finally(function(){cc6SetBusy(false);});});
+      return;
+    }
+    cc6NoShowGate(prep,function(){cc6QueueCommit(p,'cc-m-cita').finally(function(){cc6SetBusy(false);});});
+  }).catch(function(e){
+    cc6SetBusy(false);
+    var msg=(e&&e.payload&&e.payload.error)||(e&&e.message)||'No se pudo clasificar';
+    if(msg!=='ACTIVE_APPOINTMENT_EXISTS'&&msg!=='IDENTITY_CONFLICT'&&msg!=='PATIENT_ACTION_REQUIRED')cc6Toast('No se guardó',msg,'toast-alerta');
+  });
+};
+`;
+runtime=runtime.slice(0,queueStart)+queuePatch+runtime.slice(queueEnd+1);
+
+if(runtime.includes('id="cc6-contact-mode"')) throw new Error('Queue selector markup still exists');
+if((runtime.match(/id="cc6-manual-mode"/g)||[]).length!==1) throw new Error('Expected exactly one manual selector');
+if(!runtime.includes("aos_callcenter_confirm_queue_appointment_v1")) throw new Error('Queue RPC not wired');
+if(!runtime.includes('CITA AGENDADA CON ÉXITO')) throw new Error('Queue success modal missing');
+if(runtime.includes('if(window.__AOS_CC_LOOP6_V2__) return;')) throw new Error('Unsafe SPA early-return remains');
+fs.writeFileSync(jsPath,runtime,'utf8');
+
+console.log('LOOP6_V23_PATCH=OK');

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -79,7 +79,8 @@ function cc6QueueFinishModal(res,payload){
   var title=commercial?'✅ CITA AGENDADA CON ÉXITO':'Gestión registrada';
   var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
   var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
-  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
+  var rule=commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial');
+  var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+rule+'</div>';
   var m=document.createElement('div');
   m.id='cc6-queue-success-modal';m.className='mov open';m.style.zIndex='1250';
   m.innerHTML='<div class="modal" style="max-width:520px"><div class="mhd"><span style="font-size:22px">'+(commercial?'✅':'ℹ️')+'</span><div><div class="mtit">'+cc6Esc(title)+'</div></div></div>'+detail+'<div class="mfoot"><button class="mconf gr" data-ok>CONTINUAR LLAMADAS</button></div></div>';

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -78,13 +78,19 @@ function cc6QueueFinishModal(res,payload){
   var bg=commercial?'#F0FDF4':'#FFF7ED',bd=commercial?'#BBF7D0':'#FED7AA',fg=commercial?'#166534':'#92400E';
   var name=((payload.nombre||'')+' '+(payload.apellido||'')).trim()||payload.numero;
   var detail='<div style="padding:12px;background:'+bg+';border:1px solid '+bd+';border-radius:10px;color:'+fg+';line-height:1.6"><b>'+cc6Esc(name)+'</b><br>'+cc6Esc(payload.fecha_cita||'')+' · '+cc6Esc(payload.hora_cita||'')+'<br>'+cc6Esc(payload.tratamiento||'')+'<br>'+cc6Esc(payload.sede||'')+'<br>Asesor: '+cc6Esc((res&&res.executedBy)||'—')+(commercial?'':'<br><b>Regla:</b> '+cc6Esc((res&&res.eligibilityReason)||'Sin nuevo crédito comercial')+'</div>';
-  cc6InfoModal('cc6-queue-success-modal',title,detail,'CONTINUAR LLAMADAS',function(){
+  var m=document.createElement('div');
+  m.id='cc6-queue-success-modal';m.className='mov open';m.style.zIndex='1250';
+  m.innerHTML='<div class="modal" style="max-width:520px"><div class="mhd"><span style="font-size:22px">'+(commercial?'✅':'ℹ️')+'</span><div><div class="mtit">'+cc6Esc(title)+'</div></div></div>'+detail+'<div class="mfoot"><button class="mconf gr" data-ok>CONTINUAR LLAMADAS</button></div></div>';
+  document.body.appendChild(m);
+  var ok=m.querySelector('[data-ok]');
+  if(ok)ok.onclick=function(){
+    m.remove();
     if(typeof window.loadMetrics==='function')loadMetrics();
     if(typeof window.loadHistorial==='function')loadHistorial();
     if(typeof window.recargarCalendario==='function')recargarCalendario();
     if(window.AOS_pollNow)AOS_pollNow();
     if(typeof window.loadLead==='function')loadLead();
-  });
+  };
 }
 function cc6QueueCommit(payload,sourceModal){
   var pending=cc6PendingKey('QUEUE_AUTO_APPOINTMENT',payload);
@@ -132,9 +138,15 @@ runtime=runtime.slice(0,queueStart)+queuePatch+runtime.slice(queueEnd+1);
 
 if(runtime.includes('id="cc6-contact-mode"')) throw new Error('Queue selector markup still exists');
 if((runtime.match(/id="cc6-manual-mode"/g)||[]).length!==1) throw new Error('Expected exactly one manual selector');
-if(!runtime.includes("aos_callcenter_confirm_queue_appointment_v1")) throw new Error('Queue RPC not wired');
+if(!runtime.includes('aos_callcenter_confirm_queue_appointment_v1')) throw new Error('Queue RPC not wired');
 if(!runtime.includes('CITA AGENDADA CON ÉXITO')) throw new Error('Queue success modal missing');
 if(runtime.includes('if(window.__AOS_CC_LOOP6_V2__) return;')) throw new Error('Unsafe SPA early-return remains');
+const finishStart=runtime.indexOf('function cc6QueueFinishModal('),commitStart=runtime.indexOf('function cc6QueueCommit(',finishStart),queueOverrideStart=runtime.indexOf('window.ccConfirmarCita=function(){',commitStart);
+if(finishStart<0||commitStart<0||queueOverrideStart<0) throw new Error('V2.3 queue blocks missing');
+const finishBlock=runtime.slice(finishStart,commitStart),commitBlock=runtime.slice(commitStart,queueOverrideStart);
+if(finishBlock.includes('data-cancel')||finishBlock.includes('cc6InfoModal(')) throw new Error('Success modal must not expose Cancel');
+if(!finishBlock.includes('data-ok')||!finishBlock.includes('CONTINUAR LLAMADAS')||!finishBlock.includes('loadLead()')) throw new Error('Success modal continue contract incomplete');
+if(commitBlock.includes('loadLead()')) throw new Error('Next lead must not load before post-commit success confirmation');
 fs.writeFileSync(jsPath,runtime,'utf8');
 
 console.log('LOOP6_V23_PATCH=OK');

--- a/scripts/ci/loop6_patch_calls_html.mjs
+++ b/scripts/ci/loop6_patch_calls_html.mjs
@@ -67,7 +67,9 @@ const ensureFn=`function cc6EnsureSelectors(){
 `;
 runtime=runtime.slice(0,ensureStart)+ensureFn+runtime.slice(ensureEnd);
 
-const queueStart=runtime.indexOf('window.ccConfirmarCita=function(){');
+const existingQueueMarker=runtime.indexOf('/* LOOP6_V23_AUTO_QUEUE */');
+const legacyQueueOverride=runtime.indexOf('window.ccConfirmarCita=function(){');
+const queueStart=existingQueueMarker>=0?existingQueueMarker:legacyQueueOverride;
 const queueEnd=runtime.indexOf('\nwindow.guardarCitaManual=function(){',queueStart);
 if(queueStart<0||queueEnd<0) throw new Error('ccConfirmarCita override boundaries not found');
 const queuePatch=`/* LOOP6_V23_AUTO_QUEUE */

--- a/supabase/backfills/20260822015500_mkt_loop6_v23_repair_carlos_aguilar.sql
+++ b/supabase/backfills/20260822015500_mkt_loop6_v23_repair_carlos_aguilar.sql
@@ -1,0 +1,71 @@
+-- Loop 6 V2.3 deterministic repair: CARLOS ALONSO AGUILAR UCEDA / 941764266
+-- Preserve existing Call 38396 SIN CONTACTO. Add exactly one governed queue conversion.
+-- Idempotency key is excluded from the future genuine-operation gate.
+
+do $repair$
+declare
+  v_actor uuid;
+  v_res jsonb;
+  v_key text := 'repair-carlos-941764266-20260821-v23';
+begin
+  select u.id into v_actor
+  from public.aos_usuarios u
+  where u.activo=true and upper(u.nombre)='MIREYA' and u.codigo_asesor='ZIV-003'
+  limit 1;
+  if v_actor is null then raise exception 'CARLOS_REPAIR_MIREYA_NOT_FOUND'; end if;
+
+  if not exists (
+    select 1 from public.aos_leads l
+    where l.id=5894 and l.numero_limpio='941764266' and upper(coalesce(l.tratamiento,'')) like '%CAPILAR%'
+  ) then raise exception 'CARLOS_REPAIR_LEAD_PRECONDITION'; end if;
+
+  if not exists (
+    select 1 from public.aos_llamadas l
+    where l.id=38396 and l.numero_limpio='941764266' and upper(l.asesor)='MIREYA' and l.estado='SIN CONTACTO'
+  ) then raise exception 'CARLOS_REPAIR_PRIOR_CALL_PRECONDITION'; end if;
+
+  if exists (
+    select 1 from public.aos_llamadas l
+    where l.numero_limpio='941764266' and l.estado='CITA CONFIRMADA' and l.id<>38396
+      and not exists(select 1 from public.aos_callcenter_actions_v1 a where a.idempotency_key=v_key and a.llamada_id=l.id)
+  ) then raise exception 'CARLOS_REPAIR_UNEXPECTED_COMMERCIAL_CALL'; end if;
+
+  if exists (
+    select 1 from public.aos_agenda_citas a
+    where a.numero_limpio='941764266'
+      and not exists(select 1 from public.aos_callcenter_actions_v1 j where j.idempotency_key=v_key and j.agenda_id=a.id)
+  ) then raise exception 'CARLOS_REPAIR_UNEXPECTED_AGENDA'; end if;
+
+  -- Idempotent second run returns the stored result.
+  v_res := public.aos_callcenter_confirm_queue_core_v1(
+    v_actor,
+    v_key,
+    pg_catalog.jsonb_build_object(
+      'numero','941764266',
+      'lead_id',5894,
+      'tratamiento','CAPILAR',
+      'anuncio','CAPILAR- INJERTO REEL4',
+      'nombre','CARLOS ALONSO',
+      'apellido','AGUILAR UCEDA',
+      'dni','44925360',
+      'correo','aguilarucedacarlosalonso@gmail.com',
+      'tipo_atencion','CONSULTA',
+      'sede','SAN ISIDRO',
+      'fecha_cita','2026-08-22',
+      'hora_cita','14:30',
+      'tipo_cita','CONSULTA NUEVA',
+      'doctora','',
+      'obs','REPAIR LOOP 6 V2.3 — CITA CONFIRMADA NUEVO. Paciente 38 años; caída capilar asociada a antecedente de estrés. Viene de Surco. Asesor: MIREYA.',
+      'desde_dispositivo','repair',
+      'duracion_seg',0
+    ),
+    null
+  );
+  if coalesce((v_res->>'ok')::boolean,false)=false then
+    raise exception 'CARLOS_REPAIR_COMMIT_FAILED: %',v_res::text;
+  end if;
+  if (v_res->>'leadId')::bigint<>5894 or v_res->>'origin'<>'MARKETING' or v_res->>'callState'<>'CITA CONFIRMADA' then
+    raise exception 'CARLOS_REPAIR_RESULT_MISMATCH: %',v_res::text;
+  end if;
+end
+$repair$;

--- a/supabase/migrations/20260822015000_mkt_integrity_loop6_v23_auto_queue.sql
+++ b/supabase/migrations/20260822015000_mkt_integrity_loop6_v23_auto_queue.sql
@@ -1,0 +1,154 @@
+-- ASCENDA OS · MKT-INTEGRITY-HOTFIX-V3 · LOOP 6 V2.3
+-- Server-authoritative queue confirmation. No browser-selected commercial action type.
+
+create or replace function public.aos_callcenter_confirm_queue_core_v1(
+  p_actor uuid,
+  p_idempotency_key text,
+  p_payload jsonb,
+  p_test_fail_stage text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+declare
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+  v_num text := pg_catalog.regexp_replace(coalesce(v_payload->>'numero',''),'[^0-9]','','g');
+  v_lead_id bigint;
+  v_followup_id text := nullif(pg_catalog.btrim(coalesce(v_payload->>'followup_id','')),'');
+  v_action text;
+  v_source_mode text;
+  v_event_ts timestamptz := coalesce(nullif(v_payload->>'event_ts','')::timestamptz,pg_catalog.now());
+  v_user record;
+  v_lead record;
+  v_followup record;
+  v_result jsonb;
+begin
+  if p_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+  if pg_catalog.length(v_num) < 7 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_PHONE');
+  end if;
+
+  begin
+    v_lead_id := nullif(v_payload->>'lead_id','')::bigint;
+  exception when others then
+    v_lead_id := null;
+  end;
+  if v_lead_id is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','QUEUE_LEAD_REQUIRED');
+  end if;
+
+  select u.nombre,u.codigo_asesor,u.rol
+    into v_user
+  from public.aos_usuarios u
+  where u.id=p_actor and u.activo=true
+  limit 1;
+  if v_user.nombre is null or v_user.codigo_asesor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_ACTOR');
+  end if;
+
+  select t.lead_id,t.numero_limpio,t.tratamiento,t.anuncio,t.lead_ts
+    into v_lead
+  from public.aos_marketing_touchpoints_v2(null,null) t
+  where t.lead_id=v_lead_id
+    and t.numero_limpio=v_num
+    and not t.es_duplicado_tecnico_probable
+    and t.lead_ts<=v_event_ts
+  order by t.lead_ts desc
+  limit 1;
+  if v_lead.lead_id is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','QUEUE_LEAD_MISMATCH','leadId',v_lead_id,'numero',v_num);
+  end if;
+
+  if v_followup_id is not null then
+    select s."ID",pg_catalog.regexp_replace(coalesce(s."NUMERO",''),'[^0-9]','','g') numero_limpio,
+           upper(coalesce(s."ASESOR",'')) asesor,s."ID_ASESOR" id_asesor,s.lead_id_origen
+      into v_followup
+    from public.aos_seguimientos s
+    where s."ID"=v_followup_id
+    limit 1;
+    if v_followup."ID" is null then
+      return pg_catalog.jsonb_build_object('ok',false,'error','FOLLOWUP_NOT_FOUND');
+    end if;
+    if v_followup.numero_limpio<>v_num then
+      return pg_catalog.jsonb_build_object('ok',false,'error','FOLLOWUP_PHONE_MISMATCH');
+    end if;
+    if v_followup.lead_id_origen is not null and v_followup.lead_id_origen<>v_lead_id then
+      return pg_catalog.jsonb_build_object('ok',false,'error','FOLLOWUP_LEAD_MISMATCH');
+    end if;
+    if coalesce(v_followup.id_asesor,'')<>coalesce(v_user.codigo_asesor,'')
+       and upper(coalesce(v_followup.asesor,''))<>upper(coalesce(v_user.nombre,'')) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','FOLLOWUP_NOT_OWNED');
+    end if;
+    v_action := 'CALLBACK_INBOUND_APPOINTMENT';
+    v_source_mode := 'FOLLOWUP';
+  else
+    v_action := 'COMMERCIAL_CALL_APPOINTMENT';
+    v_source_mode := 'QUEUE';
+  end if;
+
+  -- Browser cannot choose source/action. Keep only server-derived values.
+  v_payload := (v_payload - 'source_mode' - 'event_ts' - 'business_date')
+    || pg_catalog.jsonb_build_object(
+         'numero',v_num,
+         'lead_id',v_lead_id,
+         'source_mode',v_source_mode,
+         'event_ts',v_event_ts,
+         'anuncio',coalesce(v_lead.anuncio,v_payload->>'anuncio',''),
+         'tratamiento',coalesce(nullif(v_payload->>'tratamiento',''),v_lead.tratamiento,'')
+       );
+
+  v_result := public.aos_callcenter_commit_action_core_v1(
+    p_actor,p_idempotency_key,v_action,v_payload,p_test_fail_stage
+  );
+  if coalesce((v_result->>'ok')::boolean,false) then
+    return v_result || pg_catalog.jsonb_build_object(
+      'queueAuto',true,
+      'derivedAction',v_action,
+      'queueLeadId',v_lead_id,
+      'queueSourceMode',v_source_mode
+    );
+  end if;
+  return v_result || pg_catalog.jsonb_build_object(
+    'queueAuto',true,
+    'derivedAction',v_action,
+    'queueLeadId',v_lead_id,
+    'queueSourceMode',v_source_mode
+  );
+end
+$function$;
+
+create or replace function public.aos_callcenter_confirm_queue_appointment_v1(
+  p_token text,
+  p_idempotency_key text,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+begin
+  v_actor := public.aos_app_actor_v3(p_token,'advisor-calls',false);
+  if v_actor is null then
+    v_actor := public.aos_app_actor_v3(p_token,'admin-calls',true);
+  end if;
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+  -- Production event time is authoritative server time.
+  v_payload := (v_payload - 'event_ts' - 'business_date')
+    || pg_catalog.jsonb_build_object('event_ts',pg_catalog.now());
+  return public.aos_callcenter_confirm_queue_core_v1(v_actor,p_idempotency_key,v_payload,null);
+end
+$function$;
+
+revoke all on function public.aos_callcenter_confirm_queue_core_v1(uuid,text,jsonb,text) from public,anon,authenticated;
+grant execute on function public.aos_callcenter_confirm_queue_core_v1(uuid,text,jsonb,text) to service_role;
+
+revoke all on function public.aos_callcenter_confirm_queue_appointment_v1(text,text,jsonb) from public;
+grant execute on function public.aos_callcenter_confirm_queue_appointment_v1(text,text,jsonb) to anon,authenticated,service_role;

--- a/supabase/rollbacks/20260822015000_mkt_integrity_loop6_v23_auto_queue_rollback.sql
+++ b/supabase/rollbacks/20260822015000_mkt_integrity_loop6_v23_auto_queue_rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback for Loop 6 V2.3 automatic queue confirmation.
+-- Does not touch V2.2 core functions or business data.
+
+drop function if exists public.aos_callcenter_confirm_queue_appointment_v1(text,text,jsonb);
+drop function if exists public.aos_callcenter_confirm_queue_core_v1(uuid,text,jsonb,text);

--- a/supabase/rollbacks/20260822015500_mkt_loop6_v23_repair_carlos_aguilar_rollback.sql
+++ b/supabase/rollbacks/20260822015500_mkt_loop6_v23_repair_carlos_aguilar_rollback.sql
@@ -1,0 +1,36 @@
+-- Exact rollback for Carlos Aguilar Loop 6 V2.3 repair.
+-- Removes ONLY rows created by repair key; preserves prior Call 38396.
+
+do $rollback$
+declare
+  v_key text := 'repair-carlos-941764266-20260821-v23';
+  v_call bigint;
+  v_agenda text;
+begin
+  select a.llamada_id,a.agenda_id into v_call,v_agenda
+  from public.aos_callcenter_actions_v1 a
+  where a.idempotency_key=v_key
+  limit 1;
+
+  if v_call is null and v_agenda is null then return; end if;
+
+  if v_agenda is not null then
+    if not exists (
+      select 1 from public.aos_agenda_citas x
+      where x.id=v_agenda and x.numero_limpio='941764266' and x.llamada_id_origen=v_call and x.lead_id_origen=5894
+    ) then raise exception 'CARLOS_ROLLBACK_AGENDA_PRECONDITION'; end if;
+    delete from public.aos_agenda_citas where id=v_agenda;
+  end if;
+
+  if v_call is not null then
+    if v_call=38396 then raise exception 'CARLOS_ROLLBACK_REFUSES_PRIOR_CALL'; end if;
+    if not exists (
+      select 1 from public.aos_llamadas l
+      where l.id=v_call and l.numero_limpio='941764266' and l.estado='CITA CONFIRMADA' and l.lead_id_origen=5894
+    ) then raise exception 'CARLOS_ROLLBACK_CALL_PRECONDITION'; end if;
+    delete from public.aos_llamadas where id=v_call;
+  end if;
+
+  delete from public.aos_callcenter_actions_v1 where idempotency_key=v_key;
+end
+$rollback$;


### PR DESCRIPTION
Implements Loop 6 V2.3 inside active MKT-INTEGRITY-HOTFIX-V3. Scope: server-authoritative queue confirmation with no browser-selected action_type; queue happy path removes the normal Call Center selector; Agenda Manual keeps exactly the 3 semantic options; success modal after committed Call+Agenda+links+journal; V2.3 cache/runtime guards; exact Carlos Aguilar repair + rollback; Rubén regression protection; Wilmer legacy rows remain REVIEW/NO AUTO CREDIT absent auditable contemporaneous management. LIVE queue migration and Carlos repair were applied only after rollback canaries and strict preconditions. Do NOT merge until the runner materializes frontend V2.3, all 15 canaries/static DOM assertions pass, global invariants pass, exact-head CI is green and main is revalidated. Loop 7 NOT STARTED.