### PR TITLE
WA-7A.3 — Attribution Ingress

### DIFF
--- a/.github/workflows/wa7a3-attribution-ingress.yml
+++ b/.github/workflows/wa7a3-attribution-ingress.yml
@@ -1,0 +1,183 @@
+name: ASCENDA WA-7A.3 Attribution Ingress
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa7a3_attribution_ingress*'
+      - 'supabase/rollbacks/*wa7a3_attribution_ingress*'
+      - 'ci/wa7a3-attribution-ingress/**'
+      - 'docs/control/WHATSAPP_WA_7A_3_ATTRIBUTION_INGRESS_EVIDENCE.md'
+      - '.github/workflows/wa7a3-attribution-ingress.yml'
+  push:
+    branches: ['feat/wa-7a-3-attribution-ingress-20260827']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa7a3-attribution-ingress-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · WA-7A.3 attribution ingress
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 45
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59842/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost lane
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Authority and scope invariants
+        run: |
+          set -euo pipefail
+          M=supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          J=app/wa-gateway.js
+          grep -q "event_type:'attribution.touchpoint'" "$J"
+          grep -q "attribution:touchpoint:" "$J"
+          grep -q 'ctwa_clid' "$J"
+          grep -q 'safeHttpsUrl' "$J"
+          grep -q 'aos_wa_events_v1' "$M"
+          grep -q 'aos_wa_attribution_touchpoints_v1' "$M"
+          grep -q 'aos_wa_identity_resolution_v1' "$M"
+          grep -q 'security_invoker=true' "$M"
+          ! grep -Eiq 'create[[:space:]]+table' "$M"
+          ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.(aos_pacientes|aos_rev_|aos_leads)' "$M"
+          ! grep -Eiq 'create[[:space:]]+or[[:space:]]+replace[[:space:]]+function[[:space:]]+public\.aos_marketing_touchpoints_v2' "$M"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M" "$J"
+
+      - name: Gateway parser and identity regressions
+        run: |
+          set -euo pipefail
+          node --check app/wa-gateway.js
+          node --test ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+          node --test ci/wa7a2-identity-verification/identity_webhook_contract.test.js
+          node --test ci/wa7a0-identity-compatibility/identity_contract.test.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa7a3-attribution"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59841/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59842/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59840/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa7a3-attribution' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59842 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-7A.3 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build certified WA + REV prerequisites
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: Attribution persistence and security behavior
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a3-attribution-ingress/tests/001_attribution_ingress.sql | tee /tmp/wa7a3-db.txt
+          grep -q 'WA7A3_ATTRIBUTION_INGRESS_PASS' /tmp/wa7a3-db.txt
+
+      - name: Destructive rollback guard
+        run: |
+          set -euo pipefail
+          if psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260827133000_wa7a3_attribution_ingress_v1.rollback.sql; then
+            echo 'WA-7A.3 rollback unexpectedly removed accepted touchpoint evidence' >&2
+            exit 1
+          fi
+          echo WA7A3_ROLLBACK_GUARD_PASS
+
+      - name: Clean synthetic provenance then rollback and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          truncate table public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260827133000_wa7a3_attribution_ingress_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.views where table_schema='public' and table_name='aos_wa_attribution_touchpoints_v1'")" = "0"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.views where table_schema='public' and table_name='aos_wa_attribution_touchpoints_v1'")" = "1"
+
+      - name: WA-7A.2 database regression
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a2-identity-verification/tests/001_identity_verification.sql | tee /tmp/wa7a2-regression.txt
+          grep -q 'WA7A2_IDENTITY_VERIFICATION_PASS' /tmp/wa7a2-regression.txt
+
+      - name: Clear identity fixtures before historical regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          truncate table public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+
+      - name: WA-7A.0 and WA-7A.1 database regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0-regression.txt
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1-regression.txt
+          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1-regression.txt
+
+      - name: Certification boundary
+        run: |
+          set -euo pipefail
+          echo 'WA-7A.3 reuses WA event/message/conversation + WA-7A.1 identity bridge; no new customer or physical touchpoint master.'
+          echo 'Explicit referral provenance only; PHONE/BSUID/username/canonical patient cannot fabricate attribution.'
+          echo 'Marketing Attribution V2 is not mutated or replaced. Fresh provider CTWA remains LIVE_PENDING while external REST/Auth hold persists.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -32,6 +32,10 @@ function usernameValue(v){
   const s=String(v==null?'':v).trim().replace(/^@/,'');
   return s?trimText(s,256):null;
 }
+function safeHttpsUrl(v){
+  const s=trimText(v,2048).trim();if(!s)return null;
+  try{const u=new URL(s);return u.protocol==='https:'?u.toString():null;}catch(e){return null;}
+}
 function isoFromUnix(v){const n=Number(v);return Number.isFinite(n)&&n>0?new Date(n*1000).toISOString():new Date().toISOString();}
 
 function recipientFromInput(d){
@@ -86,6 +90,25 @@ function contactPhones(card){
   return Array.from(seen);
 }
 function identityKey(parts){return trimText(parts.filter(Boolean).join(':'),900);}
+function referralEvidence(referral,businessScope,providerMessageId,observedAt){
+  const r=referral&&typeof referral==='object'&&!Array.isArray(referral)?referral:{};
+  const sourceId=trimText(r.source_id,256)||null;
+  const sourceType=(trimText(r.source_type,64).trim().toLowerCase()||null);
+  const sourceUrl=safeHttpsUrl(r.source_url);
+  const ctwaClid=userIdValue(r.ctwa_clid);
+  const providerLeadId=userIdValue(r.lead_id);
+  const campaignSource=trimText(r.campaign_source,256).trim()||null;
+  const headline=trimText(r.headline,512)||null;
+  const body=trimText(r.body,1000)||null;
+  const mediaType=trimText(r.media_type,64).trim().toLowerCase()||null;
+  if(![sourceId,sourceType,sourceUrl,ctwaClid,providerLeadId,campaignSource,headline,body,mediaType].some(Boolean))return null;
+  return {
+    evidence_version:'WA_7A_3_V1',channel:'WHATSAPP',provider:'META_CLOUD_API',business_scope:businessScope,
+    provider_message_id:providerMessageId,ctwa_clid:ctwaClid,source_id:sourceId,source_type:sourceType,source_url:sourceUrl,
+    ad_id:sourceType==='ad'?sourceId:null,provider_lead_id:providerLeadId,campaign_source:campaignSource,
+    headline,body,media_type:mediaType,observed_at:observedAt
+  };
+}
 
 function extractWebhook(payload){
   const messages=[];const statuses=[];const events=[];
@@ -137,6 +160,12 @@ function extractWebhook(payload){
         if(!row.provider_message_id)return;
         messages.push(row);
         events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral,sender_kind:row.from_number?'PHONE':(row.from_user_id?'BSUID':'UNKNOWN'),has_user_id:!!row.from_user_id}});
+
+        // WA-7A.3: acquisition provenance is a separate immutable event, never an identity fact.
+        const provenance=referralEvidence(referral,businessScope,row.provider_message_id,observedAt);
+        if(provenance){
+          events.push({event_key:'attribution:touchpoint:'+row.provider_message_id,event_type:'attribution.touchpoint',provider_message_id:row.provider_message_id,status:'observed',payload:provenance});
+        }
 
         // A signed Meta message carrying both identifiers is direct channel-pair evidence.
         if(fromPhone&&fromUser){

--- a/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+++ b/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
@@ -42,7 +42,11 @@ test('invalid or non-https source URL is stripped while explicit referral eviden
   assert.equal(t.payload.source_url,null);assert.equal(t.payload.source_id,'post-9');assert.equal(t.payload.ad_id,null);
 });
 
-test('replay produces the same deterministic touchpoint key',()=>{
+test('replay produces the same deterministic touchpoint key and separate messages remain separate touchpoints',()=>{
   const msg={id:'wamid.ctwa.replay',from:'51911111111',timestamp:'1786807003',type:'text',text:{body:'Hola'},referral:{source_id:'ad-88',source_type:'ad'}};
-  const a=touchpoints(wa.extractWebhook(payload([msg)));
+  const a=touchpoints(wa.extractWebhook(payload([msg])))[0];
+  const b=touchpoints(wa.extractWebhook(payload([msg])))[0];
+  assert.equal(a.event_key,b.event_key);
+  const c=touchpoints(wa.extractWebhook(payload([{...msg,id:'wamid.ctwa.replay.2'}])))[0];
+  assert.notEqual(a.event_key,c.event_key);
 });

--- a/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+++ b/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const wa=require('../../app/wa-gateway');
+
+function payload(messages,contact){
+  return {object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn-wa7a3'},contacts:contact?[contact]:[],messages}}]}]};
+}
+function touchpoints(e){return e.events.filter(x=>x.event_type==='attribution.touchpoint');}
+
+test('preserves explicit Meta referral provenance as a separate touchpoint event',()=>{
+  const p=payload([{id:'wamid.ctwa.1',from:'51911111111',timestamp:'1786807000',type:'text',text:{body:'Hola'},referral:{source_url:'https://www.facebook.com/ads/example?utm_source=meta',source_id:'ad-77',source_type:'ad',headline:'HIFU Lima',body:'Agenda hoy',media_type:'image',ctwa_clid:'ctwa-click-001',lead_id:'provider-lead-8',campaign_source:'META_CTWA'}}]);
+  const e=wa.extractWebhook(p);const t=touchpoints(e);
+  assert.equal(e.messages.length,1);assert.equal(t.length,1);
+  assert.equal(t[0].event_key,'attribution:touchpoint:wamid.ctwa.1');
+  assert.equal(t[0].provider_message_id,'wamid.ctwa.1');
+  assert.equal(t[0].payload.source_id,'ad-77');assert.equal(t[0].payload.source_type,'ad');assert.equal(t[0].payload.ad_id,'ad-77');
+  assert.equal(t[0].payload.ctwa_clid,'ctwa-click-001');assert.equal(t[0].payload.provider_lead_id,'provider-lead-8');
+  assert.equal(t[0].payload.campaign_source,'META_CTWA');assert.equal(t[0].payload.channel,'WHATSAPP');
+  assert.equal(t[0].payload.provider,'META_CLOUD_API');assert.equal(t[0].payload.evidence_version,'WA_7A_3_V1');
+  assert.equal('phone' in t[0].payload,false);assert.equal('bsuid' in t[0].payload,false);assert.equal('username' in t[0].payload,false);
+});
+
+test('keeps WA-1 legacy normalized referral shape unchanged',()=>{
+  const p=payload([{id:'wamid.ctwa.legacy',from:'51911111111',timestamp:'1786807000',type:'text',text:{body:'Hola'},referral:{source_url:'https://www.facebook.com/ads/example',source_id:'ad-77',source_type:'ad',headline:'HIFU',body:'Promo',ctwa_clid:'ctwa-1'}}]);
+  const e=wa.extractWebhook(p);
+  assert.equal(e.messages[0].ad_id,'ad-77');assert.equal(e.messages[0].campaign_source,'HIFU');
+  assert.deepEqual(Object.keys(e.messages[0].raw_referral).sort(),['body','headline','source_id','source_type']);
+});
+
+test('no explicit referral means no fabricated attribution even with phone BSUID and username',()=>{
+  const contact={wa_id:'51911111111',user_id:'bsuid-abc',profile:{name:'Demo',username:'demo_user'}};
+  const p=payload([{id:'wamid.organic.1',from:'51911111111',from_user_id:'bsuid-abc',timestamp:'1786807001',type:'text',text:{body:'Orgánico'}}],contact);
+  const e=wa.extractWebhook(p);
+  assert.equal(touchpoints(e).length,0);
+  assert.ok(e.events.some(x=>x.event_type==='identity.meta_pair'));
+});
+
+test('invalid or non-https source URL is stripped while explicit referral evidence remains',()=>{
+  const p=payload([{id:'wamid.ctwa.badurl',from:'51911111111',timestamp:'1786807002',type:'text',text:{body:'Hola'},referral:{source_url:'javascript:alert(1)',source_id:'post-9',source_type:'post',headline:'Post'}}]);
+  const t=touchpoints(wa.extractWebhook(p))[0];
+  assert.equal(t.payload.source_url,null);assert.equal(t.payload.source_id,'post-9');assert.equal(t.payload.ad_id,null);
+});
+
+test('replay produces the same deterministic touchpoint key',()=>{
+  const msg={id:'wamid.ctwa.replay',from:'51911111111',timestamp:'1786807003',type:'text',text:{body:'Hola'},referral:{source_id:'ad-88',source_type:'ad'}};
+  const a=touchpoints(wa.extractWebhook(payload([msg)));
+});

--- a/ci/wa7a3-attribution-ingress/tests/001_attribution_ingress.sql
+++ b/ci/wa7a3-attribution-ingress/tests/001_attribution_ingress.sql
@@ -1,0 +1,86 @@
+\set ON_ERROR_STOP on
+
+-- A normal inbound message binds to the existing canonical WA conversation projection.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at
+) values (
+  'wamid.wa7a3.db.1','INBOUND','51911111111','51999111222','pn-wa7a3','text','Hola','received','2026-08-27T12:00:00-05:00','2026-08-27T12:00:01-05:00'
+);
+
+-- The parser/runtime persists only explicit provenance as a deterministic event.
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values(
+  'attribution:touchpoint:wamid.wa7a3.db.1','attribution.touchpoint','wamid.wa7a3.db.1','observed',
+  jsonb_build_object(
+    'evidence_version','WA_7A_3_V1','channel','WHATSAPP','provider','META_CLOUD_API','business_scope','pn-wa7a3',
+    'provider_message_id','wamid.wa7a3.db.1','ctwa_clid','ctwa-db-1','source_id','ad-db-1','source_type','ad',
+    'source_url','https://www.facebook.com/ads/db-1','ad_id','ad-db-1','provider_lead_id','provider-lead-db-1',
+    'campaign_source','META_CTWA','headline','HIFU','body','Agenda','media_type','image','observed_at','2026-08-27T12:00:00-05:00'
+  )
+)
+on conflict(event_key) do nothing;
+
+-- Provider replay must not duplicate the acquisition touchpoint.
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+select event_key,event_type,provider_message_id,status,payload
+from public.aos_wa_events_v1
+where event_key='attribution:touchpoint:wamid.wa7a3.db.1'
+on conflict(event_key) do nothing;
+
+do $$
+declare
+  v_count bigint;
+  v_conv uuid;
+  v_patient text;
+  v_source text;
+  v_ctwa text;
+  v_ad text;
+  v_cols integer;
+begin
+  select count(*) into v_count from public.aos_wa_events_v1 where event_key='attribution:touchpoint:wamid.wa7a3.db.1';
+  if v_count<>1 then raise exception 'WA7A3_REPLAY_DUPLICATED_TOUCHPOINT'; end if;
+
+  select conversation_id,canonical_patient_id,source_id,ctwa_clid,ad_id
+  into v_conv,v_patient,v_source,v_ctwa,v_ad
+  from public.aos_wa_attribution_touchpoints_v1
+  where touchpoint_key='attribution:touchpoint:wamid.wa7a3.db.1';
+
+  if v_conv is null then raise exception 'WA7A3_CONVERSATION_LINK_MISSING'; end if;
+  if v_patient is not null then raise exception 'WA7A3_CANONICAL_IDENTITY_FABRICATED'; end if;
+  if v_source<>'ad-db-1' or v_ctwa<>'ctwa-db-1' or v_ad<>'ad-db-1' then raise exception 'WA7A3_PROVENANCE_PROJECTION_MISMATCH'; end if;
+
+  select count(*) into v_cols
+  from information_schema.columns
+  where table_schema='public' and table_name='aos_wa_attribution_touchpoints_v1'
+    and lower(column_name) similar to '%(phone|bsuid|username|contact_number|alias_value)%';
+  if v_cols<>0 then raise exception 'WA7A3_RAW_IDENTITY_LEAK'; end if;
+
+  if has_table_privilege('anon','public.aos_wa_attribution_touchpoints_v1','SELECT') then raise exception 'WA7A3_ANON_VIEW_EXPOSED'; end if;
+  if has_table_privilege('authenticated','public.aos_wa_attribution_touchpoints_v1','SELECT') then raise exception 'WA7A3_AUTH_VIEW_EXPOSED'; end if;
+  if not has_table_privilege('service_role','public.aos_wa_attribution_touchpoints_v1','SELECT') then raise exception 'WA7A3_SERVICE_VIEW_MISSING'; end if;
+
+  if has_table_privilege('service_role','public.aos_wa_events_v1','UPDATE') then raise exception 'WA7A3_EVENT_UPDATE_PRIVILEGE_OPEN'; end if;
+  if has_table_privilege('service_role','public.aos_wa_events_v1','DELETE') then raise exception 'WA7A3_EVENT_DELETE_PRIVILEGE_OPEN'; end if;
+  if has_table_privilege('service_role','public.aos_wa_events_v1','TRUNCATE') then raise exception 'WA7A3_EVENT_TRUNCATE_PRIVILEGE_OPEN'; end if;
+end
+$$;
+
+-- Even an owner-level accidental row mutation is rejected for accepted provenance.
+do $$
+begin
+  begin
+    update public.aos_wa_events_v1 set status='tampered'
+    where event_key='attribution:touchpoint:wamid.wa7a3.db.1';
+    raise exception 'WA7A3_IMMUTABILITY_UPDATE_NOT_BLOCKED';
+  exception when sqlstate '55000' then null;
+  end;
+  begin
+    delete from public.aos_wa_events_v1
+    where event_key='attribution:touchpoint:wamid.wa7a3.db.1';
+    raise exception 'WA7A3_IMMUTABILITY_DELETE_NOT_BLOCKED';
+  exception when sqlstate '55000' then null;
+  end;
+end
+$$;
+
+select 'WA7A3_ATTRIBUTION_INGRESS_PASS' as result;

--- a/docs/control/WHATSAPP_WA_7A_3_ATTRIBUTION_INGRESS_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA_7A_3_ATTRIBUTION_INGRESS_EVIDENCE.md
@@ -1,0 +1,110 @@
+# WA-7A.3 — Attribution Ingress — Evidence & Necessity Gate
+
+**Captured:** 2026-08-27 America/Lima  
+**Baseline:** `main@6c5b7199a9f9f27bd2062d5c61fc0f15b2be9a51`  
+**Status:** BUILD / CERTIFICATION IN PROGRESS
+
+## Decision
+
+`BUILD = YES` and `NEW PHYSICAL TOUCHPOINT TABLE = NO`.
+
+ASCENDA already has the required boundaries:
+
+- signed Meta ingress in `app/server-f4.js`;
+- identity-safe parser and PHONE/BSUID continuity in `app/wa-gateway.js`;
+- canonical message ledger `aos_wa_messages_v1`;
+- idempotent event ledger `aos_wa_events_v1` with unique `event_key`;
+- deterministic message → `conversation_id` projection;
+- WA-7A.1 read-only conversation → canonical patient bridge;
+- Marketing Attribution V2 downstream analytics.
+
+The missing slice is explicit acquisition evidence preservation. WA-7A.3 therefore reuses `aos_wa_events_v1` with event type `attribution.touchpoint`, adds a private read-only adapter view, and does not create another CRM, customer master, identity authority or marketing lead store.
+
+## Provider contract revalidated
+
+Current Meta WhatsApp Cloud API examples keep Click-to-WhatsApp acquisition metadata on the inbound message `referral` object, including `source_url`, `source_id`, `source_type`, `headline`, `body` and media metadata. Provider integrations can additionally expose a CTWA click id (`ctwa_clid` / provider equivalent) for Conversions API stitching.
+
+Execution references revalidated on 2026-08-27:
+
+- Meta WhatsApp Business Platform Postman collection — Received Message Triggered by Click to WhatsApp Ads.
+- Meta WhatsApp Business Platform Postman collection — Messages Object / referral semantics.
+- Twilio WhatsApp inbound webhook documentation — `ReferralCtwaClid`.
+
+WA-7A.3 stores a CTWA click id only when explicitly supplied. It never fabricates it from `source_id`, phone, BSUID, username or canonical patient identity.
+
+## Reuse boundary
+
+### Reused as immutable evidence ledger
+
+`aos_wa_events_v1`
+
+Deterministic key:
+
+`attribution:touchpoint:<provider_message_id>`
+
+Payload fields are sanitized and bounded:
+
+- evidence version;
+- channel/provider/business scope;
+- provider message id;
+- `ctwa_clid` when explicitly supplied;
+- `source_id`;
+- `source_type`;
+- safe HTTPS `source_url`;
+- `ad_id` only when source type is explicitly `ad`;
+- provider lead id when supplied;
+- explicit campaign source when supplied;
+- headline/body/media type;
+- provider observed timestamp.
+
+No phone, BSUID, username or raw webhook body is stored in attribution evidence.
+
+### Read-only adapter
+
+`aos_wa_attribution_touchpoints_v1`
+
+It joins:
+
+`immutable event → provider_message_id → canonical WA message → conversation_id → optional WA-7A.1 canonical patient resolution`.
+
+The canonical patient link remains a read-only projection. Attribution evidence never mutates identity to obtain a match.
+
+## Production discovery
+
+Pre-build production readback:
+
+- messages: 21;
+- conversations: 2;
+- WA events: 39;
+- referral-bearing messages: 0;
+- messages with `campaign_source`: 0;
+- messages with `ad_id`: 0;
+- messages with `lead_id`: 0;
+- `attribution.touchpoint` events: 0.
+
+A privilege drift was found: production `service_role` currently has broader rights on `aos_wa_events_v1` than WA-1's original append-only intent. WA-7A.3 reconciles this by revoking runtime UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER and retaining SELECT/INSERT, plus an explicit mutation guard for accepted attribution events.
+
+## Marketing Attribution boundary
+
+Marketing Attribution V2 remains authoritative for existing lead/call/cita/sale analytics. Its current `aos_marketing_touchpoints_v2()` derives historical marketing touchpoints from `aos_leads` and is not replaced.
+
+WA-7A.3 does **not** auto-create an `aos_leads` row from a WhatsApp referral. The new adapter is the governed first-mile provenance source that later revenue stitching can consume without inventing a marketing lead or phone-only attribution.
+
+## Hard invariants
+
+- `BSUID != touchpoint`;
+- channel identity != acquisition provenance;
+- username never attributes;
+- phone never attributes by itself;
+- canonical patient identity never attributes by itself;
+- absent referral/provenance evidence => no attribution touchpoint;
+- repeated provider delivery => same touchpoint key;
+- one person/conversation may have multiple legitimate touchpoints;
+- accepted touchpoint evidence is append-only and auditable;
+- no `aos_pacientes`, REV canonical or `aos_leads` mutation;
+- no Meta Ads bulk sync;
+- no campaign activation, AI send, auto-reply or auto-routing.
+
+## LIVE boundary
+
+Fresh provider CTWA end-to-end remains a separate LIVE gate. It must not be replaced by historical evidence, service-role Auth bypass or synthetic production attribution.

--- a/supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+++ b/supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
@@ -1,0 +1,75 @@
+-- WA-7A.3 — Attribution Ingress V1
+-- Reuses the existing WA event ledger as immutable provenance storage.
+-- No new customer/person/touchpoint table; no aos_leads, aos_pacientes or REV mutation.
+
+begin;
+
+-- Production drift reconciliation: WA-1 designed this ledger as append-only for runtime,
+-- but broad service_role grants were later observed in production. Restore least privilege.
+revoke update, delete, truncate, references, trigger on table public.aos_wa_events_v1 from service_role;
+grant select, insert on table public.aos_wa_events_v1 to service_role;
+
+create or replace function public.aos_wa7a3_touchpoint_immutable_guard_v1()
+returns trigger
+language plpgsql
+set search_path=''
+as $$
+begin
+  if old.event_type='attribution.touchpoint' then
+    raise exception 'WA7A3_TOUCHPOINT_IMMUTABLE' using errcode='55000';
+  end if;
+  if tg_op='DELETE' then return old; end if;
+  return new;
+end
+$$;
+
+revoke all on function public.aos_wa7a3_touchpoint_immutable_guard_v1() from public, anon, authenticated;
+grant execute on function public.aos_wa7a3_touchpoint_immutable_guard_v1() to service_role;
+
+drop trigger if exists trg_aos_wa7a3_touchpoint_immutable_guard_v1 on public.aos_wa_events_v1;
+create trigger trg_aos_wa7a3_touchpoint_immutable_guard_v1
+before update or delete on public.aos_wa_events_v1
+for each row execute function public.aos_wa7a3_touchpoint_immutable_guard_v1();
+
+create or replace view public.aos_wa_attribution_touchpoints_v1
+with (security_invoker=true, security_barrier=true)
+as
+select
+  e.id as touchpoint_id,
+  e.event_key as touchpoint_key,
+  e.provider_message_id,
+  m.conversation_id,
+  case when i.resolution_status='MATCH' then i.canonical_patient_id else null end::text as canonical_patient_id,
+  coalesce(i.resolution_status,'UNRESOLVED')::text as identity_resolution_status,
+  i.confidence_band::text as identity_confidence_band,
+  nullif(e.payload->>'ctwa_clid','')::text as ctwa_clid,
+  nullif(e.payload->>'source_id','')::text as source_id,
+  nullif(e.payload->>'source_type','')::text as source_type,
+  nullif(e.payload->>'source_url','')::text as source_url,
+  nullif(e.payload->>'ad_id','')::text as ad_id,
+  nullif(e.payload->>'provider_lead_id','')::text as provider_lead_id,
+  nullif(e.payload->>'campaign_source','')::text as campaign_source,
+  nullif(e.payload->>'headline','')::text as headline,
+  nullif(e.payload->>'body','')::text as body,
+  nullif(e.payload->>'media_type','')::text as media_type,
+  coalesce(m.provider_timestamp,e.created_at) as touchpoint_at,
+  e.created_at as persisted_at,
+  coalesce(nullif(e.payload->>'evidence_version',''),'WA_7A_3_V1')::text as evidence_version
+from public.aos_wa_events_v1 e
+join public.aos_wa_messages_v1 m
+  on m.provider_message_id=e.provider_message_id
+left join public.aos_wa_identity_resolution_v1 i
+  on i.conversation_id=m.conversation_id
+where e.event_type='attribution.touchpoint';
+
+comment on view public.aos_wa_attribution_touchpoints_v1 is
+'WA-7A.3 private read-only adapter from immutable WhatsApp attribution events to conversation and optional WA-7A.1 canonical patient resolution. It exposes no phone, BSUID or username and performs no Marketing/REV/customer mutation.';
+comment on function public.aos_wa7a3_touchpoint_immutable_guard_v1() is
+'WA-7A.3 guard: accepted attribution.touchpoint evidence cannot be updated or deleted; runtime also lacks UPDATE/DELETE/TRUNCATE on the WA event ledger.';
+
+revoke all on public.aos_wa_attribution_touchpoints_v1 from public, anon, authenticated;
+grant select on public.aos_wa_attribution_touchpoints_v1 to service_role;
+
+select pg_notify('pgrst','reload schema');
+
+commit;

--- a/supabase/rollbacks/20260827133000_wa7a3_attribution_ingress_v1.rollback.sql
+++ b/supabase/rollbacks/20260827133000_wa7a3_attribution_ingress_v1.rollback.sql
@@ -1,0 +1,23 @@
+-- WA-7A.3 guarded rollback.
+-- Accepted acquisition evidence is historical truth and must not be silently removed.
+
+begin;
+
+do $$
+begin
+  if exists(select 1 from public.aos_wa_events_v1 where event_type='attribution.touchpoint') then
+    raise exception 'WA7A3_ROLLBACK_BLOCKED_REAL_TOUCHPOINT_EVIDENCE_EXISTS';
+  end if;
+end
+$$;
+
+drop view if exists public.aos_wa_attribution_touchpoints_v1;
+drop trigger if exists trg_aos_wa7a3_touchpoint_immutable_guard_v1 on public.aos_wa_events_v1;
+drop function if exists public.aos_wa7a3_touchpoint_immutable_guard_v1();
+
+-- Deliberately do not restore UPDATE/DELETE/TRUNCATE on the existing event ledger.
+-- WA-1 originally defined runtime event storage as append-only; the revoke is drift reconciliation.
+
+select pg_notify('pgrst','reload schema');
+
+commit;


### PR DESCRIPTION
Implements the minimum WA-7A.3 boundary over exact baseline `main@6c5b7199a9f9f27bd2062d5c61fc0f15b2be9a51`.

- preserves explicit `messages[].referral` provenance as deterministic `attribution.touchpoint` events;
- reuses `aos_wa_events_v1` instead of creating a parallel touchpoint/customer master;
- hardens accepted provenance against update/delete and reconciles runtime event-ledger privilege drift;
- adds private `aos_wa_attribution_touchpoints_v1` projection: touchpoint → message → conversation → optional WA-7A.1 canonical identity;
- no phone/BSUID/username-only attribution;
- no writes to `aos_leads`, `aos_pacientes` or REV canonical identity;
- no Meta Ads Sync or AI/campaign activation;
- adds Zero-Cost parser/DB/security/rollback tests plus WA-7A.0/1/2 regressions.

Fresh provider CTWA E2E remains separately LIVE-gated if Supabase REST/Auth 402 persists.