### PR TITLE
WA-4A.1 — Zi Vital governed clinic knowledge

### DIFF
--- a/.github/workflows/wa4a1-zivital-governed-knowledge.yml
+++ b/.github/workflows/wa4a1-zivital-governed-knowledge.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
     paths:
       - 'app/wa4-knowledge.js'
-      - 'supabase/migrations/*wa4a1_zivital_governed_knowledge*'
-      - 'supabase/rollbacks/*wa4a1_zivital_governed_knowledge*'
+      - 'supabase/migrations/*wa4a1_zivital_*'
+      - 'supabase/rollbacks/*wa4a1_zivital_*'
       - 'ci/wa4a1-zivital-knowledge/**'
       - 'docs/control/WHATSAPP_WA4A1_*'
       - '.github/workflows/wa4a1-zivital-governed-knowledge.yml'
@@ -48,6 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           M=supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+          H=supabase/migrations/20260828001600_wa4a1_zivital_audience_search_isolation_v1.sql
           grep -q 'PUBLIC_CLIENT' "$M"
           grep -q 'ADVISOR_INTERNAL' "$M"
           grep -q 'OWNER_ADMIN' "$M"
@@ -57,8 +58,10 @@ jobs:
           grep -q 'Hair Revival' "$M"
           grep -q 'Contour Sculpt' "$M"
           grep -q 'CLINICAL_REVIEW_REQUIRED' "$M"
-          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M"
-          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M"
+          grep -q "when 'PUBLIC_CLIENT' then n.public_client" "$H"
+          grep -q "when 'CLINICAL_RESTRICTED' then n.clinical_restricted" "$H"
+          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M" "$H"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M" "$H"
           ! grep -q 'aos_wa4a_knowledge_search_v2' app/server-wa4.js app/wa4-copilot.js
 
       - name: Configure isolated Supabase
@@ -93,6 +96,7 @@ jobs:
           CATALOG_BEFORE=$(psql "$DB_URL" -X -qAt -c 'select count(*) from public.aos_catalogo_servicios')
           echo "$CATALOG_BEFORE" > /tmp/wa4a1-catalog-count
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828001600_wa4a1_zivital_audience_search_isolation_v1.sql
 
       - name: Database lint and governed knowledge tests
         run: |
@@ -105,10 +109,12 @@ jobs:
       - name: Audience leakage negative tests
         run: |
           set -euo pipefail
-          PUBLIC=$(psql "$DB_URL" -X -qAt -c "select coalesce(string_agg(facts::text,' '),'') from public.aos_wa4a_knowledge_search_v2('dutasteride','PUBLIC_CLIENT',24,array['CLINIC_KNOWLEDGE'])")
-          ! printf '%s' "$PUBLIC" | grep -Eqi 'prescribir|dosis|Dutasteride CAPILAR'
+          PUBLIC_COUNT=$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_wa4a_knowledge_search_v2('dutasteride','PUBLIC_CLIENT',24,array['CLINIC_KNOWLEDGE'])")
+          test "$PUBLIC_COUNT" = "0"
           CLINICAL=$(psql "$DB_URL" -X -qAt -c "select coalesce(string_agg(facts::text,' '),'') from public.aos_wa4a_knowledge_search_v2('dutasteride','CLINICAL_RESTRICTED',24,array['CLINIC_KNOWLEDGE'])")
           printf '%s' "$CLINICAL" | grep -qi 'dutasteride'
+          OWNER=$(psql "$DB_URL" -X -qAt -c "select coalesce(string_agg(facts::text,' '),'') from public.aos_wa4a_knowledge_search_v2('Sculpt Body','OWNER_ADMIN',24,array['CLINIC_KNOWLEDGE'])")
+          printf '%s' "$OWNER" | grep -q 'system_reference'
 
       - name: Rollback preserves canonical catalog and WA-4A V1
         run: |

--- a/.github/workflows/wa4a1-zivital-governed-knowledge.yml
+++ b/.github/workflows/wa4a1-zivital-governed-knowledge.yml
@@ -1,0 +1,126 @@
+name: ASCENDA WA-4A.1 Zi Vital Governed Knowledge
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa4-knowledge.js'
+      - 'supabase/migrations/*wa4a1_zivital_governed_knowledge*'
+      - 'supabase/rollbacks/*wa4a1_zivital_governed_knowledge*'
+      - 'ci/wa4a1-zivital-knowledge/**'
+      - 'docs/control/WHATSAPP_WA4A1_*'
+      - '.github/workflows/wa4a1-zivital-governed-knowledge.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa4a1-zivital-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · governed Zi Vital knowledge
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 35
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59962/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Zero-Cost and runtime contracts
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          node --check app/wa4-knowledge.js
+          node --test ci/wa4a-knowledge-fabric/wa4-knowledge.test.js
+          node --test ci/wa4a1-zivital-knowledge/wa4a1-audience.test.js
+
+      - name: Governance static invariants
+        run: |
+          set -euo pipefail
+          M=supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+          grep -q 'PUBLIC_CLIENT' "$M"
+          grep -q 'ADVISOR_INTERNAL' "$M"
+          grep -q 'OWNER_ADMIN' "$M"
+          grep -q 'CLINICAL_RESTRICTED' "$M"
+          grep -q 'SYSTEM_REFERENCE' "$M"
+          grep -q 'aos_wa4a_knowledge_search_v2' "$M"
+          grep -q 'Hair Revival' "$M"
+          grep -q 'Contour Sculpt' "$M"
+          grep -q 'CLINICAL_REVIEW_REQUIRED' "$M"
+          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M"
+          ! grep -q 'aos_wa4a_knowledge_search_v2' app/server-wa4.js app/wa4-copilot.js
+
+      - name: Configure isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa4a1-zivital"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59961/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59962/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59960/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa4a1-zivital' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59962 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+
+      - name: Build Knowledge Fabric V1 + Zi Vital V2
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a-knowledge-fabric/source_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1-zivital-knowledge/catalog_fixture.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827185000_wa4a_knowledge_fabric_v1.sql
+          CATALOG_BEFORE=$(psql "$DB_URL" -X -qAt -c 'select count(*) from public.aos_catalogo_servicios')
+          echo "$CATALOG_BEFORE" > /tmp/wa4a1-catalog-count
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+
+      - name: Database lint and governed knowledge tests
+        run: |
+          set -euo pipefail
+          (cd ci/zero-cost-staging && supabase db lint --local --schema public --level error)
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1-zivital-knowledge/tests/001_zivital_knowledge.sql | tee /tmp/wa4a1.txt
+          grep -q 'WA4A1_ZIVITAL_GOVERNED_KNOWLEDGE_PASS' /tmp/wa4a1.txt
+          ! grep -q 'not ok' /tmp/wa4a1.txt
+
+      - name: Audience leakage negative tests
+        run: |
+          set -euo pipefail
+          PUBLIC=$(psql "$DB_URL" -X -qAt -c "select coalesce(string_agg(facts::text,' '),'') from public.aos_wa4a_knowledge_search_v2('dutasteride','PUBLIC_CLIENT',24,array['CLINIC_KNOWLEDGE'])")
+          ! printf '%s' "$PUBLIC" | grep -Eqi 'prescribir|dosis|Dutasteride CAPILAR'
+          CLINICAL=$(psql "$DB_URL" -X -qAt -c "select coalesce(string_agg(facts::text,' '),'') from public.aos_wa4a_knowledge_search_v2('dutasteride','CLINICAL_RESTRICTED',24,array['CLINIC_KNOWLEDGE'])")
+          printf '%s' "$CLINICAL" | grep -qi 'dutasteride'
+
+      - name: Rollback preserves canonical catalog and WA-4A V1
+        run: |
+          set -euo pipefail
+          BEFORE=$(cat /tmp/wa4a1-catalog-count)
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260828001500_wa4a1_zivital_governed_knowledge_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c 'select count(*) from public.aos_catalogo_servicios')" = "$BEFORE"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_knowledge_nodes_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa4a_knowledge_search_v1(text,integer,text[])') is not null")" = "t"
+          echo 'WA-4A.1 TEST CERTIFIED BOUNDARY: PROD migration remains unapplied; Copilot remains SAFE-OFF.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/app/wa4-knowledge.js
+++ b/app/wa4-knowledge.js
@@ -1,18 +1,28 @@
 'use strict';
 
-// WA-4A Knowledge Fabric adapter. PROD-ready but intentionally not wired into Copilot in WA-4A.
-// It accepts only READY governed rows from aos_wa4a_knowledge_search_v1 and validates model grounding.
+// WA-4A/4A.1 Knowledge Fabric adapter.
+// Accepts only READY governed rows and enforces audience isolation for Zi Vital clinic knowledge.
+
+const AUDIENCES = Object.freeze(new Set([
+  'PUBLIC_CLIENT','ADVISOR_INTERNAL','OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE'
+]));
 
 const FIELD_ALLOWLIST = Object.freeze({
   CATALOG: new Set(['tipo','nombre','nombre_corto','categoria','precio_base','precio_oferta','duracion_sesion','num_sesiones','frecuencia','descripcion_comercial','beneficios','faqs','requiere_doctora','requiere_enfermeria']),
   PROMOTION: new Set(['nombre','descripcion','tipo_descuento','valor_descuento','tratamientos','segmentos','codigo','vigencia_inicio','vigencia_fin']),
   BRANCH: new Set(['nombre','direccion','telefono','maps_link']),
   HOURS: new Set(['sede','dia_semana','hora_apertura','hora_cierre','activo']),
-  CATEGORY: new Set(['nombre','descripcion_comercial','beneficios','faqs'])
+  CATEGORY: new Set(['nombre','descripcion_comercial','beneficios','faqs']),
+  CLINIC_KNOWLEDGE: new Set(['code','node_type','parent_code','title','aliases','answer','public_summary','system_reference','risk_level','audience'])
 });
 
 function normalize(value) {
   return String(value || '').normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase();
+}
+
+function normalizeAudience(value) {
+  const audience = String(value || 'PUBLIC_CLIENT').toUpperCase();
+  return AUDIENCES.has(audience) ? audience : 'PUBLIC_CLIENT';
 }
 
 function sanitizeFacts(domain, facts) {
@@ -23,8 +33,9 @@ function sanitizeFacts(domain, facts) {
   return out;
 }
 
-function buildKnowledgeBundle(rows, maxItems) {
+function buildKnowledgeBundle(rows, maxItems, expectedAudience) {
   const limit = Math.max(1, Math.min(Number(maxItems || 12), 24));
+  const audience = normalizeAudience(expectedAudience);
   const source = Array.isArray(rows) ? rows : [];
   const seen = new Set();
   const items = [];
@@ -35,12 +46,23 @@ function buildKnowledgeBundle(rows, maxItems) {
     if (!id || seen.has(id)) continue;
     const evidence = row.evidence_ref && typeof row.evidence_ref === 'object' ? row.evidence_ref : {};
     if (!evidence.relation || !evidence.pk) continue;
+    const domain = String(row.domain || '').toUpperCase();
+    const facts = sanitizeFacts(domain,row.facts);
+    if (domain === 'CLINIC_KNOWLEDGE') {
+      const rowAudience = normalizeAudience(facts.audience || evidence.audience);
+      if (rowAudience !== audience) continue;
+      if (!String(facts.answer || '').trim()) continue;
+      if (audience === 'PUBLIC_CLIENT') {
+        delete facts.system_reference;
+        delete facts.public_summary;
+      }
+    }
     seen.add(id);
     items.push({
       knowledge_id: id,
-      domain: String(row.domain || '').toUpperCase(),
+      domain,
       title: String(row.title || '').slice(0,240),
-      facts: sanitizeFacts(row.domain,row.facts),
+      facts,
       authority_tier: Number(row.authority_tier || 99),
       freshness_state: String(row.freshness_state || 'UNKNOWN'),
       retrieval_state: String(row.retrieval_state),
@@ -48,12 +70,15 @@ function buildKnowledgeBundle(rows, maxItems) {
         relation: String(evidence.relation).slice(0,120),
         pk: String(evidence.pk).slice(0,120),
         version: evidence.version == null ? 'UNKNOWN' : String(evidence.version).slice(0,160),
-        warning: evidence.warning == null ? null : String(evidence.warning).slice(0,120)
+        warning: evidence.warning == null ? null : String(evidence.warning).slice(0,120),
+        source_code: evidence.source_code == null ? null : String(evidence.source_code).slice(0,120),
+        source_locator: evidence.source_locator == null ? null : String(evidence.source_locator).slice(0,200),
+        audience: domain === 'CLINIC_KNOWLEDGE' ? audience : null
       }
     });
     if (items.length >= limit) break;
   }
-  return {version:'WA4A-KNOWLEDGE-V1',items,authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false};
+  return {version:'WA4A1-KNOWLEDGE-V2',audience,items,authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false};
 }
 
 function moneyValues(bundle) {
@@ -118,4 +143,4 @@ function validateGroundedSuggestion(obj, bundle) {
   return {ok:true,reply,citations,nextAction};
 }
 
-module.exports = {FIELD_ALLOWLIST, normalize, sanitizeFacts, buildKnowledgeBundle, validateGroundedSuggestion};
+module.exports = {AUDIENCES,FIELD_ALLOWLIST,normalize,normalizeAudience,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};

--- a/ci/wa4a1-zivital-knowledge/catalog_fixture.sql
+++ b/ci/wa4a1-zivital-knowledge/catalog_fixture.sql
@@ -1,0 +1,15 @@
+insert into public.aos_catalogo_servicios(nombre,tipo,categoria,descripcion_comercial,beneficios,precio_oferta,estado,updated_at) values
+('PINK GLOW 1ML','SERVICIO','BIOREVITALIZACIÓN','Fixture','Fixture',1,'ACTIVO',now()),
+('HIDROFACIAL PREMIUM','SERVICIO','FACIALES','Fixture','Fixture',1,'ACTIVO',now()),
+('HIDROFACIAL ROSTRO','SERVICIO','FACIALES','Fixture','Fixture',1,'ACTIVO',now()),
+('RF FRACCIONADA ROSTRO/CUELLO x1','SERVICIO','RF FRACCIONADA','Fixture','Fixture',1,'ACTIVO',now()),
+('DERMAPEN VIT FACIAL x1','SERVICIO','MESOTERAPIA','Fixture','Fixture',1,'ACTIVO',now()),
+('MESO CAPILAR MINOXIDIL','SERVICIO','CAPILAR','Fixture','Fixture',1,'ACTIVO',now()),
+('DUTASTERIDE CAPILAR x1','SERVICIO','CAPILAR','Fixture','Fixture',1,'ACTIVO',now()),
+('PRP CAPILAR x1','SERVICIO','CAPILAR','Fixture','Fixture',1,'ACTIVO',now()),
+('EXOSOMAS EXOSIGNAL HAIR x1','SERVICIO','CAPILAR','Fixture','Fixture',1,'ACTIVO',now()),
+('RF FRACCIONADA CAPILAR x1','SERVICIO','CAPILAR','Fixture','Fixture',1,'ACTIVO',now()),
+('DETOX IÓNICO','SERVICIO','DETOX','Fixture','Fixture',1,'ACTIVO',now()),
+('CRIOLIPÓLISIS 1 ZONA','SERVICIO','CRIOLIPÓLISIS','Fixture','Fixture',1,'ACTIVO',now()),
+('HIFU CORP ABDOMEN ALTO','SERVICIO','CORPORAL','Fixture','Fixture',1,'ACTIVO',now()),
+('ENZIMAS CORP ABDOMEN/GLÚTEOS x1','SERVICIO','CORPORAL','Fixture','Fixture',1,'ACTIVO',now());

--- a/ci/wa4a1-zivital-knowledge/tests/001_zivital_knowledge.sql
+++ b/ci/wa4a1-zivital-knowledge/tests/001_zivital_knowledge.sql
@@ -1,34 +1,30 @@
 \set ON_ERROR_STOP on
 
 select case when (select count(*) from public.aos_knowledge_sources_v1)=2 then 'ok 1 sources' else 'not ok 1 sources' end;
-select case when (select count(*) from public.aos_knowledge_nodes_v1 where status='APPROVED')=22 then 'ok 2 nodes' else 'not ok 2 nodes' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where status='APPROVED')=23 then 'ok 2 nodes' else 'not ok 2 nodes' end;
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='DOMAIN')=3 then 'ok 3 domains' else 'not ok 3 domains' end;
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='APPROACH')=8 then 'ok 4 approaches' else 'not ok 4 approaches' end;
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='PHASE')=7 then 'ok 5 phases' else 'not ok 5 phases' end;
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='ROLE')=3 then 'ok 6 roles' else 'not ok 6 roles' end;
 
--- Public client must only receive public answer and never internal/system/clinical text.
 with x as (
   select * from public.aos_wa4a_knowledge_search_v2('Skin Signature','PUBLIC_CLIENT',10,array['CLINIC_KNOWLEDGE'])
 )
 select case when exists(select 1 from x where subject_id='FACIAL_SKIN_SIGNATURE' and facts->>'audience'='PUBLIC_CLIENT' and facts ? 'answer' and not (facts ? 'system_reference') and not (facts ? 'public_summary'))
 then 'ok 7 public isolation' else 'not ok 7 public isolation' end;
 
--- Advisor gets advisor answer plus public summary, never system_reference.
 with x as (
   select * from public.aos_wa4a_knowledge_search_v2('Skin Signature','ADVISOR_INTERNAL',10,array['CLINIC_KNOWLEDGE'])
 )
 select case when exists(select 1 from x where subject_id='FACIAL_SKIN_SIGNATURE' and facts->>'audience'='ADVISOR_INTERNAL' and facts ? 'answer' and facts ? 'public_summary' and not (facts ? 'system_reference'))
 then 'ok 8 advisor isolation' else 'not ok 8 advisor isolation' end;
 
--- Owner/admin can receive system_reference.
 with x as (
   select * from public.aos_wa4a_knowledge_search_v2('Sculpt Body','OWNER_ADMIN',10,array['CLINIC_KNOWLEDGE'])
 )
 select case when exists(select 1 from x where subject_id='CORPORAL_SCULPT_BODY' and facts ? 'system_reference')
 then 'ok 9 owner system refs' else 'not ok 9 owner system refs' end;
 
--- Clinical restricted is only returned when explicitly requested.
 with pub as (
   select facts from public.aos_wa4a_knowledge_search_v2('dutasteride','PUBLIC_CLIENT',20,array['CLINIC_KNOWLEDGE'])
 ), cli as (
@@ -37,21 +33,17 @@ with pub as (
 select case when not exists(select 1 from pub where lower(facts->>'answer') like '%dutasteride%') and exists(select 1 from cli where lower(facts->>'answer') like '%dutasteride%')
 then 'ok 10 clinical isolation' else 'not ok 10 clinical isolation' end;
 
--- Aliases resolve without duplicate concepts.
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where code='CAPILAR_ACTIVACION_REGENERACION' and aliases @> '["Hair Revival"]'::jsonb)=1
 then 'ok 11 alias canonical' else 'not ok 11 alias canonical' end;
 select case when (select count(*) from public.aos_knowledge_nodes_v1 where code='CORPORAL_SCULPT_BODY' and aliases @> '["Contour Sculpt"]'::jsonb)=1
 then 'ok 12 alias sculpt' else 'not ok 12 alias sculpt' end;
 
--- Exact catalog links are additive references; no canonical catalog mutation required.
 select case when exists(select 1 from public.aos_knowledge_relations_v1 r join public.aos_catalogo_servicios s on s.id=r.target_id where r.knowledge_code='FACIAL_SKIN_SIGNATURE' and s.nombre='PINK GLOW 1ML')
 then 'ok 13 catalog relation' else 'not ok 13 catalog relation' end;
 
--- ACLs: anon/authenticated must have no table privileges.
 select case when not has_table_privilege('anon','public.aos_knowledge_nodes_v1','select') and not has_table_privilege('authenticated','public.aos_knowledge_nodes_v1','select')
 then 'ok 14 acl' else 'not ok 14 acl' end;
 
--- Search V2 service_role only.
 select case when has_function_privilege('service_role','public.aos_wa4a_knowledge_search_v2(text,text,integer,text[])','execute') and not has_function_privilege('anon','public.aos_wa4a_knowledge_search_v2(text,text,integer,text[])','execute')
 then 'ok 15 rpc acl' else 'not ok 15 rpc acl' end;
 

--- a/ci/wa4a1-zivital-knowledge/tests/001_zivital_knowledge.sql
+++ b/ci/wa4a1-zivital-knowledge/tests/001_zivital_knowledge.sql
@@ -1,0 +1,58 @@
+\set ON_ERROR_STOP on
+
+select case when (select count(*) from public.aos_knowledge_sources_v1)=2 then 'ok 1 sources' else 'not ok 1 sources' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where status='APPROVED')=22 then 'ok 2 nodes' else 'not ok 2 nodes' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='DOMAIN')=3 then 'ok 3 domains' else 'not ok 3 domains' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='APPROACH')=8 then 'ok 4 approaches' else 'not ok 4 approaches' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='PHASE')=7 then 'ok 5 phases' else 'not ok 5 phases' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where node_type='ROLE')=3 then 'ok 6 roles' else 'not ok 6 roles' end;
+
+-- Public client must only receive public answer and never internal/system/clinical text.
+with x as (
+  select * from public.aos_wa4a_knowledge_search_v2('Skin Signature','PUBLIC_CLIENT',10,array['CLINIC_KNOWLEDGE'])
+)
+select case when exists(select 1 from x where subject_id='FACIAL_SKIN_SIGNATURE' and facts->>'audience'='PUBLIC_CLIENT' and facts ? 'answer' and not (facts ? 'system_reference') and not (facts ? 'public_summary'))
+then 'ok 7 public isolation' else 'not ok 7 public isolation' end;
+
+-- Advisor gets advisor answer plus public summary, never system_reference.
+with x as (
+  select * from public.aos_wa4a_knowledge_search_v2('Skin Signature','ADVISOR_INTERNAL',10,array['CLINIC_KNOWLEDGE'])
+)
+select case when exists(select 1 from x where subject_id='FACIAL_SKIN_SIGNATURE' and facts->>'audience'='ADVISOR_INTERNAL' and facts ? 'answer' and facts ? 'public_summary' and not (facts ? 'system_reference'))
+then 'ok 8 advisor isolation' else 'not ok 8 advisor isolation' end;
+
+-- Owner/admin can receive system_reference.
+with x as (
+  select * from public.aos_wa4a_knowledge_search_v2('Sculpt Body','OWNER_ADMIN',10,array['CLINIC_KNOWLEDGE'])
+)
+select case when exists(select 1 from x where subject_id='CORPORAL_SCULPT_BODY' and facts ? 'system_reference')
+then 'ok 9 owner system refs' else 'not ok 9 owner system refs' end;
+
+-- Clinical restricted is only returned when explicitly requested.
+with pub as (
+  select facts from public.aos_wa4a_knowledge_search_v2('dutasteride','PUBLIC_CLIENT',20,array['CLINIC_KNOWLEDGE'])
+), cli as (
+  select facts from public.aos_wa4a_knowledge_search_v2('dutasteride','CLINICAL_RESTRICTED',20,array['CLINIC_KNOWLEDGE'])
+)
+select case when not exists(select 1 from pub where lower(facts->>'answer') like '%dutasteride%') and exists(select 1 from cli where lower(facts->>'answer') like '%dutasteride%')
+then 'ok 10 clinical isolation' else 'not ok 10 clinical isolation' end;
+
+-- Aliases resolve without duplicate concepts.
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where code='CAPILAR_ACTIVACION_REGENERACION' and aliases @> '["Hair Revival"]'::jsonb)=1
+then 'ok 11 alias canonical' else 'not ok 11 alias canonical' end;
+select case when (select count(*) from public.aos_knowledge_nodes_v1 where code='CORPORAL_SCULPT_BODY' and aliases @> '["Contour Sculpt"]'::jsonb)=1
+then 'ok 12 alias sculpt' else 'not ok 12 alias sculpt' end;
+
+-- Exact catalog links are additive references; no canonical catalog mutation required.
+select case when exists(select 1 from public.aos_knowledge_relations_v1 r join public.aos_catalogo_servicios s on s.id=r.target_id where r.knowledge_code='FACIAL_SKIN_SIGNATURE' and s.nombre='PINK GLOW 1ML')
+then 'ok 13 catalog relation' else 'not ok 13 catalog relation' end;
+
+-- ACLs: anon/authenticated must have no table privileges.
+select case when not has_table_privilege('anon','public.aos_knowledge_nodes_v1','select') and not has_table_privilege('authenticated','public.aos_knowledge_nodes_v1','select')
+then 'ok 14 acl' else 'not ok 14 acl' end;
+
+-- Search V2 service_role only.
+select case when has_function_privilege('service_role','public.aos_wa4a_knowledge_search_v2(text,text,integer,text[])','execute') and not has_function_privilege('anon','public.aos_wa4a_knowledge_search_v2(text,text,integer,text[])','execute')
+then 'ok 15 rpc acl' else 'not ok 15 rpc acl' end;
+
+\echo WA4A1_ZIVITAL_GOVERNED_KNOWLEDGE_PASS

--- a/ci/wa4a1-zivital-knowledge/wa4a1-audience.test.js
+++ b/ci/wa4a1-zivital-knowledge/wa4a1-audience.test.js
@@ -1,0 +1,44 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const k=require('../../app/wa4-knowledge');
+
+function clinic(audience,answer,extra){return {
+  knowledge_id:'clinic:FACIAL_SKIN_SIGNATURE',domain:'CLINIC_KNOWLEDGE',title:'Skin Signature',authority_tier:15,
+  freshness_state:'GOVERNED',conflict_state:'CLEAR',retrieval_state:'READY',
+  facts:Object.assign({code:'FACIAL_SKIN_SIGNATURE',node_type:'APPROACH',title:'Skin Signature',answer,audience,risk_level:'MEDIUM'},extra||{}),
+  evidence_ref:{relation:'public.aos_knowledge_nodes_v1',pk:'FACIAL_SKIN_SIGNATURE',version:'1',source_code:'ZV_DOMAINS_2026',source_locator:'PDF p.2-3',audience}
+}}
+
+test('public bundle rejects internal audience row',()=>{
+  const b=k.buildKnowledgeBundle([clinic('ADVISOR_INTERNAL','internal only')],12,'PUBLIC_CLIENT');
+  assert.equal(b.items.length,0);
+  assert.equal(b.audience,'PUBLIC_CLIENT');
+});
+
+test('public bundle strips system_reference even if malformed upstream row includes it',()=>{
+  const b=k.buildKnowledgeBundle([clinic('PUBLIC_CLIENT','respuesta corta',{system_reference:{secret:'internal'},public_summary:'x'})],12,'PUBLIC_CLIENT');
+  assert.equal(b.items.length,1);
+  assert.equal(b.items[0].facts.answer,'respuesta corta');
+  assert.equal(b.items[0].facts.system_reference,undefined);
+  assert.equal(b.items[0].facts.public_summary,undefined);
+});
+
+test('advisor bundle accepts only advisor row and preserves public summary',()=>{
+  const b=k.buildKnowledgeBundle([clinic('PUBLIC_CLIENT','public'),clinic('ADVISOR_INTERNAL','advisor',{public_summary:'public summary'})],12,'ADVISOR_INTERNAL');
+  assert.equal(b.items.length,1);
+  assert.equal(b.items[0].facts.answer,'advisor');
+  assert.equal(b.items[0].facts.public_summary,'public summary');
+});
+
+test('invalid audience fails safely to PUBLIC_CLIENT',()=>{
+  assert.equal(k.normalizeAudience('root_superuser'),'PUBLIC_CLIENT');
+});
+
+test('clinic knowledge remains evidence-required',()=>{
+  const b=k.buildKnowledgeBundle([clinic('PUBLIC_CLIENT','Skin Signature trabaja calidad de piel.')],12,'PUBLIC_CLIENT');
+  const bad=k.validateGroundedSuggestion({reply:'Skin Signature trabaja calidad de piel.',next_action:'REPLY',cited_knowledge_ids:[]},b);
+  assert.deepEqual(bad,{ok:false,error:'WA4A_EVIDENCE_REQUIRED'});
+  const good=k.validateGroundedSuggestion({reply:'Skin Signature trabaja calidad de piel.',next_action:'REPLY',cited_knowledge_ids:['clinic:FACIAL_SKIN_SIGNATURE']},b);
+  assert.equal(good.ok,true);
+});

--- a/docs/control/WHATSAPP_WA4A1_ZIVITAL_GOVERNED_KNOWLEDGE_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA4A1_ZIVITAL_GOVERNED_KNOWLEDGE_EVIDENCE.md
@@ -1,0 +1,78 @@
+# WA-4A.1 — Zi Vital Governed Knowledge
+
+Status: TEST-first / PROD-ready / Copilot SAFE-OFF.
+
+## Sources
+
+1. `EL_SISTEMA_DE_DOMINIOS_ZI_VITAL.pdf` — internal authoritative source for Zi Vital system, domains, approaches, related treatments/products, profiles and process framing.
+2. `PROCESO_ATENCIN_ZI_VITAL.pdf` — internal authoritative source for patient journey, roles, triage, consultation, quotation, consent, procedure and follow-up.
+
+The PDFs are not ingested as an unstructured prompt corpus. Their concepts are transformed into governed nodes with source locators, explicit risk levels and audience-specific projections.
+
+## Audience contract
+
+- `PUBLIC_CLIENT`: short explanatory answers suitable for a client. No internal strategy, system metadata or clinical instructions.
+- `ADVISOR_INTERNAL`: explanation/playbook context for advisors; includes the public summary but not owner/system internals.
+- `OWNER_ADMIN`: strategic meaning and system metadata for owner/admin decisions.
+- `CLINICAL_RESTRICTED`: clinically sensitive source content and restrictions. Must never be exposed by a public-client query.
+- `SYSTEM_REFERENCE`: canonical taxonomy/relationships for system maintenance, catalog reconciliation and future updates.
+
+## Canonical nodes
+
+### System
+- `ZV_SYSTEM` — sequence PREPARAR → ACTIVAR → REGENERAR → MANTENER; domains FACIAL/CORPORAL/CAPILAR; Detox/Vitaminas as cross-cutting concepts from the source.
+
+### Facial
+- `DOMAIN_FACIAL`
+- `FACIAL_SKIN_SIGNATURE`
+- `FACIAL_HARMONY_DESIGN`
+- `FACIAL_BIOREGEN_FACE`
+
+### Corporal
+- `DOMAIN_CORPORAL`
+- `CORPORAL_BODY_RESET`
+- `CORPORAL_SCULPT_BODY` — alias `Contour Sculpt` retained as an alias, not a second concept.
+- `CORPORAL_SCULPT_BOOTY` — alias `Volume & Firm` retained as an alias.
+
+### Capilar
+- `DOMAIN_CAPILAR`
+- `CAPILAR_ACTIVACION_REGENERACION` — alias `Hair Revival`.
+- `CAPILAR_MANTENIMIENTO_PREVENCION` — alias `Hair Guard`.
+
+### Patient journey
+- `ZV_PATIENT_JOURNEY`
+- `PHASE_1_RECEPCION`
+- `PHASE_2_TRIAJE`
+- `PHASE_3_PRECONSULTA`
+- `PHASE_4_CONSULTA_MEDICA`
+- `PHASE_5_PLAN_COTIZACION`
+- `PHASE_6_CONSENTIMIENTO_PROCEDIMIENTO`
+- `PHASE_7_CIERRE_SEGUIMIENTO`
+- roles: `ROLE_RECEPCIONISTA`, `ROLE_ENFERMERIA`, `ROLE_DOCTORA`.
+
+Total seed: 23 governed nodes + 2 source records.
+
+## Clinical governance decisions
+
+The source documents contain clinical/physiological framing that is valuable internally but must not be converted into autonomous public claims. Examples include detox/depuration language and capillary protocols mentioning minoxidil/dutasteride, PRP, exosomes and PDRN. These nodes are marked `CLINICAL_REVIEW_REQUIRED` or HIGH where appropriate. Public projections describe the Zi Vital approach without prescribing, diagnosing or guaranteeing outcomes.
+
+## Knowledge Fabric connection
+
+`aos_wa4a_knowledge_search_v2(query,audience,limit,domains)` extends WA-4A V1 and projects exactly one audience-specific answer. `app/wa4-knowledge.js` accepts `CLINIC_KNOWLEDGE` and rejects rows whose embedded audience does not equal the requested bundle audience.
+
+Knowledge authority remains:
+
+`governed/certified source facts + evidence refs > approved derived knowledge > generic LLM knowledge`.
+
+This phase connects the governed source to Knowledge Fabric only. It does **not** wire the new V2 search into `server-wa4.js`/Copilot and does not enable AI send, auto-reply or auto-routing.
+
+## Canonical catalog relations seeded
+
+Safe exact current catalog relationships are resolved when canonical catalog names exist, including selected Skin Signature, Body Reset, Sculpt Body and Capillary Activation services. Historical/product aliases remain references and must be reconciled against canonical catalog identities rather than creating duplicate products/services.
+
+## Safety / rollback
+
+- No patient, lead, sale or REV tables are read or mutated.
+- No canonical catalog row is mutated.
+- anon/authenticated have no direct table/RPC access.
+- rollback removes only WA-4A.1 knowledge objects and leaves WA-4A V1/canonical sources intact.

--- a/supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+++ b/supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
@@ -1,0 +1,368 @@
+-- WA-4A.1 — Zi Vital Governed Knowledge V1
+-- TEST-first / PROD-ready. Sources: EL SISTEMA DE DOMINIOS ZI VITAL + PROCESO ATENCION ZI VITAL.
+-- Explicit audience separation prevents internal/clinical knowledge leaking into client answers.
+begin;
+
+create table if not exists public.aos_knowledge_sources_v1 (
+  source_code text primary key,
+  title text not null,
+  source_kind text not null check (source_kind in ('INTERNAL_PDF','GOVERNED_DOCUMENT')),
+  file_name text not null,
+  authority_state text not null default 'AUTHORITATIVE_INTERNAL',
+  version text not null,
+  source_scope text not null,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.aos_knowledge_nodes_v1 (
+  code text primary key,
+  node_type text not null check (node_type in ('SYSTEM','DOMAIN','APPROACH','PATIENT_JOURNEY','PHASE','ROLE')),
+  parent_code text references public.aos_knowledge_nodes_v1(code),
+  title text not null,
+  aliases jsonb not null default '[]'::jsonb check (jsonb_typeof(aliases)='array'),
+  public_client text,
+  advisor_internal text,
+  owner_admin text,
+  clinical_restricted text,
+  system_reference jsonb not null default '{}'::jsonb check (jsonb_typeof(system_reference)='object'),
+  keywords text[] not null default '{}'::text[],
+  risk_level text not null default 'LOW' check (risk_level in ('LOW','MEDIUM','HIGH','CLINICAL_REVIEW_REQUIRED')),
+  source_code text not null references public.aos_knowledge_sources_v1(source_code),
+  source_locator text not null,
+  status text not null default 'APPROVED' check (status in ('DRAFT','APPROVED','RETIRED')),
+  version integer not null default 1 check (version > 0),
+  approved_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (public_client is not null or advisor_internal is not null or owner_admin is not null or clinical_restricted is not null)
+);
+
+create table if not exists public.aos_knowledge_relations_v1 (
+  id bigint generated always as identity primary key,
+  knowledge_code text not null references public.aos_knowledge_nodes_v1(code) on delete cascade,
+  relation_type text not null check (relation_type in ('CHILD_OF','RELATED_SERVICE','RELATED_PRODUCT','NEXT_APPROACH','SUPPORTED_BY','RESPONSIBLE_ROLE','ALIAS_OF')),
+  target_type text not null check (target_type in ('KNOWLEDGE','SERVICE','PRODUCT','CATEGORY','ROLE')),
+  target_key text not null,
+  target_id uuid,
+  relation_scope text not null default 'REFERENCE' check (relation_scope in ('PUBLIC','INTERNAL','CLINICAL','REFERENCE')),
+  source_locator text,
+  created_at timestamptz not null default now(),
+  unique(knowledge_code,relation_type,target_type,target_key)
+);
+
+revoke all on table public.aos_knowledge_sources_v1 from public,anon,authenticated;
+revoke all on table public.aos_knowledge_nodes_v1 from public,anon,authenticated;
+revoke all on table public.aos_knowledge_relations_v1 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_knowledge_sources_v1 to service_role;
+grant select,insert,update,delete on table public.aos_knowledge_nodes_v1 to service_role;
+grant select,insert,update,delete on table public.aos_knowledge_relations_v1 to service_role;
+grant usage,select on sequence public.aos_knowledge_relations_v1_id_seq to service_role;
+
+insert into public.aos_knowledge_sources_v1(source_code,title,source_kind,file_name,authority_state,version,source_scope,notes)
+values
+('ZV_DOMAINS_2026','El Sistema de Dominios Zi Vital','INTERNAL_PDF','EL_SISTEMA_DE_DOMINIOS_ZI_VITAL.pdf','AUTHORITATIVE_INTERNAL','2026-08-27','Zi Vital philosophy, domains, approaches, related treatments/products, profiles and process logic','Source language is preserved conceptually; clinical claims remain governed by risk level.'),
+('ZV_PATIENT_PROCESS_2026','Proceso Atención Zi Vital','INTERNAL_PDF','PROCESO_ATENCIN_ZI_VITAL.pdf','AUTHORITATIVE_INTERNAL','2026-08-27','Patient journey, roles, triage, consultation, quotation, consent, procedure and follow-up','Operational details are internal unless an explicit public summary is provided.')
+on conflict(source_code) do update set title=excluded.title,version=excluded.version,source_scope=excluded.source_scope,notes=excluded.notes,updated_at=now();
+
+-- SYSTEM / DOMAINS
+insert into public.aos_knowledge_nodes_v1(code,node_type,parent_code,title,aliases,public_client,advisor_internal,owner_admin,clinical_restricted,system_reference,keywords,risk_level,source_code,source_locator,status,approved_at)
+values
+('ZV_SYSTEM','SYSTEM',null,'Sistema Zi Vital','["Arquitectura de Dominios y Enfoques"]',
+ 'Zi Vital organiza el cuidado por dominios y enfoques, buscando procesos coherentes en lugar de tratamientos aislados.',
+ 'Explica primero el proceso y la lógica del plan; evita presentar cada tratamiento como una solución aislada.',
+ 'Es la arquitectura madre para ordenar catálogo, experiencia, comunicación y futuras decisiones de producto/servicio.',
+ null,
+ '{"sequence":["PREPARAR","ACTIVAR","REGENERAR","MANTENER"],"domains":["FACIAL","CORPORAL","CAPILAR"],"cross_cutting":["DETOX","VITAMINAS"]}',
+ array['zi vital','dominios','enfoques','preparar','activar','regenerar','mantener'],'LOW','ZV_DOMAINS_2026','PDF p.1-2; principle mother and domain/approach definitions','APPROVED',now()),
+('DOMAIN_FACIAL','DOMAIN','ZV_SYSTEM','Dominio Facial','["Facial"]',
+ 'El Dominio Facial reúne los procesos relacionados con piel, expresión, presencia y armonía del rostro.',
+ 'Antes de recomendar, identifica si la conversación trata calidad de piel, armonía estructural o regeneración.',
+ 'Agrupa Skin Signature, Harmony Design y BioRegen Face; debe ser la capa superior de clasificación de servicios faciales.',
+ 'La definición del enfoque clínico final corresponde a evaluación profesional; el dominio no equivale a diagnóstico.',
+ '{"approaches":["FACIAL_SKIN_SIGNATURE","FACIAL_HARMONY_DESIGN","FACIAL_BIOREGEN_FACE"]}',
+ array['facial','rostro','piel','armonia','regeneracion'],'MEDIUM','ZV_DOMAINS_2026','PDF p.2-5; Dominio I Facial','APPROVED',now()),
+('DOMAIN_CORPORAL','DOMAIN','ZV_SYSTEM','Dominio Corporal','["Corporal"]',
+ 'El Dominio Corporal organiza los procesos de preparación, contorno, reducción, firmeza y calidad del tejido corporal.',
+ 'Distingue preparación corporal, reducción/definición y proyección/firmeza; no vendas todos los procesos como reductores.',
+ 'Agrupa Body Reset, Sculpt Body y Sculpt Booty y permite ordenar el journey corporal por etapas.',
+ 'Las afirmaciones metabólicas, inflamatorias o de depuración del documento requieren validación clínica antes de comunicarse como hechos médicos.',
+ '{"approaches":["CORPORAL_BODY_RESET","CORPORAL_SCULPT_BODY","CORPORAL_SCULPT_BOOTY"]}',
+ array['corporal','cuerpo','reduccion','contorno','firmeza'],'CLINICAL_REVIEW_REQUIRED','ZV_DOMAINS_2026','PDF p.6-9; Dominio II Corporal','APPROVED',now()),
+('DOMAIN_CAPILAR','DOMAIN','ZV_SYSTEM','Dominio Capilar','["Capilar"]',
+ 'El Dominio Capilar organiza el cuidado del cabello en activación/regeneración y mantenimiento/prevención.',
+ 'En conversaciones capilares distingue caída activa de mantenimiento; explica que el plan concreto depende de evaluación.',
+ 'Debe conectar servicios capilares, productos domiciliarios y continuidad; es un dominio de largo plazo.',
+ 'Los protocolos con minoxidil, dutasteride, PRP, exosomas o PDRN son conocimiento clínico restringido y no deben convertirse en prescripción autónoma.',
+ '{"approaches":["CAPILAR_ACTIVACION_REGENERACION","CAPILAR_MANTENIMIENTO_PREVENCION"]}',
+ array['capilar','cabello','caida','densidad','mantenimiento'],'CLINICAL_REVIEW_REQUIRED','ZV_DOMAINS_2026','PDF p.9-12; Dominio III Capilar','APPROVED',now())
+on conflict(code) do update set public_client=excluded.public_client,advisor_internal=excluded.advisor_internal,owner_admin=excluded.owner_admin,clinical_restricted=excluded.clinical_restricted,system_reference=excluded.system_reference,keywords=excluded.keywords,risk_level=excluded.risk_level,source_locator=excluded.source_locator,status='APPROVED',approved_at=now(),updated_at=now();
+
+-- APPROACHES
+insert into public.aos_knowledge_nodes_v1(code,node_type,parent_code,title,aliases,public_client,advisor_internal,owner_admin,clinical_restricted,system_reference,keywords,risk_level,source_code,source_locator,status,approved_at)
+values
+('FACIAL_SKIN_SIGNATURE','APPROACH','DOMAIN_FACIAL','Skin Signature','["Calidad Cutánea · Salud · Glow Consciente"]',
+ 'Skin Signature es el enfoque facial centrado en calidad de piel: hidratación, estabilidad, luminosidad y cuidado de la barrera cutánea.',
+ 'Úsalo para explicar procesos de calidad cutánea y mantenimiento. El documento lo relaciona con hidrofacial, peelings, Pink Glow, Dermapen y radiofrecuencia fraccionada.',
+ 'Es la entrada de calidad cutánea del Dominio Facial y una base para preparar o sostener otros procesos faciales.',
+ 'No asumir que un paciente pertenece a este enfoque solo por síntomas; si ya existe indicación médica, puede explicarse la relación.',
+ '{"treatments":["Hidrofacial avanzado","Peelings médicos","Pink Glow","Dermapen con activos","Radiofrecuencia fraccionada"],"products":["Sensiclean","UltraGlow","Hydrashield","Regushield","Sensishield","SkinRegeneration","Beauty Maker","Astaxantina","Power 10 Soak Up Helper","Power 10 Firefighter","Power 10 Pore Lupin","Power 10 Cera Guard","Ultra Eyes","Serum Acne Control"]}',
+ array['skin signature','calidad de piel','glow','hidrofacial','pink glow','dermapen'],'MEDIUM','ZV_DOMAINS_2026','PDF p.2-3; Enfoque Facial 1','APPROVED',now()),
+('FACIAL_HARMONY_DESIGN','APPROACH','DOMAIN_FACIAL','Harmony Design','["Equilibrio Estructural · Expresión · Soporte"]',
+ 'Harmony Design es el enfoque facial orientado a equilibrio estructural y expresión, buscando cambios moderados y naturales.',
+ 'Relaciona este enfoque con ácido hialurónico, perfilamiento, labios, toxina, HIFU facial y enzimas faciales según evaluación.',
+ 'Es la capa de diseño estructural del Dominio Facial; su narrativa diferencial es criterio y moderación, no volumen excesivo.',
+ 'La selección de puntos, materiales y procedimiento es médica; el bot/asesor no debe prescribir ni diseñar el plan.',
+ '{"treatments":["Ácido hialurónico","Perfilamiento facial y nasal","Labios","Toxina botulínica","HIFU facial","Enzimas faciales"],"products":["Lifting B","Hydrashield","Regushield","Sensishield","Perfect Form F","Redu Fast","Zinc Premium","Lip Balm","Beauty Maker","Astaxantina","Neuro Vital"]}',
+ array['harmony design','armonia facial','perfilamiento','labios','toxina','hifu'],'HIGH','ZV_DOMAINS_2026','PDF p.3-4; Enfoque Facial 2','APPROVED',now()),
+('FACIAL_BIOREGEN_FACE','APPROACH','DOMAIN_FACIAL','BioRegen Face','["Regeneración · Longevidad · Sostén Biológico"]',
+ 'BioRegen Face es el enfoque facial de regeneración progresiva y sostén biológico, priorizando resultados naturales y de largo plazo.',
+ 'El documento lo relaciona con bioestimuladores, exosomas, PDRN/polinucleótidos, PRP e hidrataciones profundas.',
+ 'Es la propuesta regenerativa profunda del Dominio Facial y un eje de diferenciación frente a una estética centrada solo en relleno.',
+ 'Bioestimuladores, PDRN, exosomas y PRP requieren criterio clínico. Evitar promesas de regeneración garantizada.',
+ '{"treatments":["Bioestimuladores de colágeno","Exosomas","Polinucleótidos / PDRN","PRP","Hidrataciones profundas con AH"],"products":["Beauty Maker","Neuro Vital","Astaxantina","Hydrashield","Regushield","Sensishield","SkinRegeneration","UltraGlow"]}',
+ array['bioregen face','regeneracion','bioestimulador','exosomas','pdrn','prp'],'CLINICAL_REVIEW_REQUIRED','ZV_DOMAINS_2026','PDF p.5-6; Enfoque Facial 3','APPROVED',now()),
+('CORPORAL_BODY_RESET','APPROACH','DOMAIN_CORPORAL','Body Reset','["Limpieza · Descarga · Preparación Metabólica"]',
+ 'Body Reset es el enfoque de preparación corporal de Zi Vital antes de procesos de reducción o remodelación.',
+ 'Preséntalo como fase de preparación y acompañamiento; el documento lo relaciona con detox iónico, vitaminas, drenaje y ondas rusas.',
+ 'Funciona como punto de entrada del Dominio Corporal dentro de la secuencia propuesta por el documento.',
+ 'El PDF usa lenguaje de “depurar”, “toxinas” e inflamación. Esas afirmaciones no deben comunicarse como hechos médicos sin revisión clínica; Detox iónico no debe presentarse como extracción demostrada de toxinas.',
+ '{"treatments":["Detox iónico","Vitaminas endovenosas","Drenaje linfático manual","Ondas rusas"],"products":["Redu Fast","Astaxantina","Perfect Form B","Prunex"]}',
+ array['body reset','detox','preparacion corporal','drenaje','ondas rusas'],'CLINICAL_REVIEW_REQUIRED','ZV_DOMAINS_2026','PDF p.6-7; Enfoque Corporal 1','APPROVED',now()),
+('CORPORAL_SCULPT_BODY','APPROACH','DOMAIN_CORPORAL','Sculpt Body','["Contour Sculpt","Reducción · Definición · Contorno Inteligente"]',
+ 'Sculpt Body es el enfoque corporal para reducción localizada y definición de contorno dentro de un plan progresivo.',
+ 'El documento lo relaciona con criolipólisis, enzimas, HIFU corporal, radiofrecuencia, vitaminas, detox de apoyo y drenajes.',
+ 'Es la capa de reducción/definición del Dominio Corporal y sucede conceptualmente después de la preparación.',
+ 'La indicación y expectativas de reducción dependen de evaluación. No prometer medidas, velocidad ni ausencia de rebote.',
+ '{"treatments":["Criolipólisis","Enzimas recombinantes","HIFU corporal","Radiofrecuencia corporal","Vitaminas","Detox","Drenaje linfático","Ondas rusas"],"products":["Beauty Maker","Neuro Vital","Redu Fast","Astaxantina","Perfect Form B","Prunex"]}',
+ array['sculpt body','contour sculpt','reduccion','criolipolisis','hifu corporal','enzimas'],'HIGH','ZV_DOMAINS_2026','PDF p.7-8; Enfoque Corporal 2','APPROVED',now()),
+('CORPORAL_SCULPT_BOOTY','APPROACH','DOMAIN_CORPORAL','Sculpt Booty','["Volume & Firm","Proyección · Firmeza · Calidad de Tejido"]',
+ 'Sculpt Booty es el enfoque corporal de proyección, firmeza y calidad del tejido, especialmente asociado a glúteos y zonas con flacidez o estrías.',
+ 'El documento lo relaciona con ácido hialurónico corporal, bioestimuladores, enzimas para estrías, peptonas y radiofrecuencia.',
+ 'Es la capa de proyección/firmeza del Dominio Corporal y debe diferenciarse de un enfoque puramente reductor.',
+ 'Volumen, material e indicación son decisiones clínicas. Evitar promesas de forma o volumen garantizado.',
+ '{"treatments":["Ácido hialurónico corporal","Bioestimuladores corporales","Enzimas para estrías","Peptonas","Radiofrecuencia corporal"],"products":["Beauty Maker","Neuro Vital","Astaxantina"]}',
+ array['sculpt booty','volume firm','gluteos','firmeza','bioestimuladores','peptonas'],'HIGH','ZV_DOMAINS_2026','PDF p.8-9; Enfoque Corporal 3','APPROVED',now()),
+('CAPILAR_ACTIVACION_REGENERACION','APPROACH','DOMAIN_CAPILAR','Activación & Regeneración','["Hair Revival","Activación · Regeneración · Reinicio Folicular"]',
+ 'Es el enfoque capilar para pacientes cuyo plan busca trabajar caída activa, adelgazamiento o pérdida de densidad. La elección del protocolo corresponde a evaluación médica.',
+ 'Explícalo como proceso estructurado y de constancia. El documento lo relaciona con RF capilar, mesoterapia, PRP, exosomas, PDRN y productos domiciliarios.',
+ 'Es la etapa activa del Dominio Capilar y debe conectarse con productos de continuidad y controles.',
+ 'El documento enumera minoxidil, dutasteride, PRP, exosomas y PDRN. Son elementos clínicos restringidos; no prescribir ni recomendar dosis desde IA.',
+ '{"treatments":["Radiofrecuencia capilar","Mesoterapia capilar","PRP capilar","Exosomas capilares","PDRN / polinucleótidos"],"products":["Minoxidil tópico","Shampoo anticaída","Cápsulas de soporte capilar","Beauty Maker","Neuro Vital"]}',
+ array['hair revival','activacion capilar','regeneracion capilar','caida','mesoterapia','prp capilar'],'CLINICAL_REVIEW_REQUIRED','ZV_DOMAINS_2026','PDF p.10-11; Enfoque Capilar 1','APPROVED',now()),
+('CAPILAR_MANTENIMIENTO_PREVENCION','APPROACH','DOMAIN_CAPILAR','Mantenimiento & Prevención','["Hair Guard","Mantenimiento · Prevención · Protección a Largo Plazo"]',
+ 'Es el enfoque capilar para proteger resultados y sostener una rutina de mantenimiento o prevención a largo plazo.',
+ 'Úsalo cuando el paciente ya pasó por una fase activa o cuando el plan médico es preventivo; refuerza seguimiento y constancia.',
+ 'Es la etapa de continuidad del Dominio Capilar; productos domiciliarios y controles toman un papel central.',
+ 'Los ajustes de protocolo por hormonas, estrés o medicación corresponden a evaluación clínica, no a decisión autónoma de IA.',
+ '{"treatments":["RF capilar de mantenimiento","Mesoterapia de refuerzo","Controles médicos"],"products":["Shampoo preventivo","Spray fortalecedor","Cápsulas de mantenimiento","Beauty Maker","Vitaminas de soporte"]}',
+ array['hair guard','mantenimiento capilar','prevencion capilar','control capilar'],'HIGH','ZV_DOMAINS_2026','PDF p.11-12; Enfoque Capilar 2','APPROVED',now())
+on conflict(code) do update set title=excluded.title,aliases=excluded.aliases,public_client=excluded.public_client,advisor_internal=excluded.advisor_internal,owner_admin=excluded.owner_admin,clinical_restricted=excluded.clinical_restricted,system_reference=excluded.system_reference,keywords=excluded.keywords,risk_level=excluded.risk_level,source_locator=excluded.source_locator,status='APPROVED',approved_at=now(),updated_at=now();
+
+-- PATIENT JOURNEY + ROLES
+insert into public.aos_knowledge_nodes_v1(code,node_type,parent_code,title,aliases,public_client,advisor_internal,owner_admin,clinical_restricted,system_reference,keywords,risk_level,source_code,source_locator,status,approved_at)
+values
+('ZV_PATIENT_JOURNEY','PATIENT_JOURNEY','ZV_SYSTEM','Proceso de Atención Zi Vital','["Patient Journey Zi Vital"]',
+ 'La atención Zi Vital busca comprender primero el caso, explicar el proceso, realizar la evaluación médica y acompañar los siguientes pasos sin presión.',
+ 'Identifica en qué fase está la persona antes de responder o intentar cerrar: recepción, triaje, preconsulta, consulta, plan, procedimiento o seguimiento.',
+ 'El journey distribuye funciones clínicas, emocionales, comerciales y legales; debe gobernar automatizaciones y playbooks.',
+ 'La IA puede explicar el proceso, pero no sustituye triaje, diagnóstico, consentimiento ni ejecución clínica.',
+ '{"phases":["PHASE_1_RECEPCION","PHASE_2_TRIAJE","PHASE_3_PRECONSULTA","PHASE_4_CONSULTA_MEDICA","PHASE_5_PLAN_COTIZACION","PHASE_6_CONSENTIMIENTO_PROCEDIMIENTO","PHASE_7_CIERRE_SEGUIMIENTO"]}',
+ array['proceso de atencion','patient journey','recepcion','triaje','consulta','seguimiento'],'MEDIUM','ZV_PATIENT_PROCESS_2026','PDF p.1-8; complete patient process','APPROVED',now()),
+('ROLE_RECEPCIONISTA','ROLE','ZV_PATIENT_JOURNEY','Recepcionista','["Recepción"]',null,
+ 'Responsable de orden, apertura, contención inicial, aterrizaje del plan y cierre según el documento.',
+ 'Rol operativo de apertura/cierre y puente comercial; no debe invadir criterio clínico.',null,
+ '{"responsibilities":["apertura","filiacion","coordinacion","cotizacion","cierre"]}',array['recepcionista','recepcion'],'LOW','ZV_PATIENT_PROCESS_2026','PDF p.1; roles','APPROVED',now()),
+('ROLE_ENFERMERIA','ROLE','ZV_PATIENT_JOURNEY','Enfermería','["Enfermera"]',null,
+ 'Responsable de triaje, educación, preparación, acompañamiento y ejecución dentro de su competencia.',
+ 'Rol de escucha estructurada y preparación; no debe convertir el triaje en venta.',
+ 'Signos vitales, condiciones médicas y preparación clínica son información restringida y deben manejarse con privacidad.',
+ '{"responsibilities":["triaje","educacion","preparacion","acompanamiento"]}',array['enfermeria','triaje'],'HIGH','ZV_PATIENT_PROCESS_2026','PDF p.1-3; roles and triage','APPROVED',now()),
+('ROLE_DOCTORA','ROLE','ZV_PATIENT_JOURNEY','Doctora','["Médica","Doctora Zi Vital"]',
+ 'La doctora realiza la evaluación clínica y define el plan de trabajo según cada caso.',
+ 'La recomendación clínica y la definición del plan pertenecen a la doctora; el asesor explica y acompaña, no diagnostica.',
+ 'Es la autoridad de diagnóstico, criterio clínico, diseño del plan y validación médica.',
+ 'Diagnóstico, indicación, prescripción y validación médica son funciones no delegables al bot.',
+ '{"responsibilities":["diagnostico","criterio clinico","plan","validacion medica"]}',array['doctora','medica','consulta medica'],'CLINICAL_REVIEW_REQUIRED','ZV_PATIENT_PROCESS_2026','PDF p.1 and p.4-5; roles and consultation','APPROVED',now()),
+('PHASE_1_RECEPCION','PHASE','ZV_PATIENT_JOURNEY','Fase 1 — Recepción y apertura formal','[]',
+ 'La primera etapa ordena el ingreso y abre formalmente el caso antes de continuar.',
+ 'Recepción solicita filiación e identificación y completa la apertura del caso según protocolo.',
+ 'Construye confianza y seriedad; el documento exige completar esta fase antes de continuar.',
+ 'Datos personales, médicos, DNI e historia clínica son información privada; nunca exponerlos en conocimiento público.',
+ '{"responsible_role":"ROLE_RECEPCIONISTA","builds":"confianza + seriedad"}',array['fase 1','recepcion','apertura'],'HIGH','ZV_PATIENT_PROCESS_2026','PDF p.1-2; Fase 1','APPROVED',now()),
+('PHASE_2_TRIAJE','PHASE','ZV_PATIENT_JOURNEY','Fase 2 — Triaje consciente','[]',
+ 'El triaje busca comprender el contexto del paciente antes de la consulta médica.',
+ 'Se realiza como conversación estructurada, no como venta. Incluye motivación, experiencia previa, expectativas, temores, antecedentes relevantes y contexto de inversión.',
+ 'Reduce venta apresurada y mejora la calidad de la consulta al llevar contexto estructurado a la doctora.',
+ 'Condiciones médicas, alergias, tratamientos actuales, signos vitales y demás datos de salud son restringidos; la IA no debe almacenarlos o exponerlos fuera del flujo autorizado.',
+ '{"responsible_role":"ROLE_ENFERMERIA","builds":"vinculo + comprension","triage_questions":10}',array['fase 2','triaje','preguntas triaje'],'CLINICAL_REVIEW_REQUIRED','ZV_PATIENT_PROCESS_2026','PDF p.2-3; Fase 2 and 10 mandatory questions','APPROVED',now()),
+('PHASE_3_PRECONSULTA','PHASE','ZV_PATIENT_JOURNEY','Fase 3 — Explicación previa del proceso y enfoques','["Pre-consulta"]',
+ 'Antes de la consulta se explica que Zi Vital trabaja por enfoques y planes, que la doctora recomienda y que el paciente decide cómo avanzar.',
+ 'Usa esta fase para reducir ansiedad y evitar la sensación de venta forzada. No prometas que todo se realizará el mismo día.',
+ 'Prepara mentalmente al paciente y aumenta comprensión del modelo de dominios/enfoques antes de la consulta.',null,
+ '{"builds":"relajacion mental","avoids":"miedo a venta"}',array['fase 3','preconsulta','explicacion de enfoques'],'LOW','ZV_PATIENT_PROCESS_2026','PDF p.4; Fase 3','APPROVED',now()),
+('PHASE_4_CONSULTA_MEDICA','PHASE','ZV_PATIENT_JOURNEY','Fase 4 — Consulta médica personalizada','[]',
+ 'En consulta, la doctora evalúa el caso y diseña un plan con enfoque, fases, tiempos y prioridades.',
+ 'El asesor puede explicar un plan ya indicado, pero no debe anticipar cuál será la indicación médica.',
+ 'Es el punto de autoridad clínica del journey; separa recomendación médica de cierre comercial.',
+ 'Diagnóstico, evaluación de piel/cuerpo/cuero cabelludo e indicación pertenecen a la doctora.',
+ '{"responsible_role":"ROLE_DOCTORA","builds":"autoridad real"}',array['fase 4','consulta medica','plan medico'],'CLINICAL_REVIEW_REQUIRED','ZV_PATIENT_PROCESS_2026','PDF p.4-5; Fase 4','APPROVED',now()),
+('PHASE_5_PLAN_COTIZACION','PHASE','ZV_PATIENT_JOURNEY','Fase 5 — Aterrizaje del plan, cotización y decisión','[]',
+ 'Después de la recomendación médica se explica el plan, sus etapas, valor y opciones, sin presionar la decisión.',
+ 'Traduce el plan médico a pasos comprensibles y opciones de pago. Explica proceso antes que solo costo.',
+ 'Construye valor percibido y reduce choque por precio; la venta debe mantenerse separada de la autoridad médica.',null,
+ '{"responsible_role":"ROLE_RECEPCIONISTA","builds":"valor percibido","principle":"acompanar, no presionar"}',array['fase 5','cotizacion','plan','precio'],'LOW','ZV_PATIENT_PROCESS_2026','PDF p.5; Fase 5','APPROVED',now()),
+('PHASE_6_CONSENTIMIENTO_PROCEDIMIENTO','PHASE','ZV_PATIENT_JOURNEY','Fase 6 — Consentimientos, preparación y procedimiento','[]',
+ 'Antes del procedimiento se completan los consentimientos, se prepara al paciente y se explica qué puede esperar durante la atención.',
+ 'El documento permite educación y upselling consciente durante el procedimiento, pero lo define como información complementaria, no presión de cierre.',
+ 'Concentra seguridad legal, preparación, ejecución, educación y registro fotográfico clínico.',
+ 'Consentimientos, preparación clínica, ejecución y fotografías son flujos sensibles. La IA no debe sustituir consentimiento informado ni instrucciones profesionales.',
+ '{"steps":["consentimiento","preparacion","procedimiento","educacion","registro fotografico"],"principle":"sembrar, no cerrar"}',array['fase 6','consentimiento','procedimiento','preparacion'],'CLINICAL_REVIEW_REQUIRED','ZV_PATIENT_PROCESS_2026','PDF p.5-7; Fase 6','APPROVED',now()),
+('PHASE_7_CIERRE_SEGUIMIENTO','PHASE','ZV_PATIENT_JOURNEY','Fase 7 — Cierre, seguimiento y despedida','[]',
+ 'El cierre busca dejar claro el siguiente paso y mantener continuidad del proceso.',
+ 'Programa próximas sesiones cuando corresponda, explica productos complementarios y cierra con claridad y acompañamiento.',
+ 'Convierte una atención puntual en continuidad organizada sin forzar ventas.',null,
+ '{"builds":"continuidad","actions":["siguientes sesiones","productos complementarios","cierre"]}',array['fase 7','seguimiento','cierre','continuidad'],'LOW','ZV_PATIENT_PROCESS_2026','PDF p.7-8; Fase 7 and strategic table','APPROVED',now())
+on conflict(code) do update set title=excluded.title,aliases=excluded.aliases,public_client=excluded.public_client,advisor_internal=excluded.advisor_internal,owner_admin=excluded.owner_admin,clinical_restricted=excluded.clinical_restricted,system_reference=excluded.system_reference,keywords=excluded.keywords,risk_level=excluded.risk_level,source_locator=excluded.source_locator,status='APPROVED',approved_at=now(),updated_at=now();
+
+-- Structural knowledge relations.
+insert into public.aos_knowledge_relations_v1(knowledge_code,relation_type,target_type,target_key,relation_scope,source_locator)
+values
+('DOMAIN_FACIAL','CHILD_OF','KNOWLEDGE','ZV_SYSTEM','PUBLIC','Domains PDF p.1-2'),
+('FACIAL_SKIN_SIGNATURE','CHILD_OF','KNOWLEDGE','DOMAIN_FACIAL','PUBLIC','Domains PDF p.2-3'),
+('FACIAL_HARMONY_DESIGN','CHILD_OF','KNOWLEDGE','DOMAIN_FACIAL','PUBLIC','Domains PDF p.3-4'),
+('FACIAL_BIOREGEN_FACE','CHILD_OF','KNOWLEDGE','DOMAIN_FACIAL','PUBLIC','Domains PDF p.5'),
+('DOMAIN_CORPORAL','CHILD_OF','KNOWLEDGE','ZV_SYSTEM','PUBLIC','Domains PDF p.6'),
+('CORPORAL_BODY_RESET','CHILD_OF','KNOWLEDGE','DOMAIN_CORPORAL','PUBLIC','Domains PDF p.6-7'),
+('CORPORAL_SCULPT_BODY','CHILD_OF','KNOWLEDGE','DOMAIN_CORPORAL','PUBLIC','Domains PDF p.7-8'),
+('CORPORAL_SCULPT_BOOTY','CHILD_OF','KNOWLEDGE','DOMAIN_CORPORAL','PUBLIC','Domains PDF p.8-9'),
+('DOMAIN_CAPILAR','CHILD_OF','KNOWLEDGE','ZV_SYSTEM','PUBLIC','Domains PDF p.9'),
+('CAPILAR_ACTIVACION_REGENERACION','CHILD_OF','KNOWLEDGE','DOMAIN_CAPILAR','PUBLIC','Domains PDF p.10-11'),
+('CAPILAR_MANTENIMIENTO_PREVENCION','CHILD_OF','KNOWLEDGE','DOMAIN_CAPILAR','PUBLIC','Domains PDF p.11-12'),
+('CAPILAR_ACTIVACION_REGENERACION','NEXT_APPROACH','KNOWLEDGE','CAPILAR_MANTENIMIENTO_PREVENCION','REFERENCE','Domains PDF p.10-12'),
+('ZV_PATIENT_JOURNEY','CHILD_OF','KNOWLEDGE','ZV_SYSTEM','PUBLIC','Process PDF p.1'),
+('PHASE_1_RECEPCION','RESPONSIBLE_ROLE','ROLE','ROLE_RECEPCIONISTA','INTERNAL','Process PDF p.1-2'),
+('PHASE_2_TRIAJE','RESPONSIBLE_ROLE','ROLE','ROLE_ENFERMERIA','INTERNAL','Process PDF p.2-3'),
+('PHASE_4_CONSULTA_MEDICA','RESPONSIBLE_ROLE','ROLE','ROLE_DOCTORA','INTERNAL','Process PDF p.4-5'),
+('PHASE_5_PLAN_COTIZACION','RESPONSIBLE_ROLE','ROLE','ROLE_RECEPCIONISTA','INTERNAL','Process PDF p.5')
+on conflict do nothing;
+
+-- Resolve a safe subset of exact catalog links already present in the canonical catalog.
+insert into public.aos_knowledge_relations_v1(knowledge_code,relation_type,target_type,target_key,target_id,relation_scope,source_locator)
+select 'FACIAL_SKIN_SIGNATURE','RELATED_SERVICE','SERVICE',s.nombre,s.id,'REFERENCE','Domains PDF p.2-3'
+from public.aos_catalogo_servicios s where s.estado='ACTIVO' and s.tipo='SERVICIO' and s.nombre in ('PINK GLOW 1ML','HIDROFACIAL PREMIUM','HIDROFACIAL ROSTRO','RF FRACCIONADA ROSTRO/CUELLO x1','DERMAPEN VIT FACIAL x1')
+on conflict do nothing;
+insert into public.aos_knowledge_relations_v1(knowledge_code,relation_type,target_type,target_key,target_id,relation_scope,source_locator)
+select 'CAPILAR_ACTIVACION_REGENERACION','RELATED_SERVICE','SERVICE',s.nombre,s.id,'CLINICAL','Domains PDF p.10-11'
+from public.aos_catalogo_servicios s where s.estado='ACTIVO' and s.tipo='SERVICIO' and s.nombre in ('MESO CAPILAR MINOXIDIL','DUTASTERIDE CAPILAR x1','PRP CAPILAR x1','EXOSOMAS EXOSIGNAL HAIR x1','RF FRACCIONADA CAPILAR x1')
+on conflict do nothing;
+insert into public.aos_knowledge_relations_v1(knowledge_code,relation_type,target_type,target_key,target_id,relation_scope,source_locator)
+select 'CORPORAL_BODY_RESET','RELATED_SERVICE','SERVICE',s.nombre,s.id,'REFERENCE','Domains PDF p.6-7'
+from public.aos_catalogo_servicios s where s.estado='ACTIVO' and s.tipo='SERVICIO' and s.nombre in ('DETOX IÓNICO')
+on conflict do nothing;
+insert into public.aos_knowledge_relations_v1(knowledge_code,relation_type,target_type,target_key,target_id,relation_scope,source_locator)
+select 'CORPORAL_SCULPT_BODY','RELATED_SERVICE','SERVICE',s.nombre,s.id,'REFERENCE','Domains PDF p.7-8'
+from public.aos_catalogo_servicios s where s.estado='ACTIVO' and s.tipo='SERVICIO' and s.nombre in ('CRIOLIPÓLISIS 1 ZONA','HIFU CORP ABDOMEN ALTO','ENZIMAS CORP ABDOMEN/GLÚTEOS x1')
+on conflict do nothing;
+
+-- Audience-safe projection: only one audience text is exposed per call.
+create or replace function public.aos_wa4a_knowledge_search_v2(
+  p_query text,
+  p_audience text default 'PUBLIC_CLIENT',
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text,
+  domain text,
+  subject_type text,
+  subject_id text,
+  title text,
+  facts jsonb,
+  authority_tier smallint,
+  source_relation text,
+  source_pk text,
+  source_updated_at timestamptz,
+  freshness_state text,
+  conflict_state text,
+  retrieval_state text,
+  evidence_ref jsonb,
+  score integer
+)
+language sql
+stable
+security definer
+set search_path='public'
+as $$
+with params as (
+  select trim(coalesce(p_query,'')) q,
+         upper(coalesce(p_audience,'PUBLIC_CLIENT')) audience,
+         greatest(1,least(coalesce(p_limit,12),24)) lim
+),
+base as (
+  select b.* from params p
+  cross join lateral public.aos_wa4a_knowledge_search_v1(p.q,p.lim,p_domains) b
+  where p_domains is null or b.domain=any(p_domains)
+),
+clinic as (
+  select
+    'clinic:'||n.code as knowledge_id,
+    'CLINIC_KNOWLEDGE'::text as domain,
+    n.node_type::text as subject_type,
+    n.code::text as subject_id,
+    n.title::text,
+    jsonb_strip_nulls(jsonb_build_object(
+      'code',n.code,
+      'node_type',n.node_type,
+      'parent_code',n.parent_code,
+      'title',n.title,
+      'aliases',n.aliases,
+      'answer',case p.audience
+        when 'PUBLIC_CLIENT' then n.public_client
+        when 'ADVISOR_INTERNAL' then n.advisor_internal
+        when 'OWNER_ADMIN' then n.owner_admin
+        when 'CLINICAL_RESTRICTED' then n.clinical_restricted
+        when 'SYSTEM_REFERENCE' then coalesce(n.owner_admin,n.advisor_internal,n.public_client)
+        else null end,
+      'public_summary',case when p.audience in ('ADVISOR_INTERNAL','OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE') then n.public_client else null end,
+      'system_reference',case when p.audience in ('OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE') then n.system_reference else null end,
+      'risk_level',n.risk_level,
+      'audience',p.audience
+    )) as facts,
+    15::smallint as authority_tier,
+    'public.aos_knowledge_nodes_v1'::text as source_relation,
+    n.code::text as source_pk,
+    n.updated_at as source_updated_at,
+    'GOVERNED'::text as freshness_state,
+    'CLEAR'::text as conflict_state,
+    case
+      when n.status<>'APPROVED' then 'BLOCKED_UNAPPROVED'
+      when (case p.audience when 'PUBLIC_CLIENT' then n.public_client when 'ADVISOR_INTERNAL' then n.advisor_internal when 'OWNER_ADMIN' then n.owner_admin when 'CLINICAL_RESTRICTED' then n.clinical_restricted when 'SYSTEM_REFERENCE' then coalesce(n.owner_admin,n.advisor_internal,n.public_client) else null end) is null then 'BLOCKED_AUDIENCE'
+      else 'READY'
+    end::text as retrieval_state,
+    jsonb_build_object('relation','public.aos_knowledge_nodes_v1','pk',n.code,'version',n.version::text,'source_code',n.source_code,'source_locator',n.source_locator,'audience',p.audience) as evidence_ref,
+    (case
+      when public.aos_wa4a_norm_v1(n.title)=public.aos_wa4a_norm_v1(p.q) then 140
+      when public.aos_wa4a_norm_v1(n.title) like '%'||public.aos_wa4a_norm_v1(p.q)||'%' then 110
+      when public.aos_wa4a_norm_v1(n.aliases::text) like '%'||public.aos_wa4a_norm_v1(p.q)||'%' then 90
+      when public.aos_wa4a_norm_v1(array_to_string(n.keywords,' ')) like '%'||public.aos_wa4a_norm_v1(p.q)||'%' then 80
+      when public.aos_wa4a_norm_v1(concat_ws(' ',n.public_client,n.advisor_internal,n.owner_admin,n.clinical_restricted)) like '%'||public.aos_wa4a_norm_v1(p.q)||'%' then 60
+      else 10 end)::integer as score
+  from public.aos_knowledge_nodes_v1 n cross join params p
+  where n.status='APPROVED'
+    and (p_domains is null or 'CLINIC_KNOWLEDGE'=any(p_domains))
+    and (p.q='' or public.aos_wa4a_norm_v1(concat_ws(' ',n.title,n.aliases::text,array_to_string(n.keywords,' '),n.public_client,n.advisor_internal,n.owner_admin,n.clinical_restricted)) like '%'||public.aos_wa4a_norm_v1(p.q)||'%')
+),
+all_rows as (
+  select * from base
+  union all
+  select * from clinic where retrieval_state='READY'
+)
+select * from all_rows order by score desc,authority_tier asc,title limit (select lim from params);
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]) to service_role;
+
+commit;

--- a/supabase/migrations/20260828001600_wa4a1_zivital_audience_search_isolation_v1.sql
+++ b/supabase/migrations/20260828001600_wa4a1_zivital_audience_search_isolation_v1.sql
@@ -1,0 +1,86 @@
+-- WA-4A.1 hardening — search only within the requested audience projection.
+begin;
+create or replace function public.aos_wa4a_knowledge_search_v2(
+  p_query text,
+  p_audience text default 'PUBLIC_CLIENT',
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text, domain text, subject_type text, subject_id text, title text,
+  facts jsonb, authority_tier smallint, source_relation text, source_pk text,
+  source_updated_at timestamptz, freshness_state text, conflict_state text,
+  retrieval_state text, evidence_ref jsonb, score integer
+)
+language sql
+stable
+security definer
+set search_path='public'
+as $$
+with params as (
+  select trim(coalesce(p_query,'')) q,
+         case when upper(coalesce(p_audience,'PUBLIC_CLIENT')) in ('PUBLIC_CLIENT','ADVISOR_INTERNAL','OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE')
+              then upper(coalesce(p_audience,'PUBLIC_CLIENT')) else 'PUBLIC_CLIENT' end audience,
+         greatest(1,least(coalesce(p_limit,12),24)) lim
+),
+base as (
+  select b.* from params p
+  cross join lateral public.aos_wa4a_knowledge_search_v1(p.q,p.lim,p_domains) b
+  where p_domains is null or b.domain=any(p_domains)
+),
+clinic_source as (
+  select n.*,p.*,
+    case p.audience
+      when 'PUBLIC_CLIENT' then n.public_client
+      when 'ADVISOR_INTERNAL' then n.advisor_internal
+      when 'OWNER_ADMIN' then n.owner_admin
+      when 'CLINICAL_RESTRICTED' then n.clinical_restricted
+      when 'SYSTEM_REFERENCE' then concat_ws(' ',n.owner_admin,n.advisor_internal,n.public_client,n.system_reference::text)
+    end as audience_text
+  from public.aos_knowledge_nodes_v1 n cross join params p
+  where n.status='APPROVED'
+),
+clinic as (
+  select
+    'clinic:'||n.code as knowledge_id,
+    'CLINIC_KNOWLEDGE'::text as domain,
+    n.node_type::text as subject_type,
+    n.code::text as subject_id,
+    n.title::text,
+    jsonb_strip_nulls(jsonb_build_object(
+      'code',n.code,'node_type',n.node_type,'parent_code',n.parent_code,'title',n.title,'aliases',n.aliases,
+      'answer',case n.audience when 'SYSTEM_REFERENCE' then coalesce(n.owner_admin,n.advisor_internal,n.public_client) else n.audience_text end,
+      'public_summary',case when n.audience in ('ADVISOR_INTERNAL','OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE') then n.public_client end,
+      'system_reference',case when n.audience in ('OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE') then n.system_reference end,
+      'risk_level',n.risk_level,'audience',n.audience
+    )) as facts,
+    15::smallint as authority_tier,
+    'public.aos_knowledge_nodes_v1'::text as source_relation,
+    n.code::text as source_pk,
+    n.updated_at as source_updated_at,
+    'GOVERNED'::text as freshness_state,
+    'CLEAR'::text as conflict_state,
+    case when coalesce(n.audience_text,'')='' then 'BLOCKED_AUDIENCE' else 'READY' end::text as retrieval_state,
+    jsonb_build_object('relation','public.aos_knowledge_nodes_v1','pk',n.code,'version',n.version::text,'source_code',n.source_code,'source_locator',n.source_locator,'audience',n.audience) as evidence_ref,
+    (case
+      when public.aos_wa4a_norm_v1(n.title)=public.aos_wa4a_norm_v1(n.q) then 140
+      when public.aos_wa4a_norm_v1(n.title) like '%'||public.aos_wa4a_norm_v1(n.q)||'%' then 110
+      when public.aos_wa4a_norm_v1(n.aliases::text) like '%'||public.aos_wa4a_norm_v1(n.q)||'%' then 90
+      when public.aos_wa4a_norm_v1(array_to_string(n.keywords,' ')) like '%'||public.aos_wa4a_norm_v1(n.q)||'%' then 80
+      when public.aos_wa4a_norm_v1(n.audience_text) like '%'||public.aos_wa4a_norm_v1(n.q)||'%' then 60
+      else 10 end)::integer as score
+  from clinic_source n
+  where (p_domains is null or 'CLINIC_KNOWLEDGE'=any(p_domains))
+    and coalesce(n.audience_text,'')<>''
+    and (n.q='' or public.aos_wa4a_norm_v1(concat_ws(' ',n.title,n.aliases::text,array_to_string(n.keywords,' '),n.audience_text)) like '%'||public.aos_wa4a_norm_v1(n.q)||'%')
+),
+all_rows as (
+  select * from base
+  union all
+  select * from clinic where retrieval_state='READY'
+)
+select * from all_rows order by score desc,authority_tier asc,title limit (select lim from params);
+$$;
+revoke all on function public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]) to service_role;
+commit;

--- a/supabase/rollbacks/20260828001500_wa4a1_zivital_governed_knowledge_v1.rollback.sql
+++ b/supabase/rollbacks/20260828001500_wa4a1_zivital_governed_knowledge_v1.rollback.sql
@@ -1,0 +1,7 @@
+begin;
+revoke all on function public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]) from public,anon,authenticated,service_role;
+drop function if exists public.aos_wa4a_knowledge_search_v2(text,text,integer,text[]);
+drop table if exists public.aos_knowledge_relations_v1;
+drop table if exists public.aos_knowledge_nodes_v1;
+drop table if exists public.aos_knowledge_sources_v1;
+commit;


### PR DESCRIPTION
Transforms the two Zi Vital internal PDFs into governed clinic knowledge and connects that source to Knowledge Fabric V2 without wiring Copilot or applying the migration to PROD.

Scope:
- 2 authoritative internal source records;
- 23 governed nodes: system, 3 domains, 8 approaches, patient journey, 7 phases, 3 roles;
- explicit PUBLIC_CLIENT / ADVISOR_INTERNAL / OWNER_ADMIN / CLINICAL_RESTRICTED / SYSTEM_REFERENCE projections;
- aliases for Hair Revival, Hair Guard, Contour Sculpt and Volume & Firm without duplicate concepts;
- risk governance for clinical/detox/capillary claims;
- additive exact relations to selected canonical current services;
- `aos_wa4a_knowledge_search_v2` extends WA-4A retrieval with an audience argument;
- runtime adapter rejects clinic rows prepared for another audience;
- Zero-Cost isolated DB tests, negative leakage tests, ACL tests and rollback contract;
- no patient/lead/sales/REV access, no catalog mutation, no Copilot/auto-reply/AI send activation.

Operating boundary: TEST-first / PROD-ready only while current PROD REST/Auth quota debt remains. The two PDFs remain the evidence source; structured nodes are the governed derivative.