### PR TITLE
WA-7A.4 — Marketing Eligibility Foundation (TEST)

### DIFF
--- a/.github/workflows/wa7a4-marketing-eligibility.yml
+++ b/.github/workflows/wa7a4-marketing-eligibility.yml
@@ -1,0 +1,190 @@
+name: ASCENDA WA-7A.4 Marketing Eligibility Foundation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*wa7a4_marketing_eligibility*'
+      - 'supabase/rollbacks/*wa7a4_marketing_eligibility*'
+      - 'ci/wa7a4-marketing-eligibility/**'
+      - 'docs/control/WHATSAPP_WA_7A_4_MARKETING_ELIGIBILITY_EVIDENCE.md'
+      - '.github/workflows/wa7a4-marketing-eligibility.yml'
+  push:
+    branches: ['feat/wa-7a-4-marketing-eligibility-20260827']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa7a4-marketing-eligibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · WA-7A.4 marketing eligibility
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 45
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59942/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Enforce Zero-Cost lane
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+
+      - name: Authority and scope invariants
+        run: |
+          set -euo pipefail
+          M=supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+          grep -q 'aos_wa_marketing_eligibility_events_v1' "$M"
+          grep -q 'aos_wa_marketing_eligibility_v1' "$M"
+          grep -q 'aos_wa_marketing_eligibility_record_v1' "$M"
+          grep -q 'aos_wa_marketing_eligibility_check_v1' "$M"
+          grep -q 'aos_cia_channel_recipient_controls_v1' "$M"
+          grep -q "'BSUID'" "$M"
+          grep -q "'PARENT_BSUID'" "$M"
+          grep -q 'WA7A4_SOURCE_CANNOT_GRANT_CONSENT' "$M"
+          grep -q 'WA7A4_EXPLICIT_RECONSENT_REQUIRED' "$M"
+          grep -q 'security_invoker=true' "$M"
+          ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.aos_cia_channel_recipient_controls_v1' "$M"
+          ! grep -Eiq '(insert into|update|delete from)[[:space:]]+public\.(aos_pacientes|aos_leads|aos_rev_)' "$M"
+          ! grep -Eiq 'aos_marketing_touchpoints_v2' "$M"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M"
+          ! grep -Eiq '(bulk|broadcast|campaign)[_[:space:]-]*(send|dispatch)[_[:space:]-]*enabled' "$M"
+
+      - name: Configure isolated Supabase ports
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa7a4-eligibility"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59941/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59942/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59940/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa7a4-eligibility' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59942 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          echo 'WA-7A.4 isolated Postgres did not become ready' >&2
+          exit 1
+
+      - name: Build certified WA prerequisites
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815160000_wa1_secure_gateway_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815175500_wa2_conversation_live_inbox_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260815190500_wa3_boxes_routing_handoff_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260822173000_wa3_multiagent_readiness_v2.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143000_wa7a0_identity_compatibility_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143100_wa7a0_direct_insert_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825143200_wa7a0_phone_key_compat_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/cia_recipient_controls_stub.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+
+      - name: Database lint
+        working-directory: ci/zero-cost-staging
+        run: supabase db lint --local --schema public --level error
+
+      - name: Eligibility behavior, replay, security and separation
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/tests/001_marketing_eligibility.sql | tee /tmp/wa7a4-db.txt
+          grep -q 'WA7A4_MARKETING_ELIGIBILITY_PASS' /tmp/wa7a4-db.txt
+
+      - name: Destructive rollback guard
+        run: |
+          set -euo pipefail
+          if psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260827141500_wa7a4_marketing_eligibility_v1.rollback.sql; then
+            echo 'WA-7A.4 rollback unexpectedly removed accepted eligibility evidence' >&2
+            exit 1
+          fi
+          echo WA7A4_ROLLBACK_GUARD_PASS
+
+      - name: Clean synthetic eligibility then rollback and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c 'truncate table public.aos_wa_marketing_eligibility_events_v1;'
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260827141500_wa7a4_marketing_eligibility_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.tables where table_schema='public' and table_name='aos_wa_marketing_eligibility_events_v1'")" = "0"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.views where table_schema='public' and table_name='aos_wa_marketing_eligibility_v1'")" = "1"
+
+      - name: WA-7A.3 database regression
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a3-attribution-ingress/tests/001_attribution_ingress.sql | tee /tmp/wa7a3-regression.txt
+          grep -q 'WA7A3_ATTRIBUTION_INGRESS_PASS' /tmp/wa7a3-regression.txt
+
+      - name: Clear WA fixtures before identity regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          truncate table public.aos_wa_marketing_eligibility_events_v1;
+          truncate table public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+
+      - name: WA-7A.2 / 7A.1 / 7A.0 regressions
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a2-identity-verification/tests/001_identity_verification.sql | tee /tmp/wa7a2.txt
+          grep -q 'WA7A2_IDENTITY_VERIFICATION_PASS' /tmp/wa7a2.txt
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          truncate table public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/tests/001_identity_resolution.sql | tee /tmp/wa7a1.txt
+          grep -q 'WA7A1_IDENTITY_RESOLUTION_PASS' /tmp/wa7a1.txt
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 <<'SQL'
+          truncate table public.aos_wa_events_v1;
+          delete from public.aos_wa_messages_v1;
+          update public.aos_wa_channel_aliases_v1 set superseded_by=null;
+          delete from public.aos_wa_channel_aliases_v1;
+          delete from public.aos_wa_conversations_v1;
+          truncate table public.aos_rev_patient_identity_alias_v2;
+          SQL
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa7a0-identity-compatibility/tests/001_identity_compatibility.sql | tee /tmp/wa7a0.txt
+
+      - name: Certification boundary
+        run: |
+          set -euo pipefail
+          echo 'WA-7A.4 TEST CERTIFICATION ONLY: no production migration apply while Supabase REST/Auth 402 hold is active.'
+          echo 'IDENTITY != REACHABILITY != MARKETING ELIGIBILITY; ATTRIBUTION EVIDENCE != CONSENT.'
+          echo 'CIA-F17 suppression is reused read-only and can block; CIA ALLOWED never grants WhatsApp consent.'
+          echo 'No bulk sender, campaign activation, Ads Sync, AI send, auto-reply or auto-routing.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/ci/wa7a4-marketing-eligibility/cia_recipient_controls_stub.sql
+++ b/ci/wa7a4-marketing-eligibility/cia_recipient_controls_stub.sql
@@ -1,0 +1,29 @@
+-- Minimal CIA-F17 recipient-control contract used only by isolated WA-7A.4 Zero-Cost tests.
+-- Production authority remains the real CIA-F17 migration.
+
+create or replace function public.aos_cia_normalize_contact_key_v1(p_raw text)
+returns text
+language sql
+immutable parallel safe
+as $$
+select case
+  when length(regexp_replace(coalesce(p_raw,''),'\D','','g'))=9 then regexp_replace(coalesce(p_raw,''),'\D','','g')
+  when length(regexp_replace(coalesce(p_raw,''),'\D','','g'))=11 and left(regexp_replace(coalesce(p_raw,''),'\D','','g'),2)='51'
+    then right(regexp_replace(coalesce(p_raw,''),'\D','','g'),9)
+  else null
+end;
+$$;
+
+create table public.aos_cia_channel_recipient_controls_v1 (
+  contact_key text not null,
+  channel text not null check (channel in ('WHATSAPP','SMS')),
+  consent_status text not null default 'UNKNOWN' check (consent_status in ('UNKNOWN','ALLOWED','DENIED')),
+  suppression_status text not null default 'UNKNOWN' check (suppression_status in ('UNKNOWN','CLEAR','SUPPRESSED')),
+  source text not null default 'UNSET',
+  evidence jsonb not null default '{}'::jsonb,
+  updated_by_user_id uuid,
+  expires_at timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key(contact_key,channel),
+  check (public.aos_cia_normalize_contact_key_v1(contact_key)=contact_key)
+);

--- a/ci/wa7a4-marketing-eligibility/tests/001_marketing_eligibility.sql
+++ b/ci/wa7a4-marketing-eligibility/tests/001_marketing_eligibility.sql
@@ -1,0 +1,212 @@
+\set ON_ERROR_STOP on
+
+-- WA-7A.4 isolated behavior contract.
+set role postgres;
+
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,phone_number_id,contact_address,contact_address_type
+) values (
+  '71000000-0000-0000-0000-000000000001','pn-test:bsuid-user-1','pn-test','bsuid-user-1','BSUID'
+);
+
+-- 1. No routable alias -> fail closed as UNREACHABLE.
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.reachability_status<>'UNREACHABLE' or r.eligibility_status<>'NOT_ELIGIBLE' or r.send_allowed then
+    raise exception 'WA7A4_UNREACHABLE_FAIL_CLOSED_FAILED';
+  end if;
+end$$;
+
+-- 2. BSUID alone is reachability, not consent.
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,verification_status,verification_source)
+values('pn-test','BSUID','bsuid-user-1','71000000-0000-0000-0000-000000000001','VERIFIED','SIGNED_PROVIDER');
+
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.reachability_status<>'REACHABLE' or r.eligibility_status<>'UNKNOWN' or r.send_allowed then
+    raise exception 'WA7A4_BSUID_MUST_NOT_GRANT_CONSENT';
+  end if;
+end$$;
+
+-- 3. Attribution/CTWA evidence cannot grant consent.
+do $$
+begin
+  begin
+    perform public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+      'event_key','wa7a4:weak-source:1','conversation_id','71000000-0000-0000-0000-000000000001',
+      'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+      'source','CTWA','observed_at','2026-08-27T18:20:00Z','evidence',jsonb_build_object('ctwa_clid','x')
+    ));
+    raise exception 'WA7A4_WEAK_SOURCE_UNEXPECTEDLY_GRANTED';
+  exception when sqlstate '42501' then
+    if sqlerrm not like '%WA7A4_SOURCE_CANNOT_GRANT_CONSENT%' then raise; end if;
+  end;
+end$$;
+
+-- 4. Explicit MARKETING opt-in makes a reachable BSUID conversation eligible.
+select public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+  'event_key','wa7a4:marketing:allow:1','conversation_id','71000000-0000-0000-0000-000000000001',
+  'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+  'source','WEB_FORM_OPT_IN','source_ref','form:test','policy_version','WA_7A_4_V1',
+  'observed_at','2026-08-27T18:21:00Z','evidence',jsonb_build_object('explicit_opt_in',true,'categories',jsonb_build_array('MARKETING'))
+));
+
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.consent_status<>'ALLOWED' or r.suppression_status<>'CLEAR' or r.eligibility_status<>'ELIGIBLE' or not r.send_allowed then
+    raise exception 'WA7A4_EXPLICIT_MARKETING_OPTIN_FAILED';
+  end if;
+end$$;
+
+-- 5. MARKETING consent never grants CALL consent.
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='CALL';
+  if r.eligibility_status<>'UNKNOWN' or r.send_allowed then raise exception 'WA7A4_SCOPE_SEPARATION_FAILED'; end if;
+end$$;
+
+-- 6. Exact replay is idempotent; same key with changed evidence is a conflict.
+do $$
+declare r jsonb;
+begin
+  r := public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+    'event_key','wa7a4:marketing:allow:1','conversation_id','71000000-0000-0000-0000-000000000001',
+    'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+    'source','WEB_FORM_OPT_IN','source_ref','form:test','policy_version','WA_7A_4_V1',
+    'observed_at','2026-08-27T18:21:00Z','evidence',jsonb_build_object('explicit_opt_in',true,'categories',jsonb_build_array('MARKETING'))
+  ));
+  if coalesce((r->>'idempotent')::boolean,false) is not true then raise exception 'WA7A4_REPLAY_NOT_IDEMPOTENT'; end if;
+  begin
+    perform public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+      'event_key','wa7a4:marketing:allow:1','conversation_id','71000000-0000-0000-0000-000000000001',
+      'eligibility_scope','MARKETING','consent_status','DENIED','suppression_status','SUPPRESSED',
+      'source','USER_OPT_OUT','observed_at','2026-08-27T18:22:00Z','evidence',jsonb_build_object('opt_out',true)
+    ));
+    raise exception 'WA7A4_REPLAY_CONFLICT_NOT_BLOCKED';
+  exception when unique_violation then null;
+  end;
+end$$;
+
+-- 7. Opt-out immediately wins.
+select public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+  'event_key','wa7a4:marketing:deny:1','conversation_id','71000000-0000-0000-0000-000000000001',
+  'eligibility_scope','MARKETING','consent_status','DENIED','suppression_status','SUPPRESSED',
+  'source','USER_OPT_OUT','observed_at','2026-08-27T18:23:00Z','evidence',jsonb_build_object('explicit_opt_out',true)
+));
+
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.eligibility_status<>'NOT_ELIGIBLE' or r.reason_code<>'WA_SUPPRESSED' or r.send_allowed then raise exception 'WA7A4_OPTOUT_DID_NOT_WIN'; end if;
+end$$;
+
+-- 8. Silent reversal is forbidden; explicit re-consent is allowed.
+do $$
+begin
+  begin
+    perform public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+      'event_key','wa7a4:marketing:reallow:no-proof','conversation_id','71000000-0000-0000-0000-000000000001',
+      'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+      'source','WEB_FORM_OPT_IN','observed_at','2026-08-27T18:24:00Z','evidence','{}'::jsonb
+    ));
+    raise exception 'WA7A4_SILENT_REVERSAL_NOT_BLOCKED';
+  exception when sqlstate '42501' then
+    if sqlerrm not like '%WA7A4_EXPLICIT_RECONSENT_REQUIRED%' then raise; end if;
+  end;
+end$$;
+
+select public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+  'event_key','wa7a4:marketing:reallow:1','conversation_id','71000000-0000-0000-0000-000000000001',
+  'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+  'source','WEB_FORM_OPT_IN','observed_at','2026-08-27T18:25:00Z',
+  'evidence',jsonb_build_object('explicit_reconsent',true,'explicit_opt_in',true)
+));
+
+-- 9. Existing CIA-F17 suppression is a blocker, never a grant.
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,verification_status,verification_source)
+values('pn-test','PHONE','51987654321','71000000-0000-0000-0000-000000000001','VERIFIED','SIGNED_PROVIDER');
+insert into public.aos_cia_channel_recipient_controls_v1(contact_key,channel,consent_status,suppression_status,source,evidence)
+values('987654321','WHATSAPP','UNKNOWN','SUPPRESSED','CIA_TEST',jsonb_build_object('reason','legacy suppression'));
+
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.eligibility_status<>'NOT_ELIGIBLE' or r.reason_code<>'CIA_SUPPRESSED' or r.send_allowed then raise exception 'WA7A4_CIA_SUPPRESSION_FAILED'; end if;
+end$$;
+
+delete from public.aos_cia_channel_recipient_controls_v1 where contact_key='987654321' and channel='WHATSAPP';
+
+-- CIA ALLOWED alone must never grant a scope with no WA explicit consent.
+insert into public.aos_cia_channel_recipient_controls_v1(contact_key,channel,consent_status,suppression_status,source,evidence)
+values('987654321','WHATSAPP','ALLOWED','CLEAR','CIA_TEST',jsonb_build_object('legacy',true));
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='CALL';
+  if r.eligibility_status<>'UNKNOWN' or r.send_allowed then raise exception 'WA7A4_CIA_MUST_NOT_GRANT_CONSENT'; end if;
+end$$;
+
+-- 10. GLOBAL denial overrides category opt-in.
+select public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+  'event_key','wa7a4:global:deny:1','conversation_id','71000000-0000-0000-0000-000000000001',
+  'eligibility_scope','GLOBAL','consent_status','DENIED','suppression_status','SUPPRESSED',
+  'source','GLOBAL_OPT_OUT','observed_at','2026-08-27T18:26:00Z','evidence',jsonb_build_object('explicit_opt_out',true)
+));
+do $$
+declare r record;
+begin
+  select * into r from public.aos_wa_marketing_eligibility_v1
+   where conversation_id='71000000-0000-0000-0000-000000000001' and eligibility_scope='MARKETING';
+  if r.reason_code<>'WA_SUPPRESSED' or r.send_allowed then raise exception 'WA7A4_GLOBAL_SUPPRESSION_FAILED'; end if;
+end$$;
+
+-- 11. Evidence is immutable even to service_role/runtime.
+do $$
+begin
+  begin
+    update public.aos_wa_marketing_eligibility_events_v1 set source='MUTATED' where event_key='wa7a4:marketing:allow:1';
+    raise exception 'WA7A4_UPDATE_NOT_BLOCKED';
+  exception when sqlstate '55000' then null;
+  end;
+  begin
+    delete from public.aos_wa_marketing_eligibility_events_v1 where event_key='wa7a4:marketing:allow:1';
+    raise exception 'WA7A4_DELETE_NOT_BLOCKED';
+  exception when sqlstate '55000' then null;
+  end;
+end$$;
+
+-- 12. ACL boundary.
+do $$
+begin
+  if has_table_privilege('anon','public.aos_wa_marketing_eligibility_events_v1','SELECT') then raise exception 'WA7A4_ANON_EVENT_READ'; end if;
+  if has_table_privilege('authenticated','public.aos_wa_marketing_eligibility_v1','SELECT') then raise exception 'WA7A4_AUTH_VIEW_READ'; end if;
+  if not has_table_privilege('service_role','public.aos_wa_marketing_eligibility_events_v1','SELECT') then raise exception 'WA7A4_SERVICE_EVENT_READ_MISSING'; end if;
+  if has_table_privilege('service_role','public.aos_wa_marketing_eligibility_events_v1','UPDATE') then raise exception 'WA7A4_SERVICE_UPDATE_PRESENT'; end if;
+  if has_function_privilege('anon','public.aos_wa_marketing_eligibility_record_v1(jsonb)','EXECUTE') then raise exception 'WA7A4_ANON_RECORD_EXECUTE'; end if;
+end$$;
+
+-- 13. Service check returns fail-closed global result.
+do $$
+declare r jsonb;
+begin
+  r := public.aos_wa_marketing_eligibility_check_v1('71000000-0000-0000-0000-000000000001','MARKETING');
+  if coalesce((r->>'send_allowed')::boolean,true) is not false then raise exception 'WA7A4_CHECK_NOT_FAIL_CLOSED'; end if;
+end$$;
+
+select 'WA7A4_MARKETING_ELIGIBILITY_PASS' as result;

--- a/docs/control/WHATSAPP_WA_7A_4_MARKETING_ELIGIBILITY_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA_7A_4_MARKETING_ELIGIBILITY_EVIDENCE.md
@@ -1,0 +1,100 @@
+# WA-7A.4 — Marketing Eligibility Foundation — Evidence / TEST Plan
+
+**Captured:** 2026-08-27 America/Lima  
+**Baseline main:** `3bc7a70af661db7409cc77747ac63122abe8ee11`  
+**Execution mode:** `TEST / ZERO-COST / PROD-PROMOTION DEFERRED`
+
+## Necessity gate
+
+`BUILD = YES` · `NEW CONSENT MASTER = NO` · `PROD MUTATION = NO`.
+
+Existing CIA-F17 already owns `aos_cia_channel_recipient_controls_v1` with `consent_status`, `suppression_status`, source/evidence and fail-closed send preparation. It must be reused, not duplicated.
+
+However it cannot be the complete WhatsApp eligibility authority because `aos_cia_normalize_contact_key_v1(text)` is phone-centric (Peru 9-digit contact key), while WA-7A.0 explicitly supports PHONE / BSUID / PARENT_BSUID and phone is optional. CIA-F17 also stores only a current `contact_key + channel` snapshot and does not provide WA conversation-scoped immutable/category evidence.
+
+Production inventory before build:
+
+- `aos_cia_channel_recipient_controls_v1`: 0 rows;
+- `aos_cia_channel_send_requests_v1`: 0 rows;
+- `aos_cia_channel_inbound_facts_v1`: 7 rows;
+- `aos_cia_channel_send_events_v1`: 0 rows;
+- CIA recipient controls are RLS + FORCE RLS;
+- existing service_role table grants are broad and are NOT widened or mutated by WA-7A.4;
+- WA production currently has 2 conversations and active legacy PHONE aliases; BSUID-capable schema already exists.
+
+## Current provider/policy boundary
+
+Current WhatsApp Business Messaging Policy requires prior opt-in before business-initiated contact and requires businesses to honor opt-out/block/discontinue requests. Current best practices recommend category-aware opt-in and separate call opt-in. WA-7A.4 models those requirements without hard-coding legal conclusions into runtime.
+
+## Minimum build
+
+WA-7A.4 adds only a WhatsApp conversation-scoped eligibility evidence layer:
+
+- append-only `aos_wa_marketing_eligibility_events_v1`;
+- scopes: `GLOBAL`, `MARKETING`, `UTILITY`, `AUTHENTICATION`, `CALL`;
+- consent: `UNKNOWN / ALLOWED / DENIED`;
+- suppression: `UNKNOWN / CLEAR / SUPPRESSED`;
+- immutable source/evidence/policy/timestamp;
+- deterministic replay key and replay-conflict detection;
+- explicit re-consent required to reverse an earlier denial/suppression;
+- weak facts (`ATTRIBUTION`, `CTWA`, `TOUCHPOINT`, `PHONE`, `BSUID`, `USERNAME`, `MESSAGE_RECEIPT`) cannot grant `ALLOWED`;
+- `aos_wa_marketing_eligibility_v1` current projection;
+- reachability derives only from active PHONE/BSUID/PARENT_BSUID aliases; username is not reachability;
+- CIA-F17 is read-only secondary guard: active DENIED/SUPPRESSED can block, but CIA ALLOWED never grants WA consent;
+- service-only record/check functions;
+- RLS + FORCE RLS; no anon/authenticated access;
+- rollback fails closed once evidence exists.
+
+## Mandatory invariants
+
+`IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`
+
+`ATTRIBUTION EVIDENCE != CONSENT`
+
+Suppression wins. Missing consent fails closed. A reachable address is not permission. A CTWA click or inbound message is not blanket marketing consent. A category opt-in does not imply call opt-in. Opt-out can only be reversed by a new explicit re-consent event.
+
+## Scope exclusions
+
+WA-7A.4 does **not**:
+
+- create a customer/person master;
+- mutate `aos_pacientes`, `aos_leads`, REV/F5/F6 or Marketing Attribution V2;
+- modify `app/wa-gateway.js`;
+- activate bulk sending, broadcasts or campaigns;
+- activate Meta Ads Sync, Campaign Flow Router, AI send, auto-reply or auto-routing;
+- promote schema to production while the owner-directed TEST-first / Supabase-402 hold remains active.
+
+## Zero-Cost test matrix
+
+1. no alias → `UNREACHABLE / NOT_ELIGIBLE`;
+2. BSUID alias → reachable but no consent → `UNKNOWN`, send blocked;
+3. CTWA/attribution source cannot grant consent;
+4. explicit MARKETING opt-in → eligible on reachable BSUID-only conversation;
+5. MARKETING opt-in does not grant CALL;
+6. exact replay is idempotent;
+7. changed payload under same event key fails replay conflict;
+8. opt-out wins immediately;
+9. silent reactivation after opt-out is forbidden;
+10. explicit re-consent can restore the scoped permission;
+11. CIA suppression blocks;
+12. CIA ALLOWED alone cannot grant WA consent;
+13. GLOBAL suppression overrides scoped permission;
+14. evidence UPDATE/DELETE blocked;
+15. anon/authenticated ACL blocked;
+16. service-role read/insert only on evidence ledger;
+17. rollback blocked while evidence exists;
+18. rollback + clean reapply passes after synthetic evidence cleanup;
+19. WA-7A.3/7A.2/7A.1/7A.0 DB regressions pass;
+20. Zero-Cost policy passes on self-hosted runner.
+
+## Production promotion package
+
+The migration and rollback are committed but must remain unapplied to production until the production-recovery loop is authorized after Supabase renewal.
+
+Promotion order when PROD recovers:
+
+`revalidate exact main → verify WA-7A.0..7A.3 production state → fingerprint patients/leads/WA/Marketing → apply wa7a4 migration → ACL/readback → synthetic-free eligibility readback → REST/Auth health → provider/human canaries where applicable → certify PROD`.
+
+Until that promotion, the correct certification label is:
+
+`WA-7A.4 = TEST CERTIFIED / PROD-READY / PROD-PROMOTION PENDING`.

--- a/supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+++ b/supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
@@ -1,0 +1,254 @@
+-- WA-7A.4 — Marketing Eligibility Foundation V1
+-- TEST-first / PROD-ready. No production apply is implied by this migration file.
+-- Identity, reachability, attribution and marketing eligibility remain separate authorities.
+
+begin;
+
+create table if not exists public.aos_wa_marketing_eligibility_events_v1 (
+  id uuid primary key default gen_random_uuid(),
+  event_key text not null unique check (length(event_key) between 8 and 240),
+  conversation_id uuid not null references public.aos_wa_conversations_v1(id) on delete restrict,
+  eligibility_scope text not null check (eligibility_scope in ('GLOBAL','MARKETING','UTILITY','AUTHENTICATION','CALL')),
+  consent_status text not null check (consent_status in ('UNKNOWN','ALLOWED','DENIED')),
+  suppression_status text not null check (suppression_status in ('UNKNOWN','CLEAR','SUPPRESSED')),
+  source text not null check (length(source) between 2 and 80),
+  source_ref text,
+  policy_version text not null default 'WA_7A_4_V1',
+  evidence jsonb not null default '{}'::jsonb,
+  actor_user_id uuid,
+  observed_at timestamptz not null,
+  expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  check (consent_status <> 'UNKNOWN' or suppression_status <> 'UNKNOWN'),
+  check (expires_at is null or expires_at > observed_at)
+);
+
+create index if not exists aos_wa_marketing_eligibility_events_conversation_idx
+  on public.aos_wa_marketing_eligibility_events_v1(conversation_id,eligibility_scope,observed_at desc,created_at desc);
+
+alter table public.aos_wa_marketing_eligibility_events_v1 enable row level security;
+alter table public.aos_wa_marketing_eligibility_events_v1 force row level security;
+revoke all on table public.aos_wa_marketing_eligibility_events_v1 from public,anon,authenticated;
+revoke update,delete,truncate,references,trigger on table public.aos_wa_marketing_eligibility_events_v1 from service_role;
+grant select,insert on table public.aos_wa_marketing_eligibility_events_v1 to service_role;
+
+create or replace function public.aos_wa7a4_eligibility_immutable_guard_v1()
+returns trigger
+language plpgsql
+set search_path=''
+as $$
+begin
+  raise exception 'WA7A4_ELIGIBILITY_EVIDENCE_IMMUTABLE' using errcode='55000';
+end
+$$;
+revoke all on function public.aos_wa7a4_eligibility_immutable_guard_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa7a4_eligibility_immutable_guard_v1() to service_role;
+
+drop trigger if exists trg_aos_wa7a4_eligibility_immutable_guard_v1 on public.aos_wa_marketing_eligibility_events_v1;
+create trigger trg_aos_wa7a4_eligibility_immutable_guard_v1
+before update or delete on public.aos_wa_marketing_eligibility_events_v1
+for each row execute function public.aos_wa7a4_eligibility_immutable_guard_v1();
+
+create or replace function public.aos_wa_marketing_eligibility_record_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path='public','pg_temp'
+as $$
+declare
+  v_conversation_id uuid;
+  v_event_key text := trim(coalesce(p_payload->>'event_key',''));
+  v_scope text := upper(trim(coalesce(p_payload->>'eligibility_scope','')));
+  v_consent text := upper(trim(coalesce(p_payload->>'consent_status','UNKNOWN')));
+  v_suppression text := upper(trim(coalesce(p_payload->>'suppression_status','UNKNOWN')));
+  v_source text := upper(trim(coalesce(p_payload->>'source','')));
+  v_source_ref text := nullif(trim(coalesce(p_payload->>'source_ref','')),'');
+  v_policy_version text := upper(trim(coalesce(p_payload->>'policy_version','WA_7A_4_V1')));
+  v_evidence jsonb := coalesce(p_payload->'evidence','{}'::jsonb);
+  v_actor_user_id uuid;
+  v_observed_at timestamptz;
+  v_expires_at timestamptz;
+  v_existing public.aos_wa_marketing_eligibility_events_v1%rowtype;
+  v_prior public.aos_wa_marketing_eligibility_events_v1%rowtype;
+  v_id uuid;
+begin
+  if nullif(p_payload->>'conversation_id','') is null then raise exception 'WA7A4_CONVERSATION_REQUIRED' using errcode='22023'; end if;
+  v_conversation_id := (p_payload->>'conversation_id')::uuid;
+  if not exists(select 1 from public.aos_wa_conversations_v1 c where c.id=v_conversation_id) then raise exception 'WA7A4_CONVERSATION_NOT_FOUND' using errcode='23503'; end if;
+  if length(v_event_key) not between 8 and 240 then raise exception 'WA7A4_EVENT_KEY_INVALID' using errcode='22023'; end if;
+  if v_scope not in ('GLOBAL','MARKETING','UTILITY','AUTHENTICATION','CALL') then raise exception 'WA7A4_SCOPE_INVALID' using errcode='22023'; end if;
+  if v_consent not in ('UNKNOWN','ALLOWED','DENIED') or v_suppression not in ('UNKNOWN','CLEAR','SUPPRESSED') then raise exception 'WA7A4_STATE_INVALID' using errcode='22023'; end if;
+  if v_consent='UNKNOWN' and v_suppression='UNKNOWN' then raise exception 'WA7A4_EMPTY_DECISION' using errcode='22023'; end if;
+  if length(v_source) not between 2 and 80 then raise exception 'WA7A4_SOURCE_REQUIRED' using errcode='22023'; end if;
+  if nullif(p_payload->>'observed_at','') is null then raise exception 'WA7A4_OBSERVED_AT_REQUIRED' using errcode='22023'; end if;
+  v_observed_at := (p_payload->>'observed_at')::timestamptz;
+  if nullif(p_payload->>'expires_at','') is not null then v_expires_at := (p_payload->>'expires_at')::timestamptz; end if;
+  if v_expires_at is not null and v_expires_at <= v_observed_at then raise exception 'WA7A4_EXPIRY_INVALID' using errcode='22023'; end if;
+  if nullif(p_payload->>'actor_user_id','') is not null then v_actor_user_id := (p_payload->>'actor_user_id')::uuid; end if;
+
+  -- Attribution/channel facts never grant consent by themselves.
+  if v_consent='ALLOWED' and v_source in ('ATTRIBUTION','CTWA','TOUCHPOINT','PHONE','BSUID','USERNAME','MESSAGE_RECEIPT') then
+    raise exception 'WA7A4_SOURCE_CANNOT_GRANT_CONSENT' using errcode='42501';
+  end if;
+
+  select * into v_existing from public.aos_wa_marketing_eligibility_events_v1 where event_key=v_event_key;
+  if v_existing.id is not null then
+    if v_existing.conversation_id=v_conversation_id
+       and v_existing.eligibility_scope=v_scope
+       and v_existing.consent_status=v_consent
+       and v_existing.suppression_status=v_suppression
+       and v_existing.source=v_source
+       and coalesce(v_existing.source_ref,'')=coalesce(v_source_ref,'')
+       and v_existing.policy_version=v_policy_version
+       and v_existing.evidence=v_evidence
+       and v_existing.observed_at=v_observed_at
+       and v_existing.expires_at is not distinct from v_expires_at then
+      return jsonb_build_object('ok',true,'idempotent',true,'event_id',v_existing.id,'event_key',v_existing.event_key);
+    end if;
+    raise exception 'WA7A4_REPLAY_CONFLICT' using errcode='23505';
+  end if;
+
+  select * into v_prior
+  from public.aos_wa_marketing_eligibility_events_v1
+  where conversation_id=v_conversation_id and eligibility_scope=v_scope
+  order by observed_at desc,created_at desc limit 1;
+
+  -- A previous explicit denial/suppression cannot be silently cleared.
+  if v_prior.id is not null
+     and (v_prior.consent_status='DENIED' or v_prior.suppression_status='SUPPRESSED')
+     and (v_consent='ALLOWED' or v_suppression='CLEAR')
+     and coalesce((v_evidence->>'explicit_reconsent')::boolean,false) is not true then
+    raise exception 'WA7A4_EXPLICIT_RECONSENT_REQUIRED' using errcode='42501';
+  end if;
+
+  insert into public.aos_wa_marketing_eligibility_events_v1(
+    event_key,conversation_id,eligibility_scope,consent_status,suppression_status,
+    source,source_ref,policy_version,evidence,actor_user_id,observed_at,expires_at
+  ) values (
+    v_event_key,v_conversation_id,v_scope,v_consent,v_suppression,
+    v_source,v_source_ref,v_policy_version,v_evidence,v_actor_user_id,v_observed_at,v_expires_at
+  ) returning id into v_id;
+
+  return jsonb_build_object('ok',true,'idempotent',false,'event_id',v_id,'event_key',v_event_key);
+end
+$$;
+
+revoke all on function public.aos_wa_marketing_eligibility_record_v1(jsonb) from public,anon,authenticated;
+grant execute on function public.aos_wa_marketing_eligibility_record_v1(jsonb) to service_role;
+
+create or replace view public.aos_wa_marketing_eligibility_v1
+with (security_invoker=true,security_barrier=true)
+as
+with scopes(scope) as (
+  values ('MARKETING'::text),('UTILITY'::text),('AUTHENTICATION'::text),('CALL'::text)
+), latest as (
+  select distinct on (e.conversation_id,e.eligibility_scope)
+    e.*
+  from public.aos_wa_marketing_eligibility_events_v1 e
+  order by e.conversation_id,e.eligibility_scope,e.observed_at desc,e.created_at desc
+), base as (
+  select c.id as conversation_id,s.scope as eligibility_scope,
+    g.consent_status as g_consent_raw,g.suppression_status as g_suppression_raw,g.source as g_source,g.event_key as g_event_key,g.expires_at as g_expires_at,
+    e.consent_status as s_consent_raw,e.suppression_status as s_suppression_raw,e.source as s_source,e.event_key as s_event_key,e.expires_at as s_expires_at,
+    coalesce((select count(*) from public.aos_wa_channel_aliases_v1 a where a.conversation_id=c.id and a.active is true and a.alias_type in ('PHONE','BSUID','PARENT_BSUID')),0)::int as reachability_alias_count,
+    (select public.aos_cia_normalize_contact_key_v1(a.alias_value) from public.aos_wa_channel_aliases_v1 a where a.conversation_id=c.id and a.active is true and a.alias_type='PHONE' order by a.last_seen_at desc limit 1) as cia_contact_key
+  from public.aos_wa_conversations_v1 c
+  cross join scopes s
+  left join latest g on g.conversation_id=c.id and g.eligibility_scope='GLOBAL'
+  left join latest e on e.conversation_id=c.id and e.eligibility_scope=s.scope
+), effective as (
+  select b.*,
+    case when g_expires_at is not null and g_expires_at<=now() then 'UNKNOWN' else coalesce(g_consent_raw,'UNKNOWN') end as g_consent,
+    case when g_expires_at is not null and g_expires_at<=now() then 'UNKNOWN' else coalesce(g_suppression_raw,'UNKNOWN') end as g_suppression,
+    case when s_expires_at is not null and s_expires_at<=now() then 'UNKNOWN' else coalesce(s_consent_raw,'UNKNOWN') end as s_consent,
+    case when s_expires_at is not null and s_expires_at<=now() then 'UNKNOWN' else coalesce(s_suppression_raw,'UNKNOWN') end as s_suppression
+  from base b
+), guarded as (
+  select e.*,
+    c.consent_status as cia_consent_status,c.suppression_status as cia_suppression_status,c.source as cia_source,c.expires_at as cia_expires_at
+  from effective e
+  left join public.aos_cia_channel_recipient_controls_v1 c
+    on c.contact_key=e.cia_contact_key and c.channel='WHATSAPP'
+)
+select
+  conversation_id,eligibility_scope,
+  case when reachability_alias_count>0 then 'REACHABLE' else 'UNREACHABLE' end::text as reachability_status,
+  reachability_alias_count,
+  case
+    when g_consent='DENIED' or s_consent='DENIED' then 'DENIED'
+    when s_consent='ALLOWED' then 'ALLOWED'
+    when g_consent='ALLOWED' then 'ALLOWED'
+    else 'UNKNOWN'
+  end::text as consent_status,
+  case
+    when g_suppression='SUPPRESSED' or s_suppression='SUPPRESSED' then 'SUPPRESSED'
+    when s_suppression='CLEAR' and s_consent='ALLOWED' then 'CLEAR'
+    when g_suppression='CLEAR' and g_consent='ALLOWED' then 'CLEAR'
+    else 'UNKNOWN'
+  end::text as suppression_status,
+  case
+    when reachability_alias_count=0 then 'NOT_ELIGIBLE'
+    when g_suppression='SUPPRESSED' or s_suppression='SUPPRESSED' then 'NOT_ELIGIBLE'
+    when g_consent='DENIED' or s_consent='DENIED' then 'NOT_ELIGIBLE'
+    when cia_expires_at is null or cia_expires_at>now() then
+      case when cia_suppression_status='SUPPRESSED' or cia_consent_status='DENIED' then 'NOT_ELIGIBLE'
+           when ((s_consent='ALLOWED' and s_suppression='CLEAR') or (s_consent='UNKNOWN' and g_consent='ALLOWED' and g_suppression='CLEAR')) then 'ELIGIBLE'
+           else 'UNKNOWN' end
+    when ((s_consent='ALLOWED' and s_suppression='CLEAR') or (s_consent='UNKNOWN' and g_consent='ALLOWED' and g_suppression='CLEAR')) then 'ELIGIBLE'
+    else 'UNKNOWN'
+  end::text as eligibility_status,
+  case
+    when reachability_alias_count=0 then 'UNREACHABLE'
+    when g_suppression='SUPPRESSED' or s_suppression='SUPPRESSED' then 'WA_SUPPRESSED'
+    when g_consent='DENIED' or s_consent='DENIED' then 'WA_DENIED'
+    when (cia_expires_at is null or cia_expires_at>now()) and cia_suppression_status='SUPPRESSED' then 'CIA_SUPPRESSED'
+    when (cia_expires_at is null or cia_expires_at>now()) and cia_consent_status='DENIED' then 'CIA_DENIED'
+    when ((s_consent='ALLOWED' and s_suppression='CLEAR') or (s_consent='UNKNOWN' and g_consent='ALLOWED' and g_suppression='CLEAR')) then 'ELIGIBLE_EXPLICIT'
+    else 'CONSENT_UNKNOWN'
+  end::text as reason_code,
+  g_event_key as global_event_key,s_event_key as scope_event_key,
+  g_source as global_source,s_source as scope_source,
+  cia_contact_key,cia_consent_status,cia_suppression_status,cia_source,
+  (
+    reachability_alias_count>0
+    and not (g_suppression='SUPPRESSED' or s_suppression='SUPPRESSED' or g_consent='DENIED' or s_consent='DENIED')
+    and not ((cia_expires_at is null or cia_expires_at>now()) and (cia_suppression_status='SUPPRESSED' or cia_consent_status='DENIED'))
+    and ((s_consent='ALLOWED' and s_suppression='CLEAR') or (s_consent='UNKNOWN' and g_consent='ALLOWED' and g_suppression='CLEAR'))
+  )::boolean as send_allowed
+from guarded;
+
+revoke all on public.aos_wa_marketing_eligibility_v1 from public,anon,authenticated;
+grant select on public.aos_wa_marketing_eligibility_v1 to service_role;
+
+create or replace function public.aos_wa_marketing_eligibility_check_v1(p_conversation_id uuid,p_scope text default 'MARKETING')
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path='public','pg_temp'
+as $$
+declare
+  v_scope text := upper(trim(coalesce(p_scope,'MARKETING')));
+  v_row record;
+begin
+  if v_scope not in ('MARKETING','UTILITY','AUTHENTICATION','CALL') then raise exception 'WA7A4_SCOPE_INVALID' using errcode='22023'; end if;
+  select * into v_row from public.aos_wa_marketing_eligibility_v1 where conversation_id=p_conversation_id and eligibility_scope=v_scope;
+  if v_row.conversation_id is null then raise exception 'WA7A4_CONVERSATION_NOT_FOUND' using errcode='23503'; end if;
+  return jsonb_build_object(
+    'conversation_id',v_row.conversation_id,'eligibility_scope',v_row.eligibility_scope,
+    'reachability_status',v_row.reachability_status,'consent_status',v_row.consent_status,
+    'suppression_status',v_row.suppression_status,'eligibility_status',v_row.eligibility_status,
+    'reason_code',v_row.reason_code,'send_allowed',v_row.send_allowed
+  );
+end
+$$;
+revoke all on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) to service_role;
+
+comment on table public.aos_wa_marketing_eligibility_events_v1 is 'WA-7A.4 immutable, conversation-scoped eligibility evidence. Not identity, reachability or attribution authority.';
+comment on view public.aos_wa_marketing_eligibility_v1 is 'WA-7A.4 current fail-closed eligibility projection. CIA recipient controls can suppress/deny but never grant WhatsApp consent.';
+comment on function public.aos_wa_marketing_eligibility_record_v1(jsonb) is 'WA-7A.4 service-only append-only evidence recorder with replay conflict and explicit re-consent guard.';
+comment on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) is 'WA-7A.4 service-only eligibility check; send_allowed requires reachability + explicit allowed/clear evidence and no suppression.';
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260827141500_wa7a4_marketing_eligibility_v1.rollback.sql
+++ b/supabase/rollbacks/20260827141500_wa7a4_marketing_eligibility_v1.rollback.sql
@@ -1,0 +1,22 @@
+-- WA-7A.4 rollback — fail closed once eligibility evidence exists.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null
+     and exists(select 1 from public.aos_wa_marketing_eligibility_events_v1 limit 1) then
+    raise exception 'WA7A4_ROLLBACK_BLOCKED_ELIGIBILITY_EVIDENCE_EXISTS' using errcode='55000';
+  end if;
+end
+$$;
+
+drop function if exists public.aos_wa_marketing_eligibility_check_v1(uuid,text);
+drop view if exists public.aos_wa_marketing_eligibility_v1;
+drop function if exists public.aos_wa_marketing_eligibility_record_v1(jsonb);
+drop trigger if exists trg_aos_wa7a4_eligibility_immutable_guard_v1 on public.aos_wa_marketing_eligibility_events_v1;
+drop function if exists public.aos_wa7a4_eligibility_immutable_guard_v1();
+drop table if exists public.aos_wa_marketing_eligibility_events_v1;
+
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Implements WA-7A.4 on exact baseline `main@3bc7a70af661db7409cc77747ac63122abe8ee11` in owner-directed TEST-first mode.

Necessity gate: `BUILD YES / NEW CONSENT MASTER NO / PROD MUTATION NO`.

- adds immutable conversation-scoped eligibility evidence, not identity/customer authority;
- separates `IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`;
- enforces `ATTRIBUTION EVIDENCE != CONSENT`;
- supports GLOBAL / MARKETING / UTILITY / AUTHENTICATION / CALL scopes;
- BSUID/PARENT_BSUID can establish reachability without phone, but never consent;
- opt-out/suppression wins and silent reversal requires explicit re-consent evidence;
- reuses CIA-F17 recipient controls read-only: DENIED/SUPPRESSED can block, ALLOWED cannot grant WA consent;
- no writes to aos_pacientes, aos_leads, REV or Marketing Attribution V2;
- no wa-gateway/runtime change, bulk sender, Ads Sync, campaigns, AI send, auto-reply or auto-routing;
- dedicated self-hosted Zero-Cost workflow plus WA-7A.3/2/1/0 regressions;
- migration/rollback are PROD-ready but intentionally unapplied to production while Supabase REST/Auth 402 and TEST-first hold remain active.