### PR TITLE
WA-3 hotfix — preserve strong 2FA session continuity

### DIFF
--- a/app/public/wa-native-bootstrap-prelude.js
+++ b/app/public/wa-native-bootstrap-prelude.js
@@ -1,10 +1,12 @@
 // ASCENDA Conversations — PHASE S S7 minimal native bootstrap bridge.
 // Deliberately contains no layout/Lead-360 mutations. Authentication authority
-// is moving to the same-origin HttpOnly session cookie at PHASE S.
+// remains the server-side strong session; the browser cache is only a continuity
+// bridge for a token that was already issued after successful Auth V3/2FA.
 (function(){
 'use strict';
 var RETRYABLE={502:1,503:1,504:1};
 var baseFetch=window.fetch.bind(window);
+var recoveredTokenPromise=null;
 function isWaApi(input){
   var raw='';
   try{raw=typeof input==='string'?input:String(input&&input.url||'');}catch(_){return false;}
@@ -17,11 +19,25 @@ function isBootstrap(input){
 function legacyToken(){
   try{return String(sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'').trim();}catch(_){return '';}
 }
-window.fetch=function(input,init){
-  if(!isWaApi(input))return baseFetch(input,init);
+function cachedStrongToken(){
+  if(recoveredTokenPromise)return recoveredTokenPromise;
+  if(!('caches' in window))return Promise.resolve('');
+  recoveredTokenPromise=caches.open('aos-phase2-auth').then(function(c){
+    return c.match('/__aos_app_token');
+  }).then(function(r){
+    return r?r.text():'';
+  }).then(function(raw){
+    var t=String(raw||'').trim();
+    if(t.length<32)return '';
+    try{sessionStorage.setItem('aos_app_token',t);}catch(_){}
+    return t;
+  }).catch(function(){return '';});
+  return recoveredTokenPromise;
+}
+function dispatchWa(input,init,t){
   var next=Object.assign({},init||{}),h;
   try{h=new Headers((init&&init.headers)||(input&&input.headers)||{});}catch(_){h=new Headers();}
-  var t=legacyToken();if(t.length>=32)h.set('X-AOS-App-Token',t);
+  if(String(t||'').trim().length>=32)h.set('X-AOS-App-Token',String(t).trim());
   h.set('Accept','application/json');
   next.headers=h;
   next.cache='no-store';
@@ -37,5 +53,11 @@ window.fetch=function(input,init){
     });
   }
   return run();
+}
+window.fetch=function(input,init){
+  if(!isWaApi(input))return baseFetch(input,init);
+  var t=legacyToken();
+  if(t.length>=32)return dispatchWa(input,init,t);
+  return cachedStrongToken().then(function(recovered){return dispatchWa(input,init,recovered);});
 };
 })();

--- a/ci/phase-s/phase-s_contract.js
+++ b/ci/phase-s/phase-s_contract.js
@@ -7,6 +7,7 @@ const f17=fs.readFileSync('app/server-f17.js','utf8');
 const s152=fs.readFileSync('app/server-phase-s-f17.js','utf8');
 const railway=fs.readFileSync('app/railway.json','utf8');
 const authSync=fs.readFileSync('app/auth-resend-reconcile.js','utf8');
+const waPrelude=fs.readFileSync('app/public/wa-native-bootstrap-prelude.js','utf8');
 
 assert(s.includes("['server-f5.js']"),'Phase S must wrap the certified server-f5 chain');
 assert(s.includes("p==='/api/wa3/bootstrap'"),'Phase S must intercept WA3 bootstrap');
@@ -18,6 +19,10 @@ assert(s.includes("ai_send_enabled:false"),'degraded control must fail closed fo
 assert(s.includes("p==='/api/phase-s/status'"),'Phase S must expose protected diagnostics');
 assert(s.includes("p==='/health'"),'Phase S must expose non-secret Railway health');
 assert(s.includes("p==='/api/auth/v3/login'"),'Phase S must preserve Auth V3 Resend reconcile gate');
+assert(waPrelude.includes("caches.open('aos-phase2-auth')"),'WA bootstrap must recover a previously issued strong token from the existing auth bridge cache');
+assert(waPrelude.includes("c.match('/__aos_app_token')"),'WA bootstrap cache recovery must use the canonical Auth V3 bridge key');
+assert(waPrelude.includes("sessionStorage.setItem('aos_app_token',t)"),'recovered strong token should repopulate only session-scoped browser state');
+assert(!waPrelude.includes('localStorage.setItem(\'aos_app_token\''),'WA bootstrap must never persist the strong token in localStorage');
 assert(authSync.includes('aos_integration_secrets_v1'),'Auth Resend sync must target private integration vault');
 assert(!authSync.includes('/rest/v1/aos_integraciones?'),'Auth Resend sync must not write public integration catalog');
 assert(!/WHATSAPP_ACCESS_TOKEN\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded Meta access token');


### PR DESCRIPTION
Physical canary showed WA3_2FA_PANEL_REQUIRED while the server-side PASSWORD_2FA session was still valid and not revoked. Root cause: WA bootstrap only recovered X-AOS-App-Token from sessionStorage, while Auth V3 already stores the issued token in the existing aos-phase2-auth cache bridge for continuity/service-worker use. If the browser context lost sessionStorage, WA incorrectly behaved as if 2FA had expired. This hotfix keeps 2FA fail-closed and does not extend session TTL: when sessionStorage is missing, same-origin WA requests recover only the already-issued token from the canonical auth bridge cache, repopulate sessionStorage, and let the backend validate expiry/revocation/permissions normally. Logout already clears this cache. Adds Phase S static contracts and explicitly forbids localStorage persistence. No DB, routing, Meta, AI, permissions or TTL changes.