### PR TITLE
WA-7A.1 — Minimal identity resolution bridge to REV

### DIFF
--- a/.github/workflows/wa7a1-identity-resolution.yml
+++ b/.github/workflows/wa7a1-identity-resolution.yml
@@ -1,0 +1,133 @@
+name: ASCENDA WA-7A.1 Identity Resolution
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*wa7a1_identity_resolution*'
+      - 'supabase/rollbacks/*wa7a1_identity_resolution*'
+      - 'ci/wa7a1-identity-resolution/**'
+      - 'docs/control/WHATSAPP_WA_7A_1_IDENTITY_RESOLUTION_EVIDENCE.md'
+      - '.github/workflows/wa7a1-identity-resolution.yml'
+  push:
+    branches: ['feat/wa-7a-1-identity-resolution-20260825']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa7a1-identity-resolution-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · WA-7A.1 REV bridge
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 45
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59932/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost lane
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Source and authority invariants
+        run: |
+          set -euo pipefail
+          M=supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          grep -q 'aos_rev_patient_identity_alias_v2' "$M"
+          grep -q 'aos_rev_normalize_patient_identifier_v2' "$M"
+          grep -q 'IDENTITY_CONFLICT' "$M"
+          grep -q 'NO_PHONE_EVIDENCE' "$M"
+          grep -q 'PATIENT_360_PERMISSION_REQUIRED' "$M"
+          grep -q 'aos_wa3_actor_v1' "$M"
+          ! grep -Eq 'create[[:space:]]+table[[:space:]]+.*(customer|person|patient|identity)' "$M"
+          ! grep -Eq '(contact_username|USERNAME|username).*canonical_patient_id|canonical_patient_id.*(contact_username|USERNAME|username)' "$M"
+          ! grep -Eq '(insert into|update|delete from)[[:space:]]+public\.aos_pacientes' "$M"
+          ! grep -Eq '(insert into|update|delete from)[[:space:]]+public\.aos_rev_' "$M"
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa7a1-identity"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59931/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59932/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59930/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa7a1-identity' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59932 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-7A.1 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build WA certified prerequisites
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+
+      - name: Install synthetic REV authority and WA-7A.1 bridge
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: PHONE BSUID continuity and conflict behavior
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1.txt
+          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1.txt
+
+      - name: WA-7A.0 regression
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0-regression.txt
+          ! grep -q 'not ok' /tmp/wa7a0-regression.txt
+
+      - name: Derived bridge rollback and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825213500_wa7a1_identity_resolution_bridge_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_identity_resolution_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid)') is null")" = "t"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_identity_resolution_v1') is not null")" = "t"
+
+      - name: Certification boundary
+        run: |
+          set -euo pipefail
+          echo 'WA-7A.1 derives canonical identity from existing REV authority only; no CRM/customer master and no canonical mutation.'
+          echo 'LIVE REST/Auth/provider remains a separate gate.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/ci/wa7a1-identity-resolution/rev_identity_stub.sql
+++ b/ci/wa7a1-identity-resolution/rev_identity_stub.sql
@@ -1,0 +1,31 @@
+-- Synthetic REV authority for WA-7A.1 Zero-Cost tests.
+-- Mirrors only the private columns/contracts consumed by the bridge.
+
+create or replace function public.aos_rev_normalize_patient_identifier_v2(p_type text,p_value text)
+returns text language plpgsql immutable set search_path='' as $$
+declare v_type text:=upper(trim(coalesce(p_type,''))); v text:=trim(coalesce(p_value,'')); v_digits text;
+begin
+  if v_type='PHONE' then
+    v_digits:=regexp_replace(v,'[^0-9]','','g');
+    if length(v_digits)<9 then return null; end if;
+    return right(v_digits,9);
+  elsif v_type='CANONICAL_ID' then return nullif(v,'');
+  end if;
+  return null;
+end
+$$;
+
+create table public.aos_rev_patient_identity_alias_v2 (
+  identifier_type text,
+  identifier_key text,
+  canonical_patient_id text,
+  evidence_rows integer,
+  evidence_scopes jsonb,
+  candidate_count integer,
+  status text,
+  confidence_band text,
+  has_reviewed_match boolean
+);
+
+revoke all on public.aos_rev_patient_identity_alias_v2 from public,anon,authenticated;
+grant select on public.aos_rev_patient_identity_alias_v2 to service_role;

--- a/ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql
+++ b/ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql
@@ -1,0 +1,94 @@
+\set ON_ERROR_STOP on
+
+truncate table public.aos_rev_patient_identity_alias_v2;
+delete from public.aos_wa_channel_aliases_v1;
+delete from public.aos_wa_messages_v1;
+delete from public.aos_wa_conversations_v1;
+
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_name,phone_number_id,state,opened_at,updated_at,
+  contact_address,contact_address_type,contact_bsuid
+) values
+('10000000-0000-0000-0000-000000000001','phone-A:51911111111','51911111111','A','phone-A','NEW',now(),now(),'PE.ABC1','BSUID','PE.ABC1'),
+('10000000-0000-0000-0000-000000000002','phone-A:BSUID:PE.ONLY',null,'B','phone-A','NEW',now(),now(),'PE.ONLY','BSUID','PE.ONLY'),
+('10000000-0000-0000-0000-000000000003','phone-A:51922222222','51922222222','C','phone-A','NEW',now(),now(),'51922222222','PHONE',null),
+('10000000-0000-0000-0000-000000000004','phone-A:51933333333','51933333333','D','phone-A','NEW',now(),now(),'51933333333','PHONE',null),
+('10000000-0000-0000-0000-000000000005','phone-A:51955555555','51955555555','E','phone-A','NEW',now(),now(),'PE.HIGH1','BSUID','PE.HIGH1');
+
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active) values
+('phone-A','PHONE','51911111111','10000000-0000-0000-0000-000000000001',true),
+('phone-A','BSUID','PE.ABC1','10000000-0000-0000-0000-000000000001',true),
+('phone-A','BSUID','PE.ONLY','10000000-0000-0000-0000-000000000002',true),
+('phone-A','PHONE','51922222222','10000000-0000-0000-0000-000000000003',true),
+('phone-A','PHONE','51933333333','10000000-0000-0000-0000-000000000004',true),
+('phone-A','PHONE','51944444444','10000000-0000-0000-0000-000000000004',true),
+('phone-A','PHONE','51955555555','10000000-0000-0000-0000-000000000005',true),
+('phone-A','BSUID','PE.HIGH1','10000000-0000-0000-0000-000000000005',true);
+
+insert into public.aos_rev_patient_identity_alias_v2 values
+('PHONE','911111111','P-1',1,'["CANONICAL_CURRENT"]',1,'RESOLVED','MEDIUM',false),
+('PHONE','922222222','P-2A',1,'["CANONICAL_CURRENT"]',2,'CONFLICT','MEDIUM',false),
+('PHONE','922222222','P-2B',1,'["CANONICAL_CURRENT"]',2,'CONFLICT','MEDIUM',false),
+('PHONE','933333333','P-3',1,'["CANONICAL_CURRENT"]',1,'RESOLVED','MEDIUM',false),
+('PHONE','944444444','P-4',1,'["CANONICAL_CURRENT"]',1,'RESOLVED','MEDIUM',false),
+('PHONE','955555555','P-5',2,'["F5_REVIEWED_MATCH"]',1,'RESOLVED','HIGH',true);
+
+-- PHONE + BSUID: canonical result comes from REV PHONE evidence, never BSUID itself.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000001';
+  if r.resolution_status<>'MATCH' or r.canonical_patient_id<>'P-1' or r.canonical_candidate_count<>1 then raise exception 'WA7A1_PHONE_BSUID_MATCH_FAILED'; end if;
+  if r.phone_alias_count<>1 or r.bsuid_alias_count<>1 or r.resolution_method<>'REV_PATIENT_IDENTITY_ALIAS_V2' then raise exception 'WA7A1_PHONE_BSUID_EVIDENCE_FAILED'; end if;
+end $$;
+
+-- Current transport may be BSUID-only while a historical PHONE alias remains on the conversation.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000001';
+  if r.resolution_status<>'MATCH' or r.canonical_patient_id<>'P-1' then raise exception 'WA7A1_BSUID_CONTINUITY_FAILED'; end if;
+end $$;
+
+-- A genuinely BSUID-only conversation has no basis for canonical person resolution.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000002';
+  if r.resolution_status<>'UNRESOLVED' or r.canonical_patient_id is not null or r.resolution_method<>'NO_PHONE_EVIDENCE' then raise exception 'WA7A1_PURE_BSUID_MUST_STAY_UNRESOLVED'; end if;
+end $$;
+
+-- REV conflict must remain fail-closed.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000003';
+  if r.resolution_status<>'IDENTITY_CONFLICT' or r.canonical_patient_id is not null then raise exception 'WA7A1_REV_CONFLICT_NOT_CLOSED'; end if;
+end $$;
+
+-- Two individually resolved PHONE aliases pointing to different canonical patients are a conversation conflict.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000004';
+  if r.resolution_status<>'IDENTITY_CONFLICT' or r.canonical_candidate_count<>2 or r.canonical_patient_id is not null then raise exception 'WA7A1_MULTI_ALIAS_CONFLICT_NOT_CLOSED'; end if;
+end $$;
+
+-- Reviewed REV evidence is surfaced as HIGH confidence without mutating REV.
+do $$ declare r record; begin
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000005';
+  if r.resolution_status<>'MATCH' or r.canonical_patient_id<>'P-5' or r.confidence_band<>'HIGH' then raise exception 'WA7A1_REVIEWED_CONFIDENCE_FAILED'; end if;
+end $$;
+
+-- One resolution row per conversation: adding BSUID aliases cannot duplicate a canonical subject.
+do $$ declare n integer; begin
+  select count(*) into n from public.aos_wa_identity_resolution_v1 where conversation_id='10000000-0000-0000-0000-000000000001';
+  if n<>1 then raise exception 'WA7A1_DUPLICATE_RESOLUTION_ROW'; end if;
+end $$;
+
+-- No raw channel address is exposed by the bridge view.
+do $$ declare n integer; begin
+  select count(*) into n from information_schema.columns
+  where table_schema='public' and table_name='aos_wa_identity_resolution_v1'
+    and column_name in ('alias_value','contact_number','contact_bsuid','contact_username','identifier_key');
+  if n<>0 then raise exception 'WA7A1_RAW_ALIAS_EXPOSURE'; end if;
+end $$;
+
+-- Bridge remains private; RPC is the permissioned browser boundary.
+do $$ begin
+  if has_table_privilege('anon','public.aos_wa_identity_resolution_v1','SELECT') then raise exception 'WA7A1_ANON_VIEW_ACCESS'; end if;
+  if has_table_privilege('authenticated','public.aos_wa_identity_resolution_v1','SELECT') then raise exception 'WA7A1_AUTH_VIEW_ACCESS'; end if;
+  if to_regprocedure('public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid)') is null then raise exception 'WA7A1_RPC_MISSING'; end if;
+end $$;
+
+select 'WA7A1_IDENTITY_RESOLUTION_PASS' as result;

--- a/docs/control/WHATSAPP_WA_7A_1_IDENTITY_RESOLUTION_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA_7A_1_IDENTITY_RESOLUTION_EVIDENCE.md
@@ -1,0 +1,74 @@
+# WA-7A.1 — Identity Resolution — Necessity Gate & Evidence
+
+**Captured:** 2026-08-25 America/Lima  
+**Baseline:** `main@4abfdddbd8c80c88d40699fb8e1ffb6e2c60af0e`  
+**Scope:** WhatsApp channel alias → existing ASCENDA canonical patient identity.  
+**Non-goal:** no new CRM/person/customer master and no patient merge.
+
+## Discovery result
+
+ASCENDA already owns canonical identity through REV/F5/F6:
+
+- `aos_pacientes.ID_PACIENTE` is the canonical patient subject;
+- `aos_rev_patient_identity_alias_v2` already maps governed `PHONE / DOCUMENT / EMAIL / CANONICAL_ID` aliases to `canonical_patient_id` with candidate count, status, confidence and evidence;
+- `aos_rev_resolve_patient_identity_v2` already returns `MATCH / UNRESOLVED / IDENTITY_CONFLICT` and does not use fuzzy/phone-proximity identity;
+- F5 reviewed matches feed the REV alias bridge and remain auditable;
+- Patient 360 consumes canonical patient identity and already keeps conflicts visible;
+- `aos_cia_contact_identity_v1` remains a compatibility/contact projection and is not allowed to become a second patient merge authority.
+
+WA-7A.0 already owns channel continuity:
+
+- `aos_wa_channel_aliases_v1` binds `PHONE / BSUID / PARENT_BSUID` to a WhatsApp conversation;
+- BSUID and PHONE can converge on the same conversation;
+- conflicting channel aliases fail closed;
+- username is not an alias key.
+
+## Production observation before implementation
+
+At discovery time:
+
+- active WhatsApp PHONE aliases: `2`;
+- those two aliases currently have `0` exact REV patient matches;
+- they also have `0` current lead/CIA patient links under the same governed phone normalization;
+- therefore the correct current result for those conversations is `UNRESOLVED`, not creation of a new patient/person record.
+
+This is expected evidence that identity resolution must be able to represent `UNRESOLVED` safely.
+
+## Necessity gate
+
+| Capability | Existing authority | Gap | Decision |
+|---|---|---|---|
+| canonical patient subject | REV / `aos_pacientes` | none | reuse |
+| governed PHONE resolution | `aos_rev_patient_identity_alias_v2` | none | reuse |
+| conflict/candidate handling | REV | none | reuse |
+| PHONE↔BSUID conversation continuity | WA-7A.0 alias ledger | none | reuse |
+| BSUID itself as patient identity | none by design | must not be invented | keep non-authoritative |
+| conversation → canonical patient projection | none | minimal missing bridge | build derived view/RPC |
+| new CRM/customer master | not needed | would duplicate authority | forbidden |
+
+## Minimal architecture
+
+`WA PHONE/BSUID aliases → WA conversation → active PHONE evidence → REV Patient Identity Bridge V2 → canonical_patient_id | UNRESOLVED | IDENTITY_CONFLICT`
+
+Important semantics:
+
+- a BSUID never maps directly to `canonical_patient_id` merely because it exists;
+- a BSUID-only message can retain canonical continuity when its conversation already has governed PHONE evidence from an earlier observation;
+- a genuinely BSUID-only conversation with no corroborating canonical evidence remains `UNRESOLVED`;
+- if REV marks a PHONE alias conflicting, WA returns `IDENTITY_CONFLICT`;
+- if multiple active PHONE aliases on one conversation resolve to different canonical patients, WA returns `IDENTITY_CONFLICT`;
+- no canonical patient row, F5 classification or REV alias is mutated by WA-7A.1.
+
+## Implementation boundary
+
+WA-7A.1 adds only:
+
+- private derived view `aos_wa_identity_resolution_v1`;
+- permissioned read RPC `aos_wa7a1_resolve_conversation_identity_v1`;
+- Zero-Cost behavioral and rollback tests.
+
+The bridge intentionally exposes no raw phone, BSUID, username or REV identifier key.
+
+## LIVE boundary
+
+Supabase management SQL can be read/written, but REST/Auth remains HTTP 402. Therefore WA-7A.1 may certify code, CI, Zero-Cost and production schema/readback while fresh browser/Auth/Meta canaries remain blocked. No Auth/2FA or provider bypass is allowed.

--- a/supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+++ b/supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
@@ -1,0 +1,163 @@
+-- WA-7A.1 — Identity Resolution Bridge V1
+-- Minimal, read-only bridge from WhatsApp channel aliases to the existing REV Patient Identity Bridge V2.
+-- No customer/person master is created. No aos_pacientes / REV canonical mutation is performed.
+
+begin;
+
+create or replace view public.aos_wa_identity_resolution_v1 as
+with alias_counts as (
+  select
+    a.conversation_id,
+    count(*) filter (where a.active and a.alias_type='PHONE')::integer as phone_alias_count,
+    count(*) filter (where a.active and a.alias_type='BSUID')::integer as bsuid_alias_count,
+    count(*) filter (where a.active and a.alias_type='PARENT_BSUID')::integer as parent_bsuid_alias_count
+  from public.aos_wa_channel_aliases_v1 a
+  group by a.conversation_id
+), phone_aliases as (
+  select
+    a.id as alias_id,
+    a.conversation_id,
+    public.aos_rev_normalize_patient_identifier_v2('PHONE',a.alias_value) as phone_key
+  from public.aos_wa_channel_aliases_v1 a
+  where a.active is true
+    and a.alias_type='PHONE'
+), rev_hits as (
+  select
+    p.alias_id,
+    p.conversation_id,
+    p.phone_key,
+    r.canonical_patient_id,
+    r.status as rev_status,
+    r.confidence_band,
+    r.candidate_count,
+    r.has_reviewed_match
+  from phone_aliases p
+  left join public.aos_rev_patient_identity_alias_v2 r
+    on r.identifier_type='PHONE'
+   and r.identifier_key=p.phone_key
+), resolved as (
+  select
+    h.conversation_id,
+    count(distinct h.alias_id) filter (where h.canonical_patient_id is not null)::integer as matched_phone_alias_count,
+    count(distinct h.alias_id) filter (where h.canonical_patient_id is null)::integer as unresolved_phone_alias_count,
+    count(distinct h.canonical_patient_id) filter (where h.canonical_patient_id is not null)::integer as canonical_candidate_count,
+    bool_or(coalesce(h.candidate_count,0)>1 or h.rev_status='CONFLICT') as has_rev_conflict,
+    bool_or(coalesce(h.has_reviewed_match,false)) as has_reviewed_match,
+    min(h.canonical_patient_id) filter (where h.canonical_patient_id is not null) as only_candidate
+  from rev_hits h
+  group by h.conversation_id
+)
+select
+  c.id as conversation_id,
+  case
+    when coalesce(a.phone_alias_count,0)=0 then 'UNRESOLVED'
+    when coalesce(r.has_rev_conflict,false) then 'IDENTITY_CONFLICT'
+    when coalesce(r.canonical_candidate_count,0)>1 then 'IDENTITY_CONFLICT'
+    when coalesce(r.canonical_candidate_count,0)=1 then 'MATCH'
+    else 'UNRESOLVED'
+  end::text as resolution_status,
+  case
+    when coalesce(r.has_rev_conflict,false) then null
+    when coalesce(r.canonical_candidate_count,0)=1 then r.only_candidate
+    else null
+  end::text as canonical_patient_id,
+  coalesce(r.canonical_candidate_count,0)::integer as canonical_candidate_count,
+  coalesce(a.phone_alias_count,0)::integer as phone_alias_count,
+  coalesce(a.bsuid_alias_count,0)::integer as bsuid_alias_count,
+  coalesce(a.parent_bsuid_alias_count,0)::integer as parent_bsuid_alias_count,
+  coalesce(r.matched_phone_alias_count,0)::integer as matched_phone_alias_count,
+  coalesce(r.unresolved_phone_alias_count,0)::integer as unresolved_phone_alias_count,
+  case
+    when coalesce(r.has_rev_conflict,false) or coalesce(r.canonical_candidate_count,0)>1 then null
+    when coalesce(r.canonical_candidate_count,0)=1 and coalesce(r.has_reviewed_match,false) then 'HIGH'
+    when coalesce(r.canonical_candidate_count,0)=1 then 'MEDIUM'
+    else null
+  end::text as confidence_band,
+  case
+    when coalesce(a.phone_alias_count,0)=0 then 'NO_PHONE_EVIDENCE'
+    when coalesce(r.has_rev_conflict,false) or coalesce(r.canonical_candidate_count,0)>1 then 'REV_IDENTITY_CONFLICT'
+    when coalesce(r.canonical_candidate_count,0)=1 then 'REV_PATIENT_IDENTITY_ALIAS_V2'
+    else 'REV_UNRESOLVED'
+  end::text as resolution_method
+from public.aos_wa_conversations_v1 c
+left join alias_counts a on a.conversation_id=c.id
+left join resolved r on r.conversation_id=c.id;
+
+comment on view public.aos_wa_identity_resolution_v1 is
+'WA-7A.1 read-only bridge. A WhatsApp conversation inherits canonical patient resolution only from governed PHONE aliases already resolved by REV Patient Identity Bridge V2. BSUID/username never resolve a person by themselves; conflicts remain fail-closed.';
+
+revoke all on public.aos_wa_identity_resolution_v1 from public, anon, authenticated;
+grant select on public.aos_wa_identity_resolution_v1 to service_role;
+
+create or replace function public.aos_wa7a1_resolve_conversation_identity_v1(
+  p_token text,
+  p_conversation_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_wa_actor jsonb;
+  v_wa_actor_id uuid;
+  v_patient_actor uuid;
+  v_r record;
+begin
+  if p_conversation_id is null then
+    return jsonb_build_object('ok',false,'status','INVALID_CONVERSATION_ID');
+  end if;
+
+  v_wa_actor:=public.aos_wa3_actor_v1(p_token);
+  if coalesce((v_wa_actor->>'ok')::boolean,false) is not true then
+    return jsonb_build_object('ok',false,'status','WA_2FA_PANEL_REQUIRED');
+  end if;
+  v_wa_actor_id:=nullif(v_wa_actor->>'actor_id','')::uuid;
+
+  v_patient_actor:=public.aos_app_actor_v3(p_token,'advisor-patients',true);
+  if v_patient_actor is null then
+    v_patient_actor:=public.aos_app_actor_v3(p_token,'admin-patients',true);
+  end if;
+  if v_patient_actor is null then
+    return jsonb_build_object('ok',false,'status','PATIENT_360_PERMISSION_REQUIRED');
+  end if;
+  if v_patient_actor is distinct from v_wa_actor_id then
+    return jsonb_build_object('ok',false,'status','ACTOR_SCOPE_MISMATCH');
+  end if;
+
+  select * into v_r
+  from public.aos_wa_identity_resolution_v1
+  where conversation_id=p_conversation_id;
+
+  if not found then
+    return jsonb_build_object('ok',false,'status','CONVERSATION_NOT_FOUND');
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,
+    'status',v_r.resolution_status,
+    'canonical_patient_id',v_r.canonical_patient_id,
+    'canonical_candidate_count',v_r.canonical_candidate_count,
+    'confidence_band',v_r.confidence_band,
+    'resolution_method',v_r.resolution_method,
+    'evidence',jsonb_build_object(
+      'phone_alias_count',v_r.phone_alias_count,
+      'bsuid_alias_count',v_r.bsuid_alias_count,
+      'parent_bsuid_alias_count',v_r.parent_bsuid_alias_count,
+      'matched_phone_alias_count',v_r.matched_phone_alias_count,
+      'unresolved_phone_alias_count',v_r.unresolved_phone_alias_count
+    )
+  );
+end;
+$$;
+
+comment on function public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid) is
+'WA-7A.1 Auth V3/2FA read bridge for Customer 360. Reuses REV identity authority; performs no patient merge or canonical mutation and exposes no raw alias values.';
+
+revoke all on function public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid) from public;
+grant execute on function public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid) to anon, authenticated, service_role;
+
+select pg_notify('pgrst','reload schema');
+
+commit;

--- a/supabase/rollbacks/20260825213500_wa7a1_identity_resolution_bridge_v1.rollback.sql
+++ b/supabase/rollbacks/20260825213500_wa7a1_identity_resolution_bridge_v1.rollback.sql
@@ -1,0 +1,6 @@
+-- WA-7A.1 rollback — derived bridge only. No canonical or WhatsApp business data is deleted.
+begin;
+drop function if exists public.aos_wa7a1_resolve_conversation_identity_v1(text,uuid);
+drop view if exists public.aos_wa_identity_resolution_v1;
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Closes the WA-7A.1 implementation slice with a necessity-first design.

Scope:
- reuse REV Patient Identity Bridge V2 as canonical identity authority;
- derive one resolution row per WhatsApp conversation from active PHONE aliases;
- BSUID/PARENT_BSUID preserve conversation continuity but never identify a patient by themselves;
- fail closed on REV alias conflicts or multiple canonical candidates;
- expose a permissioned read RPC for WA + Patient 360 consumers;
- no customer/person master, no aos_pacientes mutation, no REV canonical mutation;
- Zero-Cost behavioral + rollback tests and evidence matrix.

Current production observation: 2 active WA PHONE aliases currently resolve to 0 exact canonical patients, so their correct state remains UNRESOLVED.

LIVE browser/provider certification remains separately blocked while Supabase REST/Auth returns HTTP 402.