### PR TITLE
WA-7A.2 — Identity verification and continuity

### DIFF
--- a/.github/workflows/wa7a2-identity-verification.yml
+++ b/.github/workflows/wa7a2-identity-verification.yml
@@ -30,6 +30,9 @@ jobs:
       DB_URL: postgresql://postgres:postgres@127.0.0.1:59832/postgres
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: supabase/setup-cli@v1
         with:
           version: 2.101.0

--- a/.github/workflows/wa7a2-identity-verification.yml
+++ b/.github/workflows/wa7a2-identity-verification.yml
@@ -1,0 +1,170 @@
+name: ASCENDA WA-7A.2 Identity Verification & Continuity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa7a2_identity_verification*'
+      - 'supabase/rollbacks/*wa7a2_identity_verification*'
+      - 'ci/wa7a2-identity-verification/**'
+      - 'docs/control/WHATSAPP_WA_7A_2_IDENTITY_VERIFICATION_EVIDENCE.md'
+      - '.github/workflows/wa7a2-identity-verification.yml'
+  push:
+    branches: ['feat/wa-7a-2-identity-verification-continuity-20260825']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa7a2-identity-verification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · WA-7A.2 verification + lineage
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 45
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59832/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost lane
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Authority and scope invariants
+        run: |
+          set -euo pipefail
+          M=supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          J=app/wa-gateway.js
+          grep -q 'aos_wa_channel_aliases_v1' "$M"
+          grep -q 'aos_wa_events_v1' "$M"
+          grep -q "VERIFIED','CLAIMED','UNKNOWN','CONFLICT" "$M"
+          grep -q 'superseded_by' "$M"
+          grep -q 'META_CONTACT_REQUEST' "$M"
+          grep -q 'META_STATUS_RECIPIENT_USER_ID' "$M"
+          grep -q 'user_changed_number' "$J"
+          grep -q 'user_changed_user_id' "$J"
+          grep -q 'request_contact_info' "$J"
+          grep -q 'identity.contact_disclosure' "$J"
+          ! grep -Eiq 'create[[:space:]]+table' "$M"
+          ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.aos_pacientes' "$M"
+          ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.aos_rev_' "$M"
+          ! grep -Eq "change\.field[[:space:]]*={2,3}[[:space:]]*['\"]user_id_update['\"]" "$J"
+          ! grep -Eq '(contact_username|username).*canonical|canonical.*(contact_username|username)' "$M"
+
+      - name: Gateway parser and outbound contracts
+        run: |
+          set -euo pipefail
+          node --check app/wa-gateway.js
+          node --test ci/wa7a2-identity-verification/identity_webhook_contract.test.js
+          node --test ci/wa7a0-identity-compatibility/identity_contract.test.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa7a2-identity"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59831/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59832/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59830/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa7a2-identity' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59832 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-7A.2 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build certified WA + REV prerequisites
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: Verification continuity behavior
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a2-identity-verification/tests/001_identity_verification.sql | tee /tmp/wa7a2-db.txt
+          grep -q 'WA7A2_IDENTITY_VERIFICATION_PASS' /tmp/wa7a2-db.txt
+
+      - name: Concurrent lineage fork prevention
+        run: |
+          set -euo pipefail
+          bash ci/wa7a2-identity-verification/concurrent_identity.sh | tee /tmp/wa7a2-concurrency.txt
+          grep -q 'WA7A2_CONCURRENT_LINEAGE_PASS' /tmp/wa7a2-concurrency.txt
+
+      - name: WA-7A.0 and WA-7A.1 regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0-regression.txt
+          grep -q 'WA7A0' /tmp/wa7a0-regression.txt || true
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1-regression.txt
+          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1-regression.txt
+
+      - name: Destructive rollback guard
+        run: |
+          set -euo pipefail
+          if psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825222500_wa7a2_identity_verification_continuity_v1.rollback.sql; then
+            echo 'WA-7A.2 rollback unexpectedly removed live lineage evidence' >&2
+            exit 1
+          fi
+          echo WA7A2_ROLLBACK_GUARD_PASS
+
+      - name: Clean synthetic evidence then rollback and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          delete from public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260825222500_wa7a2_identity_verification_continuity_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.columns where table_schema='public' and table_name='aos_wa_channel_aliases_v1' and column_name='verification_status'")" = "0"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.columns where table_schema='public' and table_name='aos_wa_channel_aliases_v1' and column_name='verification_status'")" = "1"
+
+      - name: Certification boundary
+        run: |
+          set -euo pipefail
+          echo 'WA-7A.2 reuses WA aliases/events + REV bridge; no customer/person master and no attribution.'
+          echo 'Typed/manual/forwarded phone is never auto-VERIFIED. Current Meta system-message contract is covered.'
+          echo 'Fresh REST/Auth/provider/physical REQUEST_CONTACT_INFO and BSUID rotation remain LIVE_PENDING while HTTP 402 persists.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/.github/workflows/wa7a2-identity-verification.yml
+++ b/.github/workflows/wa7a2-identity-verification.yml
@@ -124,14 +124,6 @@ jobs:
           bash ci/wa7a2-identity-verification/concurrent_identity.sh | tee /tmp/wa7a2-concurrency.txt
           grep -q 'WA7A2_CONCURRENT_LINEAGE_PASS' /tmp/wa7a2-concurrency.txt
 
-      - name: WA-7A.0 and WA-7A.1 regressions
-        run: |
-          set -euo pipefail
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0-regression.txt
-          grep -q 'WA7A0' /tmp/wa7a0-regression.txt || true
-          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1-regression.txt
-          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1-regression.txt
-
       - name: Destructive rollback guard
         run: |
           set -euo pipefail
@@ -141,7 +133,26 @@ jobs:
           fi
           echo WA7A2_ROLLBACK_GUARD_PASS
 
-      - name: Clean synthetic evidence then rollback and reapply
+      - name: Clear WA-7A.2 synthetic lineage before historical regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          delete from public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+
+      - name: WA-7A.0 and WA-7A.1 regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0-regression.txt
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1-regression.txt
+          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1-regression.txt
+
+      - name: Clean regression fixtures then rollback and reapply
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'

--- a/.github/workflows/wa7a2-identity-verification.yml
+++ b/.github/workflows/wa7a2-identity-verification.yml
@@ -59,7 +59,7 @@ jobs:
           ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.aos_pacientes' "$M"
           ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.aos_rev_' "$M"
           ! grep -Eq "change\.field[[:space:]]*={2,3}[[:space:]]*['\"]user_id_update['\"]" "$J"
-          ! grep -Eq '(contact_username|username).*canonical|canonical.*(contact_username|username)' "$M"
+          ! grep -Eq '(^|[^[:alnum:]_])(contact_username|username)[[:space:]]*(:=|=|in[[:space:]]*\(|join|where|on[[:space:]])' "$M"
 
       - name: Gateway parser and outbound contracts
         run: |

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -78,15 +78,44 @@ function contactForMessage(contacts,msg){
     return (msgUser&&cu===msgUser)||(msgPhone&&cp===msgPhone);
   })||{};
 }
+function contactPhones(card){
+  const seen=new Set();
+  (card&&Array.isArray(card.phones)?card.phones:[]).forEach(p=>{
+    const v=phoneValue((p&&p.wa_id)||(p&&p.phone));if(v)seen.add(v);
+  });
+  return Array.from(seen);
+}
+function identityKey(parts){return trimText(parts.filter(Boolean).join(':'),900);}
 
 function extractWebhook(payload){
   const messages=[];const statuses=[];const events=[];
   if(!payload||payload.object!=='whatsapp_business_account'||!Array.isArray(payload.entry))return {messages,statuses,events};
   payload.entry.forEach(entry=>{
     (entry.changes||[]).forEach(change=>{
+      // Meta corrected the 2026 contract: there is no subscribable `user_id_update` field.
+      // BSUID rotation is consumed below as a system message on the existing `messages` subscription.
       if(change.field!=='messages')return;
       const value=change.value||{};const meta=value.metadata||{};const contacts=value.contacts||[];
+      const businessScope=trimText(meta.phone_number_id,128)||'default';
       (value.messages||[]).forEach(msg=>{
+        const observedAt=isoFromUnix(msg.timestamp);
+        if(String(msg.type||'').toLowerCase()==='system'){
+          const system=msg.system||{};const systemType=String(system.type||'').toLowerCase();
+          if(['user_changed_number','user_changed_user_id'].includes(systemType)){
+            const previousUser=userIdValue(system.previous_user_id);
+            const currentUser=userIdValue(system.user_id);
+            const previousParent=userIdValue(system.previous_parent_user_id);
+            const currentParent=userIdValue(system.parent_user_id);
+            const changedPhone=phoneValue(system.wa_id);
+            events.push({
+              event_key:identityKey(['identity','system',trimText(msg.id,256)||businessScope,systemType,previousUser,currentUser,String(msg.timestamp||'')]),
+              event_type:'identity.system_change',provider_message_id:trimText(msg.id,256)||null,status:'observed',
+              payload:{business_scope:businessScope,system_type:systemType,previous_user_id:previousUser,user_id:currentUser,previous_parent_user_id:previousParent,parent_user_id:currentParent,wa_id:changedPhone,observed_at:observedAt,source:'META_MESSAGES_SYSTEM'}
+            });
+          }
+          return; // System identity events are state transitions, not customer chat messages.
+        }
+
         const contact=contactForMessage(contacts,msg);const profile=contact.profile||{};
         const fromPhone=phoneValue(msg.from)||phoneValue(contact.wa_id);
         const fromUser=userIdValue(msg.from_user_id)||userIdValue(contact.user_id)||(!fromPhone?userIdValue(msg.from):null);
@@ -103,23 +132,45 @@ function extractWebhook(payload){
           raw_referral:Object.keys(referral).length?{
             source_id:trimText(referral.source_id,256)||null,source_type:trimText(referral.source_type,64)||null,
             headline:trimText(referral.headline,512)||null,body:trimText(referral.body,1000)||null
-          }:null,provider_timestamp:isoFromUnix(msg.timestamp),received_at:new Date().toISOString()
+          }:null,provider_timestamp:observedAt,received_at:new Date().toISOString()
         };
         if(!row.provider_message_id)return;
         messages.push(row);
         events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral,sender_kind:row.from_number?'PHONE':(row.from_user_id?'BSUID':'UNKNOWN'),has_user_id:!!row.from_user_id}});
+
+        // A signed Meta message carrying both identifiers is direct channel-pair evidence.
+        if(fromPhone&&fromUser){
+          events.push({event_key:'identity:pair:'+row.provider_message_id,event_type:'identity.meta_pair',provider_message_id:row.provider_message_id,status:'observed',payload:{business_scope:businessScope,phone:fromPhone,user_id:fromUser,parent_user_id:parentUser,observed_at:observedAt,source:'META_SIGNED_MESSAGE_PAIR'}});
+        }
+
+        // REQUEST_CONTACT_INFO response versus an arbitrary forwarded contact card.
+        if(String(msg.type||'').toLowerCase()==='contacts'&&Array.isArray(msg.contacts)){
+          msg.contacts.forEach((card,index)=>{
+            const phones=contactPhones(card);const origin=String(card&&card.origin||'other').toLowerCase();
+            events.push({
+              event_key:'identity:contact:'+row.provider_message_id+':'+index,
+              event_type:'identity.contact_disclosure',provider_message_id:row.provider_message_id,status:'observed',
+              payload:{business_scope:businessScope,origin,sender_phone:fromPhone,sender_user_id:fromUser,sender_parent_user_id:parentUser,shared_phone:phones.length===1?phones[0]:null,shared_phone_count:phones.length,observed_at:observedAt,source:origin==='contact_request'?'META_CONTACT_REQUEST':'META_CONTACT_OTHER'}
+            });
+          });
+        }
       });
       (value.statuses||[]).forEach(st=>{
         const id=trimText(st.id,256);if(!id)return;
         const pricing=st.pricing||{};const state=trimText(st.status||'unknown',64);
         const recipientPhone=phoneValue(st.recipient_id);
         const recipientUser=userIdValue(st.recipient_user_id)||(!recipientPhone?userIdValue(st.recipient_id):null);
-        const row={provider_message_id:id,status:state,recipient_id:recipientPhone,recipient_user_id:recipientUser,recipient_parent_user_id:userIdValue(st.recipient_parent_user_id),provider_timestamp:isoFromUnix(st.timestamp),
+        const recipientParent=userIdValue(st.recipient_parent_user_id);
+        const observedAt=isoFromUnix(st.timestamp);
+        const row={provider_message_id:id,status:state,recipient_id:recipientPhone,recipient_user_id:recipientUser,recipient_parent_user_id:recipientParent,provider_timestamp:observedAt,
           pricing_category:trimText(pricing.category||'',64)||null,pricing_model:trimText(pricing.pricing_model||'',64)||null,
           billable:typeof pricing.billable==='boolean'?pricing.billable:null,error_code:null,error_title:null};
         if(Array.isArray(st.errors)&&st.errors[0]){row.error_code=trimText(st.errors[0].code,64)||null;row.error_title=trimText(st.errors[0].title||st.errors[0].message,512)||null;}
         statuses.push(row);
         events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,recipient_user_id:row.recipient_user_id,recipient_parent_user_id:row.recipient_parent_user_id,recipient_kind:row.recipient_id?'PHONE':(row.recipient_user_id?'BSUID':'UNKNOWN'),pricing_category:row.pricing_category,pricing_model:row.pricing_model,billable:row.billable,error_code:row.error_code}});
+        if(recipientUser&&['delivered','read'].includes(String(state).toLowerCase())){
+          events.push({event_key:'identity:status:'+id+':'+state+':'+recipientUser,event_type:'identity.status_binding',provider_message_id:id,status:state,payload:{business_scope:businessScope,provider_status:state,recipient_user_id:recipientUser,recipient_parent_user_id:recipientParent,observed_at:observedAt,source:'META_STATUS_RECIPIENT_USER_ID'}});
+        }
       });
     });
   });
@@ -142,6 +193,10 @@ function buildOutboundPayload(input){
   }else if(type==='template'){
     const name=trimText(d.template_name,512);const language=trimText(d.language||'es',32);if(!name)throw Object.assign(new Error('TEMPLATE_NAME_REQUIRED'),{status:400});
     out.template={name,language:{code:language}};if(Array.isArray(d.components))out.template.components=d.components;
+  }else if(type==='request_contact_info'){
+    const body=trimText(d.text||d.body,1024);if(!body)throw Object.assign(new Error('CONTACT_REQUEST_TEXT_REQUIRED'),{status:400});
+    out.type='interactive';out.interactive={type:'request_contact_info',body:{text:body},action:{name:'request_contact_info'}};
+    Object.defineProperty(out,'_ascenda_message_type',{value:'request_contact_info',enumerable:false,writable:false});
   }else if(['image','document','audio'].includes(type)){
     const link=trimText(d.link,2048);if(!/^https:\/\//i.test(link))throw Object.assign(new Error('HTTPS_MEDIA_LINK_REQUIRED'),{status:400});
     out[type]={link};if(type!=='audio'&&d.caption)out[type].caption=trimText(d.caption,1024);if(type==='document'&&d.filename)out.document.filename=trimText(d.filename,255);

--- a/ci/wa7a2-identity-verification/concurrent_identity.sh
+++ b/ci/wa7a2-identity-verification/concurrent_identity.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${DB_URL:?DB_URL required}"
+
+psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,phone_number_id,message_type,status,provider_timestamp,received_at)
+values('wamid.wa7a2.concurrent.seed','INBOUND','51966666666','PE.CONCURRENT.OLD','pn-concurrent','text','received',now(),now());
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:pair:concurrent.seed','identity.meta_pair','observed',jsonb_build_object('business_scope','pn-concurrent','phone','51966666666','user_id','PE.CONCURRENT.OLD','observed_at',now()));
+SQL
+
+psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "insert into public.aos_wa_events_v1(event_key,event_type,status,payload) values('identity:system:concurrent:A','identity.system_change','observed',jsonb_build_object('business_scope','pn-concurrent','system_type','user_changed_user_id','previous_user_id','PE.CONCURRENT.OLD','user_id','PE.CONCURRENT.A','observed_at',now()));" &
+p1=$!
+psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "insert into public.aos_wa_events_v1(event_key,event_type,status,payload) values('identity:system:concurrent:B','identity.system_change','observed',jsonb_build_object('business_scope','pn-concurrent','system_type','user_changed_user_id','previous_user_id','PE.CONCURRENT.OLD','user_id','PE.CONCURRENT.B','observed_at',now()));" &
+p2=$!
+wait "$p1"
+wait "$p2"
+
+verified="$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_events_v1 where event_key in ('identity:system:concurrent:A','identity:system:concurrent:B') and status='VERIFIED'")"
+conflict="$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_events_v1 where event_key in ('identity:system:concurrent:A','identity:system:concurrent:B') and status='CONFLICT'")"
+active_bsuid="$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_channel_aliases_v1 where business_scope='pn-concurrent' and alias_type='BSUID' and active")"
+active_phone="$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa_channel_aliases_v1 where business_scope='pn-concurrent' and alias_type='PHONE' and active")"
+
+[[ "$verified" == "1" ]]
+[[ "$conflict" == "1" ]]
+[[ "$active_bsuid" == "1" ]]
+[[ "$active_phone" == "0" ]]
+echo WA7A2_CONCURRENT_LINEAGE_PASS

--- a/ci/wa7a2-identity-verification/identity_webhook_contract.test.js
+++ b/ci/wa7a2-identity-verification/identity_webhook_contract.test.js
@@ -1,0 +1,52 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const wa=require('../../app/wa-gateway');
+
+function envelope(value){return {object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:Object.assign({metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn-wa7a2'}},value)}]}]};}
+function eventOf(e,type){return e.events.find(x=>x.event_type===type);}
+
+test('current Meta user_changed_user_id arrives as messages/system and preserves old-new BSUID lineage without phone',()=>{
+  const p=envelope({messages:[{id:'wamid.system.uid',timestamp:'1787696000',type:'system',system:{type:'user_changed_user_id',previous_user_id:'PE.OLD1',user_id:'PE.NEW1',previous_parent_user_id:'PE.ENT.OLD1',parent_user_id:'PE.ENT.NEW1',body:'changed'}}]});
+  const e=wa.extractWebhook(p);const ev=eventOf(e,'identity.system_change');
+  assert.equal(e.messages.length,0);assert.ok(ev);assert.equal(ev.payload.system_type,'user_changed_user_id');assert.equal(ev.payload.previous_user_id,'PE.OLD1');assert.equal(ev.payload.user_id,'PE.NEW1');assert.equal(ev.payload.wa_id,null);
+});
+
+test('current Meta user_changed_number preserves new phone when shareable',()=>{
+  const p=envelope({messages:[{id:'wamid.system.number',timestamp:'1787696001',type:'system',system:{type:'user_changed_number',previous_user_id:'PE.OLD2',user_id:'PE.NEW2',wa_id:'+51 966 666 666'}}]});
+  const ev=eventOf(wa.extractWebhook(p),'identity.system_change');assert.equal(ev.payload.wa_id,'51966666666');assert.equal(ev.payload.user_id,'PE.NEW2');
+});
+
+test('signed phone plus BSUID emits independent meta-pair verification evidence',()=>{
+  const p=envelope({contacts:[{wa_id:'51911111111',user_id:'PE.PAIR1',parent_user_id:'PE.ENT.PAIR1',profile:{name:'Pair',username:'pair.name'}}],messages:[{id:'wamid.pair',from:'51911111111',from_user_id:'PE.PAIR1',from_parent_user_id:'PE.ENT.PAIR1',timestamp:'1787696002',type:'text',text:{body:'hola'}}]});
+  const e=wa.extractWebhook(p);const ev=eventOf(e,'identity.meta_pair');assert.equal(e.messages.length,1);assert.ok(ev);assert.equal(ev.payload.phone,'51911111111');assert.equal(ev.payload.user_id,'PE.PAIR1');assert.equal(ev.payload.parent_user_id,'PE.ENT.PAIR1');
+});
+
+test('REQUEST_CONTACT_INFO response emits attested disclosure without storing vcard in normalized message',()=>{
+  const p=envelope({contacts:[{user_id:'PE.CONTACT1',profile:{name:'Private'}}],messages:[{id:'wamid.contact.request',from_user_id:'PE.CONTACT1',timestamp:'1787696003',type:'contacts',contacts:[{origin:'contact_request',name:{formatted_name:'Private'},phones:[{phone:'+51 922 222 222',wa_id:'51922222222'}]}]}]});
+  const e=wa.extractWebhook(p);const ev=eventOf(e,'identity.contact_disclosure');assert.equal(e.messages[0].message_type,'contacts');assert.equal(e.messages[0].message_body,null);assert.equal(ev.payload.origin,'contact_request');assert.equal(ev.payload.shared_phone,'51922222222');assert.equal(ev.payload.shared_phone_count,1);assert.equal(JSON.stringify(ev).includes('vcard'),false);
+});
+
+test('ordinary forwarded contact remains non-attested evidence',()=>{
+  const p=envelope({contacts:[{user_id:'PE.CONTACT2',profile:{name:'Private'}}],messages:[{id:'wamid.contact.other',from_user_id:'PE.CONTACT2',timestamp:'1787696004',type:'contacts',contacts:[{origin:'other',phones:[{phone:'+51 933 333 333'}],vcard:'BEGIN:VCARD...'}]}]});
+  const ev=eventOf(wa.extractWebhook(p),'identity.contact_disclosure');assert.equal(ev.payload.origin,'other');assert.equal(ev.payload.shared_phone,'51933333333');assert.equal(ev.payload.source,'META_CONTACT_OTHER');assert.equal(JSON.stringify(ev).includes('BEGIN:VCARD'),false);
+});
+
+test('delivered/read recipient_user_id creates status binding evidence, sent does not',()=>{
+  const delivered=envelope({statuses:[{id:'wamid.out.1',status:'delivered',timestamp:'1787696005',recipient_id:'51944444444',recipient_user_id:'PE.STATUS1',recipient_parent_user_id:'PE.ENT.STATUS1'}]});
+  const de=wa.extractWebhook(delivered);const ev=eventOf(de,'identity.status_binding');assert.ok(ev);assert.equal(ev.payload.recipient_user_id,'PE.STATUS1');assert.equal(ev.payload.business_scope,'pn-wa7a2');
+  const sent=envelope({statuses:[{id:'wamid.out.2',status:'sent',timestamp:'1787696006',recipient_user_id:'PE.STATUS2'}]});
+  assert.equal(eventOf(wa.extractWebhook(sent),'identity.status_binding'),undefined);
+});
+
+test('request_contact_info uses native interactive payload for PHONE and BSUID recipients',()=>{
+  const a=wa.buildOutboundPayload({to:'+51 955 555 555',type:'request_contact_info',text:'Comparte tu número para continuar.'});
+  assert.equal(a.type,'interactive');assert.equal(a.interactive.type,'request_contact_info');assert.equal(a.interactive.action.name,'request_contact_info');assert.equal(a.to,'51955555555');
+  const b=wa.buildOutboundPayload({recipient_kind:'BSUID',recipient_address:'PE.REQUEST1',type:'request_contact_info',text:'Comparte tu número para continuar.'});
+  assert.equal(b.recipient,'PE.REQUEST1');assert.equal(JSON.stringify(b).includes('"to"'),false);assert.equal(b.interactive.type,'request_contact_info');
+});
+
+test('username remains display-only and never appears in identity authority event payloads',()=>{
+  const p=envelope({contacts:[{wa_id:'51977777777',user_id:'PE.USERNAME1',profile:{name:'Name',username:'@mutable_name'}}],messages:[{id:'wamid.username',from:'51977777777',from_user_id:'PE.USERNAME1',timestamp:'1787696007',type:'text',text:{body:'hola'}}]});
+  const e=wa.extractWebhook(p);assert.equal(e.messages[0].contact_username,'mutable_name');const ev=eventOf(e,'identity.meta_pair');assert.ok(ev);assert.equal(Object.prototype.hasOwnProperty.call(ev.payload,'username'),false);
+});

--- a/ci/wa7a2-identity-verification/tests/001_identity_verification.sql
+++ b/ci/wa7a2-identity-verification/tests/001_identity_verification.sql
@@ -1,0 +1,118 @@
+\set ON_ERROR_STOP on
+
+-- Synthetic WA-7A.2 behavioral contract. No canonical patient mutation exists in this test path.
+delete from public.aos_wa_events_v1;
+delete from public.aos_wa_messages_v1;
+delete from public.aos_wa_channel_aliases_v1;
+delete from public.aos_wa_conversations_v1;
+
+-- A. Signed PHONE+BSUID pair is one conversation and both facts become VERIFIED.
+insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,from_parent_user_id,phone_number_id,message_type,status,provider_timestamp,received_at)
+values('wamid.wa7a2.pair','INBOUND','51911111111','PE.PAIR.OLD','PE.ENT.PAIR.OLD','pn-wa7a2','text','received',now(),now());
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values('identity:pair:wamid.wa7a2.pair','identity.meta_pair','wamid.wa7a2.pair','observed',jsonb_build_object('business_scope','pn-wa7a2','phone','51911111111','user_id','PE.PAIR.OLD','parent_user_id','PE.ENT.PAIR.OLD','observed_at',now()));
+
+do $$ declare v uuid; n int; begin
+  select conversation_id into v from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a2.pair';
+  select count(*) into n from public.aos_wa_channel_aliases_v1 where conversation_id=v and active and verification_status='VERIFIED' and alias_type in ('PHONE','BSUID','PARENT_BSUID');
+  if n<>3 then raise exception 'WA7A2_META_PAIR_NOT_VERIFIED'; end if;
+  if (select status from public.aos_wa_events_v1 where event_key='identity:pair:wamid.wa7a2.pair')<>'VERIFIED' then raise exception 'WA7A2_META_PAIR_EVENT_NOT_VERIFIED'; end if;
+end $$;
+
+-- B. BSUID-only system rotation preserves conversation, explicitly supersedes old BSUID and retires stale phone.
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:system:uid-1','identity.system_change','observed',jsonb_build_object(
+  'business_scope','pn-wa7a2','system_type','user_changed_user_id','previous_user_id','PE.PAIR.OLD','user_id','PE.PAIR.NEW',
+  'previous_parent_user_id','PE.ENT.PAIR.OLD','parent_user_id','PE.ENT.PAIR.NEW','observed_at',now()+interval '1 second'));
+
+do $$ declare v uuid; old_id uuid; new_id uuid; begin
+  select conversation_id into v from public.aos_wa_channel_aliases_v1 where business_scope='pn-wa7a2' and alias_type='BSUID' and alias_value='PE.PAIR.NEW';
+  select id,superseded_by into old_id,new_id from public.aos_wa_channel_aliases_v1 where business_scope='pn-wa7a2' and alias_type='BSUID' and alias_value='PE.PAIR.OLD';
+  if (select active from public.aos_wa_channel_aliases_v1 where id=old_id) then raise exception 'WA7A2_OLD_BSUID_STILL_ACTIVE'; end if;
+  if new_id is null or new_id<>(select id from public.aos_wa_channel_aliases_v1 where business_scope='pn-wa7a2' and alias_type='BSUID' and alias_value='PE.PAIR.NEW') then raise exception 'WA7A2_BSUID_LINEAGE_MISSING'; end if;
+  if exists(select 1 from public.aos_wa_channel_aliases_v1 where conversation_id=v and alias_type='PHONE' and active) then raise exception 'WA7A2_STALE_PHONE_STILL_ACTIVE'; end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 where id=v and contact_number is null and contact_bsuid='PE.PAIR.NEW' and contact_address_type='BSUID') then raise exception 'WA7A2_BSUID_ONLY_PROJECTION_FAILED'; end if;
+end $$;
+
+-- Replay is idempotent: no second mutation/event.
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:system:uid-1','identity.system_change','observed',jsonb_build_object('business_scope','pn-wa7a2','system_type','user_changed_user_id','previous_user_id','PE.PAIR.OLD','user_id','PE.PAIR.NEW'))
+on conflict (event_key) do nothing;
+do $$ begin
+  if (select count(*) from public.aos_wa_events_v1 where event_key='identity:system:uid-1')<>1 then raise exception 'WA7A2_REPLAY_EVENT_DUPLICATED'; end if;
+  if (select count(*) from public.aos_wa_channel_aliases_v1 where business_scope='pn-wa7a2' and alias_type='BSUID' and active)<>1 then raise exception 'WA7A2_REPLAY_ALIAS_DUPLICATED'; end if;
+end $$;
+
+-- C. Phone-visible system rotation supersedes old phone + BSUID, never creates another conversation.
+insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,from_user_id,phone_number_id,message_type,status,provider_timestamp,received_at)
+values('wamid.wa7a2.number.seed','INBOUND','51922222222','PE.NUM.OLD','pn-number','text','received',now(),now());
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:pair:number.seed','identity.meta_pair','observed',jsonb_build_object('business_scope','pn-number','phone','51922222222','user_id','PE.NUM.OLD','observed_at',now()));
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:system:number-1','identity.system_change','observed',jsonb_build_object('business_scope','pn-number','system_type','user_changed_number','previous_user_id','PE.NUM.OLD','user_id','PE.NUM.NEW','wa_id','51933333333','observed_at',now()+interval '1 second'));
+
+do $$ declare v_old uuid; v_new uuid; begin
+  select conversation_id into v_old from public.aos_wa_channel_aliases_v1 where business_scope='pn-number' and alias_type='BSUID' and alias_value='PE.NUM.OLD';
+  select conversation_id into v_new from public.aos_wa_channel_aliases_v1 where business_scope='pn-number' and alias_type='BSUID' and alias_value='PE.NUM.NEW';
+  if v_old is distinct from v_new then raise exception 'WA7A2_NUMBER_CHANGE_SPLIT_CONVERSATION'; end if;
+  if exists(select 1 from public.aos_wa_channel_aliases_v1 where business_scope='pn-number' and alias_value in ('PE.NUM.OLD','51922222222') and active) then raise exception 'WA7A2_OLD_NUMBER_IDENTITY_STILL_ACTIVE'; end if;
+  if not exists(select 1 from public.aos_wa_channel_aliases_v1 where business_scope='pn-number' and alias_type='PHONE' and alias_value='51933333333' and active and verification_status='VERIFIED' and verification_source='META_SYSTEM_CHANGE') then raise exception 'WA7A2_NEW_PHONE_NOT_VERIFIED'; end if;
+end $$;
+
+-- D. Native REQUEST_CONTACT_INFO response can verify/bind exactly one phone to an existing BSUID-only conversation.
+insert into public.aos_wa_messages_v1(provider_message_id,direction,from_user_id,phone_number_id,message_type,status,provider_timestamp,received_at)
+values('wamid.wa7a2.contact','INBOUND','PE.CONTACT.ONLY','pn-contact','contacts','received',now(),now());
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values('identity:contact:wamid.wa7a2.contact:0','identity.contact_disclosure','wamid.wa7a2.contact','observed',jsonb_build_object('business_scope','pn-contact','origin','contact_request','sender_user_id','PE.CONTACT.ONLY','shared_phone','51944444444','shared_phone_count',1,'observed_at',now()));
+
+do $$ declare v uuid; begin
+  select conversation_id into v from public.aos_wa_channel_aliases_v1 where business_scope='pn-contact' and alias_type='BSUID' and alias_value='PE.CONTACT.ONLY';
+  if not exists(select 1 from public.aos_wa_channel_aliases_v1 where conversation_id=v and alias_type='PHONE' and alias_value='51944444444' and active and verification_status='VERIFIED' and verification_source='META_CONTACT_REQUEST') then raise exception 'WA7A2_CONTACT_REQUEST_PHONE_NOT_VERIFIED'; end if;
+end $$;
+
+-- E. Forwarded/manual contact card is CLAIMED evidence only; it never becomes a routing/canonical alias.
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values('identity:contact:other:0','identity.contact_disclosure','wamid.wa7a2.contact','observed',jsonb_build_object('business_scope','pn-contact','origin','other','sender_user_id','PE.CONTACT.ONLY','shared_phone','51945555555','shared_phone_count',1,'observed_at',now()));
+do $$ begin
+  if (select status from public.aos_wa_events_v1 where event_key='identity:contact:other:0')<>'CLAIMED' then raise exception 'WA7A2_OTHER_CONTACT_NOT_CLAIMED'; end if;
+  if exists(select 1 from public.aos_wa_channel_aliases_v1 where business_scope='pn-contact' and alias_type='PHONE' and alias_value='51945555555') then raise exception 'WA7A2_CLAIMED_PHONE_POISONED_ALIAS_LEDGER'; end if;
+end $$;
+
+-- F. A verified disclosure cannot steal a phone already owned by another conversation.
+insert into public.aos_wa_messages_v1(provider_message_id,direction,from_number,phone_number_id,message_type,status,provider_timestamp,received_at)
+values('wamid.wa7a2.otherowner','INBOUND','51955555555','pn-contact','text','received',now(),now());
+insert into public.aos_wa_events_v1(event_key,event_type,status,payload)
+values('identity:contact:conflict:0','identity.contact_disclosure','observed',jsonb_build_object('business_scope','pn-contact','origin','contact_request','sender_user_id','PE.CONTACT.ONLY','shared_phone','51955555555','shared_phone_count',1,'observed_at',now()));
+do $$ declare owner_conv uuid; begin
+  if (select status from public.aos_wa_events_v1 where event_key='identity:contact:conflict:0')<>'CONFLICT' then raise exception 'WA7A2_PHONE_CONFLICT_NOT_CLOSED'; end if;
+  select conversation_id into owner_conv from public.aos_wa_channel_aliases_v1 where business_scope='pn-contact' and alias_type='PHONE' and alias_value='51955555555';
+  if owner_conv=(select conversation_id from public.aos_wa_channel_aliases_v1 where business_scope='pn-contact' and alias_type='BSUID' and alias_value='PE.CONTACT.ONLY') then raise exception 'WA7A2_CONFLICT_PHONE_WAS_STOLEN'; end if;
+end $$;
+
+-- G. recipient_user_id on delivered/read status can verify the BSUID that owns an already-bound outbound PHONE recipient.
+insert into public.aos_wa_messages_v1(provider_message_id,conversation_id,direction,to_number,phone_number_id,message_type,message_body,status,received_at)
+select 'wamid.wa7a2.status',conversation_id,'OUTBOUND','51944444444','pn-contact','text','reply','accepted',now()
+from public.aos_wa_channel_aliases_v1 where business_scope='pn-contact' and alias_type='PHONE' and alias_value='51944444444';
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values('identity:status:wamid.wa7a2.status:delivered:PE.STATUS.NEW','identity.status_binding','wamid.wa7a2.status','delivered',jsonb_build_object('business_scope','pn-contact','recipient_user_id','PE.STATUS.NEW','observed_at',now()));
+do $$ declare v uuid; begin
+  select conversation_id into v from public.aos_wa_messages_v1 where provider_message_id='wamid.wa7a2.status';
+  if not exists(select 1 from public.aos_wa_channel_aliases_v1 where conversation_id=v and alias_type='BSUID' and alias_value='PE.STATUS.NEW' and verification_status='VERIFIED' and verification_source='META_STATUS_RECIPIENT_USER_ID') then raise exception 'WA7A2_STATUS_BSUID_NOT_VERIFIED'; end if;
+  if not exists(select 1 from public.aos_wa_channel_aliases_v1 where conversation_id=v and alias_type='PHONE' and alias_value='51944444444' and verification_status='VERIFIED' and verification_source='META_STATUS_RECIPIENT_USER_ID') then raise exception 'WA7A2_STATUS_PHONE_NOT_VERIFIED'; end if;
+end $$;
+
+-- H. Username can exist on conversation/message display metadata but never in alias ledger authority.
+do $$ begin
+  if exists(select 1 from public.aos_wa_channel_aliases_v1 where alias_type not in ('PHONE','BSUID','PARENT_BSUID')) then raise exception 'WA7A2_USERNAME_ALIAS_FORBIDDEN'; end if;
+end $$;
+
+-- I. WA-7A.1 bridge remains derived from ACTIVE PHONE aliases only: BSUID-only rotation cannot retain stale canonical phone evidence.
+insert into public.aos_rev_patient_identity_alias_v2(identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,status,confidence_band,has_reviewed_match)
+values('PHONE','911111111','P-STALE',1,'["CANONICAL_CURRENT"]',1,'RESOLVED','MEDIUM',false);
+do $$ declare v uuid; r record; begin
+  select conversation_id into v from public.aos_wa_channel_aliases_v1 where business_scope='pn-wa7a2' and alias_type='BSUID' and alias_value='PE.PAIR.NEW';
+  select * into r from public.aos_wa_identity_resolution_v1 where conversation_id=v;
+  if r.resolution_status<>'UNRESOLVED' or r.canonical_patient_id is not null or r.phone_alias_count<>0 then raise exception 'WA7A2_STALE_PHONE_LEAKED_TO_WA7A1'; end if;
+end $$;
+
+select 'WA7A2_IDENTITY_VERIFICATION_PASS' as result;

--- a/docs/control/WHATSAPP_WA_7A_2_IDENTITY_VERIFICATION_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA_7A_2_IDENTITY_VERIFICATION_EVIDENCE.md
@@ -1,0 +1,116 @@
+# WA-7A.2 — Identity Verification & Continuity — Necessity Gate & Evidence
+
+**Captured:** 2026-08-25 America/Lima  
+**Baseline:** `main@0521484257ccc7f027e865d44e79c33ff7884ea9`  
+**Scope:** WhatsApp identity verification/continuity only.  
+**Non-goals:** no new customer/person master, no attribution, no Ads sync, no canonical patient mutation.
+
+## Current provider contract revalidation
+
+The 2026 rollout is still moving. Revalidation on 2026-08-25 found an important correction to the July documentation:
+
+- Meta does **not** expose a subscribable `user_id_update` webhook field.
+- BSUID rotation arrives on the already-subscribed `messages` field as a WhatsApp **system message**.
+- Current system types are:
+  - `user_changed_number`: phone changed and the new phone may be supplied in `system.wa_id`;
+  - `user_changed_user_id`: BSUID changed and no phone number is supplied; old/new BSUID lineage is provided through `previous_user_id` → `user_id` and optional parent equivalents.
+- Provider/BSP documentation written before Meta's 2026-08-11 correction may still describe `user_id_update`; ASCENDA does not add a Meta subscription for it.
+
+Current provider references checked:
+
+- Meta documentation/changelog via current references documented by Botsense (retrieved 2026-08-25): `https://botsense.io/blog/whatsapp-bsuid-webhook-user-id-update/`
+- Twilio WhatsApp username/BSUID concepts: `https://www.twilio.com/docs/whatsapp/key-concepts`
+- Twilio username rollout: `https://www.twilio.com/en-us/changelog/whatsapp-usernames`
+- YCloud BSUID/contact-request payload guide: `https://docs.ycloud.com/reference/webhook-updates-bsuid`
+- Chatwoot issue #15537 for real integration gaps around `origin` and `recipient_user_id`: `https://github.com/chatwoot/chatwoot/issues/15537`
+
+Provider-specific wrappers may rename fields, but ASCENDA's direct Meta gateway treats `messages[].system` as the canonical current Cloud API path.
+
+## Discovery matrix
+
+| Capability | Existing authority | Gap | WA-7A.2 decision |
+|---|---|---|---|
+| canonical patient identity | REV/F5/F6 + `aos_pacientes` | none | reuse; never mutate here |
+| channel continuity PHONE/BSUID/PARENT_BSUID | `aos_wa_channel_aliases_v1` | no explicit supersession/verification metadata | extend existing ledger |
+| idempotent provider evidence | `aos_wa_events_v1.event_key UNIQUE` | identity event types not interpreted | reuse existing event ledger |
+| signed Meta ingress | WA-1 gateway | system/contact identity semantics dropped | extend parser only |
+| PHONE+BSUID signed pair | WA-7A.0 stores both | no trust/source state | emit `identity.meta_pair` |
+| BSUID rotation | none | system events ignored | emit/apply `identity.system_change` |
+| REQUEST_CONTACT_INFO response | normal contacts message can be stored | `origin` and disclosed phone ignored | emit/apply `identity.contact_disclosure` |
+| forwarded contact card | message can arrive | risk of false phone binding | CLAIMED evidence only; no alias mutation |
+| `recipient_user_id` status evidence | parser preserves it in status event | not connected to alias verification | emit/apply delivered/read binding |
+| Contact Book | Meta/provider-side | no local canonical authority needed | do not mirror; consume explicit webhook evidence only |
+| username | display metadata | unsafe identity signal | never authority |
+| new customer/person master | none needed | would duplicate REV | forbidden |
+
+## Necessity gate
+
+**Build is necessary, but only at the existing boundaries.**
+
+No new customer/person/identity-master table is required. No new generic event table is required.
+
+WA-7A.2 adds only:
+
+1. lineage + verification metadata to `aos_wa_channel_aliases_v1`;
+2. a service-only identity-event trigger on the existing `aos_wa_events_v1` ledger;
+3. parser support in `app/wa-gateway.js` for current system messages, contact disclosure origin, signed pair evidence and delivered/read `recipient_user_id` evidence;
+4. native `request_contact_info` outbound payload support through the existing governed send path;
+5. Zero-Cost behavioral/concurrency/rollback tests.
+
+## Verification semantics
+
+`VERIFIED` means the **WhatsApp channel fact** is attested by provider evidence. It does not mean a canonical patient merge has occurred.
+
+Automatic trusted sources in this slice:
+
+- `META_SIGNED_MESSAGE_PAIR` — signed inbound carried PHONE + BSUID together;
+- `META_SYSTEM_CHANGE` — current Meta system identity transition;
+- `META_CONTACT_REQUEST` — `contacts[].origin=contact_request` native response;
+- `META_STATUS_RECIPIENT_USER_ID` — delivered/read status binds recipient BSUID to an already-bound outbound destination.
+
+Non-attested evidence:
+
+- `origin=other` contact cards remain `CLAIMED` evidence only and do **not** become routing aliases;
+- typed/manual phone text is not parsed into identity authority and therefore can never become VERIFIED automatically;
+- Contact Book is not queried or mirrored as a CRM.
+
+Valid states:
+
+`VERIFIED / CLAIMED / UNKNOWN / CONFLICT`.
+
+## Continuity rules
+
+- A system transition resolves its conversation from previously known scoped BSUID/parent-BSUID lineage, never username.
+- Old BSUID is retained and marked inactive with `valid_to`, `superseded_by`, `supersession_reason`.
+- New BSUID becomes the active channel alias for the same conversation.
+- If Meta supplies a new phone, the old active phone is retired and the new one is verified.
+- If the BSUID rotates and no new phone may be supplied, one known old active phone is retired rather than remaining as stale canonical evidence.
+- Multiple active prior PHONE aliases are an explicit `CONFLICT`; no blind selection occurs.
+- A native contact request may supersede one prior active phone because WhatsApp attests the disclosed phone as the user's own current contact information; multiple prior phones remain conflict/fail-closed.
+- A phone already owned by another conversation cannot be stolen by new evidence.
+- A competing old→new BSUID transition is serialized; lineage may not fork.
+
+## WA-7A.1 interaction
+
+WA-7A.1 reads **active PHONE aliases only**. Therefore retiring a stale phone after a BSUID-only phone-number change deliberately causes the canonical projection to become `UNRESOLVED` until new governed PHONE evidence is available. This is safer than silently carrying a stale patient match forward.
+
+No WA-7A.2 event writes to REV/F5/F6 or `aos_pacientes`.
+
+## Idempotency and conflict behavior
+
+Identity evidence is persisted in existing `aos_wa_events_v1` with deterministic `event_key` values.
+
+- replay uses the existing unique event key / `ON CONFLICT` behavior;
+- a conflicting event is persisted with `status=CONFLICT` and does not mutate aliases;
+- provider webhook processing can therefore acknowledge a durable conflict instead of retrying forever;
+- advisory locks serialize alias transitions and prevent concurrent lineage forks.
+
+## Rollback
+
+Rollback is allowed only before WA-7A.2 identity evidence/lineage exists. Once evidence exists, the rollback fails closed because dropping lineage columns would be destructive history loss.
+
+## LIVE boundary
+
+As of this capture, Supabase REST/Auth continues HTTP 402. Management SQL remains available.
+
+Therefore WA-7A.2 may certify code, Zero-Cost, exact-head CI, production schema/readback and Railway runtime deployment if those gates pass. It must **not** claim fresh browser/Auth/Meta/REQUEST_CONTACT_INFO/BSUID system-event LIVE certification until the normal REST/Auth/provider path recovers.

--- a/supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+++ b/supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
@@ -1,0 +1,360 @@
+-- WA-7A.2 — Identity Verification & Continuity V1
+-- Extends the existing WhatsApp alias ledger and event ledger only.
+-- No customer/person master. No aos_pacientes or REV canonical mutation.
+-- Current Meta contract (2026-08): BSUID changes arrive as system messages on the existing `messages` webhook.
+
+begin;
+
+alter table public.aos_wa_channel_aliases_v1
+  add column if not exists verification_status text not null default 'UNKNOWN',
+  add column if not exists verification_source text not null default 'LEGACY_OBSERVED',
+  add column if not exists verification_observed_at timestamptz,
+  add column if not exists evidence_event_key text,
+  add column if not exists valid_to timestamptz,
+  add column if not exists superseded_by uuid,
+  add column if not exists supersession_reason text;
+
+update public.aos_wa_channel_aliases_v1
+set verification_observed_at=coalesce(verification_observed_at,last_seen_at,first_seen_at,created_at),
+    verification_status=coalesce(nullif(verification_status,''),'UNKNOWN'),
+    verification_source=coalesce(nullif(verification_source,''),'LEGACY_OBSERVED')
+where verification_observed_at is null
+   or verification_status is null or verification_status=''
+   or verification_source is null or verification_source='';
+
+do $$ begin
+  alter table public.aos_wa_channel_aliases_v1
+    add constraint aos_wa_channel_aliases_v1_verification_status_chk
+    check (verification_status in ('VERIFIED','CLAIMED','UNKNOWN','CONFLICT'));
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.aos_wa_channel_aliases_v1
+    add constraint aos_wa_channel_aliases_v1_superseded_fk
+    foreign key (superseded_by) references public.aos_wa_channel_aliases_v1(id) on delete restrict;
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.aos_wa_channel_aliases_v1
+    add constraint aos_wa_channel_aliases_v1_no_self_supersede_chk
+    check (superseded_by is null or superseded_by<>id);
+exception when duplicate_object then null; end $$;
+
+create index if not exists aos_wa_channel_aliases_v1_lineage_idx
+  on public.aos_wa_channel_aliases_v1(conversation_id,alias_type,active,valid_to,last_seen_at desc);
+create index if not exists aos_wa_channel_aliases_v1_evidence_idx
+  on public.aos_wa_channel_aliases_v1(evidence_event_key)
+  where evidence_event_key is not null;
+
+create or replace function public.aos_wa7a2_normalize_phone_v1(p_value text)
+returns text
+language plpgsql
+immutable
+set search_path=''
+as $$
+declare v text;
+begin
+  if p_value is null or p_value ~ '[A-Za-z]' then return null; end if;
+  v:=regexp_replace(p_value,'[^0-9]','','g');
+  if char_length(v) between 8 and 20 then return v; end if;
+  return null;
+end
+$$;
+revoke all on function public.aos_wa7a2_normalize_phone_v1(text) from public,anon,authenticated;
+grant execute on function public.aos_wa7a2_normalize_phone_v1(text) to service_role;
+
+create or replace function public.aos_wa7a2_apply_identity_event_v1()
+returns trigger
+language plpgsql
+set search_path=''
+as $$
+declare
+  v_scope text:=coalesce(nullif(trim(new.payload->>'business_scope'),''),'default');
+  v_obs timestamptz:=coalesce(nullif(new.payload->>'observed_at','')::timestamptz,new.created_at,now());
+  v_phone text;
+  v_sender_phone text;
+  v_user text:=nullif(trim(coalesce(new.payload->>'user_id',new.payload->>'recipient_user_id',new.payload->>'sender_user_id')),'');
+  v_parent text:=nullif(trim(coalesce(new.payload->>'parent_user_id',new.payload->>'recipient_parent_user_id',new.payload->>'sender_parent_user_id')),'');
+  v_prev_user text:=nullif(trim(new.payload->>'previous_user_id'),'');
+  v_prev_parent text:=nullif(trim(new.payload->>'previous_parent_user_id'),'');
+  v_origin text:=lower(trim(coalesce(new.payload->>'origin','')));
+  v_system_type text:=lower(trim(coalesce(new.payload->>'system_type','')));
+  v_shared_count integer:=coalesce(nullif(new.payload->>'shared_phone_count','')::integer,case when nullif(new.payload->>'shared_phone','') is null then 0 else 1 end);
+  v_conv uuid;
+  v_phone_conv uuid;
+  v_user_conv uuid;
+  v_parent_conv uuid;
+  v_prev_user_conv uuid;
+  v_prev_parent_conv uuid;
+  v_alias uuid;
+  v_new_user_alias uuid;
+  v_new_parent_alias uuid;
+  v_new_phone_alias uuid;
+  v_prev_user_alias uuid;
+  v_prev_parent_alias uuid;
+  v_prev_user_active boolean;
+  v_prev_parent_active boolean;
+  v_prev_user_superseded uuid;
+  v_prev_parent_superseded uuid;
+  v_active_phone_count integer:=0;
+  v_old_phone_alias uuid;
+  v_old_phone text;
+  v_msg_conv uuid;
+  v_msg_phone text;
+  v_msg_user text;
+  v_conflict boolean:=false;
+begin
+  if new.event_type not in ('identity.meta_pair','identity.system_change','identity.contact_disclosure','identity.status_binding') then
+    return new;
+  end if;
+
+  -- Usernames are intentionally absent from every authority path in this function.
+  if new.event_type='identity.meta_pair' then
+    v_phone:=public.aos_wa7a2_normalize_phone_v1(new.payload->>'phone');
+    if v_phone is null or v_user is null then
+      new.status:='UNRESOLVED';
+      new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','PAIR_REQUIRES_PHONE_AND_BSUID');
+      return new;
+    end if;
+
+    perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_phone,0));
+    if v_parent is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_parent,0)); end if;
+    perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_user,0));
+
+    select conversation_id into v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone;
+    select conversation_id into v_user_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_user;
+    if v_parent is not null then select conversation_id into v_parent_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_parent; end if;
+    v_conv:=coalesce(v_user_conv,v_parent_conv,v_phone_conv);
+    if v_conv is null then
+      new.status:='UNRESOLVED';
+      new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','PAIR_HAS_NO_BOUND_CONVERSATION');
+      return new;
+    end if;
+    if (v_phone_conv is not null and v_phone_conv<>v_conv)
+       or (v_user_conv is not null and v_user_conv<>v_conv)
+       or (v_parent_conv is not null and v_parent_conv<>v_conv) then v_conflict:=true; end if;
+    if v_conflict then
+      new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','PAIR_ALIAS_CONFLICT');return new;
+    end if;
+
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+    values(v_scope,'PHONE',v_phone,v_conv,true,v_obs,v_obs,'VERIFIED','META_SIGNED_MESSAGE_PAIR',v_obs,new.event_key)
+    on conflict (business_scope,alias_type,alias_value) do update set
+      active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),
+      valid_to=null,superseded_by=null,supersession_reason=null,
+      verification_status='VERIFIED',verification_source='META_SIGNED_MESSAGE_PAIR',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now();
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+    values(v_scope,'BSUID',v_user,v_conv,true,v_obs,v_obs,'VERIFIED','META_SIGNED_MESSAGE_PAIR',v_obs,new.event_key)
+    on conflict (business_scope,alias_type,alias_value) do update set
+      active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),
+      valid_to=null,superseded_by=null,supersession_reason=null,
+      verification_status='VERIFIED',verification_source='META_SIGNED_MESSAGE_PAIR',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now();
+    if v_parent is not null then
+      insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+      values(v_scope,'PARENT_BSUID',v_parent,v_conv,true,v_obs,v_obs,'VERIFIED','META_SIGNED_MESSAGE_PAIR',v_obs,new.event_key)
+      on conflict (business_scope,alias_type,alias_value) do update set
+        active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),valid_to=null,
+        verification_status='VERIFIED',verification_source='META_SIGNED_MESSAGE_PAIR',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now();
+    end if;
+    new.status:='VERIFIED';new.payload:=new.payload||jsonb_build_object('verification_result','VERIFIED','conversation_id',v_conv);return new;
+  end if;
+
+  if new.event_type='identity.system_change' then
+    v_phone:=public.aos_wa7a2_normalize_phone_v1(coalesce(new.payload->>'phone',new.payload->>'wa_id'));
+    if v_system_type not in ('user_changed_number','user_changed_user_id') or v_user is null then
+      new.status:='UNRESOLVED';new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','UNSUPPORTED_OR_INCOMPLETE_SYSTEM_CHANGE');return new;
+    end if;
+
+    if v_phone is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_phone,0)); end if;
+    if v_prev_parent is not null or v_parent is not null then
+      if coalesce(v_prev_parent,'')<=coalesce(v_parent,'') then
+        if v_prev_parent is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_prev_parent,0)); end if;
+        if v_parent is not null and v_parent is distinct from v_prev_parent then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_parent,0)); end if;
+      else
+        if v_parent is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_parent,0)); end if;
+        if v_prev_parent is not null and v_prev_parent is distinct from v_parent then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_prev_parent,0)); end if;
+      end if;
+    end if;
+    if v_prev_user is not null and v_prev_user<=v_user then
+      perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_prev_user,0));
+      if v_user is distinct from v_prev_user then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_user,0)); end if;
+    else
+      perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_user,0));
+      if v_prev_user is not null and v_prev_user is distinct from v_user then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_prev_user,0)); end if;
+    end if;
+
+    if v_prev_user is not null then
+      select id,conversation_id,active,superseded_by into v_prev_user_alias,v_prev_user_conv,v_prev_user_active,v_prev_user_superseded
+      from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_prev_user for update;
+    end if;
+    if v_prev_parent is not null then
+      select id,conversation_id,active,superseded_by into v_prev_parent_alias,v_prev_parent_conv,v_prev_parent_active,v_prev_parent_superseded
+      from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_prev_parent for update;
+    end if;
+    select id,conversation_id into v_new_user_alias,v_user_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_user for update;
+    if v_parent is not null then select id,conversation_id into v_new_parent_alias,v_parent_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_parent for update; end if;
+
+    v_conv:=coalesce(v_prev_user_conv,v_prev_parent_conv,v_user_conv,v_parent_conv);
+    if v_conv is null then
+      new.status:='UNRESOLVED';new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','PREVIOUS_BSUID_NOT_KNOWN');return new;
+    end if;
+    if (v_prev_user_conv is not null and v_prev_user_conv<>v_conv)
+       or (v_prev_parent_conv is not null and v_prev_parent_conv<>v_conv)
+       or (v_user_conv is not null and v_user_conv<>v_conv)
+       or (v_parent_conv is not null and v_parent_conv<>v_conv) then v_conflict:=true; end if;
+    if v_conflict then new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','SYSTEM_ALIAS_CONFLICT');return new; end if;
+
+    -- A previous alias that already points to a different successor may not fork lineage.
+    if v_prev_user_alias is not null and v_prev_user_active is false and v_prev_user<>v_user then
+      if v_prev_user_superseded is not null and v_prev_user_superseded=v_new_user_alias then
+        new.status:='ALREADY_APPLIED';new.payload:=new.payload||jsonb_build_object('verification_result','VERIFIED','reason','LINEAGE_ALREADY_APPLIED','conversation_id',v_conv);return new;
+      end if;
+      new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','STALE_PREVIOUS_BSUID');return new;
+    end if;
+
+    select count(*) into v_active_phone_count from public.aos_wa_channel_aliases_v1 where conversation_id=v_conv and alias_type='PHONE' and active=true;
+    if v_active_phone_count>1 then
+      new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','MULTIPLE_ACTIVE_PHONE_ALIASES');return new;
+    elsif v_active_phone_count=1 then
+      select id,alias_value into v_old_phone_alias,v_old_phone from public.aos_wa_channel_aliases_v1 where conversation_id=v_conv and alias_type='PHONE' and active=true for update;
+    end if;
+
+    if v_phone is not null then
+      select id,conversation_id into v_new_phone_alias,v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone for update;
+      if v_phone_conv is not null and v_phone_conv<>v_conv then
+        new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','NEW_PHONE_OWNED_BY_OTHER_CONVERSATION');return new;
+      end if;
+    end if;
+
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+    values(v_scope,'BSUID',v_user,v_conv,true,v_obs,v_obs,'VERIFIED','META_SYSTEM_CHANGE',v_obs,new.event_key)
+    on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),valid_to=null,superseded_by=null,supersession_reason=null,verification_status='VERIFIED',verification_source='META_SYSTEM_CHANGE',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now()
+    returning id into v_new_user_alias;
+
+    if v_prev_user_alias is not null and v_prev_user_alias<>v_new_user_alias then
+      update public.aos_wa_channel_aliases_v1 set active=false,valid_to=v_obs,superseded_by=v_new_user_alias,supersession_reason=v_system_type,evidence_event_key=new.event_key,updated_at=now() where id=v_prev_user_alias;
+    end if;
+
+    if v_parent is not null then
+      insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+      values(v_scope,'PARENT_BSUID',v_parent,v_conv,true,v_obs,v_obs,'VERIFIED','META_SYSTEM_CHANGE',v_obs,new.event_key)
+      on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),valid_to=null,superseded_by=null,supersession_reason=null,verification_status='VERIFIED',verification_source='META_SYSTEM_CHANGE',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now()
+      returning id into v_new_parent_alias;
+    end if;
+    if v_prev_parent_alias is not null and v_prev_parent_alias is distinct from v_new_parent_alias then
+      update public.aos_wa_channel_aliases_v1 set active=false,valid_to=v_obs,superseded_by=v_new_parent_alias,supersession_reason=v_system_type,evidence_event_key=new.event_key,updated_at=now() where id=v_prev_parent_alias;
+    end if;
+
+    if v_phone is not null then
+      insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+      values(v_scope,'PHONE',v_phone,v_conv,true,v_obs,v_obs,'VERIFIED','META_SYSTEM_CHANGE',v_obs,new.event_key)
+      on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),valid_to=null,superseded_by=null,supersession_reason=null,verification_status='VERIFIED',verification_source='META_SYSTEM_CHANGE',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now()
+      returning id into v_new_phone_alias;
+    end if;
+    if v_old_phone_alias is not null and (v_phone is null or v_old_phone<>v_phone) then
+      update public.aos_wa_channel_aliases_v1 set active=false,valid_to=v_obs,superseded_by=v_new_phone_alias,supersession_reason=case when v_phone is null then 'USER_CHANGED_PHONE_NO_NEW_PHONE' else v_system_type end,evidence_event_key=new.event_key,updated_at=now() where id=v_old_phone_alias;
+    end if;
+
+    update public.aos_wa_conversations_v1 set
+      contact_number=v_phone,
+      contact_bsuid=v_user,
+      contact_parent_bsuid=case when v_prev_parent is not null then v_parent else coalesce(v_parent,contact_parent_bsuid) end,
+      contact_address=coalesce(v_phone,v_user),
+      contact_address_type=case when v_phone is not null then 'PHONE' else 'BSUID' end,
+      updated_at=now()
+    where id=v_conv;
+
+    new.status:='VERIFIED';new.payload:=new.payload||jsonb_build_object('verification_result','VERIFIED','conversation_id',v_conv,'phone_shared',v_phone is not null);return new;
+  end if;
+
+  if new.event_type='identity.contact_disclosure' then
+    v_sender_phone:=public.aos_wa7a2_normalize_phone_v1(new.payload->>'sender_phone');
+    v_phone:=public.aos_wa7a2_normalize_phone_v1(new.payload->>'shared_phone');
+    if v_phone is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_phone,0)); end if;
+    if v_sender_phone is not null and v_sender_phone is distinct from v_phone then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_sender_phone,0)); end if;
+    if v_user is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_user,0)); end if;
+
+    if v_sender_phone is not null then select conversation_id into v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_sender_phone; end if;
+    if v_user is not null then select conversation_id into v_user_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_user; end if;
+    v_conv:=coalesce(v_user_conv,v_phone_conv);
+    if v_conv is null then new.status:='UNRESOLVED';new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','CONTACT_SENDER_NOT_BOUND');return new; end if;
+    if v_user_conv is not null and v_phone_conv is not null and v_user_conv<>v_phone_conv then new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','CONTACT_SENDER_ALIAS_CONFLICT');return new; end if;
+
+    -- Only WhatsApp's native request response is attested. Forwarded/manual contact cards are evidence only.
+    if v_origin<>'contact_request' then
+      new.status:=case when v_phone is null then 'UNKNOWN' else 'CLAIMED' end;
+      new.payload:=new.payload||jsonb_build_object('verification_result',new.status,'reason','NON_ATTESTED_CONTACT_SHARE','conversation_id',v_conv);
+      return new;
+    end if;
+    if v_shared_count<>1 or v_phone is null then
+      new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','CONTACT_REQUEST_AMBIGUOUS_PHONE','conversation_id',v_conv);return new;
+    end if;
+
+    select id,conversation_id into v_new_phone_alias,v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone for update;
+    if v_phone_conv is not null and v_phone_conv<>v_conv then new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','ATTESTED_PHONE_OWNED_BY_OTHER_CONVERSATION');return new; end if;
+
+    select count(*) into v_active_phone_count from public.aos_wa_channel_aliases_v1 where conversation_id=v_conv and alias_type='PHONE' and active=true and alias_value<>v_phone;
+    if v_active_phone_count>1 then new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','MULTIPLE_PRIOR_PHONE_ALIASES');return new; end if;
+    if v_active_phone_count=1 then select id,alias_value into v_old_phone_alias,v_old_phone from public.aos_wa_channel_aliases_v1 where conversation_id=v_conv and alias_type='PHONE' and active=true and alias_value<>v_phone for update; end if;
+
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+    values(v_scope,'PHONE',v_phone,v_conv,true,v_obs,v_obs,'VERIFIED','META_CONTACT_REQUEST',v_obs,new.event_key)
+    on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),valid_to=null,superseded_by=null,supersession_reason=null,verification_status='VERIFIED',verification_source='META_CONTACT_REQUEST',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now()
+    returning id into v_new_phone_alias;
+    if v_old_phone_alias is not null then update public.aos_wa_channel_aliases_v1 set active=false,valid_to=v_obs,superseded_by=v_new_phone_alias,supersession_reason='META_CONTACT_REQUEST',evidence_event_key=new.event_key,updated_at=now() where id=v_old_phone_alias; end if;
+    update public.aos_wa_conversations_v1 set contact_number=v_phone,contact_address=v_phone,contact_address_type='PHONE',updated_at=now() where id=v_conv;
+    new.status:='VERIFIED';new.payload:=new.payload||jsonb_build_object('verification_result','VERIFIED','conversation_id',v_conv);return new;
+  end if;
+
+  if new.event_type='identity.status_binding' then
+    if new.status not in ('delivered','read','received','sent') then null; end if;
+    if v_user is null then new.status:='UNRESOLVED';new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','STATUS_HAS_NO_RECIPIENT_BSUID');return new; end if;
+    select conversation_id,to_number,to_user_id into v_msg_conv,v_msg_phone,v_msg_user from public.aos_wa_messages_v1 where provider_message_id=new.provider_message_id and direction='OUTBOUND';
+    if v_msg_conv is null then new.status:='UNRESOLVED';new.payload:=new.payload||jsonb_build_object('verification_result','UNRESOLVED','reason','OUTBOUND_MESSAGE_NOT_BOUND');return new; end if;
+    v_phone:=public.aos_wa7a2_normalize_phone_v1(v_msg_phone);
+    if v_phone is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PHONE|'||v_phone,0)); end if;
+    if v_parent is not null then perform pg_advisory_xact_lock(hashtextextended(v_scope||'|PARENT_BSUID|'||v_parent,0)); end if;
+    perform pg_advisory_xact_lock(hashtextextended(v_scope||'|BSUID|'||v_user,0));
+    select conversation_id into v_user_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='BSUID' and alias_value=v_user;
+    if v_parent is not null then select conversation_id into v_parent_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PARENT_BSUID' and alias_value=v_parent; end if;
+    if v_phone is not null then select conversation_id into v_phone_conv from public.aos_wa_channel_aliases_v1 where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone; end if;
+    if (v_user_conv is not null and v_user_conv<>v_msg_conv) or (v_parent_conv is not null and v_parent_conv<>v_msg_conv) or (v_phone_conv is not null and v_phone_conv<>v_msg_conv) then
+      new.status:='CONFLICT';new.payload:=new.payload||jsonb_build_object('verification_result','CONFLICT','reason','STATUS_BINDING_ALIAS_CONFLICT');return new;
+    end if;
+    insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+    values(v_scope,'BSUID',v_user,v_msg_conv,true,v_obs,v_obs,'VERIFIED','META_STATUS_RECIPIENT_USER_ID',v_obs,new.event_key)
+    on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),verification_status='VERIFIED',verification_source='META_STATUS_RECIPIENT_USER_ID',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now();
+    if v_parent is not null then
+      insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at,verification_status,verification_source,verification_observed_at,evidence_event_key)
+      values(v_scope,'PARENT_BSUID',v_parent,v_msg_conv,true,v_obs,v_obs,'VERIFIED','META_STATUS_RECIPIENT_USER_ID',v_obs,new.event_key)
+      on conflict (business_scope,alias_type,alias_value) do update set active=true,last_seen_at=greatest(public.aos_wa_channel_aliases_v1.last_seen_at,excluded.last_seen_at),verification_status='VERIFIED',verification_source='META_STATUS_RECIPIENT_USER_ID',verification_observed_at=v_obs,evidence_event_key=new.event_key,updated_at=now();
+    end if;
+    if v_phone is not null then
+      update public.aos_wa_channel_aliases_v1 set verification_status='VERIFIED',verification_source='META_STATUS_RECIPIENT_USER_ID',verification_observed_at=v_obs,evidence_event_key=new.event_key,last_seen_at=greatest(last_seen_at,v_obs),updated_at=now()
+      where business_scope=v_scope and alias_type='PHONE' and alias_value=v_phone and conversation_id=v_msg_conv;
+    end if;
+    update public.aos_wa_conversations_v1 set contact_bsuid=coalesce(contact_bsuid,v_user),contact_parent_bsuid=coalesce(contact_parent_bsuid,v_parent),updated_at=now() where id=v_msg_conv;
+    new.status:='VERIFIED';new.payload:=new.payload||jsonb_build_object('verification_result','VERIFIED','conversation_id',v_msg_conv,'phone_bound',v_phone is not null);return new;
+  end if;
+
+  return new;
+end
+$$;
+
+comment on function public.aos_wa7a2_apply_identity_event_v1() is
+'WA-7A.2 service-only BEFORE INSERT event processor. Reuses aos_wa_events_v1 idempotency and aos_wa_channel_aliases_v1; preserves lineage, treats non-attested contact cards as CLAIMED evidence only, and never mutates canonical patient identity.';
+
+drop trigger if exists trg_aos_wa7a2_apply_identity_event_v1 on public.aos_wa_events_v1;
+create trigger trg_aos_wa7a2_apply_identity_event_v1
+before insert on public.aos_wa_events_v1
+for each row
+when (new.event_type in ('identity.meta_pair','identity.system_change','identity.contact_disclosure','identity.status_binding'))
+execute function public.aos_wa7a2_apply_identity_event_v1();
+
+revoke all on function public.aos_wa7a2_apply_identity_event_v1() from public,anon,authenticated;
+
+comment on table public.aos_wa_channel_aliases_v1 is
+'WhatsApp scoped channel alias ledger. WA-7A.2 adds verification/source/evidence and non-destructive supersession lineage. BSUID is not a canonical person id; username is never an alias authority.';
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260825222500_wa7a2_identity_verification_continuity_v1.rollback.sql
+++ b/supabase/rollbacks/20260825222500_wa7a2_identity_verification_continuity_v1.rollback.sql
@@ -1,0 +1,44 @@
+-- WA-7A.2 rollback — safe only before identity verification/lineage evidence exists.
+-- Once evidence exists, deleting lineage would be destructive and rollback must fail closed.
+
+begin;
+
+do $$
+begin
+  if exists(
+    select 1 from public.aos_wa_events_v1
+    where event_type in ('identity.meta_pair','identity.system_change','identity.contact_disclosure','identity.status_binding')
+  ) then
+    raise exception 'WA7A2_ROLLBACK_BLOCKED_IDENTITY_EVIDENCE_EXISTS';
+  end if;
+  if exists(
+    select 1 from public.aos_wa_channel_aliases_v1
+    where evidence_event_key is not null or superseded_by is not null or valid_to is not null
+  ) then
+    raise exception 'WA7A2_ROLLBACK_BLOCKED_ALIAS_LINEAGE_EXISTS';
+  end if;
+end
+$$;
+
+drop trigger if exists trg_aos_wa7a2_apply_identity_event_v1 on public.aos_wa_events_v1;
+drop function if exists public.aos_wa7a2_apply_identity_event_v1();
+drop function if exists public.aos_wa7a2_normalize_phone_v1(text);
+
+drop index if exists public.aos_wa_channel_aliases_v1_evidence_idx;
+drop index if exists public.aos_wa_channel_aliases_v1_lineage_idx;
+
+alter table public.aos_wa_channel_aliases_v1 drop constraint if exists aos_wa_channel_aliases_v1_no_self_supersede_chk;
+alter table public.aos_wa_channel_aliases_v1 drop constraint if exists aos_wa_channel_aliases_v1_superseded_fk;
+alter table public.aos_wa_channel_aliases_v1 drop constraint if exists aos_wa_channel_aliases_v1_verification_status_chk;
+
+alter table public.aos_wa_channel_aliases_v1
+  drop column if exists supersession_reason,
+  drop column if exists superseded_by,
+  drop column if exists valid_to,
+  drop column if exists evidence_event_key,
+  drop column if exists verification_observed_at,
+  drop column if exists verification_source,
+  drop column if exists verification_status;
+
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Implements the minimum WA-7A.2 slice on top of WA-7A.0/7A.1.

Scope:
- reuse `aos_wa_channel_aliases_v1` and `aos_wa_events_v1`; no new customer/person master or event ledger;
- add verification state/source/evidence and old→new alias supersession lineage;
- consume current Meta `messages[].system` identity changes (`user_changed_number` / `user_changed_user_id`), not a nonexistent subscribable `user_id_update` field;
- preserve signed PHONE+BSUID pair evidence;
- distinguish native `contacts[].origin=contact_request` from forwarded/manual contact cards;
- use delivered/read `recipient_user_id` as provider binding evidence;
- support governed `request_contact_info` interactive payloads;
- conflicts persist fail-closed without alias theft or canonical mutation;
- replay/idempotency, concurrency fork prevention, rollback guard, WA-7A.0/7A.1 regressions and Zero-Cost CI.

Hard boundaries:
- username never identity authority;
- typed/manual/forwarded phone never auto-VERIFIED;
- BSUID is portfolio/business scoped, not a canonical person ID;
- Contact Book is not mirrored as CRM;
- no attribution, Ads Sync, AI send, auto-reply, auto-routing or campaign automation;
- REST/Auth/provider LIVE remains blocked while Supabase returns HTTP 402.