### PR TITLE
ASC-PERF R1 — bootstrap Node on Zero-Cost Linux runner

### DIFF
--- a/.github/workflows/asc-perf-audit-360.yml
+++ b/.github/workflows/asc-perf-audit-360.yml
@@ -37,10 +37,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Enforce zero-cost runner
         run: |
           set -euo pipefail
           test "${{ runner.environment }}" = "self-hosted"
+          node --version
           python3 scripts/ci/enforce-zero-cost-policy.py
 
       - name: Studio hard-off contract


### PR DESCRIPTION
## Failure reproduced
The self-hosted runner is online and matched correctly (`ASCENDA-ZERO-COST-V2`). Zero-Cost enforcement passed, but `PERF-1A` failed before the scanner because the runner host has no `node` executable in PATH (`exit 127`).

## Fix
Add `actions/setup-node@v4` with Node 20 before the ASC-PERF census and print `node --version` in the runner gate.

This is CI-only. No production runtime, database, Studio state, auth, WhatsApp semantics or business data changes.

## Expected gate
`Setup Node → Zero-Cost PASS → Studio HARD-OFF contract PASS → Runtime census PASS → Census integrity PASS`.