### PR TITLE
ASC-PERF R1 — exact-head audit + Studio hard off

### DIFF
--- a/.github/workflows/asc-perf-audit-360.yml
+++ b/.github/workflows/asc-perf-audit-360.yml
@@ -1,0 +1,77 @@
+name: ASCENDA ASC-PERF Audit 360
+
+on:
+  push:
+    branches:
+      - 'perf/asc-perf-*'
+    paths:
+      - 'app/**'
+      - 'sentinel/**'
+      - 'tools/perf-audit/**'
+      - 'ci/performance/**'
+      - 'docs/control/ASCENDA_PERFORMANCE_*'
+      - '.github/workflows/asc-perf-audit-360.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'sentinel/**'
+      - 'tools/perf-audit/**'
+      - 'ci/performance/**'
+      - 'docs/control/ASCENDA_PERFORMANCE_*'
+      - '.github/workflows/asc-perf-audit-360.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: asc-perf-audit-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-census:
+    name: PERF-1A static runtime census
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce zero-cost runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Studio hard-off contract
+        run: |
+          set -euo pipefail
+          grep -q 'AOS_STUDIO_BACKGROUND_ENABLED=false' app/railway.json
+          grep -q "process.env.AOS_STUDIO_BACKGROUND_ENABLED || 'false'" app/server.js
+          echo 'ASC-STUDIO HARD OFF CONTRACT PASS'
+
+      - name: Runtime census
+        run: |
+          set -euo pipefail
+          node tools/perf-audit/runtime-census.mjs app sentinel | tee /tmp/asc-perf-census.log
+          grep -q '^ASC-PERF-1A STATIC CENSUS$' /tmp/asc-perf-census.log
+          grep -q '^candidate_files_end$' /tmp/asc-perf-census.log
+
+      - name: Census integrity
+        run: |
+          set -euo pipefail
+          test -s "$RUNNER_TEMP/asc-perf-runtime-census.json"
+          node - <<'NODE'
+          const fs = require('fs');
+          const p = process.env.RUNNER_TEMP + '/asc-perf-runtime-census.json';
+          const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+          if (d.schema !== 'asc-perf-runtime-census/v1') throw new Error('bad schema');
+          if (!Number.isInteger(d.filesScanned) || d.filesScanned < 1) throw new Error('empty census');
+          if (!Array.isArray(d.findings) || !Array.isArray(d.recurrentNetworkCandidates)) throw new Error('missing arrays');
+          console.log(JSON.stringify({filesScanned:d.filesScanned,linesScanned:d.linesScanned,findings:d.findingsCount,recurrentNetworkCandidateFiles:d.recurrentNetworkCandidateCount,fastIntervals:d.fastIntervalCandidateCount,broadReads:d.broadReadCandidateCount}));
+          NODE
+
+      - name: No persisted audit artifact
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/asc-perf-runtime-census.json" /tmp/asc-perf-census.log || true

--- a/app/railway.json
+++ b/app/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "echo 'Skip build — Phase S outer runtime: node server-phase-s-f17.js -> server-phase-s.js -> server-f17.js -> server-f5.js -> server-wa4.js -> server-wa3.js -> server-wa2.js -> server-f4.js'"
   },
   "deploy": {
-    "startCommand": "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js",
+    "startCommand": "env AOS_STUDIO_BACKGROUND_ENABLED=false NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE"

--- a/docs/control/ASCENDA_PERFORMANCE_R1_EXACT_HEAD_CURRENT.md
+++ b/docs/control/ASCENDA_PERFORMANCE_R1_EXACT_HEAD_CURRENT.md
@@ -1,0 +1,31 @@
+# ASCENDA OS — ASC-PERF R1 EXACT HEAD CURRENT
+
+**Status:** RUNNER GATE R1 / EXECUTING  
+**Captured:** 2026-08-24 America/Lima  
+**Exact main:** `a6443b9c29336781264d5871d9b5ab60c93f4444`  
+**Branch:** `perf/asc-perf-r1-studio-off-20260824`  
+**PR:** `#355` DRAFT
+
+## Drift reconciliation
+
+`main` advanced from the prior ASC-PERF baseline through merged PR #354, `WA-3 hardening — coalesce duplicate reads and hidden-tab load`.
+
+R1 is therefore being rerun from the new exact `main` instead of certifying the stale PR #353 head.
+
+## Studio directive
+
+ASCENDA Studio is not an active workstream. It must produce no background operational calls while hibernated.
+
+Runtime contract for this gate:
+
+- Railway start command forces `AOS_STUDIO_BACKGROUND_ENABLED=false`;
+- current `server.js` defaults the Studio scheduler to OFF;
+- no Studio data/table/assets are deleted;
+- manual Studio code remains preserved for a future explicit reactivation gate;
+- no Studio background scheduler may register in production while the forced runtime value remains false.
+
+## R1 objective
+
+Run `ASCENDA ASC-PERF Audit 360` on the self-hosted Linux Zero-Cost runner and capture a complete static runtime census against the exact post-PR-354 codebase.
+
+No PERF-3 remediation is certified from estimates alone.

--- a/tools/perf-audit/runtime-census.mjs
+++ b/tools/perf-audit/runtime-census.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const roots = process.argv.slice(2).length ? process.argv.slice(2) : ['app', 'sentinel'];
+const allowedExt = new Set(['.js', '.cjs', '.mjs', '.jsx', '.ts', '.tsx', '.html']);
+const excludedDirs = new Set(['node_modules', '.git', 'dist', 'build', 'coverage', '.next']);
+
+const patterns = [
+  ['SET_INTERVAL', /\bsetInterval\s*\(/],
+  ['SET_TIMEOUT', /\bsetTimeout\s*\(/],
+  ['MUTATION_OBSERVER', /\bMutationObserver\s*\(/],
+  ['VISIBILITY_EVENT', /(?:addEventListener\s*\(\s*['\"]visibilitychange|onvisibilitychange\b)/],
+  ['FOCUS_EVENT', /(?:addEventListener\s*\(\s*['\"]focus|\.onfocus\s*=)/],
+  ['ONLINE_EVENT', /(?:addEventListener\s*\(\s*['\"]online|\.ononline\s*=)/],
+  ['OFFLINE_EVENT', /(?:addEventListener\s*\(\s*['\"]offline|\.onoffline\s*=)/],
+  ['PAGEHIDE_EVENT', /(?:addEventListener\s*\(\s*['\"]pagehide|\.onpagehide\s*=)/],
+  ['DOCUMENT_HIDDEN', /\bdocument\.hidden\b/],
+  ['FETCH', /\bfetch\s*\(/],
+  ['WINDOW_FETCH_PATCH', /\bwindow\.fetch\s*=/],
+  ['XHR', /\bXMLHttpRequest\b/],
+  ['WEBSOCKET', /\bWebSocket\s*\(/],
+  ['EVENT_SOURCE', /\bEventSource\s*\(/],
+  ['SEND_BEACON', /\bnavigator\.sendBeacon\s*\(/],
+  ['SERVICE_WORKER', /\bserviceWorker\b/],
+  ['REST_V1', /\/rest\/v1\//],
+  ['RPC_PATH', /\/rpc\//],
+  ['RPC_HELPER', /\b(?:rpc|sbRpc|serviceRpc)\s*\(/],
+  ['SB_FETCH_HELPER', /\b(?:sbFetch|sbGet|api)\s*\(/],
+  ['PROMISE_ALL', /\bPromise\.all\s*\(/],
+  ['MAP_CALL', /\.map\s*\(/],
+  ['SELECT_STAR_URL', /select=\*/i],
+  ['SELECT_STAR_CLIENT', /\.select\s*\(\s*['\"]\*['\"]\s*\)/],
+  ['LARGE_LIMIT', /(?:limit=|\.limit\s*\()\s*(?:1[0-9]{2,}|[2-9][0-9]{2,})/i],
+  ['POLL_NAME', /\b(?:poll|polling|heartbeat|refresh|refetch|retry|backoff|pump|cron|worker|tick)\w*\b/i],
+];
+
+const redactionRules = [
+  [/eyJ[A-Za-z0-9._-]{20,}/g, '[JWT_REDACTED]'],
+  [/(?:sk|sbp|ghp|github_pat|xox[baprs])-?[A-Za-z0-9_\-]{12,}/gi, '[TOKEN_REDACTED]'],
+  [/(Authorization\s*[:=]\s*)[^,;\n]+/gi, '$1[REDACTED]'],
+  [/(apikey\s*[:=]\s*)[^,;\n]+/gi, '$1[REDACTED]'],
+];
+
+function sanitizeLine(line) {
+  let out = String(line || '').trim();
+  for (const [re, replacement] of redactionRules) out = out.replace(re, replacement);
+  if (out.length > 260) out = out.slice(0, 257) + '...';
+  return out;
+}
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && excludedDirs.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (allowedExt.has(path.extname(entry.name).toLowerCase())) out.push(full);
+  }
+  return out;
+}
+
+function literalIntervalMs(line) {
+  const m = line.match(/setInterval\s*\([^\n]*?,\s*(\d{2,})\s*\)/);
+  return m ? Number(m[1]) : null;
+}
+
+const files = [...new Set(roots.flatMap(root => walk(path.join(repoRoot, root))))].sort();
+const findings = [];
+const fileFacts = new Map();
+
+for (const file of files) {
+  const rel = path.relative(repoRoot, file).replaceAll('\\', '/');
+  const text = fs.readFileSync(file, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const facts = {
+    file: rel,
+    lineCount: lines.length,
+    hasNetworkPrimitive: false,
+    hasRecurrentConstruct: false,
+    hasVisibilityGuard: false,
+    patternCounts: {},
+  };
+
+  lines.forEach((line, i) => {
+    for (const [name, re] of patterns) {
+      if (!re.test(line)) continue;
+      facts.patternCounts[name] = (facts.patternCounts[name] || 0) + 1;
+      if (['FETCH','XHR','WEBSOCKET','EVENT_SOURCE','SEND_BEACON','REST_V1','RPC_PATH','RPC_HELPER','SB_FETCH_HELPER'].includes(name)) facts.hasNetworkPrimitive = true;
+      if (['SET_INTERVAL','SET_TIMEOUT','MUTATION_OBSERVER','VISIBILITY_EVENT','FOCUS_EVENT','ONLINE_EVENT','OFFLINE_EVENT','PAGEHIDE_EVENT','SERVICE_WORKER'].includes(name)) facts.hasRecurrentConstruct = true;
+      if (name === 'DOCUMENT_HIDDEN' || name === 'VISIBILITY_EVENT') facts.hasVisibilityGuard = true;
+      findings.push({
+        file: rel,
+        line: i + 1,
+        pattern: name,
+        intervalMs: name === 'SET_INTERVAL' ? literalIntervalMs(line) : null,
+        source: sanitizeLine(line),
+      });
+    }
+  });
+  fileFacts.set(rel, facts);
+}
+
+const countsByPattern = {};
+for (const f of findings) countsByPattern[f.pattern] = (countsByPattern[f.pattern] || 0) + 1;
+
+const recurrentNetworkCandidates = [...fileFacts.values()]
+  .filter(f => f.hasRecurrentConstruct && f.hasNetworkPrimitive)
+  .map(f => ({
+    file: f.file,
+    hasVisibilityGuard: f.hasVisibilityGuard,
+    recurrent: Object.fromEntries(Object.entries(f.patternCounts).filter(([k]) => ['SET_INTERVAL','SET_TIMEOUT','MUTATION_OBSERVER','VISIBILITY_EVENT','FOCUS_EVENT','ONLINE_EVENT','OFFLINE_EVENT','PAGEHIDE_EVENT','SERVICE_WORKER'].includes(k))),
+    network: Object.fromEntries(Object.entries(f.patternCounts).filter(([k]) => ['FETCH','XHR','WEBSOCKET','EVENT_SOURCE','SEND_BEACON','REST_V1','RPC_PATH','RPC_HELPER','SB_FETCH_HELPER'].includes(k))),
+    broadReadSignals: Object.fromEntries(Object.entries(f.patternCounts).filter(([k]) => ['SELECT_STAR_URL','SELECT_STAR_CLIENT','LARGE_LIMIT'].includes(k))),
+    fanoutSignals: Object.fromEntries(Object.entries(f.patternCounts).filter(([k]) => ['PROMISE_ALL','MAP_CALL'].includes(k))),
+  }))
+  .sort((a, b) => a.file.localeCompare(b.file));
+
+const fastIntervalFindings = findings
+  .filter(f => f.pattern === 'SET_INTERVAL' && Number.isFinite(f.intervalMs) && f.intervalMs < 5000)
+  .map(f => ({ file: f.file, line: f.line, intervalMs: f.intervalMs }));
+
+const broadReadFindings = findings
+  .filter(f => ['SELECT_STAR_URL','SELECT_STAR_CLIENT','LARGE_LIMIT'].includes(f.pattern))
+  .map(f => ({ file: f.file, line: f.line, pattern: f.pattern }));
+
+const result = {
+  schema: 'asc-perf-runtime-census/v1',
+  generatedAt: new Date().toISOString(),
+  roots,
+  filesScanned: files.length,
+  linesScanned: [...fileFacts.values()].reduce((n, f) => n + f.lineCount, 0),
+  findingsCount: findings.length,
+  countsByPattern,
+  recurrentNetworkCandidateCount: recurrentNetworkCandidates.length,
+  fastIntervalCandidateCount: fastIntervalFindings.length,
+  broadReadCandidateCount: broadReadFindings.length,
+  recurrentNetworkCandidates,
+  fastIntervalFindings,
+  broadReadFindings,
+  findings,
+  notes: [
+    'Static evidence only; candidates require runtime/consumer triage before defect classification.',
+    'SET_TIMEOUT is intentionally broad because recursive timers cannot be reliably identified with single-line regex.',
+    'No secrets should be emitted; source lines are redacted defensively.',
+  ],
+};
+
+const outDir = process.env.RUNNER_TEMP || path.join(repoRoot, '.tmp');
+fs.mkdirSync(outDir, { recursive: true });
+const outPath = path.join(outDir, 'asc-perf-runtime-census.json');
+fs.writeFileSync(outPath, JSON.stringify(result, null, 2));
+
+console.log('ASC-PERF-1A STATIC CENSUS');
+console.log(`files_scanned=${result.filesScanned}`);
+console.log(`lines_scanned=${result.linesScanned}`);
+console.log(`findings=${result.findingsCount}`);
+console.log(`recurrent_network_candidate_files=${result.recurrentNetworkCandidateCount}`);
+console.log(`fast_interval_candidates_lt_5000ms=${result.fastIntervalCandidateCount}`);
+console.log(`broad_read_candidates=${result.broadReadCandidateCount}`);
+console.log('counts_by_pattern=' + JSON.stringify(result.countsByPattern));
+console.log('candidate_files_begin');
+for (const item of recurrentNetworkCandidates) {
+  console.log(JSON.stringify({ file: item.file, hiddenGuard: item.hasVisibilityGuard, recurrent: item.recurrent, network: item.network, broad: item.broadReadSignals, fanout: item.fanoutSignals }));
+}
+console.log('candidate_files_end');
+console.log(`census_json=${outPath}`);


### PR DESCRIPTION
## Scope
Reconcile ASC-PERF onto latest `main@a6443b9c29336781264d5871d9b5ab60c93f4444`, preserve the newly merged WA read-coalescing hardening, execute Runner Gate R1, and hard-disable ASCENDA Studio background activity until the Studio workstream is intentionally resumed.

## Studio owner directive
Studio is not being worked on now. Background activity must have zero operational effect. This branch forces Railway production runtime to start with `AOS_STUDIO_BACKGROUND_ENABLED=false`, overriding any stale Railway environment value for the process tree. Current `server.js` already defaults Studio scheduler to OFF and only registers it when the variable is true.

No Studio tables/data/assets are deleted. Manual Studio functionality is preserved for future reactivation, but the background scheduler is forced OFF.

## ASC-PERF R1
- restore `tools/perf-audit/runtime-census.mjs` on exact latest main;
- restore `ASCENDA ASC-PERF Audit 360` Zero-Cost workflow;
- add CI contract asserting Studio hard-off runtime configuration;
- run only on `[self-hosted, Linux, X64, ascenda-zero-cost-v2]`;
- reconcile dynamic/static evidence before PERF-3 remediation.

## Drift reconciliation
Prior ASC-PERF draft PR #353 was based on `ae0448d0...`. `main` advanced through merged PR #354 (WA read coalescing) to `a6443b9c...`. This PR is the exact-head continuation; it must not regress PR #354.

## Safety
No DB migration, RLS, auth, 2FA, ownership, AI-send, auto-routing, Meta, Sales truth or patient data mutation in this slice. Studio hard-off is reversible by removing the forced env assignment only after a future Studio reactivation gate.
