### PR TITLE
WA-3 hotfix — session-scoped rate limiting and explicit WhatsApp panel roles

### DIFF
--- a/app/server-wa3-v2.js
+++ b/app/server-wa3-v2.js
@@ -3,6 +3,7 @@
 // Handles only readiness/queue/claim/team summary. Existing server-wa3.js remains ownership, routing and human-send authority.
 const http=require('http');
 const https=require('https');
+const crypto=require('crypto');
 const {spawn}=require('child_process');
 
 const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10);
@@ -149,14 +150,26 @@ async function claimNext(req,res){
   }catch(e){writeJson(res,503,{ok:false,error:'WA3_CLAIM_UNAVAILABLE'});}
 }
 
+// Per-session limiter. The WA3V2 boundary sits behind multiple internal wrappers,
+// so socket.remoteAddress is normally loopback and MUST NOT be the primary key.
+// Reads and writes use independent buckets so UI polling can never block a human action.
 const buckets=new Map();
+function rateIdentity(req){
+  const token=strongToken(req);
+  if(token)return 'session:'+crypto.createHash('sha256').update(token).digest('hex').slice(0,32);
+  return 'unauth:'+String(req.socket.remoteAddress||'unknown');
+}
 function rateAllowed(req){
-  const key=String(req.socket.remoteAddress||'unknown'),now=Date.now();
+  const now=Date.now();
+  const read=req.method==='GET'||req.method==='HEAD';
+  const scope=read?'read':'write';
+  const limit=read?600:120;
+  const key=rateIdentity(req)+'|'+scope;
   let b=buckets.get(key);
   if(!b||now-b.start>60000){b={start:now,n:0};buckets.set(key,b);}
   b.n++;
-  if(buckets.size>1000){for(const [k,v] of buckets)if(now-v.start>120000)buckets.delete(k);}
-  return b.n<=120;
+  if(buckets.size>2000){for(const [k,v] of buckets)if(now-v.start>120000)buckets.delete(k);}
+  return b.n<=limit;
 }
 function proxy(req,res){
   const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT});

--- a/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
+++ b/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
@@ -29,6 +29,16 @@ assert(server.includes('requireActor(req,res,true)'));
 assert(server.includes("privacy:'NO_CUSTOMER_DATA'"));
 assert(!server.includes('contact_number'));
 assert(!server.includes('message_body'));
+
+// Regression: every Railway/internal wrapper connection can share loopback remoteAddress.
+// Authenticated WA-3 traffic must therefore be limited by a non-reversible session key,
+// with reads isolated from human/admin write actions.
+assert(server.includes("const crypto=require('crypto')"));
+assert(server.includes("crypto.createHash('sha256').update(token)"));
+assert(server.includes("const scope=read?'read':'write'"));
+assert(server.includes("const limit=read?600:120"));
+assert(!server.includes("const key=String(req.socket.remoteAddress||'unknown'),now=Date.now()"));
+
 assert(wa4.includes("['server-wa3-v2.js']"));
 assert(wa4.includes('Copilot only'));
 console.log('WA-3 V2 UI/boundary contract: PASS');

--- a/supabase/migrations/20260822212500_wa3_panel_registry_labels_v1.sql
+++ b/supabase/migrations/20260822212500_wa3_panel_registry_labels_v1.sql
@@ -1,0 +1,8 @@
+-- WA-3 canary UX governance: make WhatsApp panel permissions explicit and durable.
+update public.aos_paneles_disponibles
+set nombre='WhatsApp Hub — Admin/Supervisor', categoria='admin'
+where id='admin-whatsapp';
+
+update public.aos_paneles_disponibles
+set nombre='WhatsApp Hub — Asesor', categoria='asesor'
+where id='whatsapp-agent';

--- a/supabase/rollbacks/20260822212500_wa3_panel_registry_labels_v1.rollback.sql
+++ b/supabase/rollbacks/20260822212500_wa3_panel_registry_labels_v1.rollback.sql
@@ -1,0 +1,8 @@
+-- Roll back WA-3 panel labels/categories to the immediately previous registry state.
+update public.aos_paneles_disponibles
+set nombre='WhatsApp Live Inbox', categoria='admin'
+where id='admin-whatsapp';
+
+update public.aos_paneles_disponibles
+set nombre='WhatsApp Hub', categoria='asesor'
+where id='whatsapp-agent';


### PR DESCRIPTION
## Root cause
`server-wa3-v2.js` rate limited every `/api/wa3/*` request by `req.socket.remoteAddress`. Behind ASCENDA's internal wrappers, admin and advisor traffic shares loopback, so normal polling could exhaust the shared 120 req/min bucket and block legitimate timeline/route actions with `WA3_RATE_LIMIT`.

## Fix
- Rate-limit authenticated traffic by SHA-256 session identity, never raw token.
- Separate read and write buckets so polling cannot block human/admin mutations.
- Preserve fail-closed `WA3_RATE_LIMIT` behavior.
- Add regression assertions preventing return to shared-loopback primary keys.
- Persist distinct panel registry labels:
  - `admin-whatsapp` → `WhatsApp Hub — Admin/Supervisor`
  - `whatsapp-agent` → `WhatsApp Hub — Asesor`

## Canary state
- MIREYA has `whatsapp-agent`, active VENTAS_GENERAL membership, max_active=2, PASSWORD_2FA, AVAILABLE.
- `zi vital` remains owned by CESAR; failed UI attempt made no ownership mutation.
- auto-routing, AI send, Copilot and auto-reply remain OFF.

## Scope
No change to WA-3 route/release/ownership RPCs, Meta credentials, AI behavior, message persistence, notifications or conversation data.