### PR TITLE
WA-CLOSEOUT — fail-closed Supabase 402 quota circuit

### DIFF
--- a/.github/workflows/asc-perf-performance-guard.yml
+++ b/.github/workflows/asc-perf-performance-guard.yml
@@ -46,6 +46,12 @@ jobs:
           set -euo pipefail
           test "${{ runner.environment }}" = "self-hosted"
           python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: WA Supabase quota circuit contract
+        run: |
+          set -euo pipefail
+          node --check app/supabase-quota-circuit.js
+          node --check app/supabase-quota-circuit-preload.cjs
+          node ci/performance/wa-supabase-quota-circuit-contract.js
       - name: Build runtime census
         run: |
           set -euo pipefail

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -166,7 +166,7 @@ jobs:
           if ($sync -notmatch 'aos_integration_secrets_v1') { throw 'Private integration vault target missing' }
           if ($sync -match '/rest/v1/aos_integraciones(?:\?|["''])') { throw 'Public integration catalog must not receive provider secret' }
           if (($s + $sync + $s152 + $f17 + $quota) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
-          if ($quota -notmatch 'Phase-S\|WA3V2\|F17') { throw 'WA quota circuit runtime allowlist missing' }
+          if ($quota -notmatch 'Phase-S\|WA2\|WA3\|WA3V2\|WA4\|F17') { throw 'WA quota circuit runtime allowlist missing' }
           if ($quota -match 'SUPABASE_SERVICE_ROLE_KEY') { throw 'WA quota preload must not inspect service-role credential' }
           $phaseSEntries = @(
             'node server-phase-s.js',

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -166,7 +166,7 @@ jobs:
           if ($sync -notmatch 'aos_integration_secrets_v1') { throw 'Private integration vault target missing' }
           if ($sync -match '/rest/v1/aos_integraciones(?:\?|["''])') { throw 'Public integration catalog must not receive provider secret' }
           if (($s + $sync + $s152 + $f17 + $quota) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
-          if ($quota -notmatch 'Phase-S\|WA2\|WA3\|WA3V2\|WA4\|F17') { throw 'WA quota circuit runtime allowlist missing' }
+          if ($quota -notmatch 'Phase-S\|WA2\|WA3\|WA3V2\|WA4\|WA-Gateway\|F17') { throw 'WA quota circuit runtime allowlist missing' }
           if ($quota -match 'SUPABASE_SERVICE_ROLE_KEY') { throw 'WA quota preload must not inspect service-role credential' }
           $phaseSEntries = @(
             'node server-phase-s.js',

--- a/.github/workflows/phase-s-wa3-stabilization.yml
+++ b/.github/workflows/phase-s-wa3-stabilization.yml
@@ -9,6 +9,8 @@ on:
       - 'app/server-f17.js'
       - 'app/auth-resend-reconcile.js'
       - 'app/railway.json'
+      - 'app/supabase-quota-circuit.js'
+      - 'app/supabase-quota-circuit-preload.cjs'
       - 'app/server-f5.js'
       - 'app/server-wa4.js'
       - 'app/server-wa3.js'
@@ -18,6 +20,7 @@ on:
       - 'app/public/wa-shell-integration.js'
       - 'app/public/wa-native-panel.js'
       - 'ci/phase-s/**'
+      - 'ci/performance/wa-supabase-quota-circuit-contract.js'
       - 'ci/phase16/test_auth_resend_reconcile.js'
       - 'ci/phase4-revenue/**'
       - 'ci/wa2-conversation-live-inbox/**'
@@ -26,6 +29,7 @@ on:
       - 'ci/phase5-historical-identity/**'
       - 'docs/control/WHATSAPP_PHASE_S_*'
       - 'docs/control/WHATSAPP_REVENUE_HUB_EXPANSION_*'
+      - 'docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_*'
       - '.github/workflows/phase-s-wa3-stabilization.yml'
   push:
     branches: ['phase-s/wa3-stabilization-human-outbound']
@@ -64,6 +68,8 @@ jobs:
             'app/server-phase-s.js',
             'app/server-f17.js',
             'app/auth-resend-reconcile.js',
+            'app/supabase-quota-circuit.js',
+            'app/supabase-quota-circuit-preload.cjs',
             'app/server-f5.js',
             'app/server-wa4.js',
             'app/server-wa3.js',
@@ -75,6 +81,7 @@ jobs:
             'ci/phase-s/wa_native_s8_contract.js',
             'ci/phase-s/wa_customer_window_s10_contract.js',
             'ci/phase-s/wa_s11_live_sync_meta_auth_contract.js',
+            'ci/performance/wa-supabase-quota-circuit-contract.js',
             'ci/phase16/test_auth_resend_reconcile.js'
           )
           foreach ($file in $files) {
@@ -104,6 +111,12 @@ jobs:
         shell: powershell
         run: |
           node ci/phase-s/wa_s11_live_sync_meta_auth_contract.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: WA Supabase quota circuit contract
+        shell: powershell
+        run: |
+          node ci/performance/wa-supabase-quota-circuit-contract.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Auth Resend private-vault regression
@@ -137,6 +150,7 @@ jobs:
           $s152 = Get-Content app/server-phase-s-f17.js -Raw
           $f17 = Get-Content app/server-f17.js -Raw
           $sync = Get-Content app/auth-resend-reconcile.js -Raw
+          $quota = Get-Content app/supabase-quota-circuit-preload.cjs -Raw
           $cfg = Get-Content app/railway.json -Raw | ConvertFrom-Json
           $rawStart = [string]$cfg.deploy.startCommand
           $studioPrefix = 'env AOS_STUDIO_BACKGROUND_ENABLED=false '
@@ -151,16 +165,20 @@ jobs:
           if ($s -notmatch 'WA_CUSTOMER_WINDOW_CLOSED') { throw 'WA 24h customer window gate missing' }
           if ($sync -notmatch 'aos_integration_secrets_v1') { throw 'Private integration vault target missing' }
           if ($sync -match '/rest/v1/aos_integraciones(?:\?|["''])') { throw 'Public integration catalog must not receive provider secret' }
-          if (($s + $sync + $s152 + $f17) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
+          if (($s + $sync + $s152 + $f17 + $quota) -match '(SUPABASE_SERVICE_ROLE_KEY|RESEND_API_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*["''][^"'']+["'']') { throw 'hard-coded secret detected' }
+          if ($quota -notmatch 'Phase-S\|WA3V2\|F17') { throw 'WA quota circuit runtime allowlist missing' }
+          if ($quota -match 'SUPABASE_SERVICE_ROLE_KEY') { throw 'WA quota preload must not inspect service-role credential' }
           $phaseSEntries = @(
             'node server-phase-s.js',
             "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js",
-            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js"
+            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js",
+            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s.js"
           )
           $s152Entries = @(
             'node server-phase-s-f17.js',
             "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js",
-            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js"
+            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js",
+            "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s-f17.js"
           )
           $directOk = $phaseSEntries -contains $start
           $bootstrapOk = ($s152Entries -contains $start) -and
@@ -193,5 +211,6 @@ jobs:
           Write-Host 'WA S8 NATIVE WORKSPACE CONTRACT PASS'
           Write-Host 'WA S10 CUSTOMER-WINDOW CONTRACT PASS'
           Write-Host 'WA S11 LIVE-SYNC + META-AUTH CONTRACT PASS'
+          Write-Host 'WA SUPABASE QUOTA CIRCUIT CONTRACT PASS'
           Write-Host 'AUTH RESEND PRIVATE-VAULT RECONCILIATION GATE PASS'
-          Write-Host 'Production validation remaining: deploy health + provider readiness + authenticated human outbound canary inside an open 24h window.'
+          Write-Host 'Production validation remaining: Supabase quota reset + deploy health + provider readiness + authenticated human outbound canary inside an open 24h window.'

--- a/app/railway.json
+++ b/app/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "echo 'Skip build — Phase S outer runtime: node server-phase-s-f17.js -> server-phase-s.js -> server-f17.js -> server-f5.js -> server-wa4.js -> server-wa3.js -> server-wa2.js -> server-f4.js'"
   },
   "deploy": {
-    "startCommand": "env AOS_STUDIO_BACKGROUND_ENABLED=false NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js",
+    "startCommand": "env AOS_STUDIO_BACKGROUND_ENABLED=false NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s-f17.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE"

--- a/app/supabase-quota-circuit-preload.cjs
+++ b/app/supabase-quota-circuit-preload.cjs
@@ -1,0 +1,78 @@
+'use strict';
+
+const https = require('https');
+const { EventEmitter } = require('events');
+const { createSupabaseQuotaCircuit } = require('./supabase-quota-circuit');
+
+if (!global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__) {
+  const baseRequest = https.request;
+  const circuit = createSupabaseQuotaCircuit();
+  let configuredHost = 'ituyqwstonmhnfshnaqz.supabase.co';
+  try { configuredHost = new URL(process.env.SUPABASE_URL || ('https://' + configuredHost)).hostname; } catch (_) {}
+  const userAgentRe = /^AscendaOS-(?:Phase-S|WA3V2|F17)\//i;
+
+  function requestOptions(args) {
+    const first = args[0];
+    const second = args[1];
+    if (first instanceof URL) return { hostname: first.hostname, headers: second && second.headers || {} };
+    if (typeof first === 'string') {
+      try { const u = new URL(first); return { hostname: u.hostname, headers: second && second.headers || {} }; } catch (_) { return { hostname: '', headers: second && second.headers || {} }; }
+    }
+    return first && typeof first === 'object' ? first : {};
+  }
+
+  function header(headers, name) {
+    if (!headers) return '';
+    const lower = String(name).toLowerCase();
+    for (const k of Object.keys(headers)) if (String(k).toLowerCase() === lower) return String(headers[k] == null ? '' : headers[k]);
+    return '';
+  }
+
+  function isTarget(args) {
+    const opts = requestOptions(args);
+    const host = String(opts.hostname || opts.host || '').split(':')[0].toLowerCase();
+    const ua = header(opts.headers, 'user-agent');
+    return host === String(configuredHost || '').toLowerCase() && userAgentRe.test(ua);
+  }
+
+  class BlockedRequest extends EventEmitter {
+    constructor(err) { super(); this.err = err; this.finished = false; }
+    write() { return true; }
+    setTimeout() { return this; }
+    abort() { return this.destroy(this.err); }
+    destroy(err) {
+      if (this.finished) return this;
+      this.finished = true;
+      const e = err || this.err;
+      setImmediate(() => this.emit('error', e));
+      return this;
+    }
+    end() {
+      if (!this.finished) {
+        this.finished = true;
+        setImmediate(() => this.emit('error', this.err));
+      }
+      return this;
+    }
+  }
+
+  https.request = function aosQuotaAwareRequest() {
+    const args = Array.prototype.slice.call(arguments);
+    if (!isTarget(args)) return baseRequest.apply(https, args);
+
+    let ticket;
+    try { ticket = circuit.beforeRequest(); }
+    catch (e) { return new BlockedRequest(e); }
+
+    const req = baseRequest.apply(https, args);
+    req.once('response', function(res) { circuit.recordStatus(res && res.statusCode, ticket); });
+    req.once('error', function() { circuit.recordError(ticket); });
+    return req;
+  };
+
+  global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__ = {
+    installed: true,
+    host: configuredHost,
+    snapshot: function() { return circuit.snapshot(); }
+  };
+}

--- a/app/supabase-quota-circuit-preload.cjs
+++ b/app/supabase-quota-circuit-preload.cjs
@@ -9,7 +9,7 @@ if (!global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__) {
   const circuit = createSupabaseQuotaCircuit();
   let configuredHost = 'ituyqwstonmhnfshnaqz.supabase.co';
   try { configuredHost = new URL(process.env.SUPABASE_URL || ('https://' + configuredHost)).hostname; } catch (_) {}
-  const userAgentRe = /^AscendaOS-(?:Phase-S|WA2|WA3|WA3V2|WA4|F17)\//i;
+  const userAgentRe = /^AscendaOS-(?:Phase-S|WA2|WA3|WA3V2|WA4|WA-Gateway|F17)\//i;
 
   function requestOptions(args) {
     const first = args[0];

--- a/app/supabase-quota-circuit-preload.cjs
+++ b/app/supabase-quota-circuit-preload.cjs
@@ -9,7 +9,7 @@ if (!global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__) {
   const circuit = createSupabaseQuotaCircuit();
   let configuredHost = 'ituyqwstonmhnfshnaqz.supabase.co';
   try { configuredHost = new URL(process.env.SUPABASE_URL || ('https://' + configuredHost)).hostname; } catch (_) {}
-  const userAgentRe = /^AscendaOS-(?:Phase-S|WA3V2|F17)\//i;
+  const userAgentRe = /^AscendaOS-(?:Phase-S|WA2|WA3|WA3V2|WA4|F17)\//i;
 
   function requestOptions(args) {
     const first = args[0];

--- a/app/supabase-quota-circuit.js
+++ b/app/supabase-quota-circuit.js
@@ -1,0 +1,93 @@
+'use strict';
+
+function positiveInt(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+function createSupabaseQuotaCircuit(options) {
+  const opts = options || {};
+  const now = typeof opts.now === 'function' ? opts.now : function() { return Date.now(); };
+  const configured = positiveInt(opts.cooldownMs != null ? opts.cooldownMs : process.env.SUPABASE_QUOTA_COOLDOWN_MS, 15 * 60 * 1000);
+  const cooldownMs = Math.max(60 * 1000, Math.min(60 * 60 * 1000, configured));
+
+  let blockedUntil = 0;
+  let openedAt = 0;
+  let probeInFlight = false;
+  let openCount = 0;
+  let shortCircuitCount = 0;
+  let probeCount = 0;
+
+  function blockedError() {
+    const remaining = Math.max(0, blockedUntil - now());
+    return Object.assign(new Error('SUPABASE_QUOTA_BLOCKED'), {
+      code: 'SUPABASE_QUOTA_BLOCKED',
+      status: 503,
+      upstreamStatus: 402,
+      upstream_status: 402,
+      retryAfterMs: remaining,
+      retry_after_ms: remaining
+    });
+  }
+
+  function beforeRequest() {
+    const t = now();
+    if (blockedUntil > t) {
+      shortCircuitCount++;
+      throw blockedError();
+    }
+    if (blockedUntil > 0) {
+      if (probeInFlight) {
+        shortCircuitCount++;
+        throw blockedError();
+      }
+      probeInFlight = true;
+      probeCount++;
+      return { probe: true };
+    }
+    return { probe: false };
+  }
+
+  function recordStatus(status, ticket) {
+    const code = Number(status || 0);
+    if (code === 402) {
+      openedAt = now();
+      blockedUntil = openedAt + cooldownMs;
+      probeInFlight = false;
+      openCount++;
+      return;
+    }
+    if (ticket && ticket.probe) {
+      blockedUntil = 0;
+      openedAt = 0;
+      probeInFlight = false;
+    }
+  }
+
+  function recordError(ticket) {
+    if (ticket && ticket.probe) {
+      blockedUntil = 0;
+      openedAt = 0;
+      probeInFlight = false;
+    }
+  }
+
+  function snapshot() {
+    const t = now();
+    return {
+      open: blockedUntil > t,
+      cooldown_ms: cooldownMs,
+      opened_at_ms: openedAt || null,
+      blocked_until_ms: blockedUntil || null,
+      retry_after_ms: Math.max(0, blockedUntil - t),
+      probe_in_flight: probeInFlight,
+      open_count: openCount,
+      short_circuit_count: shortCircuitCount,
+      probe_count: probeCount
+    };
+  }
+
+  return { beforeRequest, recordStatus, recordError, snapshot };
+}
+
+module.exports = { createSupabaseQuotaCircuit };

--- a/ci/performance/wa-supabase-quota-circuit-contract.js
+++ b/ci/performance/wa-supabase-quota-circuit-contract.js
@@ -13,6 +13,8 @@ async function coreContract() {
   assert.deepStrictEqual(circuit.beforeRequest(), { probe: false });
   circuit.recordStatus(401, { probe: false });
   assert.strictEqual(circuit.snapshot().open, false, '401 must not open quota circuit');
+  circuit.recordStatus(403, { probe: false });
+  assert.strictEqual(circuit.snapshot().open, false, '403 must not open quota circuit');
   circuit.recordStatus(429, { probe: false });
   assert.strictEqual(circuit.snapshot().open, false, '429 must not open quota circuit');
   circuit.recordStatus(500, { probe: false });
@@ -93,13 +95,19 @@ async function preloadContract() {
   assert.strictEqual(network, 1, 'first target call must reach network');
   assert.strictEqual(global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__.snapshot().open, true, 'preload circuit did not open');
 
-  const second = await call('AscendaOS-Phase-S/1.0');
-  assert(second.error && second.error.code === 'SUPABASE_QUOTA_BLOCKED', 'second target call must short-circuit locally');
-  assert.strictEqual(network, 1, 'blocked target call escaped to network');
-
-  const wa3 = await call('AscendaOS-WA3V2/1.0');
-  assert(wa3.error && wa3.error.code === 'SUPABASE_QUOTA_BLOCKED', 'WA3V2 must share process quota circuit');
-  assert.strictEqual(network, 1, 'WA3V2 blocked call escaped to network');
+  const targetAgents = [
+    'AscendaOS-Phase-S/1.0',
+    'AscendaOS-WA2/1.0',
+    'AscendaOS-WA3/1.0',
+    'AscendaOS-WA3V2/1.0',
+    'AscendaOS-WA4/1.0',
+    'AscendaOS-F17/1.4'
+  ];
+  for (const ua of targetAgents) {
+    const blocked = await call(ua);
+    assert(blocked.error && blocked.error.code === 'SUPABASE_QUOTA_BLOCKED', ua + ' must short-circuit during quota block');
+  }
+  assert.strictEqual(network, 1, 'blocked WA-family calls escaped to network');
 
   const nonTarget = await call('OtherRuntime/1.0');
   assert.strictEqual(nonTarget.status, 402, 'non-WA target must preserve base transport behavior');
@@ -112,7 +120,7 @@ function staticContract() {
   const railway = fs.readFileSync(path.join(process.cwd(), 'app/railway.json'), 'utf8');
   const preload = fs.readFileSync(path.join(process.cwd(), 'app/supabase-quota-circuit-preload.cjs'), 'utf8');
   assert(railway.includes('--require ./supabase-quota-circuit-preload.cjs'), 'Railway quota preload missing');
-  assert(preload.includes('Phase-S|WA3V2|F17'), 'WA runtime target allowlist missing');
+  assert(preload.includes('Phase-S|WA2|WA3|WA3V2|WA4|F17'), 'full WA runtime target allowlist missing');
   assert(preload.includes('configuredHost'), 'Supabase host scoping missing');
   assert(!preload.includes('SUPABASE_SERVICE_ROLE_KEY'), 'preload must not inspect service-role credentials');
 }

--- a/ci/performance/wa-supabase-quota-circuit-contract.js
+++ b/ci/performance/wa-supabase-quota-circuit-contract.js
@@ -101,6 +101,7 @@ async function preloadContract() {
     'AscendaOS-WA3/1.0',
     'AscendaOS-WA3V2/1.0',
     'AscendaOS-WA4/1.0',
+    'AscendaOS-WA-Gateway/1.0',
     'AscendaOS-F17/1.4'
   ];
   for (const ua of targetAgents) {
@@ -109,8 +110,8 @@ async function preloadContract() {
   }
   assert.strictEqual(network, 1, 'blocked WA-family calls escaped to network');
 
-  const nonTarget = await call('OtherRuntime/1.0');
-  assert.strictEqual(nonTarget.status, 402, 'non-WA target must preserve base transport behavior');
+  const nonTarget = await call('AscendaOS-F4-RevenueProxy/1.0');
+  assert.strictEqual(nonTarget.status, 402, 'non-WA revenue proxy must preserve base transport behavior');
   assert.strictEqual(network, 2, 'non-target runtime was incorrectly intercepted');
 
   https.request = original;
@@ -120,7 +121,7 @@ function staticContract() {
   const railway = fs.readFileSync(path.join(process.cwd(), 'app/railway.json'), 'utf8');
   const preload = fs.readFileSync(path.join(process.cwd(), 'app/supabase-quota-circuit-preload.cjs'), 'utf8');
   assert(railway.includes('--require ./supabase-quota-circuit-preload.cjs'), 'Railway quota preload missing');
-  assert(preload.includes('Phase-S|WA2|WA3|WA3V2|WA4|F17'), 'full WA runtime target allowlist missing');
+  assert(preload.includes('Phase-S|WA2|WA3|WA3V2|WA4|WA-Gateway|F17'), 'full WA runtime target allowlist missing');
   assert(preload.includes('configuredHost'), 'Supabase host scoping missing');
   assert(!preload.includes('SUPABASE_SERVICE_ROLE_KEY'), 'preload must not inspect service-role credentials');
 }

--- a/ci/performance/wa-supabase-quota-circuit-contract.js
+++ b/ci/performance/wa-supabase-quota-circuit-contract.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { EventEmitter } = require('events');
+const { createSupabaseQuotaCircuit } = require('../../app/supabase-quota-circuit');
+
+async function coreContract() {
+  let now = 1000;
+  const circuit = createSupabaseQuotaCircuit({ cooldownMs: 60000, now: function() { return now; } });
+
+  assert.deepStrictEqual(circuit.beforeRequest(), { probe: false });
+  circuit.recordStatus(401, { probe: false });
+  assert.strictEqual(circuit.snapshot().open, false, '401 must not open quota circuit');
+  circuit.recordStatus(429, { probe: false });
+  assert.strictEqual(circuit.snapshot().open, false, '429 must not open quota circuit');
+  circuit.recordStatus(500, { probe: false });
+  assert.strictEqual(circuit.snapshot().open, false, '5xx must not open quota circuit');
+
+  circuit.recordStatus(402, { probe: false });
+  assert.strictEqual(circuit.snapshot().open, true, '402 must open quota circuit');
+  assert.throws(function() { circuit.beforeRequest(); }, function(e) {
+    return e && e.code === 'SUPABASE_QUOTA_BLOCKED' && e.upstreamStatus === 402;
+  }, 'open circuit must fail locally with 402 compatibility metadata');
+
+  now += 60000;
+  const probe = circuit.beforeRequest();
+  assert.strictEqual(probe.probe, true, 'cooldown expiry must allow exactly one probe');
+  assert.throws(function() { circuit.beforeRequest(); }, /SUPABASE_QUOTA_BLOCKED/, 'parallel probe must be suppressed');
+  circuit.recordStatus(500, probe);
+  assert.strictEqual(circuit.snapshot().open, false, 'non-402 probe result must release quota circuit');
+  assert.strictEqual(circuit.beforeRequest().probe, false, 'normal traffic must resume after non-402 probe');
+
+  circuit.recordStatus(402, { probe: false });
+  now += 60000;
+  const successProbe = circuit.beforeRequest();
+  circuit.recordStatus(200, successProbe);
+  const final = circuit.snapshot();
+  assert.strictEqual(final.open, false, 'successful probe must close circuit');
+  assert(final.open_count >= 2, 'open counter missing');
+  assert(final.short_circuit_count >= 2, 'short-circuit counter missing');
+  assert(final.probe_count >= 2, 'probe counter missing');
+}
+
+async function preloadContract() {
+  const https = require('https');
+  const original = https.request;
+  let network = 0;
+  let status = 402;
+
+  https.request = function fakeRequest(options, callback) {
+    network++;
+    const req = new EventEmitter();
+    if (typeof callback === 'function') req.on('response', callback);
+    req.write = function() { return true; };
+    req.setTimeout = function() { return req; };
+    req.destroy = function(err) { setImmediate(function() { req.emit('error', err || new Error('DESTROYED')); }); return req; };
+    req.end = function() {
+      setImmediate(function() {
+        const res = new EventEmitter();
+        res.statusCode = status;
+        req.emit('response', res);
+        setImmediate(function() { res.emit('end'); });
+      });
+      return req;
+    };
+    return req;
+  };
+
+  delete global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__;
+  delete require.cache[require.resolve('../../app/supabase-quota-circuit-preload.cjs')];
+  require('../../app/supabase-quota-circuit-preload.cjs');
+
+  function call(userAgent) {
+    return new Promise(function(resolve) {
+      const req = https.request({
+        hostname: 'ituyqwstonmhnfshnaqz.supabase.co',
+        path: '/rest/v1/rpc/aos_wa3_actor_v1',
+        method: 'POST',
+        headers: { 'User-Agent': userAgent }
+      }, function(res) {
+        res.on('end', function() { resolve({ status: res.statusCode }); });
+      });
+      req.on('error', function(e) { resolve({ error: e }); });
+      req.write('{}');
+      req.end();
+    });
+  }
+
+  const first = await call('AscendaOS-Phase-S/1.0');
+  assert.strictEqual(first.status, 402, 'first upstream 402 must be observable by caller');
+  assert.strictEqual(network, 1, 'first target call must reach network');
+  assert.strictEqual(global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__.snapshot().open, true, 'preload circuit did not open');
+
+  const second = await call('AscendaOS-Phase-S/1.0');
+  assert(second.error && second.error.code === 'SUPABASE_QUOTA_BLOCKED', 'second target call must short-circuit locally');
+  assert.strictEqual(network, 1, 'blocked target call escaped to network');
+
+  const wa3 = await call('AscendaOS-WA3V2/1.0');
+  assert(wa3.error && wa3.error.code === 'SUPABASE_QUOTA_BLOCKED', 'WA3V2 must share process quota circuit');
+  assert.strictEqual(network, 1, 'WA3V2 blocked call escaped to network');
+
+  const nonTarget = await call('OtherRuntime/1.0');
+  assert.strictEqual(nonTarget.status, 402, 'non-WA target must preserve base transport behavior');
+  assert.strictEqual(network, 2, 'non-target runtime was incorrectly intercepted');
+
+  https.request = original;
+}
+
+function staticContract() {
+  const railway = fs.readFileSync(path.join(process.cwd(), 'app/railway.json'), 'utf8');
+  const preload = fs.readFileSync(path.join(process.cwd(), 'app/supabase-quota-circuit-preload.cjs'), 'utf8');
+  assert(railway.includes('--require ./supabase-quota-circuit-preload.cjs'), 'Railway quota preload missing');
+  assert(preload.includes('Phase-S|WA3V2|F17'), 'WA runtime target allowlist missing');
+  assert(preload.includes('configuredHost'), 'Supabase host scoping missing');
+  assert(!preload.includes('SUPABASE_SERVICE_ROLE_KEY'), 'preload must not inspect service-role credentials');
+}
+
+(async function main() {
+  await coreContract();
+  await preloadContract();
+  staticContract();
+  console.log('WA_SUPABASE_QUOTA_CIRCUIT_CONTRACT_PASS');
+})().catch(function(err) {
+  console.error(err);
+  process.exit(1);
+});

--- a/ci/phase-s/phase-s_contract.js
+++ b/ci/phase-s/phase-s_contract.js
@@ -7,6 +7,7 @@ const f17=fs.readFileSync('app/server-f17.js','utf8');
 const s152=fs.readFileSync('app/server-phase-s-f17.js','utf8');
 const railway=fs.readFileSync('app/railway.json','utf8');
 const authSync=fs.readFileSync('app/auth-resend-reconcile.js','utf8');
+const quota=fs.readFileSync('app/supabase-quota-circuit-preload.cjs','utf8');
 const waPrelude=fs.readFileSync('app/public/wa-native-bootstrap-prelude.js','utf8');
 
 assert(s.includes("['server-f5.js']"),'Phase S must wrap the certified server-f5 chain');
@@ -26,16 +27,20 @@ assert(!waPrelude.includes("localStorage.setItem('aos_app_token'"),'WA bootstrap
 assert(authSync.includes('aos_integration_secrets_v1'),'Auth Resend sync must target private integration vault');
 assert(!authSync.includes('/rest/v1/aos_integraciones?'),'Auth Resend sync must not write public integration catalog');
 assert(!/WHATSAPP_ACCESS_TOKEN\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded Meta access token');
-assert(!/SUPABASE_SERVICE_ROLE_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded service role');
+assert(!/SUPABASE_SERVICE_ROLE_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+quota),'no hard-coded service role');
 assert(!/RESEND_API_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+authSync),'no hard-coded Resend API key');
+assert(quota.includes('Phase-S|WA3V2|F17'),'quota preload must remain limited to recurrent WA runtime user-agents');
+assert(!quota.includes('SUPABASE_SERVICE_ROLE_KEY'),'quota preload must never inspect service-role credentials');
 
 const cfg=JSON.parse(railway);
 const legacy='node server-phase-s.js';
 const sentinel="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
 const sentinelEmail="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js";
+const sentinelEmailQuota="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s.js";
 const s152Legacy='node server-phase-s-f17.js';
 const s152Sentinel="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js";
 const s152SentinelEmail="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s-f17.js";
+const s152SentinelEmailQuota="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s-f17.js";
 const start=cfg.deploy.startCommand;
 const studioHardOffPrefix='env AOS_STUDIO_BACKGROUND_ENABLED=false ';
 const studioHardOff=String(start||'').startsWith(studioHardOffPrefix);
@@ -45,14 +50,14 @@ if(studioHardOff){
   normalizedStart=remainder.startsWith('NODE_OPTIONS=')?'env '+remainder:remainder;
 }
 assert(studioHardOff,'Studio background must remain HARD-OFF while ASC-PERF owns the mutable lane');
-const directPhaseS=[legacy,sentinel,sentinelEmail].includes(normalizedStart);
-const f17Bootstrap=[s152Legacy,s152Sentinel,s152SentinelEmail].includes(normalizedStart)
+const directPhaseS=[legacy,sentinel,sentinelEmail,sentinelEmailQuota].includes(normalizedStart);
+const f17Bootstrap=[s152Legacy,s152Sentinel,s152SentinelEmail,s152SentinelEmailQuota].includes(normalizedStart)
   && s152.includes("a[0]==='server-f5.js'")
   && s152.includes("a[0]='server-f17.js'")
   && s152.includes("require('./server-phase-s.js')")
   && f17.includes("['server-f5.js']");
 assert(directPhaseS||f17Bootstrap,'Phase S start command must be direct or an exact certified F17 bootstrap/preload chain after the Studio HARD-OFF prefix');
-if([sentinel,sentinelEmail,s152Sentinel,s152SentinelEmail].includes(normalizedStart)){
+if([sentinel,sentinelEmail,sentinelEmailQuota,s152Sentinel,s152SentinelEmail,s152SentinelEmailQuota].includes(normalizedStart)){
   assert(!String(cfg.build&&cfg.build.buildCommand||'').includes('NODE_OPTIONS'),'runtime preloads must not contaminate build');
 }
 assert.strictEqual(cfg.deploy.healthcheckPath,'/health');

--- a/ci/phase-s/phase-s_contract.js
+++ b/ci/phase-s/phase-s_contract.js
@@ -29,7 +29,7 @@ assert(!authSync.includes('/rest/v1/aos_integraciones?'),'Auth Resend sync must 
 assert(!/WHATSAPP_ACCESS_TOKEN\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded Meta access token');
 assert(!/SUPABASE_SERVICE_ROLE_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+quota),'no hard-coded service role');
 assert(!/RESEND_API_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+authSync),'no hard-coded Resend API key');
-assert(quota.includes('Phase-S|WA3V2|F17'),'quota preload must remain limited to recurrent WA runtime user-agents');
+assert(quota.includes('Phase-S|WA2|WA3|WA3V2|WA4|F17'),'quota preload must remain limited to the full recurrent WA runtime family');
 assert(!quota.includes('SUPABASE_SERVICE_ROLE_KEY'),'quota preload must never inspect service-role credentials');
 
 const cfg=JSON.parse(railway);

--- a/ci/phase-s/phase-s_contract.js
+++ b/ci/phase-s/phase-s_contract.js
@@ -29,7 +29,7 @@ assert(!authSync.includes('/rest/v1/aos_integraciones?'),'Auth Resend sync must 
 assert(!/WHATSAPP_ACCESS_TOKEN\s*=\s*['\"][^'\"]+['\"]/.test(s),'no hard-coded Meta access token');
 assert(!/SUPABASE_SERVICE_ROLE_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+quota),'no hard-coded service role');
 assert(!/RESEND_API_KEY\s*=\s*['\"][^'\"]+['\"]/.test(s+authSync),'no hard-coded Resend API key');
-assert(quota.includes('Phase-S|WA2|WA3|WA3V2|WA4|F17'),'quota preload must remain limited to the full recurrent WA runtime family');
+assert(quota.includes('Phase-S|WA2|WA3|WA3V2|WA4|WA-Gateway|F17'),'quota preload must remain limited to the full recurrent WA runtime family including secure gateway persistence');
 assert(!quota.includes('SUPABASE_SERVICE_ROLE_KEY'),'quota preload must never inspect service-role credentials');
 
 const cfg=JSON.parse(railway);

--- a/ci/phase2-cartera/ui_contract.py
+++ b/ci/phase2-cartera/ui_contract.py
@@ -73,6 +73,7 @@ assert 'if (abonoFailed)' in caja
 prod = railway.split('"environments"')[0]
 studio_prefix='"startCommand": "env AOS_STUDIO_BACKGROUND_ENABLED=false '
 normalized_prod=prod.replace(studio_prefix,'"startCommand": "env ',1) if studio_prefix in prod else prod
+normalized_prod=normalized_prod.replace(' --require ./supabase-quota-circuit-preload.cjs','')
 sentinel_phase_s = "\"startCommand\": \"env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js\""
 sentinel_phase_s_email = "\"startCommand\": \"env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js\""
 sentinel_s152 = "\"startCommand\": \"env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js\""

--- a/ci/phase5-historical-identity/f5_upload_contract.js
+++ b/ci/phase5-historical-identity/f5_upload_contract.js
@@ -32,6 +32,7 @@ if(studioHardOff){
   const remainder=rawStart.slice(studioHardOffPrefix.length);
   start=remainder.startsWith('NODE_OPTIONS=')?'env '+remainder:remainder;
 }
+start=start.replace(' --require ./supabase-quota-circuit-preload.cjs','');
 ok(studioHardOff,'Studio background must remain HARD-OFF while ASC-PERF owns the mutable lane');
 const sentinelPhaseS="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js";
 const sentinelPhaseSEmail="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js";

--- a/ci/wa2-conversation-live-inbox/ui_contract.py
+++ b/ci/wa2-conversation-live-inbox/ui_contract.py
@@ -51,9 +51,10 @@ assert "textContent" in ui or "esc(" in ui
 
 start=railway['deploy']['startCommand']
 # ASC-PERF/Studio containment may prepend this exact fail-closed runtime flag.
-# Normalize only this known prefix; arbitrary env wrappers remain rejected.
+# Normalize only this known prefix and the certified WA quota preload; arbitrary env wrappers remain rejected.
 studio_fail_closed_prefix='env AOS_STUDIO_BACKGROUND_ENABLED=false '
 normalized_start=('env '+start[len(studio_fail_closed_prefix):]) if start.startswith(studio_fail_closed_prefix) else start
+normalized_start=normalized_start.replace(' --require ./supabase-quota-circuit-preload.cjs','')
 sentinel_phase_s="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 sentinel_phase_s_email="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js"
 sentinel_s152="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js"

--- a/ci/wa3-boxes-routing-handoff/ui_contract.py
+++ b/ci/wa3-boxes-routing-handoff/ui_contract.py
@@ -25,10 +25,10 @@ assert "['server-wa2.js']" in server
 assert "proxy(req,res)" in server
 assert "X-Ascenda-WA3-Routing':'v1'" in server
 start=railway['deploy']['startCommand']
-# ASC-PERF/Studio containment may prepend this exact fail-closed runtime flag.
-# Normalize only this known prefix; arbitrary env wrappers remain rejected.
+# Normalize only the known Studio fail-closed prefix and certified WA quota preload.
 studio_fail_closed_prefix='env AOS_STUDIO_BACKGROUND_ENABLED=false '
 normalized_start=('env '+start[len(studio_fail_closed_prefix):]) if start.startswith(studio_fail_closed_prefix) else start
+normalized_start=normalized_start.replace(' --require ./supabase-quota-circuit-preload.cjs','')
 sentinel_phase_s="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 sentinel_phase_s_email="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js"
 sentinel_s152="env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js"

--- a/ci/wa4-ai-sales-router/ui_contract.py
+++ b/ci/wa4-ai-sales-router/ui_contract.py
@@ -22,6 +22,7 @@ rail = json.loads((root/'app/railway.json').read_text())
 start = rail['deploy']['startCommand']
 studio_fail_closed_prefix='env AOS_STUDIO_BACKGROUND_ENABLED=false '
 normalized_start=('env '+start[len(studio_fail_closed_prefix):]) if start.startswith(studio_fail_closed_prefix) else start
+normalized_start=normalized_start.replace(' --require ./supabase-quota-circuit-preload.cjs','')
 sentinel_phase_s = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s.js"
 sentinel_phase_s_email = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs' node server-phase-s.js"
 sentinel_s152 = "env NODE_OPTIONS='--require ./sentinel-sentry-init.cjs' node server-phase-s-f17.js"

--- a/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
@@ -13,11 +13,11 @@ The application is therefore creating avoidable failed traffic while production 
 
 ## Objective
 
-Introduce a process-local Supabase quota circuit for the recurrent WA runtime clients so that the first upstream 402 opens a bounded cooldown and subsequent matching calls fail locally without issuing another network request until a controlled probe window reopens.
+Introduce a process-local Supabase quota circuit for the WA runtime family so that the first upstream 402 opens a bounded cooldown and subsequent matching calls fail locally without issuing another network request until a controlled probe window reopens.
 
 ## Implementation scope
 
-To avoid rewriting three already-certified wrappers, the circuit is loaded as a small runtime preload through the existing Railway `NODE_OPTIONS` chain:
+To avoid rewriting already-certified wrappers, the circuit is loaded as a small runtime preload through the existing Railway `NODE_OPTIONS` chain:
 
 - `app/supabase-quota-circuit.js` — pure state machine;
 - `app/supabase-quota-circuit-preload.cjs` — scoped `https.request` interceptor;
@@ -26,7 +26,7 @@ To avoid rewriting three already-certified wrappers, the circuit is loaded as a 
 The interceptor is intentionally narrow. It applies only when both conditions are true:
 
 1. request hostname equals the configured ASCENDA Supabase hostname;
-2. `User-Agent` belongs to one of the recurrent WA wrappers: `AscendaOS-Phase-S/*`, `AscendaOS-WA3V2/*`, `AscendaOS-F17/*`.
+2. `User-Agent` belongs to the WA runtime family: `AscendaOS-Phase-S/*`, `AscendaOS-WA2/*`, `AscendaOS-WA3/*`, `AscendaOS-WA3V2/*`, `AscendaOS-WA4/*`, or `AscendaOS-F17/*`.
 
 Other runtime traffic is not intercepted. The state remains process-local because each wrapper runs in a separate Node process and inherits `NODE_OPTIONS`.
 
@@ -53,8 +53,9 @@ This is a protection budget, not a live production performance certification. Ex
 
 - pure state-machine contract for open → local short-circuit → cooldown → single probe → reset;
 - negative contract: 401/403/429/500 never open the quota circuit;
-- preload behavior contract proves first target 402 reaches the caller, the next target request makes zero network calls, and a non-target runtime remains untouched;
+- preload behavior contract proves first target 402 reaches the caller, all six WA runtime user-agent families short-circuit after opening, and a non-target runtime remains untouched;
 - static contract proves Railway loads the preload and the WA runtime allowlist/host scope are present;
+- historical runtime contracts normalize only this exact certified preload and continue rejecting arbitrary wrappers;
 - existing Phase S / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain mandatory;
 - Performance Guard remains mandatory;
 - Zero-Cost WA-3 FINAL local Supabase/pgTAP/concurrency/rollback remains mandatory.

--- a/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
@@ -13,29 +13,35 @@ The application is therefore creating avoidable failed traffic while production 
 
 ## Objective
 
-Introduce a process-local Supabase quota circuit for WA runtime wrappers so that the first upstream 402 opens a bounded cooldown and subsequent Supabase calls fail locally without issuing another network request until a controlled probe window reopens.
+Introduce a process-local Supabase quota circuit for the recurrent WA runtime clients so that the first upstream 402 opens a bounded cooldown and subsequent matching calls fail locally without issuing another network request until a controlled probe window reopens.
 
-## Scope
+## Implementation scope
 
-Adopt one shared helper in the WA runtime processes that currently own recurrent Supabase calls:
+To avoid rewriting three already-certified wrappers, the circuit is loaded as a small runtime preload through the existing Railway `NODE_OPTIONS` chain:
 
-- `app/server-phase-s.js`;
-- `app/server-wa3-v2.js`;
-- `app/server-f17.js`.
+- `app/supabase-quota-circuit.js` — pure state machine;
+- `app/supabase-quota-circuit-preload.cjs` — scoped `https.request` interceptor;
+- `app/railway.json` — adds the preload to the existing Sentry/email preload chain.
 
-The helper is process-local by design because these wrappers run as separate Node processes.
+The interceptor is intentionally narrow. It applies only when both conditions are true:
+
+1. request hostname equals the configured ASCENDA Supabase hostname;
+2. `User-Agent` belongs to one of the recurrent WA wrappers: `AscendaOS-Phase-S/*`, `AscendaOS-WA3V2/*`, `AscendaOS-F17/*`.
+
+Other runtime traffic is not intercepted. The state remains process-local because each wrapper runs in a separate Node process and inherits `NODE_OPTIONS`.
 
 ## Required semantics
 
 1. First real upstream `402` opens the circuit.
-2. Circuit remains open for a bounded cooldown; default target: 15 minutes.
-3. While open, requests fail locally with a deterministic `SUPABASE_QUOTA_BLOCKED` error and `upstreamStatus=402` / `upstream_status=402` compatibility metadata.
+2. Circuit remains open for a bounded cooldown; default: 15 minutes, bounded to 1–60 minutes.
+3. While open, matching requests fail locally with deterministic `SUPABASE_QUOTA_BLOCKED` and compatibility metadata `upstreamStatus=402` / `upstream_status=402`.
 4. No credentials, session tokens, customer data or provider payload are stored by the circuit.
 5. 401/403/429/5xx do not open the quota circuit.
-6. Successful probe after cooldown closes/rearms normal operation.
-7. Security remains fail-closed: no actor, 2FA, ownership, RLS or permission bypass.
-8. Production data/schema are untouched.
-9. The circuit is not a substitute for the August 29 production revalidation gate.
+6. Cooldown expiry permits one probe; parallel probes are suppressed.
+7. Any non-402 probe result releases the quota circuit; a successful 2xx probe therefore rearms normal operation immediately.
+8. Security remains fail-closed: no actor, 2FA, ownership, RLS or permission bypass.
+9. Production data/schema are untouched.
+10. The circuit is not a substitute for the August 29 production revalidation gate.
 
 ## Performance intent
 
@@ -45,16 +51,17 @@ This is a protection budget, not a live production performance certification. Ex
 
 ## Tests
 
-- pure unit/behavior contract for open → short-circuit → cooldown → successful probe reset;
-- negative contract: 401/403/429/500 never open this quota circuit;
-- wrapper static/runtime contract confirms all three WA callers use the shared circuit;
-- existing Phase S / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain green;
-- Performance Guard remains green;
-- Zero-Cost WA-3 FINAL local Supabase/pgTAP/concurrency/rollback remains green.
+- pure state-machine contract for open → local short-circuit → cooldown → single probe → reset;
+- negative contract: 401/403/429/500 never open the quota circuit;
+- preload behavior contract proves first target 402 reaches the caller, the next target request makes zero network calls, and a non-target runtime remains untouched;
+- static contract proves Railway loads the preload and the WA runtime allowlist/host scope are present;
+- existing Phase S / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain mandatory;
+- Performance Guard remains mandatory;
+- Zero-Cost WA-3 FINAL local Supabase/pgTAP/concurrency/rollback remains mandatory.
 
 ## Rollback
 
-Revert the helper adoption commit(s). No SQL rollback and no production data recovery are required because this slice makes no DB/schema mutation.
+Remove the preload from `app/railway.json` and revert the two helper files. No SQL rollback and no production data recovery are required because this slice makes no DB/schema mutation.
 
 ## Production state
 

--- a/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
@@ -7,7 +7,7 @@
 
 ## Incident
 
-Supabase project `ituyqwstonmhnfshnaqz` is `ACTIVE_HEALTHY`, but current API logs show repeated HTTP `402` responses while the Free-plan egress quota is exhausted. WA recurrent callers continue reaching Supabase during the blocked billing window, especially `aos_wa3_actor_v1` from Phase S / WA3V2 and notification RPCs from F17.
+Supabase project `ituyqwstonmhnfshnaqz` is `ACTIVE_HEALTHY`, but current API logs show repeated HTTP `402` responses while the Free-plan egress quota is exhausted. WA recurrent callers continue reaching Supabase during the blocked billing window, especially `aos_wa3_actor_v1` from Phase S / WA3V2 and notification RPCs from F17. The secure WA gateway also owns inbound/outbound persistence calls and must be protected from repeated 402 writes during provider retries.
 
 The application is therefore creating avoidable failed traffic while production cannot serve reliable data. A 402 must not be treated like a transient application error that deserves tight retry loops.
 
@@ -26,9 +26,9 @@ To avoid rewriting already-certified wrappers, the circuit is loaded as a small 
 The interceptor is intentionally narrow. It applies only when both conditions are true:
 
 1. request hostname equals the configured ASCENDA Supabase hostname;
-2. `User-Agent` belongs to the WA runtime family: `AscendaOS-Phase-S/*`, `AscendaOS-WA2/*`, `AscendaOS-WA3/*`, `AscendaOS-WA3V2/*`, `AscendaOS-WA4/*`, or `AscendaOS-F17/*`.
+2. `User-Agent` belongs to the WA runtime family: `AscendaOS-Phase-S/*`, `AscendaOS-WA2/*`, `AscendaOS-WA3/*`, `AscendaOS-WA3V2/*`, `AscendaOS-WA4/*`, `AscendaOS-WA-Gateway/*`, or `AscendaOS-F17/*`.
 
-Other runtime traffic is not intercepted. The state remains process-local because each wrapper runs in a separate Node process and inherits `NODE_OPTIONS`.
+The mixed Revenue client `AscendaOS-F4-RevenueProxy/*` is deliberately excluded; the secure WA persistence client `AscendaOS-WA-Gateway/*` is included. Other runtime traffic is not intercepted. The state remains process-local because each wrapper runs in a separate Node process and inherits `NODE_OPTIONS`.
 
 ## Required semantics
 
@@ -45,7 +45,7 @@ Other runtime traffic is not intercepted. The state remains process-local becaus
 
 ## Performance intent
 
-During a quota block, Supabase request volume from each covered WA process should collapse from recurrent polling cadence to at most one quota probe per cooldown window, rather than one failed request per UI/pump tick.
+During a quota block, Supabase request volume from each covered WA process should collapse from recurrent polling/provider-retry cadence to at most one quota probe per cooldown window, rather than one failed request per UI/pump/provider tick.
 
 This is a protection budget, not a live production performance certification. Exact live request-rate verification remains blocked until Supabase quota resets.
 
@@ -53,10 +53,10 @@ This is a protection budget, not a live production performance certification. Ex
 
 - pure state-machine contract for open → local short-circuit → cooldown → single probe → reset;
 - negative contract: 401/403/429/500 never open the quota circuit;
-- preload behavior contract proves first target 402 reaches the caller, all six WA runtime user-agent families short-circuit after opening, and a non-target runtime remains untouched;
+- preload behavior contract proves first target 402 reaches the caller, all seven WA runtime user-agent families short-circuit after opening, and `F4-RevenueProxy` remains untouched;
 - static contract proves Railway loads the preload and the WA runtime allowlist/host scope are present;
 - historical runtime contracts normalize only this exact certified preload and continue rejecting arbitrary wrappers;
-- existing Phase S / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain mandatory;
+- existing Phase S / WA-1 / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain mandatory;
 - Performance Guard remains mandatory;
 - Zero-Cost WA-3 FINAL local Supabase/pgTAP/concurrency/rollback remains mandatory.
 

--- a/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_WA_CLOSEOUT_402_CIRCUIT_IMPACT_REPORT.md
@@ -1,0 +1,61 @@
+# ASCENDA Conversations — WA-CLOSEOUT Supabase 402 Circuit Impact Report
+
+**Workstream:** `WA-CLOSEOUT`  
+**Entry:** `main@48e7c7022bcd8bff6f2a9757717c17246e6b3e59`  
+**Risk:** HIGH  
+**Mode:** fail-closed / no production DB mutation / Zero-Cost + exact-head CI
+
+## Incident
+
+Supabase project `ituyqwstonmhnfshnaqz` is `ACTIVE_HEALTHY`, but current API logs show repeated HTTP `402` responses while the Free-plan egress quota is exhausted. WA recurrent callers continue reaching Supabase during the blocked billing window, especially `aos_wa3_actor_v1` from Phase S / WA3V2 and notification RPCs from F17.
+
+The application is therefore creating avoidable failed traffic while production cannot serve reliable data. A 402 must not be treated like a transient application error that deserves tight retry loops.
+
+## Objective
+
+Introduce a process-local Supabase quota circuit for WA runtime wrappers so that the first upstream 402 opens a bounded cooldown and subsequent Supabase calls fail locally without issuing another network request until a controlled probe window reopens.
+
+## Scope
+
+Adopt one shared helper in the WA runtime processes that currently own recurrent Supabase calls:
+
+- `app/server-phase-s.js`;
+- `app/server-wa3-v2.js`;
+- `app/server-f17.js`.
+
+The helper is process-local by design because these wrappers run as separate Node processes.
+
+## Required semantics
+
+1. First real upstream `402` opens the circuit.
+2. Circuit remains open for a bounded cooldown; default target: 15 minutes.
+3. While open, requests fail locally with a deterministic `SUPABASE_QUOTA_BLOCKED` error and `upstreamStatus=402` / `upstream_status=402` compatibility metadata.
+4. No credentials, session tokens, customer data or provider payload are stored by the circuit.
+5. 401/403/429/5xx do not open the quota circuit.
+6. Successful probe after cooldown closes/rearms normal operation.
+7. Security remains fail-closed: no actor, 2FA, ownership, RLS or permission bypass.
+8. Production data/schema are untouched.
+9. The circuit is not a substitute for the August 29 production revalidation gate.
+
+## Performance intent
+
+During a quota block, Supabase request volume from each covered WA process should collapse from recurrent polling cadence to at most one quota probe per cooldown window, rather than one failed request per UI/pump tick.
+
+This is a protection budget, not a live production performance certification. Exact live request-rate verification remains blocked until Supabase quota resets.
+
+## Tests
+
+- pure unit/behavior contract for open → short-circuit → cooldown → successful probe reset;
+- negative contract: 401/403/429/500 never open this quota circuit;
+- wrapper static/runtime contract confirms all three WA callers use the shared circuit;
+- existing Phase S / WA-2 / WA-3 / WA-4 / S14 / S15 contracts remain green;
+- Performance Guard remains green;
+- Zero-Cost WA-3 FINAL local Supabase/pgTAP/concurrency/rollback remains green.
+
+## Rollback
+
+Revert the helper adoption commit(s). No SQL rollback and no production data recovery are required because this slice makes no DB/schema mutation.
+
+## Production state
+
+Do not use Supabase Cloud for certification while 402 persists. After reset, the WA-PROD-CERT sequence must explicitly confirm `402 → 200`, then exercise auth/2FA, WA smoke, inbound/outbound, ownership, boxes, alerts and egress metrics before any `PRODUCTION CERTIFIED 100%` claim.


### PR DESCRIPTION
## WA-CLOSEOUT scope
Exact entry: `main@48e7c7022bcd8bff6f2a9757717c17246e6b3e59`.

Supabase management state is `ACTIVE_HEALTHY`, while fresh API logs show sustained HTTP 402 quota responses. Recurrent WA calls are still reaching Supabase during the blocked egress window, dominated by `aos_wa3_actor_v1`, F17 push configuration, and secure gateway persistence when provider traffic arrives.

## Change
- Add a pure process-local Supabase quota circuit.
- Load it through the existing Railway `NODE_OPTIONS` preload chain.
- Scope interception to the configured ASCENDA Supabase hostname **and** WA runtime User-Agents only: Phase-S, WA2, WA3, WA3V2, WA4, WA-Gateway, F17.
- Deliberately leave mixed `F4-RevenueProxy` traffic untouched.
- First real 402 opens a 15-minute bounded cooldown.
- Matching calls during cooldown fail locally with `SUPABASE_QUOTA_BLOCKED`; no network retry.
- After cooldown, exactly one probe is admitted per process; parallel probes are suppressed.
- Any non-402 probe releases the quota circuit.
- 401/403/429/5xx never open this quota circuit.
- No DB/schema/data change; no secrets inspected or persisted.
- Preserve 2FA, actor validation, ownership, routing, RLS and fail-closed behavior.

## CI
- Behavioral contract covers the state machine, short-circuit, single-probe, all seven WA runtime families and explicit Revenue non-target pass-through.
- Performance Guard executes the contract on `ascenda-zero-cost-v2`.
- Phase S runtime-chain CI executes syntax + behavior and accepts only the exact new preload chain.
- Historical WA2/WA3/WA4/F5/Cartera topology contracts normalize only this exact certified preload; business/data behavior is untouched.
- Existing WA/Ascenda workflows remain required.

## Production boundary
This PR is not a live certification. Supabase Cloud remains unusable as a reliable test target while 402 persists. Post-reset WA-PROD-CERT still requires 402→200, auth/2FA, inbound/outbound, ownership, boxes, alerts, provider health, egress metrics and canary.

Keep `auto_routing=false`, `ai_send=false`, `copilot=false`, `auto_reply=false`.