### PR TITLE
WA-7A.0 — PHONE + BSUID identity compatibility

### DIFF
--- a/.github/workflows/wa7a0-identity-compatibility.yml
+++ b/.github/workflows/wa7a0-identity-compatibility.yml
@@ -158,8 +158,8 @@ jobs:
       - name: Safe rollback remains possible before BSUID adoption
         run: |
           set -euo pipefail
-          dropdb -h 127.0.0.1 -p 59922 -U postgres --if-exists wa7a0_rollback
-          createdb -h 127.0.0.1 -p 59922 -U postgres wa7a0_rollback
+          PGPASSWORD=postgres dropdb -h 127.0.0.1 -p 59922 -U postgres --if-exists wa7a0_rollback
+          PGPASSWORD=postgres createdb -h 127.0.0.1 -p 59922 -U postgres wa7a0_rollback
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql

--- a/.github/workflows/wa7a0-identity-compatibility.yml
+++ b/.github/workflows/wa7a0-identity-compatibility.yml
@@ -7,8 +7,10 @@ on:
       - 'app/wa-gateway.js'
       - 'supabase/migrations/*wa7a0_identity_compatibility*'
       - 'supabase/migrations/*wa7a0_direct_insert_compat*'
+      - 'supabase/migrations/*wa7a0_phone_key_compat*'
       - 'supabase/rollbacks/*wa7a0_identity_compatibility*'
       - 'supabase/rollbacks/*wa7a0_direct_insert_compat*'
+      - 'supabase/rollbacks/*wa7a0_phone_key_compat*'
       - 'ci/wa7a0-identity-compatibility/**'
       - '.github/workflows/wa7a0-identity-compatibility.yml'
   push:
@@ -66,6 +68,7 @@ jobs:
           grep -q "WA7A0_IDENTITY_CONFLICT" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
           grep -q "recipient_kind" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
           grep -q "m.provider_message_id=v_provider_id" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          grep -q "WA-2 certified PHONE key" supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
           grep -q "WA7A0_ROLLBACK_BLOCKED_BSUID_DATA" supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
           ! grep -Eq "alias_type[^\n]*(USERNAME|username)" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
           ! grep -Eq "(SUPABASE_SERVICE_ROLE_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*['\"][^'\"]+['\"]" app/wa-gateway.js
@@ -97,10 +100,15 @@ jobs:
       - name: Build synthetic prerequisite schema
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
 
-      - name: Apply certified WA prerequisites
+      - name: Apply WA-1 and seed certified pre-WA2 fixture
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa2-conversation-live-inbox/pre_migration_fixture.sql
+
+      - name: Apply certified WA-2 WA-3 S14 prerequisites
+        run: |
+          set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
@@ -111,6 +119,7 @@ jobs:
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
 
       - name: Database lint
         working-directory: ci/zero-cost-staging
@@ -120,6 +129,7 @@ jobs:
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa2-conversation-live-inbox/tests/001_wa2_store.sql | tee /tmp/wa7a0-wa2.txt
+          grep -q '1..51' /tmp/wa7a0-wa2.txt
           ! grep -q 'not ok' /tmp/wa7a0-wa2.txt
 
       - name: Preserve WA-3 routing and ownership
@@ -136,13 +146,14 @@ jobs:
       - name: Rollback blocks destructive downgrade after BSUID evidence
         run: |
           set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143200_wa7a0_phone_key_compat_v1.rollback.sql
           set +e
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql > /tmp/wa7a0-blocked.txt 2>&1
           RC=$?
           set -e
           test "$RC" -ne 0
           grep -q 'WA7A0_ROLLBACK_BLOCKED_BSUID_DATA' /tmp/wa7a0-blocked.txt
-          test "$(psql "$DB_URL" -X -qAt -c \"select to_regclass('public.aos_wa_channel_aliases_v1') is not null\")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_channel_aliases_v1') is not null")" = "t"
 
       - name: Safe rollback remains possible before BSUID adoption
         run: |
@@ -157,17 +168,19 @@ jobs:
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260817221500_wa_s14_web_push_notification_transport.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143200_wa7a0_phone_key_compat_v1.rollback.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql
           psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
-          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select to_regclass('public.aos_wa_channel_aliases_v1') is null\")" = "t"
-          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select is_nullable='NO' from information_schema.columns where table_schema='public' and table_name='aos_wa_conversations_v1' and column_name='contact_number'\")" = "t"
-          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select to_regprocedure('public.aos_wa3_human_send_authorize_v1(text,uuid)') is not null\")" = "t"
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_channel_aliases_v1') is null")" = "t"
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c "select is_nullable='NO' from information_schema.columns where table_schema='public' and table_name='aos_wa_conversations_v1' and column_name='contact_number'")" = "t"
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa3_human_send_authorize_v1(text,uuid)') is not null")" = "t"
 
       - name: Certification boundary
         run: |
           set -euo pipefail
-          test "$(psql "$DB_URL" -X -qAt -c \"select count(*) from public.aos_wa_channel_aliases_v1 where alias_type='BSUID'\")" -ge 1
-          test "$(psql "$DB_URL" -X -qAt -c \"select count(*) from public.aos_wa_conversations_v1 where contact_address_type='BSUID'\")" -ge 1
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_channel_aliases_v1 where alias_type='BSUID'")" -ge 1
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_conversations_v1 where contact_address_type='BSUID'")" -ge 1
           echo 'WA-7A.0 CODE/DB/ZERO-COST contract complete; LIVE provider canary is a separate gate.'
 
       - name: Stop isolated Supabase

--- a/.github/workflows/wa7a0-identity-compatibility.yml
+++ b/.github/workflows/wa7a0-identity-compatibility.yml
@@ -1,0 +1,176 @@
+name: ASCENDA WA-7A.0 Identity Compatibility
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa7a0_identity_compatibility*'
+      - 'supabase/migrations/*wa7a0_direct_insert_compat*'
+      - 'supabase/rollbacks/*wa7a0_identity_compatibility*'
+      - 'supabase/rollbacks/*wa7a0_direct_insert_compat*'
+      - 'ci/wa7a0-identity-compatibility/**'
+      - '.github/workflows/wa7a0-identity-compatibility.yml'
+  push:
+    branches: ['feat/wa-7a-0-identity-compatibility-20260825']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa7a0-identity-compatibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · WA-7A.0 PHONE + BSUID
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 45
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59922/postgres
+      ROLLBACK_DB_URL: postgresql://postgres:postgres@127.0.0.1:59922/wa7a0_rollback
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost lane
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Runtime syntax and gateway contracts
+        run: |
+          set -euo pipefail
+          node --check app/wa-gateway.js
+          node --check app/server-f4.js
+          node --check app/server-wa2.js
+          node --check app/server-wa3.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+          node --test ci/wa7a0-identity-compatibility/identity_contract.test.js
+
+      - name: Source safety invariants
+        run: |
+          set -euo pipefail
+          grep -q "from_user_id" app/wa-gateway.js
+          grep -q "from_parent_user_id" app/wa-gateway.js
+          grep -q "contact_username" app/wa-gateway.js
+          grep -q "out.recipient=recipient.address" app/wa-gateway.js
+          grep -q "enumerable:false" app/wa-gateway.js
+          grep -q "WA7A0_IDENTITY_CONFLICT" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          grep -q "recipient_kind" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          grep -q "m.provider_message_id=v_provider_id" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          grep -q "WA7A0_ROLLBACK_BLOCKED_BSUID_DATA" supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
+          ! grep -Eq "alias_type[^\n]*(USERNAME|username)" supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          ! grep -Eq "(SUPABASE_SERVICE_ROLE_KEY|WHATSAPP_ACCESS_TOKEN)\s*=\s*['\"][^'\"]+['\"]" app/wa-gateway.js
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa7a0-identity"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59921/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59922/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59920/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa7a0-identity' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59922 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-7A.0 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build synthetic prerequisite schema
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+
+      - name: Apply certified WA prerequisites
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260817221500_wa_s14_web_push_notification_transport.sql
+
+      - name: Apply WA-7A.0 identity compatibility
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: Preserve WA-2 phone behavior
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa2-conversation-live-inbox/tests/001_wa2_store.sql | tee /tmp/wa7a0-wa2.txt
+          ! grep -q 'not ok' /tmp/wa7a0-wa2.txt
+
+      - name: Preserve WA-3 routing and ownership
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/tests/001_wa3_routing.sql | tee /tmp/wa7a0-wa3-v1.txt
+          ! grep -q 'not ok' /tmp/wa7a0-wa3-v1.txt
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/tests/002_wa3_multiagent_v2.sql | tee /tmp/wa7a0-wa3-v2.txt
+          ! grep -q 'not ok' /tmp/wa7a0-wa3-v2.txt
+
+      - name: PHONE + BSUID database behavior
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql
+
+      - name: Rollback blocks destructive downgrade after BSUID evidence
+        run: |
+          set -euo pipefail
+          set +e
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql > /tmp/wa7a0-blocked.txt 2>&1
+          RC=$?
+          set -e
+          test "$RC" -ne 0
+          grep -q 'WA7A0_ROLLBACK_BLOCKED_BSUID_DATA' /tmp/wa7a0-blocked.txt
+          test "$(psql "$DB_URL" -X -qAt -c \"select to_regclass('public.aos_wa_channel_aliases_v1') is not null\")" = "t"
+
+      - name: Safe rollback remains possible before BSUID adoption
+        run: |
+          set -euo pipefail
+          dropdb -h 127.0.0.1 -p 59922 -U postgres --if-exists wa7a0_rollback
+          createdb -h 127.0.0.1 -p 59922 -U postgres wa7a0_rollback
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260817221500_wa_s14_web_push_notification_transport.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql
+          psql "$ROLLBACK_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select to_regclass('public.aos_wa_channel_aliases_v1') is null\")" = "t"
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select is_nullable='NO' from information_schema.columns where table_schema='public' and table_name='aos_wa_conversations_v1' and column_name='contact_number'\")" = "t"
+          test "$(psql "$ROLLBACK_DB_URL" -X -qAt -c \"select to_regprocedure('public.aos_wa3_human_send_authorize_v1(text,uuid)') is not null\")" = "t"
+
+      - name: Certification boundary
+        run: |
+          set -euo pipefail
+          test "$(psql "$DB_URL" -X -qAt -c \"select count(*) from public.aos_wa_channel_aliases_v1 where alias_type='BSUID'\")" -ge 1
+          test "$(psql "$DB_URL" -X -qAt -c \"select count(*) from public.aos_wa_conversations_v1 where contact_address_type='BSUID'\")" -ge 1
+          echo 'WA-7A.0 CODE/DB/ZERO-COST contract complete; LIVE provider canary is a separate gate.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -15,9 +15,47 @@ function verifyMetaSignature(rawBody,signatureHeader,appSecret){
   return safeEqualText(header.toLowerCase(),digest.toLowerCase());
 }
 
-function normalizePhone(v){return String(v||'').replace(/\D/g,'').slice(0,20);}
-function isoFromUnix(v){const n=Number(v);return Number.isFinite(n)&&n>0?new Date(n*1000).toISOString():new Date().toISOString();}
 function trimText(v,max){return String(v==null?'':v).slice(0,max||4000);}
+function normalizePhone(v){return String(v||'').replace(/\D/g,'').slice(0,20);}
+function phoneValue(v){
+  const raw=String(v==null?'':v).trim();
+  if(!raw||/[A-Za-z]/.test(raw))return null;
+  const digits=normalizePhone(raw);
+  return digits.length>=8&&digits.length<=20?digits:null;
+}
+function userIdValue(v){
+  const s=String(v==null?'':v).trim();
+  if(!s||s.length>256||/[\u0000-\u001f\u007f]/.test(s))return null;
+  return s;
+}
+function usernameValue(v){
+  const s=String(v==null?'':v).trim().replace(/^@/,'');
+  return s?trimText(s,256):null;
+}
+function isoFromUnix(v){const n=Number(v);return Number.isFinite(n)&&n>0?new Date(n*1000).toISOString():new Date().toISOString();}
+
+function recipientFromInput(d){
+  const explicitKind=String(d&&d.recipient_kind||'').trim().toUpperCase();
+  const explicitAddress=userIdValue(d&&d.recipient_address);
+  const explicitRecipient=userIdValue(d&&d.recipient);
+  if(explicitKind==='PHONE'){
+    const phone=phoneValue(explicitAddress||d.to);
+    if(!phone)throw Object.assign(new Error('INVALID_RECIPIENT'),{status:400});
+    return {kind:'PHONE',address:phone};
+  }
+  if(explicitKind==='BSUID'){
+    const bsuid=userIdValue(explicitAddress||explicitRecipient||d.to);
+    if(!bsuid)throw Object.assign(new Error('INVALID_RECIPIENT'),{status:400});
+    return {kind:'BSUID',address:bsuid};
+  }
+  const phone=phoneValue(d&&d.to);
+  if(phone)return {kind:'PHONE',address:phone};
+  const bsuid=userIdValue(explicitRecipient||(d&&d.to));
+  if(bsuid)return {kind:'BSUID',address:bsuid};
+  throw Object.assign(new Error('INVALID_RECIPIENT'),{status:400});
+}
+function recipientAddress(payload){return userIdValue(payload&&(payload.to||payload.recipient));}
+function recipientKind(payload){return payload&&payload.recipient?'BSUID':'PHONE';}
 
 function messageBody(msg){
   if(msg.text&&msg.text.body)return trimText(msg.text.body,8000);
@@ -31,8 +69,14 @@ function messageBody(msg){
   if(msg.document&&msg.document.caption)return trimText(msg.document.caption,4000);
   return '';
 }
-function mediaId(msg){
-  const t=msg.type;const obj=t&&msg[t];return obj&&obj.id?trimText(obj.id,256):null;
+function mediaId(msg){const t=msg.type;const obj=t&&msg[t];return obj&&obj.id?trimText(obj.id,256):null;}
+function contactForMessage(contacts,msg){
+  const msgPhone=phoneValue(msg&&msg.from);
+  const msgUser=userIdValue(msg&&msg.from_user_id)||(!msgPhone?userIdValue(msg&&msg.from):null);
+  return (contacts||[]).find(c=>{
+    const cp=phoneValue(c&&c.wa_id);const cu=userIdValue(c&&c.user_id);
+    return (msgUser&&cu===msgUser)||(msgPhone&&cp===msgPhone);
+  })||{};
 }
 
 function extractWebhook(payload){
@@ -43,11 +87,17 @@ function extractWebhook(payload){
       if(change.field!=='messages')return;
       const value=change.value||{};const meta=value.metadata||{};const contacts=value.contacts||[];
       (value.messages||[]).forEach(msg=>{
-        const from=normalizePhone(msg.from);const contact=contacts.find(c=>normalizePhone(c.wa_id)===from)||{};
+        const contact=contactForMessage(contacts,msg);const profile=contact.profile||{};
+        const fromPhone=phoneValue(msg.from)||phoneValue(contact.wa_id);
+        const fromUser=userIdValue(msg.from_user_id)||userIdValue(contact.user_id)||(!fromPhone?userIdValue(msg.from):null);
+        const parentUser=userIdValue(msg.from_parent_user_id)||userIdValue(contact.parent_user_id);
         const referral=msg.referral||{};
         const row={
-          provider_message_id:trimText(msg.id,256),direction:'INBOUND',from_number:from,to_number:normalizePhone(meta.display_phone_number),
-          phone_number_id:trimText(meta.phone_number_id,128)||null,contact_name:trimText(contact.profile&&contact.profile.name,256)||null,
+          provider_message_id:trimText(msg.id,256),direction:'INBOUND',
+          from_number:fromPhone,to_number:phoneValue(meta.display_phone_number),
+          from_user_id:fromUser,from_parent_user_id:parentUser,to_user_id:null,to_parent_user_id:null,
+          phone_number_id:trimText(meta.phone_number_id,128)||null,
+          contact_name:trimText(profile.name,256)||null,contact_username:usernameValue(profile.username),
           message_type:trimText(msg.type||'unknown',64),message_body:messageBody(msg)||null,media_id:mediaId(msg),status:'received',
           campaign_source:trimText(referral.headline||referral.source_type||'',512)||null,ad_id:trimText(referral.source_id||'',256)||null,
           raw_referral:Object.keys(referral).length?{
@@ -57,17 +107,19 @@ function extractWebhook(payload){
         };
         if(!row.provider_message_id)return;
         messages.push(row);
-        events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral}});
+        events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral,sender_kind:row.from_number?'PHONE':(row.from_user_id?'BSUID':'UNKNOWN'),has_user_id:!!row.from_user_id}});
       });
       (value.statuses||[]).forEach(st=>{
         const id=trimText(st.id,256);if(!id)return;
         const pricing=st.pricing||{};const state=trimText(st.status||'unknown',64);
-        const row={provider_message_id:id,status:state,recipient_id:normalizePhone(st.recipient_id),provider_timestamp:isoFromUnix(st.timestamp),
+        const recipientPhone=phoneValue(st.recipient_id);
+        const recipientUser=userIdValue(st.recipient_user_id)||(!recipientPhone?userIdValue(st.recipient_id):null);
+        const row={provider_message_id:id,status:state,recipient_id:recipientPhone,recipient_user_id:recipientUser,recipient_parent_user_id:userIdValue(st.recipient_parent_user_id),provider_timestamp:isoFromUnix(st.timestamp),
           pricing_category:trimText(pricing.category||'',64)||null,pricing_model:trimText(pricing.pricing_model||'',64)||null,
           billable:typeof pricing.billable==='boolean'?pricing.billable:null,error_code:null,error_title:null};
         if(Array.isArray(st.errors)&&st.errors[0]){row.error_code=trimText(st.errors[0].code,64)||null;row.error_title=trimText(st.errors[0].title||st.errors[0].message,512)||null;}
         statuses.push(row);
-        events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,pricing_category:row.pricing_category,pricing_model:row.pricing_model,billable:row.billable,error_code:row.error_code}});
+        events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,recipient_user_id:row.recipient_user_id,recipient_parent_user_id:row.recipient_parent_user_id,recipient_kind:row.recipient_id?'PHONE':(row.recipient_user_id?'BSUID':'UNKNOWN'),pricing_category:row.pricing_category,pricing_model:row.pricing_model,billable:row.billable,error_code:row.error_code}});
       });
     });
   });
@@ -75,8 +127,16 @@ function extractWebhook(payload){
 }
 
 function buildOutboundPayload(input){
-  const d=input||{};const to=normalizePhone(d.to);if(to.length<8||to.length>15)throw Object.assign(new Error('INVALID_RECIPIENT'),{status:400});
-  const type=String(d.type||'text').toLowerCase();const out={messaging_product:'whatsapp',recipient_type:'individual',to,type};
+  const d=input||{};const recipient=recipientFromInput(d);const type=String(d.type||'text').toLowerCase();
+  const out={messaging_product:'whatsapp',recipient_type:'individual'};
+  if(recipient.kind==='PHONE')out.to=recipient.address;
+  else{
+    out.recipient=recipient.address;
+    // Compatibility alias for existing ASCENDA server code. Non-enumerable means it is never sent to Meta.
+    Object.defineProperty(out,'to',{value:recipient.address,enumerable:false,writable:false});
+  }
+  Object.defineProperty(out,'_recipient_kind',{value:recipient.kind,enumerable:false,writable:false});
+  out.type=type;
   if(type==='text'){
     const body=trimText(d.text,4096);if(!body)throw Object.assign(new Error('TEXT_REQUIRED'),{status:400});out.text={preview_url:false,body};
   }else if(type==='template'){
@@ -90,10 +150,12 @@ function buildOutboundPayload(input){
 }
 
 function validIdempotencyKey(v){return /^[A-Za-z0-9._:-]{16,120}$/.test(String(v||''));}
+function normalizeCanaryAddress(v){const p=phoneValue(v);return p?('PHONE:'+p):('BSUID:'+String(v||'').trim());}
 function canaryAllows(to,mode,allowCsv){
   if(String(mode||'true').toLowerCase()!=='true')return true;
-  const allowed=new Set(String(allowCsv||'').split(',').map(normalizePhone).filter(Boolean));
-  return allowed.has(normalizePhone(to));
+  const candidate=normalizeCanaryAddress(to);if(candidate==='BSUID:')return false;
+  const allowed=new Set(String(allowCsv||'').split(',').map(x=>x.trim()).filter(Boolean).map(normalizeCanaryAddress));
+  return allowed.has(candidate);
 }
 
-module.exports={verifyMetaSignature,extractWebhook,buildOutboundPayload,normalizePhone,validIdempotencyKey,canaryAllows,safeEqualText};
+module.exports={verifyMetaSignature,extractWebhook,buildOutboundPayload,normalizePhone,phoneValue,userIdValue,recipientAddress,recipientKind,validIdempotencyKey,canaryAllows,safeEqualText};

--- a/ci/wa7a0-identity-compatibility/identity_contract.test.js
+++ b/ci/wa7a0-identity-compatibility/identity_contract.test.js
@@ -1,0 +1,54 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const wa=require('../../app/wa-gateway');
+
+test('phone inbound remains backward compatible',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn1'},contacts:[{wa_id:'51999111222',profile:{name:'Paciente Demo'}}],messages:[{id:'wamid.phone',from:'51999111222',timestamp:'1786807000',type:'text',text:{body:'Hola'}}]}}]}]};
+  const e=wa.extractWebhook(p);const m=e.messages[0];
+  assert.equal(m.from_number,'51999111222');assert.equal(m.from_user_id,null);assert.equal(m.contact_name,'Paciente Demo');
+});
+
+test('BSUID-only inbound preserves user identity without fabricating phone',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn1'},contacts:[{user_id:'PE.user.abc123',parent_user_id:'PE.parent.001',profile:{name:'Privado',username:'@privado.pe'}}],messages:[{id:'wamid.bsuid',from_user_id:'PE.user.abc123',from_parent_user_id:'PE.parent.001',timestamp:'1786807000',type:'text',text:{body:'Hola privado'}}]}}]}]};
+  const e=wa.extractWebhook(p);const m=e.messages[0];
+  assert.equal(m.from_number,null);assert.equal(m.from_user_id,'PE.user.abc123');assert.equal(m.from_parent_user_id,'PE.parent.001');assert.equal(m.contact_username,'privado.pe');
+  assert.equal(e.events[0].payload.sender_kind,'BSUID');
+});
+
+test('phone plus BSUID preserves both independent facts',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'15551627684',phone_number_id:'pn1'},contacts:[{wa_id:'51999111222',user_id:'PE.user.same',profile:{name:'Dual'}}],messages:[{id:'wamid.dual',from:'51999111222',from_user_id:'PE.user.same',timestamp:'1786807000',type:'text',text:{body:'Dual'}}]}}]}]};
+  const m=wa.extractWebhook(p).messages[0];
+  assert.equal(m.from_number,'51999111222');assert.equal(m.from_user_id,'PE.user.same');
+});
+
+test('status preserves recipient_user_id when phone is absent',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{statuses:[{id:'wamid.out',status:'delivered',timestamp:'1786807100',recipient_user_id:'PE.user.abc123',recipient_parent_user_id:'PE.parent.001'}]}}]}]};
+  const e=wa.extractWebhook(p);assert.equal(e.statuses[0].recipient_id,null);assert.equal(e.statuses[0].recipient_user_id,'PE.user.abc123');assert.equal(e.events[0].payload.recipient_kind,'BSUID');
+});
+
+test('BSUID outbound serializes provider recipient and never provider to',()=>{
+  const payload=wa.buildOutboundPayload({recipient_kind:'BSUID',recipient_address:'PE.user.abc123',type:'text',text:'Hola'});
+  assert.equal(payload.recipient,'PE.user.abc123');assert.equal(payload.to,'PE.user.abc123');assert.equal(wa.recipientKind(payload),'BSUID');
+  const sent=JSON.parse(JSON.stringify(payload));assert.equal(sent.recipient,'PE.user.abc123');assert.equal(Object.prototype.hasOwnProperty.call(sent,'to'),false);
+});
+
+test('legacy server to value can represent BSUID without provider to leak',()=>{
+  const payload=wa.buildOutboundPayload({to:'PE.user.legacy',type:'text',text:'Hola'});
+  assert.equal(wa.recipientKind(payload),'BSUID');assert.equal(payload.to,'PE.user.legacy');assert.equal(JSON.stringify(payload).includes('"to"'),false);
+});
+
+test('phone outbound remains unchanged',()=>{
+  const payload=wa.buildOutboundPayload({to:'+51 999 999 999',type:'text',text:'Hola'});
+  assert.equal(payload.to,'51999999999');assert.equal(payload.recipient,undefined);assert.equal(wa.recipientKind(payload),'PHONE');
+});
+
+test('username is never accepted as explicit routing kind',()=>{
+  assert.throws(()=>wa.buildOutboundPayload({recipient_kind:'USERNAME',recipient_address:'@someone',type:'text',text:'Hola'}),/INVALID_RECIPIENT/);
+});
+
+test('canary allowlist supports phone and BSUID independently',()=>{
+  assert.equal(wa.canaryAllows('+51 911 111 111','true','51911111111,PE.user.safe'),true);
+  assert.equal(wa.canaryAllows('PE.user.safe','true','51911111111,PE.user.safe'),true);
+  assert.equal(wa.canaryAllows('PE.user.other','true','51911111111,PE.user.safe'),false);
+});

--- a/ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql
+++ b/ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql
@@ -1,0 +1,93 @@
+\set ON_ERROR_STOP on
+
+-- WA-7A.0 DB behavioral contract. Any violated invariant aborts psql.
+
+do $$
+declare
+  v_c1 uuid;
+  v_c2 uuid;
+  v_req text:='wa7a0:req:1234567890123456';
+begin
+  if not exists(select 1 from information_schema.columns where table_schema='public' and table_name='aos_wa_messages_v1' and column_name='from_user_id') then raise exception 'MISSING_FROM_USER_ID'; end if;
+  if not exists(select 1 from information_schema.columns where table_schema='public' and table_name='aos_wa_conversations_v1' and column_name='contact_address') then raise exception 'MISSING_CONTACT_ADDRESS'; end if;
+  if not exists(select 1 from information_schema.columns where table_schema='public' and table_name='aos_wa_outbound_requests_v1' and column_name='recipient_address') then raise exception 'MISSING_RECIPIENT_ADDRESS'; end if;
+  if to_regclass('public.aos_wa_channel_aliases_v1') is null then raise exception 'MISSING_ALIAS_LEDGER'; end if;
+
+  -- First inbound exposes phone + BSUID.
+  insert into public.aos_wa_messages_v1(
+    provider_message_id,direction,from_number,from_user_id,from_parent_user_id,phone_number_id,contact_name,contact_username,message_type,message_body,status,provider_timestamp,received_at
+  ) values (
+    'wamid.wa7a0.dual','INBOUND','51911112222','PE.user.001','PE.parent.001','pn-wa7a0','Dual User','dual.user','text','hola','received',now(),now()
+  );
+  select conversation_id into v_c1 from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a0.dual';
+  if v_c1 is null then raise exception 'DUAL_NOT_BOUND'; end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 where id=v_c1 and contact_number='51911112222' and contact_bsuid='PE.user.001' and contact_address_type='PHONE' and contact_address='51911112222' and contact_username='dual.user') then raise exception 'DUAL_FACTS_NOT_PRESERVED'; end if;
+  if (select count(*) from public.aos_wa_channel_aliases_v1 where conversation_id=v_c1 and alias_type in ('PHONE','BSUID','PARENT_BSUID'))<>3 then raise exception 'DUAL_ALIASES_MISSING'; end if;
+
+  -- Later privacy-safe inbound exposes only BSUID. It MUST remain in same conversation.
+  insert into public.aos_wa_messages_v1(
+    provider_message_id,direction,from_number,from_user_id,phone_number_id,contact_name,contact_username,message_type,message_body,status,provider_timestamp,received_at
+  ) values (
+    'wamid.wa7a0.bsuid-only','INBOUND',null,'PE.user.001','pn-wa7a0','Dual User','dual.newname','text','privado','received',now()+interval '1 second',now()
+  );
+  select conversation_id into v_c2 from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a0.bsuid-only';
+  if v_c2 is distinct from v_c1 then raise exception 'BSUID_ONLY_SPLIT_CONVERSATION'; end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 where id=v_c1 and contact_number='51911112222' and contact_address_type='BSUID' and contact_address='PE.user.001' and contact_username='dual.newname') then raise exception 'BSUID_CURRENT_ADDRESS_NOT_UPDATED'; end if;
+
+  -- A later phone observation also converges to same conversation.
+  insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at)
+  values('wamid.wa7a0.phone-again','INBOUND','51911112222','pn-wa7a0','text','phone again','received',now()+interval '2 seconds',now());
+  select conversation_id into v_c2 from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a0.phone-again';
+  if v_c2 is distinct from v_c1 then raise exception 'PHONE_ALIAS_SPLIT_CONVERSATION'; end if;
+
+  -- Legacy WA-3 server can pass BSUID through its old `to_number` property; DB normalizes it.
+  insert into public.aos_wa_messages_v1(provider_message_id,conversation_id,direction,to_number,phone_number_id,message_type,message_body,status,received_at)
+  values('wamid.wa7a0.out-bsuid',v_c1,'OUTBOUND','PE.user.001','pn-wa7a0','text','reply','accepted',now());
+  if not exists(select 1 from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a0.out-bsuid' and to_number is null and to_user_id='PE.user.001' and conversation_id=v_c1) then raise exception 'LEGACY_OUTBOUND_NOT_NORMALIZED'; end if;
+
+  -- Outbound idempotency ledger gains generic recipient semantics without losing phone compatibility.
+  insert into public.aos_wa_outbound_requests_v1(idempotency_key,actor_id,to_number,message_type,state)
+  values(v_req,gen_random_uuid(),'PE.user.001','text','PENDING');
+  if not exists(select 1 from public.aos_wa_outbound_requests_v1 where idempotency_key=v_req and to_number is null and recipient_kind='BSUID' and recipient_address='PE.user.001') then raise exception 'OUTBOUND_BSUID_LEDGER_NOT_NORMALIZED'; end if;
+
+  insert into public.aos_wa_outbound_requests_v1(idempotency_key,actor_id,to_number,message_type,state)
+  values('wa7a0:req:phone:1234567890',gen_random_uuid(),'+51 922 222 222','text','PENDING');
+  if not exists(select 1 from public.aos_wa_outbound_requests_v1 where idempotency_key='wa7a0:req:phone:1234567890' and to_number='51922222222' and recipient_kind='PHONE' and recipient_address='51922222222') then raise exception 'OUTBOUND_PHONE_COMPAT_BROKEN'; end if;
+
+  -- Username must never become an alias/merge authority.
+  if exists(select 1 from public.aos_wa_channel_aliases_v1 where alias_type not in ('PHONE','BSUID','PARENT_BSUID')) then raise exception 'USERNAME_ALIAS_FORBIDDEN'; end if;
+end
+$$;
+
+-- Two already-distinct identities presented together must fail closed, never merge silently.
+do $$
+declare conflict_seen boolean:=false;
+begin
+  insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,phone_number_id,message_type,status,received_at)
+  values('wamid.wa7a0.identity-a','INBOUND','51933333333','PE.user.A','pn-wa7a0','text','received',now());
+  insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,phone_number_id,message_type,status,received_at)
+  values('wamid.wa7a0.identity-b','INBOUND','51944444444','PE.user.B','pn-wa7a0','text','received',now());
+  begin
+    insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,phone_number_id,message_type,status,received_at)
+    values('wamid.wa7a0.conflict','INBOUND','51933333333','PE.user.B','pn-wa7a0','text','received',now());
+  exception when unique_violation then
+    if position('WA7A0_IDENTITY_CONFLICT' in sqlerrm)>0 then conflict_seen:=true; else raise; end if;
+  end;
+  if not conflict_seen then raise exception 'IDENTITY_CONFLICT_DID_NOT_FAIL_CLOSED'; end if;
+end
+$$;
+
+-- Security/access contract and S14 resolver source contract.
+do $$
+declare def text;
+begin
+  if has_table_privilege('anon','public.aos_wa_channel_aliases_v1','select') then raise exception 'ALIAS_LEDGER_ANON_READABLE'; end if;
+  if has_table_privilege('authenticated','public.aos_wa_channel_aliases_v1','select') then raise exception 'ALIAS_LEDGER_AUTH_READABLE'; end if;
+  select pg_get_functiondef('public.aos_push_targets_for_wa_v1(jsonb)'::regprocedure) into def;
+  if position('m.provider_message_id=v_provider_id' in def)=0 then raise exception 'S14_STILL_PHONE_PRIMARY'; end if;
+  select pg_get_functiondef('public.aos_wa3_human_send_authorize_v1(text,uuid)'::regprocedure) into def;
+  if position('recipient_kind' in def)=0 or position('recipient_address' in def)=0 then raise exception 'WA3_GENERIC_RECIPIENT_MISSING'; end if;
+end
+$$;
+
+select 'WA-7A.0 identity compatibility DB contract PASS' as result;

--- a/supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+++ b/supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
@@ -1,0 +1,329 @@
+-- WA-7A.0 — WhatsApp Identity Compatibility V1
+-- Additive PHONE + BSUID compatibility. Username is display-only.
+-- This migration is safe for the existing phone-first runtime: legacy `to_number`
+-- continues to work while BSUID values are normalized into generic recipient fields.
+
+begin;
+
+alter table public.aos_wa_messages_v1
+  add column if not exists from_user_id text,
+  add column if not exists from_parent_user_id text,
+  add column if not exists to_user_id text,
+  add column if not exists to_parent_user_id text,
+  add column if not exists contact_username text;
+
+create index if not exists aos_wa_messages_v1_from_user_idx
+  on public.aos_wa_messages_v1(phone_number_id, from_user_id, created_at desc)
+  where from_user_id is not null;
+create index if not exists aos_wa_messages_v1_to_user_idx
+  on public.aos_wa_messages_v1(phone_number_id, to_user_id, created_at desc)
+  where to_user_id is not null;
+
+alter table public.aos_wa_conversations_v1
+  alter column contact_number drop not null,
+  add column if not exists contact_address text,
+  add column if not exists contact_address_type text,
+  add column if not exists contact_bsuid text,
+  add column if not exists contact_parent_bsuid text,
+  add column if not exists contact_username text;
+
+update public.aos_wa_conversations_v1
+set contact_address = coalesce(contact_address, nullif(regexp_replace(coalesce(contact_number,''),'[^0-9]','','g'),'')),
+    contact_address_type = coalesce(contact_address_type, case when nullif(regexp_replace(coalesce(contact_number,''),'[^0-9]','','g'),'') is not null then 'PHONE' end)
+where contact_address is null or contact_address_type is null;
+
+alter table public.aos_wa_conversations_v1
+  add constraint aos_wa_conversations_v1_contact_address_type_chk
+  check (contact_address_type in ('PHONE','BSUID')) not valid;
+alter table public.aos_wa_conversations_v1 validate constraint aos_wa_conversations_v1_contact_address_type_chk;
+alter table public.aos_wa_conversations_v1 alter column contact_address set not null;
+alter table public.aos_wa_conversations_v1 alter column contact_address_type set not null;
+
+create index if not exists aos_wa_conversations_v1_bsuid_idx
+  on public.aos_wa_conversations_v1(phone_number_id, contact_bsuid)
+  where contact_bsuid is not null;
+create index if not exists aos_wa_conversations_v1_address_idx
+  on public.aos_wa_conversations_v1(phone_number_id, contact_address_type, contact_address);
+
+create table if not exists public.aos_wa_channel_aliases_v1 (
+  id uuid primary key default gen_random_uuid(),
+  business_scope text not null,
+  alias_type text not null check (alias_type in ('PHONE','BSUID','PARENT_BSUID')),
+  alias_value text not null check (char_length(trim(alias_value)) between 1 and 256),
+  conversation_id uuid not null references public.aos_wa_conversations_v1(id) on delete restrict,
+  active boolean not null default true,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (business_scope, alias_type, alias_value)
+);
+create index if not exists aos_wa_channel_aliases_v1_conversation_idx
+  on public.aos_wa_channel_aliases_v1(conversation_id, alias_type, last_seen_at desc);
+alter table public.aos_wa_channel_aliases_v1 enable row level security;
+alter table public.aos_wa_channel_aliases_v1 force row level security;
+revoke all on table public.aos_wa_channel_aliases_v1 from public, anon, authenticated;
+grant select, insert, update on table public.aos_wa_channel_aliases_v1 to service_role;
+
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,first_seen_at,last_seen_at)
+select coalesce(nullif(c.phone_number_id,''),'default'), 'PHONE', regexp_replace(c.contact_number,'[^0-9]','','g'), c.id, c.created_at, c.updated_at
+from public.aos_wa_conversations_v1 c
+where nullif(regexp_replace(coalesce(c.contact_number,''),'[^0-9]','','g'),'') is not null
+on conflict (business_scope,alias_type,alias_value) do update
+set last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),updated_at=now();
+
+alter table public.aos_wa_outbound_requests_v1
+  alter column to_number drop not null,
+  add column if not exists recipient_kind text,
+  add column if not exists recipient_address text;
+
+update public.aos_wa_outbound_requests_v1
+set to_number=regexp_replace(to_number,'[^0-9]','','g'),
+    recipient_kind='PHONE',
+    recipient_address=regexp_replace(to_number,'[^0-9]','','g')
+where recipient_address is null and nullif(regexp_replace(coalesce(to_number,''),'[^0-9]','','g'),'') is not null;
+
+alter table public.aos_wa_outbound_requests_v1
+  add constraint aos_wa_outbound_requests_v1_recipient_kind_chk
+  check (recipient_kind in ('PHONE','BSUID')) not valid;
+alter table public.aos_wa_outbound_requests_v1 validate constraint aos_wa_outbound_requests_v1_recipient_kind_chk;
+alter table public.aos_wa_outbound_requests_v1 alter column recipient_kind set not null;
+alter table public.aos_wa_outbound_requests_v1 alter column recipient_address set not null;
+
+create or replace function public.aos_wa7a0_normalize_outbound_request_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare v_raw text; v_phone text;
+begin
+  v_raw:=trim(coalesce(new.recipient_address,new.to_number,''));
+  if v_raw='' then raise exception 'WA7A0_RECIPIENT_REQUIRED' using errcode='23514'; end if;
+  v_phone:=case when v_raw !~ '[A-Za-z]' then nullif(regexp_replace(v_raw,'[^0-9]','','g'),'') else null end;
+  if new.recipient_kind is null then
+    new.recipient_kind:=case when v_phone is not null and char_length(v_phone) between 8 and 20 then 'PHONE' else 'BSUID' end;
+  end if;
+  if new.recipient_kind='PHONE' then
+    if v_phone is null or char_length(v_phone) not between 8 and 20 then raise exception 'WA7A0_INVALID_PHONE_RECIPIENT' using errcode='23514'; end if;
+    new.to_number:=v_phone;new.recipient_address:=v_phone;
+  elsif new.recipient_kind='BSUID' then
+    if char_length(v_raw)>256 then raise exception 'WA7A0_INVALID_BSUID_RECIPIENT' using errcode='23514'; end if;
+    new.to_number:=null;new.recipient_address:=v_raw;
+  else
+    raise exception 'WA7A0_INVALID_RECIPIENT_KIND' using errcode='23514';
+  end if;
+  new.updated_at:=now();
+  return new;
+end
+$$;
+
+drop trigger if exists trg_aos_wa7a0_normalize_outbound_request_v1 on public.aos_wa_outbound_requests_v1;
+create trigger trg_aos_wa7a0_normalize_outbound_request_v1
+before insert or update of to_number,recipient_kind,recipient_address on public.aos_wa_outbound_requests_v1
+for each row execute function public.aos_wa7a0_normalize_outbound_request_v1();
+
+-- Replace WA-2 binder with identity-aware deterministic binding.
+-- Scope is intentionally phone_number_id (narrower than portfolio scope); cross-number
+-- portfolio reconciliation belongs to WA-7A.1 and must not be guessed here.
+create or replace function public.aos_wa2_bind_conversation_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare
+  v_scope text;
+  v_phone text;
+  v_bsuid text;
+  v_parent text;
+  v_kind text;
+  v_address text;
+  v_key text;
+  v_ts timestamptz;
+  v_conv uuid;
+  v_phone_conv uuid;
+  v_bsuid_conv uuid;
+  v_parent_conv uuid;
+  v_existing uuid;
+begin
+  v_scope:=coalesce(nullif(trim(new.phone_number_id),''),'default');
+  v_ts:=coalesce(new.provider_timestamp,new.received_at,new.sent_at,new.created_at,now());
+
+  -- Compatibility normalization for old server code that still writes a generic BSUID
+  -- into from_number/to_number. Never strip letters out of a BSUID.
+  if new.direction='INBOUND' then
+    if new.from_user_id is null and nullif(trim(coalesce(new.from_number,'')),'') is not null and new.from_number ~ '[A-Za-z]' then
+      new.from_user_id:=left(trim(new.from_number),256);new.from_number:=null;
+    end if;
+    v_phone:=case when coalesce(new.from_number,'') !~ '[A-Za-z]' then nullif(regexp_replace(coalesce(new.from_number,''),'[^0-9]','','g'),'') else null end;
+    v_bsuid:=nullif(left(trim(coalesce(new.from_user_id,'')),256),'');
+    v_parent:=nullif(left(trim(coalesce(new.from_parent_user_id,'')),256),'');
+  else
+    if new.to_user_id is null and nullif(trim(coalesce(new.to_number,'')),'') is not null and new.to_number ~ '[A-Za-z]' then
+      new.to_user_id:=left(trim(new.to_number),256);new.to_number:=null;
+    end if;
+    v_phone:=case when coalesce(new.to_number,'') !~ '[A-Za-z]' then nullif(regexp_replace(coalesce(new.to_number,''),'[^0-9]','','g'),'') else null end;
+    v_bsuid:=nullif(left(trim(coalesce(new.to_user_id,'')),256),'');
+    v_parent:=nullif(left(trim(coalesce(new.to_parent_user_id,'')),256),'');
+  end if;
+
+  if v_phone is not null and char_length(v_phone) not between 8 and 20 then v_phone:=null; end if;
+  if v_phone is null and v_bsuid is null and v_parent is null then
+    raise exception 'WA7A0_CONTACT_REQUIRED' using errcode='23514';
+  end if;
+
+  v_kind:=case when v_phone is not null then 'PHONE' else 'BSUID' end;
+  v_address:=coalesce(v_phone,v_bsuid,v_parent);
+
+  -- Lock every presented alias in a fixed order to prevent concurrent split conversations.
+  if v_phone is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_phone,0)); end if;
+  if v_parent is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_parent,0)); end if;
+  if v_bsuid is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_bsuid,0)); end if;
+
+  if new.conversation_id is not null then
+    select id into v_conv from public.aos_wa_conversations_v1 where id=new.conversation_id for update;
+    if v_conv is null then raise exception 'WA7A0_CONVERSATION_BIND_FAILED'; end if;
+  else
+    if v_phone is not null then select conversation_id into v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone; end if;
+    if v_parent is not null then select conversation_id into v_parent_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_parent; end if;
+    if v_bsuid is not null then select conversation_id into v_bsuid_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_bsuid; end if;
+
+    v_existing:=coalesce(v_bsuid_conv,v_parent_conv,v_phone_conv);
+    if (v_phone_conv is not null and v_existing<>v_phone_conv)
+       or (v_parent_conv is not null and v_existing<>v_parent_conv)
+       or (v_bsuid_conv is not null and v_existing<>v_bsuid_conv) then
+      raise exception 'WA7A0_IDENTITY_CONFLICT' using errcode='23505';
+    end if;
+    v_conv:=v_existing;
+
+    if v_conv is null then
+      v_key:=v_scope||':'||v_kind||':'||v_address;
+      insert into public.aos_wa_conversations_v1(
+        conversation_key,contact_number,contact_name,phone_number_id,state,opened_at,updated_at,
+        contact_address,contact_address_type,contact_bsuid,contact_parent_bsuid,contact_username
+      ) values (
+        v_key,v_phone,nullif(new.contact_name,''),new.phone_number_id,'NEW',v_ts,now(),
+        v_address,v_kind,v_bsuid,v_parent,nullif(new.contact_username,'')
+      )
+      on conflict (conversation_key) do nothing
+      returning id into v_conv;
+      if v_conv is null then select id into v_conv from public.aos_wa_conversations_v1 where conversation_key=v_key; end if;
+    end if;
+  end if;
+
+  if v_conv is null then raise exception 'WA7A0_CONVERSATION_BIND_FAILED'; end if;
+
+  update public.aos_wa_conversations_v1
+  set contact_number=coalesce(v_phone,contact_number),
+      contact_name=coalesce(nullif(new.contact_name,''),contact_name),
+      phone_number_id=coalesce(new.phone_number_id,phone_number_id),
+      contact_address=v_address,
+      contact_address_type=v_kind,
+      contact_bsuid=coalesce(v_bsuid,contact_bsuid),
+      contact_parent_bsuid=coalesce(v_parent,contact_parent_bsuid),
+      contact_username=coalesce(nullif(new.contact_username,''),contact_username),
+      updated_at=now()
+  where id=v_conv;
+
+  if v_phone is not null then
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,first_seen_at,last_seen_at)
+    values(v_scope,'PHONE',v_phone,v_conv,v_ts,v_ts)
+    on conflict (business_scope,alias_type,alias_value) do update set last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),active=true,updated_at=now();
+    select conversation_id into v_existing from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone;
+    if v_existing<>v_conv then raise exception 'WA7A0_IDENTITY_CONFLICT' using errcode='23505'; end if;
+  end if;
+  if v_parent is not null then
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,first_seen_at,last_seen_at)
+    values(v_scope,'PARENT_BSUID',v_parent,v_conv,v_ts,v_ts)
+    on conflict (business_scope,alias_type,alias_value) do update set last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),active=true,updated_at=now();
+    select conversation_id into v_existing from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_parent;
+    if v_existing<>v_conv then raise exception 'WA7A0_IDENTITY_CONFLICT' using errcode='23505'; end if;
+  end if;
+  if v_bsuid is not null then
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,first_seen_at,last_seen_at)
+    values(v_scope,'BSUID',v_bsuid,v_conv,v_ts,v_ts)
+    on conflict (business_scope,alias_type,alias_value) do update set last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),active=true,updated_at=now();
+    select conversation_id into v_existing from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_bsuid;
+    if v_existing<>v_conv then raise exception 'WA7A0_IDENTITY_CONFLICT' using errcode='23505'; end if;
+  end if;
+
+  new.conversation_id:=v_conv;
+  return new;
+end
+$$;
+
+-- Keep all existing WA-3 authorization gates. Return a generic recipient in addition
+-- to the legacy `to_number` key so current runtime remains compatible during rollout.
+create or replace function public.aos_wa3_human_send_authorize_v1(p_token text,p_conversation_id uuid)
+returns jsonb language plpgsql stable security definer set search_path='' as $$
+declare v_actor jsonb; v_uid uuid; v_conv record; v_enabled boolean; v_address text; v_kind text;
+begin
+  v_actor:=public.aos_wa3_actor_v1(p_token);
+  if coalesce((v_actor->>'ok')::boolean,false) is not true then return v_actor; end if;
+  v_uid:=(v_actor->>'actor_id')::uuid;
+  select human_send_enabled into v_enabled from public.aos_wa_routing_control_v1 where id=1;
+  if coalesce(v_enabled,false) is not true then return jsonb_build_object('ok',false,'error','WA3_HUMAN_SEND_DISABLED'); end if;
+  select c.id,c.contact_number,c.contact_address,c.contact_address_type,c.owner_user_id,c.state,c.box_id into v_conv from public.aos_wa_conversations_v1 c where c.id=p_conversation_id;
+  if v_conv.id is null then return jsonb_build_object('ok',false,'error','WA3_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.owner_user_id is distinct from v_uid then return jsonb_build_object('ok',false,'error','WA3_NOT_OWNER'); end if;
+  if v_conv.state not in ('HUMAN_ACTIVE','AI_COPILOT') then return jsonb_build_object('ok',false,'error','WA3_HUMAN_MODE_REQUIRED'); end if;
+  if not exists(select 1 from public.aos_wa_assignments_v1 a where a.conversation_id=p_conversation_id and a.owner_user_id=v_uid and a.state='ACTIVE') then return jsonb_build_object('ok',false,'error','WA3_ACTIVE_ASSIGNMENT_REQUIRED'); end if;
+  v_address:=coalesce(v_conv.contact_address,v_conv.contact_number);
+  v_kind:=coalesce(v_conv.contact_address_type,case when v_conv.contact_number is not null then 'PHONE' end);
+  if v_address is null or v_kind not in ('PHONE','BSUID') then return jsonb_build_object('ok',false,'error','WA7A0_RECIPIENT_UNAVAILABLE'); end if;
+  return jsonb_build_object('ok',true,'actor_id',v_uid,'conversation_id',v_conv.id,
+    'to_number',v_address,'recipient_kind',v_kind,'recipient_address',v_address,
+    'state',v_conv.state,'box_id',v_conv.box_id);
+end
+$$;
+
+-- S14 strict dependency: resolve inbound push by immutable provider message evidence,
+-- not by a mandatory phone number. Signature is unchanged for runtime compatibility.
+create or replace function public.aos_push_targets_for_wa_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_phone text:=trim(coalesce(p_payload->>'phone_number_id',''));
+  v_provider_id text:=trim(coalesce(p_payload->>'provider_message_id',''));
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_subs jsonb;
+begin
+  if v_provider_id='' then return jsonb_build_object('ok',false,'eligible',false,'error','INVALID_WA_TARGET'); end if;
+  select c.* into v_conv
+  from public.aos_wa_messages_v1 m
+  join public.aos_wa_conversations_v1 c on c.id=m.conversation_id
+  where m.provider_message_id=v_provider_id
+    and m.direction='INBOUND'
+    and (v_phone='' or c.phone_number_id=v_phone)
+    and c.last_message_id=v_provider_id
+  order by c.updated_at desc
+  limit 1;
+  if not found then return jsonb_build_object('ok',true,'eligible',false,'reason','CONVERSATION_NOT_CURRENT'); end if;
+  if v_conv.state<>'HUMAN_ACTIVE' or v_conv.owner_user_id is null or v_conv.last_message_direction<>'INBOUND' then
+    return jsonb_build_object('ok',true,'eligible',false,'reason','HUMAN_OWNER_REQUIRED');
+  end if;
+  select coalesce(jsonb_agg(jsonb_build_object('id',s.id,'endpoint',s.endpoint,'p256dh',s.p256dh,'auth',s.auth) order by s.updated_at desc),'[]'::jsonb)
+  into v_subs from public.aos_push_subscriptions_v1 s
+  where s.user_id=v_conv.owner_user_id and s.active=true and coalesce((s.channel_preferences->>'WHATSAPP')::boolean,true)=true;
+  return jsonb_build_object('ok',true,'eligible',true,'conversation_id',v_conv.id,'owner_user_id',v_conv.owner_user_id,
+    'contact_name',v_conv.contact_name,'contact_number',v_conv.contact_number,'contact_address_type',v_conv.contact_address_type,
+    'contact_username',v_conv.contact_username,'subscriptions',v_subs);
+end
+$$;
+
+revoke all on function public.aos_wa7a0_normalize_outbound_request_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa2_bind_conversation_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa3_human_send_authorize_v1(text,uuid) from public;
+revoke all on function public.aos_push_targets_for_wa_v1(jsonb) from public,anon,authenticated;
+grant execute on function public.aos_wa3_human_send_authorize_v1(text,uuid) to anon,authenticated,service_role;
+grant execute on function public.aos_push_targets_for_wa_v1(jsonb) to service_role;
+
+comment on table public.aos_wa_channel_aliases_v1 is 'WA-7A.0 channel alias continuity ledger. PHONE/BSUID/PARENT_BSUID map to one conversation within the current phone_number_id scope; not a canonical customer master.';
+comment on column public.aos_wa_conversations_v1.contact_address is 'Current provider-routable WhatsApp address. May be PHONE or BSUID; not canonical person identity.';
+comment on column public.aos_wa_conversations_v1.contact_username is 'WhatsApp username for display/search UX only. Never routing or merge authority.';
+comment on function public.aos_wa2_bind_conversation_v1() is 'WA-7A.0 identity-compatible binder. PHONE+BSUID aliases converge; conflicts fail closed.';
+comment on function public.aos_push_targets_for_wa_v1(jsonb) is 'S14 target resolver keyed by provider message/conversation evidence; phone is optional.';
+
+commit;

--- a/supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+++ b/supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
@@ -1,0 +1,37 @@
+-- WA-7A.0 direct conversation insert compatibility.
+-- Existing WA-3/WA-4 controlled code and tests may create phone conversations directly.
+-- Populate the generic address automatically without changing their caller contract.
+
+begin;
+
+create or replace function public.aos_wa7a0_conversation_address_compat_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare v_phone text;
+begin
+  if new.contact_address is null and new.contact_number is not null then
+    v_phone:=nullif(regexp_replace(new.contact_number,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then
+      new.contact_number:=v_phone;
+      new.contact_address:=v_phone;
+      new.contact_address_type:='PHONE';
+    end if;
+  end if;
+  if new.contact_address_type='PHONE' and new.contact_number is null and new.contact_address is not null then
+    v_phone:=nullif(regexp_replace(new.contact_address,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then new.contact_number:=v_phone;new.contact_address:=v_phone; end if;
+  end if;
+  return new;
+end
+$$;
+
+drop trigger if exists trg_aos_wa7a0_conversation_address_compat_v1 on public.aos_wa_conversations_v1;
+create trigger trg_aos_wa7a0_conversation_address_compat_v1
+before insert or update of contact_number,contact_address,contact_address_type on public.aos_wa_conversations_v1
+for each row execute function public.aos_wa7a0_conversation_address_compat_v1();
+
+revoke all on function public.aos_wa7a0_conversation_address_compat_v1() from public,anon,authenticated;
+
+commit;

--- a/supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+++ b/supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
@@ -1,0 +1,45 @@
+-- WA-7A.0 phone conversation-key compatibility
+-- Preserve the certified WA-2 key shape for PHONE conversations while BSUID
+-- conversations use their explicit typed namespace.
+
+begin;
+
+create or replace function public.aos_wa7a0_conversation_address_compat_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare v_phone text; v_scope text;
+begin
+  if new.contact_address is null and new.contact_number is not null then
+    v_phone:=nullif(regexp_replace(new.contact_number,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then
+      new.contact_number:=v_phone;
+      new.contact_address:=v_phone;
+      new.contact_address_type:='PHONE';
+    end if;
+  end if;
+  if new.contact_address_type='PHONE' and new.contact_number is null and new.contact_address is not null then
+    v_phone:=nullif(regexp_replace(new.contact_address,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then
+      new.contact_number:=v_phone;
+      new.contact_address:=v_phone;
+    end if;
+  end if;
+
+  -- WA-2 certified PHONE key is `<phone_number_id>:<digits>`.
+  -- Only rewrite the new WA-7A.0 typed candidate; never rewrite arbitrary
+  -- conversation keys created by controlled WA-3/WA-4 fixtures or tools.
+  if new.contact_address_type='PHONE' and new.contact_address is not null then
+    v_scope:=coalesce(nullif(trim(new.phone_number_id),''),'default');
+    if new.conversation_key=v_scope||':PHONE:'||new.contact_address then
+      new.conversation_key:=v_scope||':'||new.contact_address;
+    end if;
+  end if;
+  return new;
+end
+$$;
+
+revoke all on function public.aos_wa7a0_conversation_address_compat_v1() from public,anon,authenticated;
+
+commit;

--- a/supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
+++ b/supabase/rollbacks/20260825143000_wa7a0_identity_compatibility_v1.rollback.sql
@@ -1,0 +1,142 @@
+-- WA-7A.0 Identity Compatibility V1 rollback
+-- Fail closed once BSUID evidence exists because the phone-only model cannot represent it.
+
+begin;
+
+do $$
+begin
+  if exists(select 1 from public.aos_wa_messages_v1 where from_user_id is not null or from_parent_user_id is not null or to_user_id is not null or to_parent_user_id is not null)
+     or exists(select 1 from public.aos_wa_conversations_v1 where contact_address_type='BSUID' or contact_bsuid is not null or contact_parent_bsuid is not null)
+     or exists(select 1 from public.aos_wa_channel_aliases_v1 where alias_type in ('BSUID','PARENT_BSUID'))
+     or exists(select 1 from public.aos_wa_outbound_requests_v1 where recipient_kind='BSUID') then
+    raise exception 'WA7A0_ROLLBACK_BLOCKED_BSUID_DATA' using errcode='55000';
+  end if;
+end
+$$;
+
+drop trigger if exists trg_aos_wa7a0_normalize_outbound_request_v1 on public.aos_wa_outbound_requests_v1;
+drop function if exists public.aos_wa7a0_normalize_outbound_request_v1();
+
+-- Restore phone-only WA-2 bind behavior.
+create or replace function public.aos_wa2_bind_conversation_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare
+  v_contact text;
+  v_key text;
+  v_ts timestamptz;
+  v_conv uuid;
+begin
+  if tg_op='UPDATE' and new.conversation_id is not null then return new; end if;
+  v_contact:=regexp_replace(coalesce(case when new.direction='INBOUND' then new.from_number else new.to_number end,''),'[^0-9]','','g');
+  if v_contact='' then raise exception 'WA2_CONTACT_REQUIRED' using errcode='23514'; end if;
+  v_key:=coalesce(nullif(new.phone_number_id,''),'default')||':'||v_contact;
+  v_ts:=coalesce(new.provider_timestamp,new.received_at,new.sent_at,new.created_at,now());
+  insert into public.aos_wa_conversations_v1(conversation_key,contact_number,contact_name,phone_number_id,state,opened_at,updated_at)
+  values(v_key,v_contact,nullif(new.contact_name,''),new.phone_number_id,'NEW',v_ts,now())
+  on conflict(conversation_key) do nothing returning id into v_conv;
+  if v_conv is null then select id into v_conv from public.aos_wa_conversations_v1 where conversation_key=v_key; end if;
+  if v_conv is null then raise exception 'WA2_CONVERSATION_BIND_FAILED'; end if;
+  new.conversation_id:=v_conv;return new;
+end
+$$;
+
+-- Restore WA-3 authorization response to phone-only recipient.
+create or replace function public.aos_wa3_human_send_authorize_v1(p_token text,p_conversation_id uuid)
+returns jsonb language plpgsql stable security definer set search_path='' as $$
+declare v_actor jsonb; v_uid uuid; v_conv record; v_enabled boolean;
+begin
+  v_actor:=public.aos_wa3_actor_v1(p_token);
+  if coalesce((v_actor->>'ok')::boolean,false) is not true then return v_actor; end if;
+  v_uid:=(v_actor->>'actor_id')::uuid;
+  select human_send_enabled into v_enabled from public.aos_wa_routing_control_v1 where id=1;
+  if coalesce(v_enabled,false) is not true then return jsonb_build_object('ok',false,'error','WA3_HUMAN_SEND_DISABLED'); end if;
+  select c.id,c.contact_number,c.owner_user_id,c.state,c.box_id into v_conv from public.aos_wa_conversations_v1 c where c.id=p_conversation_id;
+  if v_conv.id is null then return jsonb_build_object('ok',false,'error','WA3_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.owner_user_id is distinct from v_uid then return jsonb_build_object('ok',false,'error','WA3_NOT_OWNER'); end if;
+  if v_conv.state not in ('HUMAN_ACTIVE','AI_COPILOT') then return jsonb_build_object('ok',false,'error','WA3_HUMAN_MODE_REQUIRED'); end if;
+  if not exists(select 1 from public.aos_wa_assignments_v1 a where a.conversation_id=p_conversation_id and a.owner_user_id=v_uid and a.state='ACTIVE') then return jsonb_build_object('ok',false,'error','WA3_ACTIVE_ASSIGNMENT_REQUIRED'); end if;
+  return jsonb_build_object('ok',true,'actor_id',v_uid,'conversation_id',v_conv.id,'to_number',v_conv.contact_number,'state',v_conv.state,'box_id',v_conv.box_id);
+end
+$$;
+
+-- Restore S14 phone-target resolver.
+create or replace function public.aos_push_targets_for_wa_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_contact text:=regexp_replace(coalesce(p_payload->>'contact_number',''),'\D','','g');
+  v_phone text:=trim(coalesce(p_payload->>'phone_number_id',''));
+  v_provider_id text:=trim(coalesce(p_payload->>'provider_message_id',''));
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_subs jsonb;
+begin
+  if length(v_contact)<8 or v_provider_id='' then return jsonb_build_object('ok',false,'eligible',false,'error','INVALID_WA_TARGET'); end if;
+  select * into v_conv from public.aos_wa_conversations_v1 c
+  where regexp_replace(c.contact_number,'\D','','g')=v_contact
+    and (v_phone='' or c.phone_number_id=v_phone)
+    and c.last_message_id=v_provider_id
+  order by c.updated_at desc limit 1;
+  if not found then return jsonb_build_object('ok',true,'eligible',false,'reason','CONVERSATION_NOT_CURRENT'); end if;
+  if v_conv.state<>'HUMAN_ACTIVE' or v_conv.owner_user_id is null or v_conv.last_message_direction<>'INBOUND' then
+    return jsonb_build_object('ok',true,'eligible',false,'reason','HUMAN_OWNER_REQUIRED');
+  end if;
+  select coalesce(jsonb_agg(jsonb_build_object('id',s.id,'endpoint',s.endpoint,'p256dh',s.p256dh,'auth',s.auth) order by s.updated_at desc),'[]'::jsonb)
+  into v_subs from public.aos_push_subscriptions_v1 s
+  where s.user_id=v_conv.owner_user_id and s.active=true and coalesce((s.channel_preferences->>'WHATSAPP')::boolean,true)=true;
+  return jsonb_build_object('ok',true,'eligible',true,'conversation_id',v_conv.id,'owner_user_id',v_conv.owner_user_id,'contact_name',v_conv.contact_name,'contact_number',v_conv.contact_number,'subscriptions',v_subs);
+end
+$$;
+
+update public.aos_wa_outbound_requests_v1
+set to_number=recipient_address
+where recipient_kind='PHONE' and to_number is null;
+
+do $$
+begin
+  if exists(select 1 from public.aos_wa_conversations_v1 where contact_number is null)
+     or exists(select 1 from public.aos_wa_outbound_requests_v1 where to_number is null) then
+    raise exception 'WA7A0_ROLLBACK_PHONE_REQUIRED' using errcode='55000';
+  end if;
+end
+$$;
+
+alter table public.aos_wa_outbound_requests_v1 drop constraint if exists aos_wa_outbound_requests_v1_recipient_kind_chk;
+alter table public.aos_wa_outbound_requests_v1 alter column to_number set not null;
+alter table public.aos_wa_outbound_requests_v1 drop column if exists recipient_kind;
+alter table public.aos_wa_outbound_requests_v1 drop column if exists recipient_address;
+
+alter table public.aos_wa_conversations_v1 drop constraint if exists aos_wa_conversations_v1_contact_address_type_chk;
+alter table public.aos_wa_conversations_v1 alter column contact_number set not null;
+drop index if exists public.aos_wa_conversations_v1_bsuid_idx;
+drop index if exists public.aos_wa_conversations_v1_address_idx;
+alter table public.aos_wa_conversations_v1
+  drop column if exists contact_address,
+  drop column if exists contact_address_type,
+  drop column if exists contact_bsuid,
+  drop column if exists contact_parent_bsuid,
+  drop column if exists contact_username;
+
+drop table if exists public.aos_wa_channel_aliases_v1;
+
+drop index if exists public.aos_wa_messages_v1_from_user_idx;
+drop index if exists public.aos_wa_messages_v1_to_user_idx;
+alter table public.aos_wa_messages_v1
+  drop column if exists from_user_id,
+  drop column if exists from_parent_user_id,
+  drop column if exists to_user_id,
+  drop column if exists to_parent_user_id,
+  drop column if exists contact_username;
+
+revoke all on function public.aos_wa2_bind_conversation_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa3_human_send_authorize_v1(text,uuid) from public;
+revoke all on function public.aos_push_targets_for_wa_v1(jsonb) from public,anon,authenticated;
+grant execute on function public.aos_wa3_human_send_authorize_v1(text,uuid) to anon,authenticated,service_role;
+grant execute on function public.aos_push_targets_for_wa_v1(jsonb) to service_role;
+
+commit;

--- a/supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql
+++ b/supabase/rollbacks/20260825143100_wa7a0_direct_insert_compat_v1.rollback.sql
@@ -1,0 +1,14 @@
+begin;
+do $$
+begin
+  if exists(select 1 from public.aos_wa_messages_v1 where from_user_id is not null or from_parent_user_id is not null or to_user_id is not null or to_parent_user_id is not null)
+     or exists(select 1 from public.aos_wa_conversations_v1 where contact_address_type='BSUID' or contact_bsuid is not null or contact_parent_bsuid is not null)
+     or exists(select 1 from public.aos_wa_channel_aliases_v1 where alias_type in ('BSUID','PARENT_BSUID'))
+     or exists(select 1 from public.aos_wa_outbound_requests_v1 where recipient_kind='BSUID') then
+    raise exception 'WA7A0_ROLLBACK_BLOCKED_BSUID_DATA' using errcode='55000';
+  end if;
+end
+$$;
+drop trigger if exists trg_aos_wa7a0_conversation_address_compat_v1 on public.aos_wa_conversations_v1;
+drop function if exists public.aos_wa7a0_conversation_address_compat_v1();
+commit;

--- a/supabase/rollbacks/20260825143200_wa7a0_phone_key_compat_v1.rollback.sql
+++ b/supabase/rollbacks/20260825143200_wa7a0_phone_key_compat_v1.rollback.sql
@@ -1,0 +1,25 @@
+begin;
+create or replace function public.aos_wa7a0_conversation_address_compat_v1()
+returns trigger
+language plpgsql
+set search_path=public,pg_temp
+as $$
+declare v_phone text;
+begin
+  if new.contact_address is null and new.contact_number is not null then
+    v_phone:=nullif(regexp_replace(new.contact_number,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then
+      new.contact_number:=v_phone;
+      new.contact_address:=v_phone;
+      new.contact_address_type:='PHONE';
+    end if;
+  end if;
+  if new.contact_address_type='PHONE' and new.contact_number is null and new.contact_address is not null then
+    v_phone:=nullif(regexp_replace(new.contact_address,'[^0-9]','','g'),'');
+    if v_phone is not null and char_length(v_phone) between 8 and 20 then new.contact_number:=v_phone;new.contact_address:=v_phone; end if;
+  end if;
+  return new;
+end
+$$;
+revoke all on function public.aos_wa7a0_conversation_address_compat_v1() from public,anon,authenticated;
+commit;


### PR DESCRIPTION
## Scope
Implement WA-7A.0 Identity Compatibility on top of the sealed WA-7A baseline.

## Core changes
- Parse direct Cloud API BSUID fields (`contacts[].user_id`, `messages[].from_user_id`, parent ids, username display metadata).
- Preserve phone and BSUID as independent facts; never derive phone from BSUID or route by username.
- Outbound payload supports PHONE via `to` and BSUID via provider `recipient` while keeping a non-enumerable compatibility alias for current ASCENDA server code.
- Add `aos_wa_channel_aliases_v1` to converge PHONE + BSUID + PARENT_BSUID onto one conversation inside the current `phone_number_id` scope.
- BSUID-only after phone+BSUID remains the same conversation.
- Conflicting already-known aliases fail closed with `WA7A0_IDENTITY_CONFLICT`.
- Add generic outbound `recipient_kind` / `recipient_address`; phone fields stay phone-only/nullable.
- Preserve WA-3 authorization/ownership/2FA/kill-switch semantics; authorization now returns a generic recipient in addition to the legacy key.
- Strict S14 dependency updated: target Push by immutable provider-message/conversation evidence instead of mandatory phone.
- Rollback refuses destructive downgrade after BSUID evidence exists.

## Safety
- No auto-routing/AI/Copilot activation.
- No canonical customer merge.
- No username scraping or username identity authority.
- No attribution changes yet (WA-7A.3).
- No bulk campaign sender yet (future phase).

## Baseline
`main@51caf0029bc38f2a164bb648854d0c08d1cbcd94`

## LIVE boundary
This PR must pass dedicated Zero-Cost DB/runtime regression before any production migration is applied. Supabase SQL management access is currently reachable, but fresh REST/provider/LIVE recovery has not yet been certified.