### PR TITLE
ASC-PERF R1 — runner execution exact-current

### DIFF
--- a/docs/control/ASCENDA_PERFORMANCE_R1_RUNNER_EXECUTION_CURRENT.md
+++ b/docs/control/ASCENDA_PERFORMANCE_R1_RUNNER_EXECUTION_CURRENT.md
@@ -1,0 +1,25 @@
+# ASCENDA OS — ASC-PERF R1 RUNNER EXECUTION CURRENT
+
+**Status:** EXECUTING  
+**Captured:** 2026-08-24 America/Lima  
+**Exact main:** `0a85b936c6db9c45c00fa2deeecaafeb13a386c6`  
+**Branch:** `perf/asc-perf-r1-execution-20260824`
+
+## Objective
+
+Trigger `ASCENDA ASC-PERF Audit 360` from a branch created directly from the exact current main after:
+
+- PR #354 WA read-coalescing hardening;
+- PR #355 ASC-PERF tooling bootstrap;
+- PR #355 Studio HARD-OFF runtime directive.
+
+## Required R1-A evidence
+
+- self-hosted Linux Zero-Cost runner executes;
+- Studio hard-off contract passes;
+- static runtime census completes;
+- census integrity passes;
+- candidate files and aggregate counts are captured from the job log;
+- no remediation is certified until findings are reconciled.
+
+This file is an execution trigger and evidence anchor; it contains no production behavior change.

--- a/docs/control/ASCENDA_PERFORMANCE_R1_RUNNER_EXECUTION_CURRENT.md
+++ b/docs/control/ASCENDA_PERFORMANCE_R1_RUNNER_EXECUTION_CURRENT.md
@@ -1,6 +1,6 @@
 # ASCENDA OS — ASC-PERF R1 RUNNER EXECUTION CURRENT
 
-**Status:** EXECUTING  
+**Status:** EXECUTING / SYNCHRONIZE RETRY 1  
 **Captured:** 2026-08-24 America/Lima  
 **Exact main:** `0a85b936c6db9c45c00fa2deeecaafeb13a386c6`  
 **Branch:** `perf/asc-perf-r1-execution-20260824`
@@ -21,5 +21,9 @@ Trigger `ASCENDA ASC-PERF Audit 360` from a branch created directly from the exa
 - census integrity passes;
 - candidate files and aggregate counts are captured from the job log;
 - no remediation is certified until findings are reconciled.
+
+## Control-plane note
+
+The first PR-open event occurred immediately after the audit workflow was merged into `main`. This no-op evidence update intentionally generates a fresh `synchronize` event after the base workflow is already present and indexed. If no workflow run is created after this event, classify the absence as a CI/control-plane trigger problem rather than a runner test failure.
 
 This file is an execution trigger and evidence anchor; it contains no production behavior change.

--- a/tools/perf-audit/R1_TRIGGER.txt
+++ b/tools/perf-audit/R1_TRIGGER.txt
@@ -1,0 +1,1 @@
+ASC-PERF R1 trigger only. No runtime effect.


### PR DESCRIPTION
## Superseded
This execution trigger was based on `main@0a85b936...` before the Linux runner prerequisite was corrected.

Runner connectivity was proven by rerunning the historical ASC-PERF job: `ASCENDA-ZERO-COST-V2` executed and Zero-Cost passed, but census failed with `node: command not found` (exit 127).

PR #357 fixes that CI prerequisite by adding explicit `actions/setup-node@v4`.

This PR is closed without merge to avoid stale R1 evidence. A fresh R1 execution must start from the post-#357 main.