### PR TITLE
WA-7A baseline — BSUID-safe identity & attribution foundation

### DIFF
--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,15 +1,14 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
 **Status:** CURRENT / WHATSAPP REVENUE HUB V2  
-**Captured:** 2026-08-24 America/Lima  
-**Baseline before WA-3.5 closeout:** `main@6292852fad190f1489836fc34644a2161aa575a2`  
-**Closeout PR:** `#372`  
-**ACTIVE LOCK:** `WA-3.5 — REVENUE INBOX UX CLOSEOUT`  
-**NEXT LOCK AFTER MERGE:** `WA-7A — META ATTRIBUTION INGRESS`
+**Captured:** 2026-08-25 America/Lima  
+**Baseline:** `main@e454c9535eeff00c665794c2ac319dcc38bdf13f`  
+**WA-3.5:** `CLOSED / OFFLINE CERTIFIED 100%`  
+**ACTIVE LOCK:** `WA-7A — WHATSAPP IDENTITY & ATTRIBUTION FOUNDATION`
 
 ## Owner directive
 
-Finish WA-3.5 completely before moving the mutable lane to WA-7A. At most one HIGH/CRITICAL mutable workstream may operate at a time.
+Continue WhatsApp Revenue Hub under the improved 2026 identity model discovered before WA-7A implementation. At most one HIGH/CRITICAL mutable workstream may operate at a time.
 
 ## Preserved portfolio state
 
@@ -20,9 +19,7 @@ Finish WA-3.5 completely before moving the mutable lane to WA-7A. At most one HI
 - MKT Integrity Loop 6 V2.3 = PAUSED / RECOVERABLE.
 - CIA, Sentinel, KronIA and unrelated product/data work remain read-only/regression-only unless WA proves a strict dependency.
 
-## WA-3 / closeout baseline
-
-The certified WA foundation preserves:
+## WA foundation preserved
 
 - signed Meta gateway + replay/idempotency controls;
 - canonical conversation projection;
@@ -41,26 +38,94 @@ The certified WA foundation preserves:
 - Supabase 402 fail-closed retry containment;
 - `auto_routing=false`, `ai_send=false`, `copilot=false`, `auto_reply=false`.
 
-## WA-3.5 closeout scope
+## New WA-7A lock scope
 
-### P0 — CLOSED in product scope
+WA-7A is explicitly expanded from attribution-only to:
 
-Revenue Inbox filters, campaign selector, richer cards and shared canonical snapshot with no duplicate polling.
+`WHATSAPP IDENTITY & ATTRIBUTION FOUNDATION`.
 
-### P1A — CLOSED in product scope
+This is a corrective architecture decision based on the 2026 WhatsApp username/BSUID rollout and implementation evidence from current providers/open-source systems.
 
-Populate-only quick replies, scoped/expiring drafts, keyboard shortcuts and responsive baseline.
+### WA-7A.0 — Identity Compatibility
 
-### P2 — CLOSED in product scope
+May mutate:
 
-- DETAILS uses native WA-3 authority;
-- CUSTOMER 360 reuses REV-F6 on demand with existing patient permissions and narrow commercial projection;
-- CAMPAIGN exposes only current provenance and hands expansion to WA-7A;
-- ACTIVITY uses canonical timestamps;
-- COPILOT remains SAFE-OFF;
-- P2 is event-driven with zero timers/polling/MutationObserver.
+- WhatsApp ingress parsing;
+- channel recipient abstraction;
+- BSUID/username-safe transport contracts;
+- identity-safe message/status envelope;
+- tests/migrations strictly necessary to persist governed channel identifiers.
 
-Internal notes are a governance exclusion until a canonical write contract exists; they must not be implemented as browser-only truth.
+Must not mutate unrelated Revenue/CIA/Agenda/AI logic.
+
+### WA-7A.1 — Identity Resolution
+
+May add/adapt channel alias contracts that hand off to canonical REV/F5 identity resolution.
+
+Must not create a parallel person/customer master.
+
+### WA-7A.2 — Verification & Continuity
+
+May handle:
+
+- identifier update events;
+- old/new BSUID lineage;
+- governed contact-info disclosure;
+- verification/source metadata.
+
+Must not silently overwrite canonical contact facts.
+
+### WA-7A.3 — Attribution Ingress
+
+May persist immutable CTWA/referral/touchpoint evidence.
+
+Must not infer attribution from phone, username or customer identity alone.
+
+### WA-7A.4 — Marketing Eligibility Foundation
+
+May model addressability/reachability/consent/suppression/preferences needed by future campaigns.
+
+Must not build or activate bulk marketing sending yet.
+
+## Mandatory identity invariants
+
+- `phone` is nullable for WhatsApp.
+- BSUID is an alias, not the canonical ASCENDA person id.
+- BSUID is portfolio-scoped.
+- username is display-only and mutable.
+- username must never be a routing primary key or cold-marketing import key.
+- identifier changes preserve lineage; no destructive overwrite.
+- phone disclosure does not automatically imply verified ownership.
+- Contact Book is provider assistance, not canonical identity.
+- provider-specific payload naming remains inside adapter/transport boundaries.
+
+## Mandatory attribution invariants
+
+- `BSUID != ctwa_clid/touchpoint`.
+- one canonical person may have many acquisition touchpoints.
+- first-inbound provenance is immutable evidence.
+- webhook signature and replay/idempotency remain mandatory.
+- missing referral fields must degrade safely.
+- no broad Ads sync before WA-7B.
+
+## Mandatory marketing invariants
+
+- `IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
+- a technically reachable recipient is not automatically marketing-authorized.
+- future bulk campaigns operate on governed WhatsApp recipients, not just phone-number rows.
+- consumer username discovery/scraping is not a supported growth strategy.
+- auth templates that require phone remain phone-only.
+
+## Current known technical debt to resolve first
+
+`app/wa-gateway.js` currently:
+
+- digit-normalizes `msg.from`;
+- looks up contact `wa_id` through phone normalization;
+- stores inbound identity in `from_number`;
+- requires outbound `to` to normalize to an 8–15 digit phone number.
+
+Therefore WA-7A implementation must begin with an identity-compatibility contract before new attribution persistence is allowed.
 
 ## Production hold
 
@@ -69,25 +134,16 @@ Supabase production remains HTTP 402. Therefore:
 - no production auth bypass;
 - no Cloud write retries merely to exercise WA;
 - historical counts are not fresh readback;
-- `WA-3.5 LIVE / PRODUCTION CERTIFIED 100%` remains false;
-- code/CI/Zero-Cost closeout may complete independently.
+- WA LIVE certification remains false;
+- code/CI/Zero-Cost implementation may continue independently.
 
-LIVE recovery gate:
+LIVE recovery gate remains:
 
-`402 → 200 → Railway exact health → Auth/2FA → provider health → signed inbound → allowlisted outbound → terminal delivery → CESAR↔MIREYA handoff/claim/send/reassign/isolation/readback → notifications → WA-3.5 visual smoke → egress observation`.
+`402 → 200 → Railway exact health → Auth/2FA → provider health → signed inbound → allowlisted outbound → terminal delivery → CESAR↔MIREYA handoff/claim/send/reassign/isolation/readback → notifications → WA visual smoke → egress observation`.
 
 ## Lock transition rule
 
-The mutable lock moves to `WA-7A — META ATTRIBUTION INGRESS` only after:
-
-1. PR #372 final exact-head `ASCENDA WA-3.5 Closeout` = SUCCESS;
-2. `main` anti-drift readback passes;
-3. merge uses exact `expected_head_sha`;
-4. Railway status for the merge is checked;
-5. GitHub CURRENT + certificate are reconciled;
-6. Notion is updated last.
-
-WA-7A may then mutate only attribution-ingress scope. It must not simultaneously open WA-4/WA-5/WA-6 product mutations.
+WA-7A remains the sole mutable HIGH/CRITICAL lane until its scoped closeout is certified. WA-4A must not become mutable merely because an individual WA-7A subphase passes.
 
 ## Safety invariants
 
@@ -95,7 +151,8 @@ WA-7A may then mutate only attribution-ingress scope. It must not simultaneously
 - no secrets in Git/Notion/chat/frontend;
 - no autonomous diagnosis;
 - no AI auto-reply before future controlled-autonomy gates;
-- no attribution from phone alone;
+- no phone-only attribution;
+- no username-only merge;
 - no parallel CRM/Agenda/sales/email truth;
 - fail-closed recovery;
 - exact-head → merge → reconciliation → next lock.

--- a/docs/control/WHATSAPP_REVENUE_HUB_CURRENT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_CURRENT.md
@@ -1,61 +1,163 @@
 # ASCENDA Conversations — WhatsApp Revenue Hub — CURRENT
 
-**Captured:** 2026-08-24 America/Lima  
+**Captured:** 2026-08-25 America/Lima  
 **Program:** `WHATSAPP-REVENUE-HUB-V2`  
-**Current closeout PR:** `#372 — WA-3.5 Closeout`  
-**Baseline before PR #372:** `main@6292852fad190f1489836fc34644a2161aa575a2`  
-**WA-3.5 product code head:** `71a8a327bf832c58ea50b0998a41a73306e30bdb`  
+**GitHub baseline:** `main@e454c9535eeff00c665794c2ac319dcc38bdf13f`  
+**WA-3.5 closeout:** `PR #372 — MERGED / CODE-CI-ZERO-COST OFFLINE CERTIFIED 100%`  
 **Production hold:** Supabase project `ituyqwstonmhnfshnaqz` currently HTTP 402
 
 ## Current phase state
 
 - `WA-V2-0 — Baseline & Governance` = **CLOSED**.
 - `WA-3 — Human Operations Multiagent` = **OFFLINE CERTIFIED / LIVE HOLD**.
-- `WA-3.5 — Revenue Inbox UX` = **CLOSEOUT / CODE-CI-ZERO-COST** in PR #372.
-- `WA-7A — Meta Attribution Ingress` = **NEXT MUTABLE PHASE AFTER #372 MERGE**.
+- `WA-3.5 — Revenue Inbox UX` = **OFFLINE CERTIFIED 100% / LIVE HOLD**.
+- `WA-7A — WhatsApp Identity & Attribution Foundation` = **ACTIVE NEXT MUTABLE PHASE**.
 - `WA-4A/B/C`, `WA-5`, `WA-6`, `WA-7B/C/D`, `WA-8`, `WA-9..14` = future roadmap.
 - Notifications `S13 → S15.5` = **CLOSED / REGRESSION ONLY**.
 - Existing WA-4 infrastructure remains **SAFE-OFF**: `ai_send=false`, `copilot=false`, `auto_reply=false`.
+- `auto_routing=false` remains fail-closed during the current LIVE hold.
 
-## WA-3.5 implemented scope
+## Why WA-7A was expanded before implementation
 
-### P0 — Revenue Inbox
+The 2026 WhatsApp username rollout changes the identity contract of the channel:
 
-- shared canonical inbox snapshot; no duplicate read owner;
-- filters for all/mine, human requested, unread, waiting customer, bot/AI-active and finalised;
-- canonical campaign filter;
-- richer cards with direction/time, unread, owner, campaign, handoff age and 24h state;
-- canonical state model preserved.
+- a consumer phone number may be absent from inbound/outbound messaging payloads;
+- WhatsApp supplies a Business-Scoped User ID (`BSUID`) for the business-portfolio/user relationship;
+- username is informational/display data and must not be treated as the routing or canonical identity key;
+- BSUID is portfolio-scoped and may change when the WhatsApp user changes phone number;
+- authentication templates such as one-tap/zero-tap/copy-code still require phone numbers;
+- phone availability and WhatsApp reachability are now separate concepts.
 
-### P1A — Advisor productivity
+ASCENDA therefore must stop assuming `WhatsApp identity == numero_limpio`.
 
-- safe quick replies that populate, never auto-send;
-- actor+conversation drafts, bounded and expiring;
-- keyboard shortcuts;
-- responsive baseline;
-- no internal-note browser truth.
+Current `app/wa-gateway.js` is still phone-first: it normalizes `msg.from` to digits and outbound validates `to` as an 8–15 digit phone number. WA-7A must fix this before attribution features depend on the old assumption.
 
-### P2 — Governed context
+## New identity model
 
-- `DETAILS` keeps native WA-3 operational authority;
-- `CUSTOMER 360` reuses canonical REV-F6 Patient 360 on demand and existing patient permissions;
-- `CAMPAIGN` exposes existing `campaign_source`, `ad_id`, `lead_id` only and hands expanded provenance to WA-7A;
-- `ACTIVITY` derives from canonical conversation timestamps;
-- `COPILOT` remains visible SAFE-OFF pending WA-4A/B/C;
-- tablet/mobile Context drawer and explicit degraded/empty states;
-- P2 owns zero polling timers, zero MutationObserver, zero direct WA `/api/` calls and zero provider/Cloud transport.
+WhatsApp channel identity is now modeled as aliases attached to an existing canonical ASCENDA person/contact boundary, not as a replacement CRM identity.
+
+### Channel identity facts
+
+Store when supplied and governed:
+
+- `phone_e164` — nullable;
+- `whatsapp_bsuid` — portfolio-scoped routing identity;
+- `whatsapp_parent_bsuid` — optional lineage field when emitted by provider/platform;
+- `whatsapp_username` — display/search aid only;
+- `business_portfolio_id`;
+- validity/status metadata for identifier changes;
+- provider evidence and observed timestamps.
+
+Never use username as a primary key or marketing-address import key.
+
+### Recipient abstraction
+
+Outbound code must move from a phone-only parameter to a channel recipient contract conceptually equivalent to:
+
+`ChannelRecipient { channel=WHATSAPP, kind=PHONE|BSUID, value, portfolio_id }`.
+
+Adapters may expose provider-specific field names, but product/business logic must not depend on them.
+
+## WA-7A subphases
+
+### WA-7A.0 — Identity Compatibility
+
+- accept phone+BSUID or BSUID-only inbound safely;
+- preserve username as display-only;
+- eliminate phone-only parsing/routing assumptions;
+- support outbound routing by PHONE or BSUID where the provider permits it;
+- preserve auth-template phone-only restrictions;
+- no duplicate conversation/contact creation merely because phone visibility changes.
+
+### WA-7A.1 — Identity Resolution
+
+- link channel aliases to existing canonical identity through governed REV/F5 boundaries;
+- never auto-merge persons from username similarity;
+- phone matching may help identity resolution but is never attribution authority;
+- conflicting identifiers fail closed to review/explicit resolution.
+
+### WA-7A.2 — Identity Verification & Continuity
+
+- consume identifier-update events when supplied (`user_id_update`/provider equivalent);
+- retain old→new BSUID lineage instead of destructive overwrite;
+- support governed `REQUEST_CONTACT_INFO` acquisition when useful;
+- distinguish `VERIFIED / CLAIMED / UNKNOWN / CONFLICT` contact data;
+- Contact Book may assist continuity but is not ASCENDA's canonical identity store.
+
+### WA-7A.3 — Attribution Ingress
+
+Persist immutable first-inbound provenance when supplied:
+
+- `ctwa_clid` or provider-equivalent CTWA click identifier;
+- referral/source id and source type;
+- source URL when supplied and policy-safe;
+- ad id;
+- lead id;
+- campaign source;
+- headline/body when permitted;
+- sanitized raw referral evidence;
+- immutable touchpoint id;
+- message/provider/replay identifiers and observed timestamps.
+
+`BSUID` identifies a WhatsApp relationship. `ctwa_clid`/touchpoint identifies acquisition provenance. They are not interchangeable.
+
+### WA-7A.4 — Marketing Eligibility Foundation
+
+This does **not** build the bulk campaign product yet. It creates the governed foundation:
+
+- recipient identity;
+- WhatsApp reachability;
+- marketing consent/eligibility;
+- user marketing preference (`stop/resume` or provider equivalent);
+- suppression reason;
+- last eligibility observation.
+
+Core rule:
+
+`IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
+
+A reachable BSUID is not automatically marketing consent.
+
+## Acquisition / marketing implications
+
+- Consumer usernames do not become a cold-prospect directory or scrape/import list.
+- A WhatsApp-native lead can be valuable even when `phone_e164 = NULL` if a governed BSUID relationship exists.
+- Business username can become a new inbound acquisition source and should be preserved as provenance when observable.
+- Future campaigns must address eligible WhatsApp recipients, not merely rows that contain phone numbers.
+- Cold username blasting is out of scope and must not be inferred as supported behavior.
+
+## Attribution architecture
+
+Target:
+
+`Meta Ad / Business Username / Organic / QR / Web → signed WhatsApp ingress → immutable touchpoint/provenance → WhatsApp channel identity → canonical identity resolver → conversation → appointment/sale/revenue`.
+
+A single person may have multiple touchpoints. Never collapse customer identity and acquisition touchpoint into one record.
+
+## WA-3.5 preserved scope
+
+WA-3.5 remains closed in product scope:
+
+- P0 Revenue Inbox;
+- P1A advisor productivity;
+- P2 governed `DETAILS / CUSTOMER 360 / CAMPAIGN / ACTIVITY / COPILOT`;
+- zero P2 polling/timers/MutationObserver;
+- Customer 360 on demand through canonical REV-F6 permission boundaries;
+- Copilot SAFE-OFF.
 
 ## Security / authority invariants
 
-- explicit `whatsapp-agent` permission and strong Auth V3/2FA;
-- boxes/members/`max_active`;
-- AVAILABLE/AWAY/OFFLINE readiness with fail-closed stale handling;
-- `HUMAN_REQUESTED` queue semantics;
-- queue privacy;
-- claim/reassign/release and concurrent single-owner claim;
-- exact-owner human send + customer 24h window;
-- supervisor/manual intervention and ownership-loss recovery;
-- `auto_routing=false`, `ai_send=false`, `copilot=false`, `auto_reply=false` during live hold.
+- signed Meta webhook + replay/idempotency;
+- strong Auth V3/2FA;
+- explicit `whatsapp-agent` authorization;
+- exact-owner send + customer 24h window;
+- queue/privacy/claim/reassign/release/supervisor controls;
+- one active HIGH/CRITICAL mutable workstream;
+- no secrets in frontend/Git/Notion;
+- no phone-only attribution;
+- no username-only identity merge;
+- no parallel CRM/Agenda/revenue truth;
+- no AI auto-reply/autonomous send.
 
 Canonical persisted conversation states remain:
 
@@ -63,34 +165,23 @@ Canonical persisted conversation states remain:
 
 There is no persisted literal `BOT_ACTIVE`.
 
-## WA-3.5 product-head evidence
-
-At `71a8a327bf832c58ea50b0998a41a73306e30bdb` the following passed:
-
-- WA-3.5 Closeout;
-- WA-3 Boxes Routing Handoff with local DB/pgTAP/concurrency/rollback;
-- WA-3.5 P1A including P0 regression;
-- WA-3 FINAL Presence Handoff FAST + DB;
-- Performance Guard;
-- ASC-PERF Audit 360;
-- S14 Web Push;
-- S15 Unified Notifications.
-
-The final certification/documentation head is governed by `ASCENDA WA-3.5 Closeout`; docs-only changes do not alter the validated product code tree.
-
 ## Production boundary
 
-`WA-3.5 LIVE / PRODUCTION CERTIFIED 100% = NOT YET`.
+`WA LIVE / PRODUCTION CERTIFIED 100% = NOT YET` while Supabase production remains HTTP 402 and fresh provider/session canaries cannot be executed.
 
-Do not bypass login or security while Supabase is on 402. When Cloud recovers, perform exact-SHA Railway health, Auth/2FA, provider health, signed inbound, allowlisted outbound, terminal status, CESAR↔MIREYA handoff/claim/send/reassign/isolation/readback, notifications, Revenue Inbox visual smoke and egress observation.
+When Cloud recovers, historical evidence does not substitute fresh certification.
 
-## Next lock
+## External research baseline
 
-After PR #372 merges with its exact expected head and final closeout gate green:
+Architecture update is based on the 2026 WhatsApp username/BSUID rollout plus observed ecosystem migration patterns. Confirmed provider behavior includes:
 
-`WA-7A — META ATTRIBUTION INGRESS`.
+- Twilio WhatsApp Usernames / BSUID rollout and Peru rollout group;
+- BSUID as `ExternalUserId`, phone nullable, username informational;
+- BSUID portfolio scope and regeneration on phone-number change;
+- outbound BSUID support with authentication-template exceptions;
+- Contact Book as a provider continuity aid, not a replacement for ASCENDA canonical identity.
 
-WA-7A owns explicit first-inbound Meta provenance/touchpoints. Attribution must never be fabricated from phone matching.
+Community/BSP implementations are treated as engineering evidence, not policy authority. Provider/Meta policy must be rechecked at implementation and LIVE certification time.
 
-Authoritative certificate: `docs/control/WHATSAPP_REVENUE_HUB_WA_3_5_OFFLINE_CERTIFICATE.md`.
+Authoritative design contract: `docs/control/WHATSAPP_WA_7A_IDENTITY_ATTRIBUTION_FOUNDATION.md`.
 Authoritative roadmap: `docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md`.

--- a/docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md
@@ -1,29 +1,32 @@
 # ASCENDA Conversations — WhatsApp Revenue Hub V2 — ROADMAP CURRENT
 
-**Captured:** 2026-08-24 America/Lima  
-**Baseline before WA-3.5 closeout:** `main@6292852fad190f1489836fc34644a2161aa575a2`  
-**Active closeout:** `WA-3.5 / PR #372`  
-**Next mutable phase after merge:** `WA-7A — META ATTRIBUTION INGRESS`  
-**LIVE hold:** Supabase HTTP 402 + provider/session canary recertification
+**Captured:** 2026-08-25 America/Lima  
+**Current GitHub baseline:** `main@e454c9535eeff00c665794c2ac319dcc38bdf13f`  
+**WA-3.5:** `CLOSED / CODE-CI-ZERO-COST OFFLINE CERTIFIED 100%`  
+**Active next mutable phase:** `WA-7A — WHATSAPP IDENTITY & ATTRIBUTION FOUNDATION`  
+**LIVE hold:** Supabase HTTP 402 + fresh provider/session canary recertification
 
 ## North Star
 
-`Meta Ads / Organic → WhatsApp → explicit provenance → canonical identity → conversation → handling state + sales stage → knowledge → human/AI → business tools → appointment/follow-up/call → attendance → sale → revenue attribution → learning`.
+`Meta Ads / Business Username / Organic / QR / Web → WhatsApp → explicit provenance + channel identity → canonical identity → conversation → handling state + sales stage → knowledge → human/AI → business tools → appointment/follow-up/call → attendance → sale → revenue attribution → learning`.
 
 ## Architecture rules
 
 - WA is a governed conversation/channel product, not a CRM replacement.
-- F5 owns canonical identity/provenance resolution boundaries.
-- REV/F3/F4/F6 own revenue and Customer 360 truth.
-- CIA owns governed acquisition/channel facts.
-- Agenda and Call Center remain existing ASCENDA systems consumed through contracts.
+- The phone number is a contact point, not a mandatory WhatsApp primary key.
+- BSUID is a WhatsApp channel identity alias scoped to the business portfolio.
+- Username is informational/display data and is never canonical routing identity.
+- Canonical person resolution remains governed by REV/F5 identity boundaries.
+- Acquisition touchpoints are separate from person/channel identity.
+- `ctwa_clid`/referral evidence identifies provenance; it must not be confused with BSUID.
 - Meta attribution requires explicit provenance; phone matching alone is never attribution authority.
+- `IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
 - Knowledge is source-governed; a general model is never authoritative for price, promo, availability, stock or clinical facts.
 - CODE/CI/ZERO-COST certification is distinct from LIVE production certification.
 
 ## Phase graph
 
-`WA-V2-0 ✅ → WA-3 ✅ OFFLINE → WA-3.5 ✅ OFFLINE CLOSEOUT → WA-7A → WA-4A → WA-4B → WA-4C → WA-5 → WA-6 → WA-7B → WA-7C → WA-7D → WA-8 → WA-9..WA-14`
+`WA-V2-0 ✅ → WA-3 ✅ OFFLINE → WA-3.5 ✅ OFFLINE → WA-7A [0→4] → WA-4A → WA-4B → WA-4C → WA-5 → WA-6 → WA-7B → WA-7C → WA-7D → WA-8 → WA-9..WA-14`
 
 ## WA-V2-0 — Baseline & Governance
 
@@ -37,75 +40,164 @@ Implemented: permissions/2FA, boxes/members/max-active, presence/readiness, huma
 
 ## WA-3.5 — Revenue Inbox UX
 
-**Status: CODE/CI/ZERO-COST CLOSEOUT — PR #372.**
+**Status: OFFLINE CERTIFIED 100% / LIVE HOLD.**
 
-### P0 — canonical workspace foundation — DONE
+### Closed scope
 
-- all / mine / human requested / unread / waiting customer / bot-AI / finalised filters;
-- campaign filter from canonical `campaign_source`;
-- richer conversation cards and handoff/24h context;
-- existing timeline and notification/auth restoration preserved;
-- shared inbox snapshot remains the single read owner.
+- P0 canonical Revenue Inbox;
+- P1A advisor productivity;
+- P2 governed side-panel context;
+- no duplicate inbox read owner;
+- no browser-only internal notes;
+- no P2 polling/timers/MutationObserver;
+- Customer 360 reuses REV-F6 on-demand/permission-gated;
+- Campaign exposes factual provenance only;
+- Copilot remains SAFE-OFF.
 
-### P1A — advisor productivity — DONE
+## WA-7A — WhatsApp Identity & Attribution Foundation — ACTIVE NEXT
 
-- generic quick replies, populate-only;
-- per-actor/per-conversation drafts with TTL and size bound;
-- keyboard shortcuts;
-- responsive baseline;
-- no browser-only internal notes.
+### Why this precedes attribution-only implementation
 
-### P2 — governed side-panel context — DONE
+The 2026 WhatsApp username rollout means new conversations may not expose a consumer phone number. Existing ASCENDA WA gateway behavior is phone-first, so attribution must not be built on top of a soon-invalid identity assumption.
 
-- `DETAILS` — native WA-3 authority;
-- `CUSTOMER 360` — canonical REV-F6 read model, on-demand and permission-gated, narrow commercial projection;
-- `CAMPAIGN` — current factual provenance only;
-- `ACTIVITY` — canonical conversation milestones;
-- `COPILOT` — SAFE-OFF integration boundary;
-- mobile Context drawer and explicit degraded states;
-- event-driven only: zero P2 pollers/timers/MutationObserver.
+WA-7A therefore owns both:
 
-### WA-3.5 governance exclusions
+1. **channel identity compatibility/continuity**, and
+2. **immutable acquisition provenance at first inbound**.
 
-- internal notes require a governed persistence contract; they are not browser truth;
-- treatment/sales-stage are not fabricated merely to satisfy UI filters;
-- private media/STT belongs to WA-5;
-- Copilot autonomy belongs to WA-4C;
-- expanded attribution belongs to WA-7A.
+It does not replace canonical ASCENDA identity and does not yet build the full campaign manager.
 
-### WA-3.5 LIVE exit
+### WA-7A.0 — Identity Compatibility
 
-Requires Supabase recovery plus a fresh real production smoke. Until then: offline certified only.
+**Goal:** make WhatsApp transport identity phone-optional.
 
-## WA-7A — Meta Attribution Ingress — NEXT
+Required:
 
-**Purpose:** preserve explicit Meta provenance at the first inbound, before identity or downstream business logic can blur the original touchpoint.
+- parse and persist phone+BSUID or BSUID-only safely;
+- store username only as display/search aid;
+- keep business portfolio scope with BSUID;
+- replace phone-only recipient assumptions with `PHONE|BSUID`;
+- retain phone-only restriction for authentication template types that require it;
+- update tests so an alphanumeric BSUID cannot be digit-normalized or rejected as an invalid phone;
+- preserve all WA-1/WA-3 auth/ownership/idempotency authority.
 
-### Target facts
+Exit:
 
-Persist when supplied by Meta:
+- inbound BSUID-only does not create blank/garbled `from_number`;
+- outbound can address a governed BSUID where provider support permits;
+- no existing phone-based conversation regression.
 
+### WA-7A.1 — Identity Resolution
+
+**Goal:** connect channel aliases to canonical ASCENDA identity without unsafe merges.
+
+Required:
+
+- alias model linking `canonical_contact/person` ↔ `phone` ↔ `BSUID` ↔ optional username;
+- explicit portfolio scope;
+- conflict states;
+- no merge from username similarity;
+- no assumption that BSUID is a universal cross-portfolio customer ID;
+- reuse REV/F5 resolution contracts rather than creating a parallel CRM.
+
+Exit:
+
+- same person is not duplicated solely because phone visibility changes;
+- conflicts fail closed;
+- identity evidence is auditable.
+
+### WA-7A.2 — Identity Verification & Continuity
+
+**Goal:** preserve identity through contact disclosure and WhatsApp identifier changes.
+
+Required:
+
+- consume `user_id_update` or provider-equivalent events when available;
+- retain prior/current BSUID lineage;
+- support governed `REQUEST_CONTACT_INFO` acquisition where useful;
+- distinguish contact source and verification state;
+- optionally use delivery/status evidence as corroboration only when contractually reliable;
+- treat Contact Book as provider-side assistance, never canonical ASCENDA identity.
+
+Suggested contact states:
+
+`VERIFIED / CLAIMED / UNKNOWN / CONFLICT`.
+
+Exit:
+
+- identifier replacement never destroys lineage;
+- newly disclosed phone joins the existing identity instead of creating a duplicate;
+- unverified contact claims cannot silently override canonical data.
+
+### WA-7A.3 — Attribution Ingress
+
+**Goal:** preserve immutable acquisition touchpoints at the first inbound.
+
+Persist when supplied:
+
+- `ctwa_clid` or provider-equivalent click identifier;
 - referral/source id and source type;
-- referral headline/body where policy permits;
+- source URL when supplied and policy-safe;
 - ad id;
 - lead id;
 - campaign source;
+- headline/body when permitted;
 - sanitized raw referral evidence;
 - immutable touchpoint id;
-- received-at/provider identifiers necessary for replay/idempotency.
+- provider message/event ids;
+- replay/idempotency evidence and observed timestamps.
 
-### Flow
+Flow:
 
-`Meta signed webhook → referral parser → immutable provenance/touchpoint → canonical conversation → identity resolver`.
+`Meta signed webhook → identity-safe envelope → provenance parser → immutable touchpoint → canonical conversation → identity resolver`.
 
-### Rules
+Rules:
 
+- `BSUID != touchpoint`;
+- one customer may own many touchpoints;
 - no attribution from phone alone;
-- webhook signature and replay/idempotency remain mandatory;
-- provenance is immutable evidence, not a mutable CRM label;
-- parser must degrade safely when referral fields are absent;
-- no broad Meta Ads sync yet — that belongs to WA-7B;
-- real CTWA/live provider canary remains required for LIVE exit when Cloud is available.
+- parser degrades safely when referral/CTWA fields are absent;
+- no broad Meta Ads sync yet — that belongs to WA-7B.
+
+### WA-7A.4 — Marketing Eligibility Foundation
+
+**Goal:** prepare future campaigns without conflating addressability and consent.
+
+Persist/derive through governed contracts:
+
+- recipient identity kind/value;
+- WhatsApp reachability;
+- marketing consent/eligibility;
+- `stop/resume` or provider-equivalent preference events;
+- suppression reason;
+- last eligibility observation.
+
+Rules:
+
+- a BSUID-only contact can be a valid WhatsApp-native customer/lead;
+- reachable does not mean marketing-authorized;
+- username is not a cold-prospect import key;
+- no consumer-username scraping/directory assumption;
+- no bulk marketing engine in WA-7A.
+
+Exit:
+
+- future campaign engine can select eligible WhatsApp recipients by governed recipient identity instead of requiring every row to have a phone number.
+
+## Future campaign identity model
+
+Conceptual audience decomposition:
+
+- `PHONE + BSUID`;
+- `BSUID-only`;
+- `PHONE-only`;
+- `not WhatsApp reachable`.
+
+Marketing eligibility is then evaluated separately from identity/reachability.
+
+## Business Username inbound
+
+Business username may become a new inbound acquisition/discovery source. When provider evidence identifies this origin, preserve it as provenance. Do not infer it merely because a business username exists.
 
 ## WA-4A — Knowledge Fabric
 
@@ -151,6 +243,13 @@ SLO/error budgets, provider failure policy, load/performance, cost ceilings, ret
 - WA-12 Controlled AI Autonomy;
 - WA-13 Revenue Optimization;
 - WA-14 reusable platform core.
+
+## Research / evidence policy for WA-7A
+
+- Meta/provider current documentation is policy/transport authority.
+- BSPs and public repositories are implementation evidence, not permission to assume policy behavior.
+- Any capability observed only in community code remains provisional until verified against current provider behavior.
+- Re-check rollout/policy immediately before LIVE certification because usernames/BSUID behavior is actively rolling out during 2026.
 
 ## Standard phase loop
 

--- a/docs/control/WHATSAPP_WA_7A_IDENTITY_ATTRIBUTION_FOUNDATION.md
+++ b/docs/control/WHATSAPP_WA_7A_IDENTITY_ATTRIBUTION_FOUNDATION.md
@@ -1,0 +1,252 @@
+# WA-7A — WhatsApp Identity & Attribution Foundation
+
+**Decision date:** 2026-08-25 America/Lima  
+**Status:** ARCHITECTURE BASELINE / PRE-IMPLEMENTATION  
+**Parent program:** `WHATSAPP-REVENUE-HUB-V2`  
+**Baseline:** `main@e454c9535eeff00c665794c2ac319dcc38bdf13f`  
+**Mutable lane:** `WA-7A`
+
+## 1. Decision
+
+WA-7A is expanded from `Meta Attribution Ingress` to:
+
+`WhatsApp Identity & Attribution Foundation`.
+
+Reason: the 2026 WhatsApp username rollout makes consumer phone numbers optional in messaging relationships. Building attribution on the existing phone-first gateway would create identity loss/duplication and routing failures.
+
+## 2. Evidence classification
+
+### Confirmed provider behavior
+
+Current provider documentation confirms:
+
+- WhatsApp usernames can mask a consumer phone number;
+- BSUID is supplied as the business-scoped routing identity;
+- phone may be absent;
+- username is informational and does not control delivery;
+- BSUID is scoped to a business portfolio;
+- BSUID may regenerate if the WhatsApp user changes phone number;
+- outbound BSUID messaging is supported for normal messaging types where rollout/provider support permits;
+- one-tap/zero-tap/copy-code authentication templates require phone numbers;
+- Contact Book can preserve phone+BSUID relationships but is portfolio-scoped and configurable.
+
+### Engineering evidence, not policy authority
+
+Public BSP/open-source migrations show recurring implementation hazards:
+
+- duplicate contacts when phone+BSUID later becomes BSUID-only;
+- split conversation history;
+- phone validators corrupting/rejecting BSUID values;
+- reply/status paths that assume E.164;
+- need for recipient abstraction and identity aliases.
+
+ASCENDA treats these as design evidence. Policy/permission decisions remain governed by current Meta/provider documentation at implementation and LIVE time.
+
+## 3. Non-goals
+
+WA-7A does not:
+
+- create a new CRM/customer master;
+- infer customer identity from username;
+- infer attribution from phone;
+- build Meta Ads bulk sync (`WA-7B`);
+- build the bulk campaign sender;
+- activate AI/Copilot/auto-routing;
+- scrape/discover consumer usernames;
+- bypass marketing consent/eligibility rules.
+
+## 4. Identity entities
+
+### Canonical person/contact
+
+Owned by existing ASCENDA identity boundaries.
+
+### WhatsApp channel alias
+
+Minimum conceptual fields:
+
+- `canonical_identity_id` or governed unresolved reference;
+- `business_portfolio_id`;
+- `bsuid`;
+- `username` nullable/display-only;
+- `phone_e164` nullable;
+- `status`;
+- `valid_from`;
+- `valid_to`;
+- `superseded_by`;
+- `observed_at`;
+- provider evidence reference.
+
+Optional provider fields such as `parent_bsuid` may be preserved when actually emitted and understood.
+
+### Channel recipient
+
+Provider-neutral interface:
+
+```text
+ChannelRecipient
+- channel: WHATSAPP
+- kind: PHONE | BSUID
+- value
+- portfolio_id
+```
+
+Transport adapters map this to Meta/BSP-specific payload fields.
+
+## 5. Identity resolution rules
+
+- exact existing alias match is strongest channel continuity evidence;
+- BSUID cannot be assumed universal across portfolios;
+- username similarity provides no automatic merge authority;
+- phone can be a matching signal, but conflicting canonical identities fail closed;
+- transition from phone-visible to BSUID-only must retain the same conversation/contact when evidence supports continuity;
+- newly disclosed phone joins existing identity only through governed resolution;
+- identifier update events preserve old→new lineage.
+
+## 6. Contact verification
+
+Contact facts should carry source and confidence/verification state.
+
+Suggested verification values:
+
+`VERIFIED / CLAIMED / UNKNOWN / CONFLICT`.
+
+Suggested sources:
+
+`META_CONTACT_REQUEST / EXISTING_CRM / LEAD_FORM / MANUAL / IMPORT / PROVIDER_CONTACT_BOOK / OTHER`.
+
+`REQUEST_CONTACT_INFO` is the preferred native mechanism when the product legitimately needs the user's phone. A manually typed or forwarded contact must not silently become verified ownership.
+
+## 7. Attribution / provenance entities
+
+Identity and touchpoint are different entities.
+
+### Channel identity
+
+Who/which WhatsApp relationship is speaking:
+
+`BSUID / PHONE`.
+
+### Acquisition touchpoint
+
+Why/how the conversation originated:
+
+- `ctwa_clid` or provider-equivalent CTWA click id;
+- referral/source id/type;
+- source URL when supplied;
+- `ad_id`;
+- `lead_id`;
+- campaign source;
+- headline/body when permitted;
+- immutable raw/sanitized evidence;
+- provider message/event IDs;
+- received/observed timestamp.
+
+A single canonical person may own multiple touchpoints.
+
+## 8. Ingress ordering
+
+Target:
+
+`signed webhook → replay/idempotency gate → identity-safe envelope → provenance parser → immutable touchpoint → conversation projection → canonical identity resolver`.
+
+Do not digit-normalize unknown sender identifiers before identifying their type.
+
+## 9. Marketing foundation
+
+Future campaigns must operate on governed WhatsApp recipients.
+
+Separate:
+
+1. **Identity** — whom the channel relationship represents.
+2. **Reachability** — whether WhatsApp can technically address the recipient.
+3. **Marketing eligibility** — whether the recipient may receive the intended marketing category at that time.
+
+Suggested eligibility metadata:
+
+- consent/eligibility state;
+- preference stop/resume state when provider emits it;
+- suppression reason;
+- last observed/checked time;
+- policy/provider evidence.
+
+No inference:
+
+`BSUID present → marketing consent`.
+
+## 10. Consumer vs business username
+
+### Consumer username
+
+- optional;
+- user-controlled;
+- mutable;
+- display/discovery mechanism inside WhatsApp;
+- never canonical key;
+- never cold-prospect import key.
+
+### Business username
+
+May become a valid inbound discovery/acquisition source. Preserve explicit evidence of that source when available; do not fabricate provenance merely because the business owns a username.
+
+## 11. Current ASCENDA gap
+
+`app/wa-gateway.js` currently assumes phone identity:
+
+- `normalizePhone(msg.from)`;
+- normalized `wa_id` contact comparison;
+- `from_number` as inbound identity;
+- outbound `to` requires 8–15 digits.
+
+This is the first implementation boundary to change.
+
+## 12. Required CI contracts before DB/product expansion
+
+At minimum:
+
+1. BSUID-only inbound survives parsing unchanged.
+2. phone+BSUID inbound preserves both identifiers.
+3. username never controls routing.
+4. PHONE outbound remains compatible.
+5. BSUID outbound does not pass through E.164 validation.
+6. auth templates reject BSUID where provider requires phone.
+7. contact/identity continuity does not duplicate when phone disappears.
+8. identifier update preserves lineage.
+9. touchpoint and channel identity remain separate.
+10. absent referral/CTWA data does not fabricate attribution.
+11. replay/idempotency remains exact.
+12. existing WA-3 owner/2FA/24h send authority remains intact.
+
+## 13. Subphase order
+
+`WA-7A.0 Identity Compatibility`
+→ `WA-7A.1 Identity Resolution`
+→ `WA-7A.2 Verification & Continuity`
+→ `WA-7A.3 Attribution Ingress`
+→ `WA-7A.4 Marketing Eligibility Foundation`.
+
+Do not skip 7A.0 to implement CTWA fields first.
+
+## 14. LIVE hold
+
+Supabase HTTP 402 currently prevents fresh production certification. Offline/code/CI work may continue. Any provider behavior that cannot be proven offline remains explicitly `LIVE_PENDING`.
+
+## 15. Revalidation rule
+
+Usernames/BSUID rollout and provider behavior are actively changing during 2026. Before each externally dependent implementation slice and before LIVE certification:
+
+- re-check current Meta/provider documentation;
+- compare current payload examples/field names;
+- keep provider-specific names in adapters;
+- update this contract if authoritative behavior changes.
+
+## 16. External baseline references
+
+- Twilio changelog — WhatsApp Usernames supported, July 7 2026:
+  `https://www.twilio.com/en-us/changelog/whatsapp-usernames`
+- Twilio key concepts — usernames, BSUID, Contact Book, rollout:
+  `https://www.twilio.com/docs/whatsapp/key-concepts`
+- Twilio developer guidance — identity migration, July 29 2026:
+  `https://www.twilio.com/en-us/blog/products/whatsapp-just-changed-how-customers-identify-themselves`
+
+These references document provider-observed Meta behavior; current Meta/provider policy remains authoritative at execution time.


### PR DESCRIPTION
## Purpose
Formalize the improved WA-7A architecture before product/runtime implementation.

## Why
WhatsApp Usernames/BSUID rollout means consumer phone numbers can be absent. Current `app/wa-gateway.js` remains phone-first (`normalizePhone(msg.from)` and E.164-only outbound validation). Attribution must not be built on that assumption.

## Decisions
- Rename/expand WA-7A to **WhatsApp Identity & Attribution Foundation**.
- Split WA-7A into:
  - 7A.0 Identity Compatibility
  - 7A.1 Identity Resolution
  - 7A.2 Verification & Continuity
  - 7A.3 Attribution Ingress
  - 7A.4 Marketing Eligibility Foundation
- Treat phone as nullable contact point, BSUID as portfolio-scoped channel alias, username as display-only.
- Separate `BSUID` identity from `ctwa_clid`/touchpoint attribution.
- Separate `IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
- Future bulk campaigns target governed WhatsApp recipients, not only phone-number rows.
- Contact Book is provider assistance, not canonical ASCENDA identity.
- Preserve existing WA-3 ownership/Auth/2FA/24h/idempotency and SAFE-OFF controls.

## Scope
Documentation/governance only. No runtime, DB, provider, Supabase or Railway behavior changes in this PR.

## Baseline
`main@e454c9535eeff00c665794c2ac319dcc38bdf13f`

## External evidence
Revalidated against current Twilio WhatsApp Username/BSUID documentation and July 2026 rollout guidance; implementation evidence from BSP/open-source ecosystems is treated as engineering evidence, not policy authority.

## LIVE boundary
Supabase production remains HTTP 402. No LIVE certification is claimed by this PR.