### PR TITLE
WA-4A.1C — Treatment & Pricing Architecture

### DIFF
--- a/.github/workflows/wa4a1c-treatment-pricing-architecture.yml
+++ b/.github/workflows/wa4a1c-treatment-pricing-architecture.yml
@@ -1,0 +1,132 @@
+name: ASCENDA WA-4A.1C Treatment Pricing Architecture
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*wa4a1c*'
+      - 'supabase/rollbacks/*wa4a1c*'
+      - 'ci/wa4a1c-treatment-pricing/**'
+      - 'docs/control/WHATSAPP_WA4A1C_*'
+      - '.github/workflows/wa4a1c-treatment-pricing-architecture.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa4a1c-treatment-pricing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: ZERO-COST · treatment pricing architecture
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 35
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59982/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Zero-Cost and static governance
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          M=supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
+          grep -q 'aos_wa4_price_authority_v1' "$M"
+          grep -q 'aos_wa4_quote_preview_v1' "$M"
+          grep -q 'STRUCTURAL_NOT_PRESCRIPTIVE' "$M"
+          grep -q 'REQUIRED_BY_PLAN' "$M"
+          grep -q 'TOPPING_ELIGIBLE' "$M"
+          grep -q 'discount_applied' "$M"
+          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M"
+          ! grep -Eiq '(update|insert into|delete from)[[:space:]]+public\.aos_(catalogo_servicios|cotizaciones|cotizacion_items|pagos|planes_trabajo|plan_trabajo_items)' "$M"
+
+      - name: Existing WA knowledge regressions
+        run: |
+          set -euo pipefail
+          node --check app/wa4-knowledge.js
+          node --test ci/wa4a-knowledge-fabric/wa4-knowledge.test.js
+          node --test ci/wa4a1-zivital-knowledge/wa4a1-audience.test.js
+
+      - name: Configure isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa4a1c-pricing"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59981/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59982/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59980/' supabase/config.toml
+
+      - name: Start isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa4a1c-pricing' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59982 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+
+      - name: Build certified WA knowledge baseline
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a-knowledge-fabric/source_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1b-zivital-commercial/catalog_fixture.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827185000_wa4a_knowledge_fabric_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828014500_wa4a1b_zivital_commercial_knowledge_graph_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828014600_wa4a1b_prephase_and_mapping_hardening_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828014700_wa4a1b_explicit_exception_mapping_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828014800_wa4a1b_product_composition_semantics_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828014900_wa4a1b_relation_reconciliation_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828015000_wa4a1b_domain_code_reconciliation_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/data_patches/20260828_wa4a1b_vitaminas_detox_commercial_enrichment.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/data_patches/20260828_wa4a1b_internal_product_completion.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/data_patches/20260828_wa4a1b_prunex_knowledge_hardening.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1b-zivital-commercial/tests/001_commercial_graph.sql | tee /tmp/wa4a1b-regression.txt
+          grep -q 'WA4A1B_ZIVITAL_COMMERCIAL_GRAPH_PASS' /tmp/wa4a1b-regression.txt
+
+      - name: Apply 1C fixture and architecture
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1c-treatment-pricing/source_fixture.sql
+          echo "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_catalogo_servicios")" > /tmp/catalog-count-before
+          echo "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_catalogo_toppings")" > /tmp/topping-count-before
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
+
+      - name: Database lint and 1C certification
+        run: |
+          set -euo pipefail
+          (cd ci/zero-cost-staging && supabase db lint --local --schema public --level error)
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a1c-treatment-pricing/tests/001_treatment_pricing.sql | tee /tmp/wa4a1c.txt
+          grep -q 'WA4A1C_TREATMENT_PRICING_ARCHITECTURE_PASS' /tmp/wa4a1c.txt
+
+      - name: Rollback preserves canonical sources and WA-4A.1B
+        run: |
+          set -euo pipefail
+          BEFORE_C=$(cat /tmp/catalog-count-before)
+          BEFORE_T=$(cat /tmp/topping-count-before)
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260828033500_wa4a1c_treatment_pricing_architecture_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c 'select count(*) from public.aos_catalogo_servicios')" = "$BEFORE_C"
+          test "$(psql "$DB_URL" -X -qAt -c 'select count(*) from public.aos_catalogo_toppings')" = "$BEFORE_T"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_knowledge_entity_map_v1') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa4_process_templates_v1') is null")" = "t"
+          echo 'WA-4A.1C TEST CERTIFIED BOUNDARY: pricing/process architecture is read-only; PROD feature DDL unapplied; WA-4B remains blocked until closeout.'
+
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/ci/wa4a1c-treatment-pricing/source_fixture.sql
+++ b/ci/wa4a1c-treatment-pricing/source_fixture.sql
@@ -1,0 +1,46 @@
+-- WA-4A.1C isolated TEST source fixture. Synthetic only.
+-- Assumes WA-4A.1B catalog_fixture already created exactly 167 services + 50 products.
+
+create table if not exists public.aos_catalogo_toppings (
+  id text primary key,
+  nombre text not null,
+  categoria_vinculada text,
+  precio numeric,
+  descripcion text,
+  tipo_pago text,
+  sesiones text,
+  estado text default 'ACTIVO',
+  created_at timestamptz default now()
+);
+
+delete from public.aos_catalogo_toppings;
+insert into public.aos_catalogo_toppings(id,nombre,categoria_vinculada,precio,descripcion,tipo_pago,sesiones,estado)
+select gen_random_uuid()::text,
+       'TOPPING TEST '||gs,
+       case when gs<=5 then 'FACIALES' when gs<=10 then 'CORPORAL' when gs<=15 then 'CAPILAR' else 'VITAMINAS' end,
+       case when gs=1 then 0 else 49+gs end,
+       'Topping sintético de contrato','SOLO_CON_SERVICIO',
+       case when gs=2 then 'X 3 SESIONES' else '' end,'ACTIVO'
+from generate_series(1,20) gs;
+
+-- One intentional price anomaly to prove fail-closed behavior.
+update public.aos_catalogo_servicios
+set precio_base=100,precio_oferta=120,updated_at=now()
+where id=(select id from public.aos_catalogo_servicios where tipo='SERVICIO' and estado='ACTIVO' order by nombre limit 1);
+
+-- One intentional stale row to prove freshness fail-closed behavior.
+update public.aos_catalogo_servicios
+set updated_at=now()-interval '181 days'
+where id=(select id from public.aos_catalogo_servicios where tipo='PRODUCTO' and estado='ACTIVO' order by nombre limit 1);
+
+do $$ begin
+  if (select count(*) from public.aos_catalogo_servicios where estado='ACTIVO' and tipo='SERVICIO')<>167 then
+    raise exception '1C fixture service shape drift';
+  end if;
+  if (select count(*) from public.aos_catalogo_servicios where estado='ACTIVO' and tipo='PRODUCTO')<>50 then
+    raise exception '1C fixture product shape drift';
+  end if;
+  if (select count(*) from public.aos_catalogo_toppings where estado='ACTIVO')<>20 then
+    raise exception '1C fixture toppings shape drift';
+  end if;
+end $$;

--- a/ci/wa4a1c-treatment-pricing/tests/001_treatment_pricing.sql
+++ b/ci/wa4a1c-treatment-pricing/tests/001_treatment_pricing.sql
@@ -1,0 +1,172 @@
+\set ON_ERROR_STOP on
+
+-- Structural contracts.
+do $$ begin
+  if (select count(*) from public.aos_wa4_process_templates_v1 where template_state='APPROVED')<>8 then
+    raise exception 'expected eight approved Zi Vital process templates';
+  end if;
+  if (select count(*) from public.aos_wa4_process_role_policy_v1)<>8 then
+    raise exception 'expected eight process component roles';
+  end if;
+  if exists(select 1 from public.aos_wa4_process_role_policy_v1 where can_auto_assign) then
+    raise exception 'no process role may auto-assign in WA-4A.1C';
+  end if;
+  if (select count(*) from public.aos_wa4_price_authority_v1)<>217 then
+    raise exception 'price authority must cover 217 active catalog entities';
+  end if;
+  if (select count(*) from public.aos_wa4_process_entity_context_v1)<>217 then
+    raise exception 'process context must cover 217/217 mapped entities';
+  end if;
+  if (select count(*) from public.aos_wa4_topping_authority_v1)<>20 then
+    raise exception 'topping authority must cover 20 active fixture toppings';
+  end if;
+  if (select count(*) from public.aos_wa4_topping_authority_v1 where benefit_mode='ZERO_PRICE_BENEFIT_CANDIDATE')<>1 then
+    raise exception 'zero-price benefit semantics missing';
+  end if;
+end $$;
+
+-- Fail-closed price anomaly + stale evidence.
+do $$ begin
+  if (select count(*) from public.aos_wa4_price_authority_v1 where price_state='REVIEW_REQUIRED_OFFER_ABOVE_BASE' and ready_for_quote=false)<>1 then
+    raise exception 'offer-above-base anomaly must fail closed';
+  end if;
+  if (select count(*) from public.aos_wa4_price_authority_v1 where freshness_state='STALE_REVIEW' and ready_for_quote=false)<>1 then
+    raise exception 'stale price must fail closed';
+  end if;
+  if nullif(public.aos_wa4_price_fingerprint_v1(),'') is null then
+    raise exception 'price fingerprint missing';
+  end if;
+end $$;
+
+-- Normal catalog preview and progressive view preserve scope/total.
+do $$
+declare
+  v_id text;
+  v_phase text;
+  v_complete jsonb;
+  v_progressive jsonb;
+begin
+  select entity_id::text, commercial_phase_codes[1]
+    into v_id,v_phase
+  from public.aos_wa4_process_entity_context_v1
+  where entity_type='SERVICIO' and ready_for_quote=true
+    and commercial_phase_codes && array['COMMERCIAL_F1_PREP_ACT','COMMERCIAL_F2_INTERVENTION','COMMERCIAL_F3_CONTINUITY']
+  order by entity_name limit 1;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_type','CATALOG','source_id',v_id,'quantity',2,'phase_code',v_phase,'role','OPTIONAL_SUPPORT')),
+    'COMPLETE',false
+  ) into v_complete;
+  if not coalesce((v_complete->>'ok')::boolean,false) then raise exception 'complete preview failed: %',v_complete; end if;
+  if coalesce((v_complete->>'discount_applied')::boolean,true) then raise exception 'preview applied discount'; end if;
+  if not coalesce((v_complete->>'scope_preserved')::boolean,false) then raise exception 'preview did not preserve scope'; end if;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_type','CATALOG','source_id',v_id,'quantity',2,'phase_code',v_phase,'role','OPTIONAL_SUPPORT')),
+    'PROGRESSIVE',false
+  ) into v_progressive;
+  if not coalesce((v_progressive->>'ok')::boolean,false) then raise exception 'progressive preview failed: %',v_progressive; end if;
+  if (v_progressive->>'canonical_total')::numeric<>(v_complete->>'canonical_total')::numeric then
+    raise exception 'payment mode changed canonical scope total';
+  end if;
+  if v_progressive->'progressive_view' is null then raise exception 'progressive phase view missing'; end if;
+end $$;
+
+-- REQUIRED_BY_PLAN cannot be self-declared without plan authority.
+do $$
+declare
+  v_id text;
+  v_phase text;
+  v_denied jsonb;
+  v_allowed jsonb;
+begin
+  select entity_id::text, commercial_phase_codes[1]
+  into v_id,v_phase
+  from public.aos_wa4_process_entity_context_v1
+  where entity_type='SERVICIO' and ready_for_quote=true
+  order by entity_name limit 1;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_id',v_id,'phase_code',v_phase,'role','REQUIRED_BY_PLAN')),
+    'COMPLETE',false
+  ) into v_denied;
+  if v_denied->>'error'<>'AUTHORIZED_PLAN_REQUIRED' then raise exception 'required role did not fail closed: %',v_denied; end if;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_id',v_id,'phase_code',v_phase,'role','REQUIRED_BY_PLAN')),
+    'COMPLETE',true
+  ) into v_allowed;
+  if not coalesce((v_allowed->>'ok')::boolean,false) then raise exception 'authorized required role failed: %',v_allowed; end if;
+end $$;
+
+-- Product support and topping semantics.
+do $$
+declare
+  v_product text;
+  v_top text;
+  v_product_result jsonb;
+  v_top_result jsonb;
+begin
+  select entity_id::text into v_product
+  from public.aos_wa4_process_entity_context_v1
+  where entity_type='PRODUCTO' and ready_for_quote=true and commercial_phase_codes @> array['COMMERCIAL_F3_CONTINUITY']
+  order by entity_name limit 1;
+  select topping_id into v_top from public.aos_wa4_topping_authority_v1 where benefit_mode='ZERO_PRICE_BENEFIT_CANDIDATE' limit 1;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_id',v_product,'phase_code','COMMERCIAL_F3_CONTINUITY','role','PRODUCT_SUPPORT')),
+    'COMPLETE',false
+  ) into v_product_result;
+  if not coalesce((v_product_result->>'ok')::boolean,false) then raise exception 'product support preview failed: %',v_product_result; end if;
+
+  select public.aos_wa4_quote_preview_v1(
+    jsonb_build_array(jsonb_build_object('source_type','TOPPING','source_id',v_top,'phase_code','COMMERCIAL_F3_CONTINUITY','role','TOPPING_ELIGIBLE')),
+    'COMPLETE',false
+  ) into v_top_result;
+  if not coalesce((v_top_result->>'ok')::boolean,false) then raise exception 'topping preview failed: %',v_top_result; end if;
+  if v_top_result#>>'{lines,0,benefit_mode}'<>'ZERO_PRICE_BENEFIT_CANDIDATE' then raise exception 'zero-price topping not explicit'; end if;
+end $$;
+
+-- Anomalous and stale catalog prices cannot be quoted.
+do $$
+declare
+  v_bad text;
+  v_stale text;
+  v_phase text;
+  v_result jsonb;
+begin
+  select entity_id::text, commercial_phase_codes[1] into v_bad,v_phase
+  from public.aos_wa4_process_entity_context_v1 where price_state='REVIEW_REQUIRED_OFFER_ABOVE_BASE' limit 1;
+  select public.aos_wa4_quote_preview_v1(jsonb_build_array(jsonb_build_object('source_id',v_bad,'phase_code',v_phase,'role','OPTIONAL_SUPPORT')),'COMPLETE',false) into v_result;
+  if v_result->>'error'<>'PRICE_NOT_READY' then raise exception 'anomalous price did not fail closed: %',v_result; end if;
+
+  select entity_id::text, commercial_phase_codes[1] into v_stale,v_phase
+  from public.aos_wa4_process_entity_context_v1 where freshness_state='STALE_REVIEW' limit 1;
+  select public.aos_wa4_quote_preview_v1(jsonb_build_array(jsonb_build_object('source_id',v_stale,'phase_code',v_phase,'role',case when (select entity_type from public.aos_wa4_process_entity_context_v1 where entity_id=v_stale::uuid)='PRODUCTO' then 'PRODUCT_SUPPORT' else 'OPTIONAL_SUPPORT' end)),'COMPLETE',false) into v_result;
+  if v_result->>'error'<>'PRICE_NOT_READY' then raise exception 'stale price did not fail closed: %',v_result; end if;
+end $$;
+
+-- Least privilege: no end-user direct data/RPC access.
+do $$ begin
+  if has_table_privilege('anon','public.aos_wa4_price_authority_v1','SELECT') or
+     has_table_privilege('authenticated','public.aos_wa4_price_authority_v1','SELECT') or
+     has_table_privilege('anon','public.aos_wa4_process_templates_v1','SELECT') or
+     has_table_privilege('authenticated','public.aos_wa4_process_templates_v1','SELECT') then
+    raise exception '1C pricing/process data leaked to end-user roles';
+  end if;
+  if has_function_privilege('anon','public.aos_wa4_quote_preview_v1(jsonb,text,boolean)','EXECUTE') or
+     has_function_privilege('authenticated','public.aos_wa4_quote_preview_v1(jsonb,text,boolean)','EXECUTE') then
+    raise exception 'quote preview leaked to end-user roles';
+  end if;
+  if not has_function_privilege('service_role','public.aos_wa4_quote_preview_v1(jsonb,text,boolean)','EXECUTE') then
+    raise exception 'service_role missing quote preview';
+  end if;
+end $$;
+
+-- Canonical sources remain unchanged in shape and count.
+do $$ begin
+  if (select count(*) from public.aos_catalogo_servicios where estado='ACTIVO')<>217 then raise exception 'catalog mutated by 1C'; end if;
+  if (select count(*) from public.aos_catalogo_toppings where estado='ACTIVO')<>20 then raise exception 'toppings mutated by 1C'; end if;
+end $$;
+
+select 'WA4A1C_TREATMENT_PRICING_ARCHITECTURE_PASS' as certification;

--- a/docs/control/WHATSAPP_WA4A1C_TREATMENT_PRICING_EVIDENCE.md
+++ b/docs/control/WHATSAPP_WA4A1C_TREATMENT_PRICING_EVIDENCE.md
@@ -1,0 +1,180 @@
+# WA-4A.1C — Treatment & Pricing Architecture — Evidence
+
+Date: 2026-08-28 America/Lima  
+Parent: WA-4A.1B certified commercial knowledge graph  
+Baseline main: `510d66bd4b63b1c26b457c0d80e2ca5b960465c7`
+
+## Objective
+Build a governed, read-only architecture that combines current Zi Vital price facts with the certified Domain / Approach / Commercial Phase / Clinical Lifecycle semantics, while preserving professional clinical authority and existing quotation/payment systems.
+
+## Necessity gate
+
+`BUILD = YES`  
+`NEW PRICE MASTER = NO`  
+`NEW QUOTE MASTER = NO`  
+`NEW PAYMENT MASTER = NO`  
+`NEW PATIENT PLAN MASTER = NO`  
+`MINIMAL PRIVATE READ MODEL + STRUCTURAL PROCESS TEMPLATES + READ-ONLY PREVIEW = YES`
+
+Reason: PROD already contains the necessary operational authorities:
+
+- `aos_catalogo_servicios` — active service/product catalog and current price fields;
+- `aos_catalogo_toppings` — topping/add-on prices and category linkage;
+- `aos_cotizaciones` + `aos_cotizacion_items` — historical/current quote snapshots;
+- `aos_pagos` — payments;
+- `aos_planes_trabajo` + `aos_plan_trabajo_items` — patient-specific work-plan model;
+- `aos_sesiones_tratamiento` — session execution/payment state;
+- `aos_catalogo_variantes` and `aos_catalogo_servicio_producto` exist but currently have no rows;
+- `aos_promociones` exists but currently has no rows.
+
+Therefore 1C must reuse these sources and must not create parallel business truth.
+
+## PROD discovery readback
+
+### Catalog price shape
+
+Active catalog = 217 rows:
+
+- services = 167;
+- service `precio_oferta` present = 167/167;
+- service `precio_base` present = 132/167;
+- products = 50;
+- product `precio_oferta` present = 50/50;
+- product `precio_base` present = 26/50;
+- active rows with nonpositive offer = 0;
+- duplicate active names = 0;
+- rows with `precio_oferta > precio_base` = 7;
+- current discovery fingerprint including catalog+toppings = `4f2bdff1a36dc1c621c237a8da655155`.
+
+The seven offer-above-base rows are review debt, not silently auto-corrected:
+
+- MESO CAPILAR VIT x1 — base 290 / offer 299;
+- MESO CAPILAR VIT x3 — base 850 / offer 899;
+- MESOTERAPIA CORPORAL 2 AMP x1 — base 350 / offer 399;
+- ENZIMAS FACIAL MCCM x1 — base 550 / offer 599;
+- ENZIMAS FACIAL PBSERUM x1 — base 550 / offer 699;
+- DESCONGESTIVO PÁRPADOS — base 39 / offer 49;
+- PEPTOPLUS x5 — base 350 / offer 599.
+
+1C policy: these values fail closed for automated quote preview until the price semantics are reviewed. The architecture does not rewrite them.
+
+### Toppings / variants / links / promotions
+
+- active toppings = 20/20;
+- one topping (`DRENAJE LINFÁTICO`) has explicit price 0 and must be represented as `ZERO_PRICE_BENEFIT_CANDIDATE`, not as a hidden discount;
+- active variants = 0;
+- service→product links = 0;
+- active promotions = 0.
+
+The absence of relations/promotions is not filled with invented associations.
+
+### Existing quotations
+
+- quotes = 284;
+- `PAGADO_COMPLETO` = 229;
+- `PAGADO_PARCIAL` = 39;
+- `ANULADO` = 12;
+- `CREADO` = 3;
+- `POR_PAGAR` = 1;
+- quote items = 623: 449 SERVICIO + 174 PRODUCTO;
+- missing/nonpositive quote-item price = 0;
+- quantity <= 0 = 0;
+- subtotal math mismatch = 0;
+- quote items linked to plan items = 0;
+- `sesiones_programadas` field is present on all 623 rows but currently equals 0 for all 623.
+
+Historical quote item prices are snapshots and are not rewritten when catalog prices change.
+
+### Existing patient-plan layer
+
+- `aos_planes_trabajo` exists but currently has 0 rows;
+- `aos_plan_trabajo_items` exists but currently has 0 rows;
+- the schema already supports service/product, session count, frequency, price, dose, timing, alternatives, selected state, phase, priority, quote link, sale link and appointment link.
+
+This is the correct future patient-specific authority; WA-4A.1C process templates must remain structural and must not replace it.
+
+### Existing RPC risk boundary
+
+`aos_crear_cotizacion(jsonb)` and `aos_plan_a_cotizacion(...)` accept caller-provided prices. They remain legacy/operational functions and are NOT promoted to WA4 price authority.
+
+WA-4A.1C therefore introduces a private read-only preview that resolves prices from the canonical catalog/topping sources and fails closed on stale/anomalous values. It does not replace or mutate legacy quote RPCs in this phase.
+
+## 1C architecture
+
+### Price authority
+
+`aos_wa4_price_authority_v1`:
+
+- reads only active `aos_catalogo_servicios`;
+- exposes base + offer + canonical quote candidate;
+- classifies missing/nonpositive/offer-above-base price;
+- applies 180-day freshness guard;
+- generates evidence reference;
+- never writes price.
+
+`aos_wa4_topping_authority_v1`:
+
+- reads active `aos_catalogo_toppings`;
+- separates `PAID_ADDON` from `ZERO_PRICE_BENEFIT_CANDIDATE`;
+- topping is candidate-only and never auto-added.
+
+### Process templates
+
+Eight structural templates mirror the certified approaches:
+
+- Facial / Skin Signature;
+- Facial / Harmony Design;
+- Facial / BioRegen Face;
+- Corporal / Body Reset;
+- Corporal / Sculpt Body;
+- Corporal / Sculpt Booty;
+- Capilar / Activación & Regeneración;
+- Capilar / Mantenimiento & Prevención.
+
+All templates are `STRUCTURAL_NOT_PRESCRIPTIVE`; they contain no hardcoded current prices and no patient-specific dose/session prescription.
+
+### Component roles
+
+- `REQUIRED_BY_PLAN`;
+- `OPTIONAL_SUPPORT`;
+- `ALTERNATIVE`;
+- `DEPENDENT`;
+- `CONTROL`;
+- `MAINTENANCE`;
+- `PRODUCT_SUPPORT`;
+- `TOPPING_ELIGIBLE`.
+
+No role is auto-assignable. `REQUIRED_BY_PLAN`, `ALTERNATIVE`, `DEPENDENT` and `CONTROL` require authorized-plan context where applicable.
+
+### Read-only quote preview
+
+`aos_wa4_quote_preview_v1(jsonb,text,boolean)`:
+
+- private/service-role only;
+- no patient input;
+- no quote/payment/plan write;
+- requires explicit component role + commercial phase;
+- validates phase against WA-4A.1B entity mapping;
+- obtains current prices only from governed read models;
+- fails closed on stale/anomalous price;
+- `COMPLETE` vs `PROGRESSIVE` changes presentation only, never canonical scope/total;
+- progressive view groups the same total by F1/F2/F3;
+- no discount math;
+- topping requires explicit TOPPING_ELIGIBLE role and context approval;
+- returns price fingerprint/evidence refs for later copilot use.
+
+## Safety boundary
+
+- no `aos_pacientes`, lead, sale or REV mutation;
+- no catalog price mutation;
+- no quote/payment/plan mutation;
+- no price copied from PDF/document examples;
+- no margin/cost exposed publicly;
+- no autonomous discount;
+- no autonomous clinical selection;
+- no AI send/auto-reply/auto-routing activation;
+- WA-4B remains blocked until exact-head 1C certification and closeout.
+
+## PROD boundary
+
+WA-4A.1C feature DDL remains TEST-first / PROD-ready while the existing promotion hold remains. PROD is used only for read-only inventory/fingerprint in this phase; no 1C feature migration is applied during TEST certification.

--- a/supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
+++ b/supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
@@ -13,7 +13,6 @@ create table public.aos_wa4_process_role_policy_v1 (
   public_exposable boolean not null default false,
   created_at timestamptz not null default now()
 );
-
 revoke all on table public.aos_wa4_process_role_policy_v1 from public,anon,authenticated;
 grant select on table public.aos_wa4_process_role_policy_v1 to service_role;
 
@@ -27,11 +26,7 @@ values
 ('CONTROL','Control','Seguimiento/control de un componente o fase ya indicada.',false,true,array['SERVICIO'],true),
 ('MAINTENANCE','Mantenimiento','Continuidad posterior; no modifica retrospectivamente la intervención principal.',false,false,array['SERVICIO','PRODUCTO'],true),
 ('PRODUCT_SUPPORT','Producto de soporte','Producto domiciliario o de continuidad aprobado; nunca universal ni obligatorio por categoría.',false,false,array['PRODUCTO'],true),
-('TOPPING_ELIGIBLE','Topping elegible','Beneficio/add-on candidato sujeto a coherencia, autorización y reglas de no-descuento.',false,false,array['TOPPING'],false)
-on conflict(role_code) do update set
- title=excluded.title,semantics=excluded.semantics,can_auto_assign=excluded.can_auto_assign,
- requires_authorized_plan=excluded.requires_authorized_plan,allowed_entity_types=excluded.allowed_entity_types,
- public_exposable=excluded.public_exposable;
+('TOPPING_ELIGIBLE','Topping elegible','Beneficio/add-on candidato sujeto a coherencia, autorización y reglas de no-descuento.',false,false,array['TOPPING'],false);
 
 create table public.aos_wa4_process_templates_v1 (
   template_code text primary key,
@@ -50,9 +45,8 @@ create table public.aos_wa4_process_templates_v1 (
   updated_at timestamptz not null default now(),
   unique(domain_code,approach_code)
 );
-
 revoke all on table public.aos_wa4_process_templates_v1 from public,anon,authenticated;
-grant select,insert,update,delete on table public.aos_wa4_process_templates_v1 to service_role;
+grant select on table public.aos_wa4_process_templates_v1 to service_role;
 
 insert into public.aos_wa4_process_templates_v1
 (template_code,domain_code,approach_code,title,public_summary,advisor_summary,evidence_note)
@@ -64,11 +58,7 @@ values
 ('TPL_CORPORAL_SCULPT','DOMAIN_CORPORAL','CORPORAL_SCULPT_BODY','Corporal · Sculpt Body','Proceso de contorno y reducción progresiva definido por evaluación.','Separa preparación, intervención y continuidad; no promete medidas ni rebote cero.','WA-4A.1B + Arquitectura Comercial Zi Vital.'),
 ('TPL_CORPORAL_BOOTY','DOMAIN_CORPORAL','CORPORAL_SCULPT_BOOTY','Corporal · Sculpt Booty','Proceso de firmeza/proyección y calidad tisular según evaluación.','Estructura opciones sin convertir aparatología, inyectables o sesiones en obligación automática.','WA-4A.1B + Arquitectura Comercial Zi Vital.'),
 ('TPL_CAPILAR_ACTIVATE','DOMAIN_CAPILAR','CAPILAR_ACTIVACION_REGENERACION','Capilar · Activación & Regeneración','Proceso capilar de activación/regeneración sujeto a evaluación profesional.','Organiza intervención y continuidad; fármacos, dosis, sesiones y activos son autoridad clínica.','WA-4A.1B; protocolos farmacológicos permanecen CLINICAL_RESTRICTED.'),
-('TPL_CAPILAR_MAINTAIN','DOMAIN_CAPILAR','CAPILAR_MANTENIMIENTO_PREVENCION','Capilar · Mantenimiento & Prevención','Proceso de continuidad capilar para sostener resultados cuando corresponde.','Permite servicios/productos de soporte sin volverlos add-ons universales.','WA-4A.1B + Arquitectura Comercial Zi Vital.')
-on conflict(template_code) do update set
- domain_code=excluded.domain_code,approach_code=excluded.approach_code,title=excluded.title,
- public_summary=excluded.public_summary,advisor_summary=excluded.advisor_summary,
- phase_sequence=excluded.phase_sequence,evidence_note=excluded.evidence_note,updated_at=now();
+('TPL_CAPILAR_MAINTAIN','DOMAIN_CAPILAR','CAPILAR_MANTENIMIENTO_PREVENCION','Capilar · Mantenimiento & Prevención','Proceso de continuidad capilar para sostener resultados cuando corresponde.','Permite servicios/productos de soporte sin volverlos add-ons universales.','WA-4A.1B + Arquitectura Comercial Zi Vital.');
 
 create or replace view public.aos_wa4_price_authority_v1 as
 select
@@ -82,7 +72,7 @@ select
   c.num_sesiones,
   c.frecuencia,
   c.updated_at as price_source_updated_at,
-  greatest(0,(current_date - c.updated_at::date))::integer as age_days,
+  greatest(0,(current_date-c.updated_at::date))::integer as age_days,
   case
     when c.precio_oferta is null and c.precio_base is null then 'MISSING_PRICE'
     when coalesce(c.precio_oferta,c.precio_base,0)<=0 then 'INVALID_NONPOSITIVE_PRICE'
@@ -98,7 +88,6 @@ select
   'aos_catalogo_servicios:'||c.id::text||':'||to_char(c.updated_at at time zone 'UTC','YYYY-MM-DD"T"HH24:MI:SS') as evidence_ref
 from public.aos_catalogo_servicios c
 where c.estado='ACTIVO' and c.tipo in ('SERVICIO','PRODUCTO');
-
 revoke all on table public.aos_wa4_price_authority_v1 from public,anon,authenticated;
 grant select on table public.aos_wa4_price_authority_v1 to service_role;
 
@@ -120,14 +109,17 @@ select
   'aos_catalogo_toppings:'||t.id::text as evidence_ref
 from public.aos_catalogo_toppings t
 where t.estado='ACTIVO';
-
 revoke all on table public.aos_wa4_topping_authority_v1 from public,anon,authenticated;
 grant select on table public.aos_wa4_topping_authority_v1 to service_role;
 
+-- Contract bridge: WA-4A.1B maps knowledge entity types as SERVICE/PRODUCT,
+-- while the canonical runtime catalog uses SERVICIO/PRODUCTO. The pricing layer
+-- exposes the canonical catalog type and preserves the 1B mapping type separately.
 create or replace view public.aos_wa4_process_entity_context_v1 as
 select
   m.entity_id,
-  m.entity_type,
+  p.entity_type,
+  m.entity_type as knowledge_entity_type,
   m.entity_name,
   m.category,
   m.domain_codes,
@@ -136,7 +128,7 @@ select
   m.clinical_lifecycle,
   m.zi_function,
   m.mapping_state,
-  m.confidence,
+  m.mapping_confidence,
   p.precio_base,
   p.precio_oferta,
   p.quote_price,
@@ -149,7 +141,6 @@ select
   p.evidence_ref as price_evidence_ref
 from public.aos_knowledge_entity_map_v1 m
 join public.aos_wa4_price_authority_v1 p on p.entity_id=m.entity_id;
-
 revoke all on table public.aos_wa4_process_entity_context_v1 from public,anon,authenticated;
 grant select on table public.aos_wa4_process_entity_context_v1 to service_role;
 
@@ -198,11 +189,11 @@ declare
   v_role_policy record;
   v_unit numeric;
   v_subtotal numeric;
-  v_total numeric := 0;
-  v_lines jsonb := '[]'::jsonb;
-  v_phase_totals jsonb := '{"COMMERCIAL_F1_PREP_ACT":0,"COMMERCIAL_F2_INTERVENTION":0,"COMMERCIAL_F3_CONTINUITY":0}'::jsonb;
+  v_total numeric:=0;
+  v_lines jsonb:='[]'::jsonb;
+  v_phase_totals jsonb:='{"COMMERCIAL_F1_PREP_ACT":0,"COMMERCIAL_F2_INTERVENTION":0,"COMMERCIAL_F3_CONTINUITY":0}'::jsonb;
   v_prev numeric;
-  v_mode text := upper(trim(coalesce(p_payment_mode,'')));
+  v_mode text:=upper(trim(coalesce(p_payment_mode,'')));
   v_count integer;
 begin
   if p_components is null or jsonb_typeof(p_components)<>'array' then
@@ -323,7 +314,6 @@ begin
   );
 end;
 $$;
-
 revoke all on function public.aos_wa4_quote_preview_v1(jsonb,text,boolean) from public,anon,authenticated;
 grant execute on function public.aos_wa4_quote_preview_v1(jsonb,text,boolean) to service_role;
 

--- a/supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
+++ b/supabase/migrations/20260828033500_wa4a1c_treatment_pricing_architecture_v1.sql
@@ -1,0 +1,335 @@
+-- WA-4A.1C — Treatment & Pricing Architecture V1
+-- TEST-first / PROD-ready. Reuses canonical catalog/quotes/toppings and WA-4A.1B semantics.
+-- No patient, price, quote, payment or AI-send mutation.
+begin;
+
+create table public.aos_wa4_process_role_policy_v1 (
+  role_code text primary key,
+  title text not null,
+  semantics text not null,
+  can_auto_assign boolean not null default false,
+  requires_authorized_plan boolean not null default false,
+  allowed_entity_types text[] not null,
+  public_exposable boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+revoke all on table public.aos_wa4_process_role_policy_v1 from public,anon,authenticated;
+grant select on table public.aos_wa4_process_role_policy_v1 to service_role;
+
+insert into public.aos_wa4_process_role_policy_v1
+(role_code,title,semantics,can_auto_assign,requires_authorized_plan,allowed_entity_types,public_exposable)
+values
+('REQUIRED_BY_PLAN','Requerido por plan','Solo puede marcarse como requerido cuando un plan autorizado lo selecciona expresamente.',false,true,array['SERVICIO'],false),
+('OPTIONAL_SUPPORT','Soporte opcional','Puede apoyar el proceso pero no es obligatorio ni debe presentarse como necesidad clínica.',false,false,array['SERVICIO','PRODUCTO'],false),
+('ALTERNATIVE','Alternativa','Opción sustitutiva que exige elección autorizada; nunca se auto-selecciona por similitud.',false,true,array['SERVICIO','PRODUCTO'],false),
+('DEPENDENT','Dependiente','Solo tiene sentido cuando existe el componente del que depende; la dependencia debe ser explícita.',false,true,array['SERVICIO','PRODUCTO'],false),
+('CONTROL','Control','Seguimiento/control de un componente o fase ya indicada.',false,true,array['SERVICIO'],true),
+('MAINTENANCE','Mantenimiento','Continuidad posterior; no modifica retrospectivamente la intervención principal.',false,false,array['SERVICIO','PRODUCTO'],true),
+('PRODUCT_SUPPORT','Producto de soporte','Producto domiciliario o de continuidad aprobado; nunca universal ni obligatorio por categoría.',false,false,array['PRODUCTO'],true),
+('TOPPING_ELIGIBLE','Topping elegible','Beneficio/add-on candidato sujeto a coherencia, autorización y reglas de no-descuento.',false,false,array['TOPPING'],false)
+on conflict(role_code) do update set
+ title=excluded.title,semantics=excluded.semantics,can_auto_assign=excluded.can_auto_assign,
+ requires_authorized_plan=excluded.requires_authorized_plan,allowed_entity_types=excluded.allowed_entity_types,
+ public_exposable=excluded.public_exposable;
+
+create table public.aos_wa4_process_templates_v1 (
+  template_code text primary key,
+  domain_code text not null references public.aos_knowledge_nodes_v1(code),
+  approach_code text not null references public.aos_knowledge_nodes_v1(code),
+  title text not null,
+  public_summary text not null,
+  advisor_summary text not null,
+  phase_sequence text[] not null default array['COMMERCIAL_F1_PREP_ACT','COMMERCIAL_F2_INTERVENTION','COMMERCIAL_F3_CONTINUITY'],
+  clinical_scope text not null default 'STRUCTURAL_NOT_PRESCRIPTIVE' check (clinical_scope='STRUCTURAL_NOT_PRESCRIPTIVE'),
+  price_authority text not null default 'aos_catalogo_servicios',
+  template_state text not null default 'APPROVED' check (template_state in ('DRAFT','APPROVED','RETIRED')),
+  source_code text not null default 'ZV_COMMERCIAL_ARCH_2026' references public.aos_knowledge_sources_v1(source_code),
+  evidence_note text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(domain_code,approach_code)
+);
+
+revoke all on table public.aos_wa4_process_templates_v1 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_wa4_process_templates_v1 to service_role;
+
+insert into public.aos_wa4_process_templates_v1
+(template_code,domain_code,approach_code,title,public_summary,advisor_summary,evidence_note)
+values
+('TPL_FACIAL_SKIN','DOMAIN_FACIAL','FACIAL_SKIN_SIGNATURE','Facial · Skin Signature','Proceso orientado a calidad de piel y continuidad según evaluación.','Ordena preparación, intervención de calidad cutánea y mantenimiento sin convertir el enfoque en combo fijo.','WA-4A.1B + Arquitectura Comercial Zi Vital; estructura, no prescripción.'),
+('TPL_FACIAL_HARMONY','DOMAIN_FACIAL','FACIAL_HARMONY_DESIGN','Facial · Harmony Design','Proceso orientado a armonía y soporte facial definido por evaluación.','Permite explicar intervención estructural y controles sin inferir material, dosis, ml o zonas.','WA-4A.1B + Arquitectura Comercial Zi Vital; selección clínica permanece profesional.'),
+('TPL_FACIAL_BIOREGEN','DOMAIN_FACIAL','FACIAL_BIOREGEN_FACE','Facial · BioRegen Face','Proceso orientado a regeneración y sostén progresivo según evaluación.','Ordena intervención regenerativa, control y mantenimiento sin promesas ni selección automática de activos.','WA-4A.1B + Arquitectura Comercial Zi Vital.'),
+('TPL_CORPORAL_RESET','DOMAIN_CORPORAL','CORPORAL_BODY_RESET','Corporal · Body Reset','Proceso de preparación corporal cuando corresponde al plan.','F1 puede ser protagonista; nunca presentar detox o soporte como requisito universal.','WA-4A.1B; claims detox/metabólicos permanecen review-gated.'),
+('TPL_CORPORAL_SCULPT','DOMAIN_CORPORAL','CORPORAL_SCULPT_BODY','Corporal · Sculpt Body','Proceso de contorno y reducción progresiva definido por evaluación.','Separa preparación, intervención y continuidad; no promete medidas ni rebote cero.','WA-4A.1B + Arquitectura Comercial Zi Vital.'),
+('TPL_CORPORAL_BOOTY','DOMAIN_CORPORAL','CORPORAL_SCULPT_BOOTY','Corporal · Sculpt Booty','Proceso de firmeza/proyección y calidad tisular según evaluación.','Estructura opciones sin convertir aparatología, inyectables o sesiones en obligación automática.','WA-4A.1B + Arquitectura Comercial Zi Vital.'),
+('TPL_CAPILAR_ACTIVATE','DOMAIN_CAPILAR','CAPILAR_ACTIVACION_REGENERACION','Capilar · Activación & Regeneración','Proceso capilar de activación/regeneración sujeto a evaluación profesional.','Organiza intervención y continuidad; fármacos, dosis, sesiones y activos son autoridad clínica.','WA-4A.1B; protocolos farmacológicos permanecen CLINICAL_RESTRICTED.'),
+('TPL_CAPILAR_MAINTAIN','DOMAIN_CAPILAR','CAPILAR_MANTENIMIENTO_PREVENCION','Capilar · Mantenimiento & Prevención','Proceso de continuidad capilar para sostener resultados cuando corresponde.','Permite servicios/productos de soporte sin volverlos add-ons universales.','WA-4A.1B + Arquitectura Comercial Zi Vital.')
+on conflict(template_code) do update set
+ domain_code=excluded.domain_code,approach_code=excluded.approach_code,title=excluded.title,
+ public_summary=excluded.public_summary,advisor_summary=excluded.advisor_summary,
+ phase_sequence=excluded.phase_sequence,evidence_note=excluded.evidence_note,updated_at=now();
+
+create or replace view public.aos_wa4_price_authority_v1 as
+select
+  c.id as entity_id,
+  c.tipo as entity_type,
+  c.nombre as entity_name,
+  c.categoria,
+  c.precio_base,
+  c.precio_oferta,
+  coalesce(c.precio_oferta,c.precio_base) as quote_price,
+  c.num_sesiones,
+  c.frecuencia,
+  c.updated_at as price_source_updated_at,
+  greatest(0,(current_date - c.updated_at::date))::integer as age_days,
+  case
+    when c.precio_oferta is null and c.precio_base is null then 'MISSING_PRICE'
+    when coalesce(c.precio_oferta,c.precio_base,0)<=0 then 'INVALID_NONPOSITIVE_PRICE'
+    when c.precio_base is not null and c.precio_oferta is not null and c.precio_oferta>c.precio_base then 'REVIEW_REQUIRED_OFFER_ABOVE_BASE'
+    else 'READY'
+  end as price_state,
+  case when current_date-c.updated_at::date<=180 then 'FRESH' else 'STALE_REVIEW' end as freshness_state,
+  (
+    coalesce(c.precio_oferta,c.precio_base,0)>0
+    and not (c.precio_base is not null and c.precio_oferta is not null and c.precio_oferta>c.precio_base)
+    and current_date-c.updated_at::date<=180
+  ) as ready_for_quote,
+  'aos_catalogo_servicios:'||c.id::text||':'||to_char(c.updated_at at time zone 'UTC','YYYY-MM-DD"T"HH24:MI:SS') as evidence_ref
+from public.aos_catalogo_servicios c
+where c.estado='ACTIVO' and c.tipo in ('SERVICIO','PRODUCTO');
+
+revoke all on table public.aos_wa4_price_authority_v1 from public,anon,authenticated;
+grant select on table public.aos_wa4_price_authority_v1 to service_role;
+
+create or replace view public.aos_wa4_topping_authority_v1 as
+select
+  t.id as topping_id,
+  t.nombre,
+  t.categoria_vinculada,
+  t.precio,
+  t.tipo_pago,
+  t.sesiones,
+  t.descripcion,
+  case
+    when t.precio is null or t.precio<0 then 'INVALID_PRICE'
+    when t.precio=0 then 'ZERO_PRICE_BENEFIT_CANDIDATE'
+    else 'PAID_ADDON'
+  end as benefit_mode,
+  (t.precio is not null and t.precio>=0 and t.estado='ACTIVO') as ready_for_consideration,
+  'aos_catalogo_toppings:'||t.id::text as evidence_ref
+from public.aos_catalogo_toppings t
+where t.estado='ACTIVO';
+
+revoke all on table public.aos_wa4_topping_authority_v1 from public,anon,authenticated;
+grant select on table public.aos_wa4_topping_authority_v1 to service_role;
+
+create or replace view public.aos_wa4_process_entity_context_v1 as
+select
+  m.entity_id,
+  m.entity_type,
+  m.entity_name,
+  m.category,
+  m.domain_codes,
+  m.approach_codes,
+  m.commercial_phase_codes,
+  m.clinical_lifecycle,
+  m.zi_function,
+  m.mapping_state,
+  m.confidence,
+  p.precio_base,
+  p.precio_oferta,
+  p.quote_price,
+  p.price_state,
+  p.freshness_state,
+  p.ready_for_quote,
+  p.num_sesiones,
+  p.frecuencia,
+  p.price_source_updated_at,
+  p.evidence_ref as price_evidence_ref
+from public.aos_knowledge_entity_map_v1 m
+join public.aos_wa4_price_authority_v1 p on p.entity_id=m.entity_id;
+
+revoke all on table public.aos_wa4_process_entity_context_v1 from public,anon,authenticated;
+grant select on table public.aos_wa4_process_entity_context_v1 to service_role;
+
+create or replace function public.aos_wa4_price_fingerprint_v1()
+returns text
+language sql
+security definer
+set search_path=''
+as $$
+  select md5(coalesce(string_agg(x.payload,'|' order by x.sort_key),'EMPTY'))
+  from (
+    select 'C:'||c.id::text as sort_key,
+           'C:'||c.id::text||':'||coalesce(c.precio_base::text,'NULL')||':'||coalesce(c.precio_oferta::text,'NULL')||':'||coalesce(c.updated_at::text,'NULL') as payload
+    from public.aos_catalogo_servicios c
+    where c.estado='ACTIVO' and c.tipo in ('SERVICIO','PRODUCTO')
+    union all
+    select 'T:'||t.id::text,
+           'T:'||t.id::text||':'||coalesce(t.precio::text,'NULL')||':'||coalesce(t.estado,'NULL')
+    from public.aos_catalogo_toppings t
+    where t.estado='ACTIVO'
+  ) x;
+$$;
+revoke all on function public.aos_wa4_price_fingerprint_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa4_price_fingerprint_v1() to service_role;
+
+create or replace function public.aos_wa4_quote_preview_v1(
+  p_components jsonb,
+  p_payment_mode text default 'COMPLETE',
+  p_authorized_plan boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_item jsonb;
+  v_source_type text;
+  v_source_id text;
+  v_role text;
+  v_phase text;
+  v_qty integer;
+  v_qty_text text;
+  v_ctx record;
+  v_top record;
+  v_role_policy record;
+  v_unit numeric;
+  v_subtotal numeric;
+  v_total numeric := 0;
+  v_lines jsonb := '[]'::jsonb;
+  v_phase_totals jsonb := '{"COMMERCIAL_F1_PREP_ACT":0,"COMMERCIAL_F2_INTERVENTION":0,"COMMERCIAL_F3_CONTINUITY":0}'::jsonb;
+  v_prev numeric;
+  v_mode text := upper(trim(coalesce(p_payment_mode,'')));
+  v_count integer;
+begin
+  if p_components is null or jsonb_typeof(p_components)<>'array' then
+    return jsonb_build_object('ok',false,'error','INVALID_COMPONENT_ARRAY');
+  end if;
+  v_count:=jsonb_array_length(p_components);
+  if v_count<1 or v_count>50 then
+    return jsonb_build_object('ok',false,'error','INVALID_COMPONENT_COUNT','count',v_count);
+  end if;
+  if v_mode not in ('COMPLETE','PROGRESSIVE') then
+    return jsonb_build_object('ok',false,'error','INVALID_PAYMENT_MODE');
+  end if;
+
+  for v_item in select value from jsonb_array_elements(p_components)
+  loop
+    v_source_type:=upper(trim(coalesce(v_item->>'source_type','CATALOG')));
+    v_source_id:=trim(coalesce(v_item->>'source_id',''));
+    v_role:=upper(trim(coalesce(v_item->>'role','')));
+    v_phase:=upper(trim(coalesce(v_item->>'phase_code','')));
+    v_qty_text:=trim(coalesce(v_item->>'quantity','1'));
+
+    if v_qty_text !~ '^[1-9][0-9]*$' then
+      return jsonb_build_object('ok',false,'error','INVALID_QUANTITY','source_id',v_source_id);
+    end if;
+    v_qty:=v_qty_text::integer;
+    if v_qty>100 then
+      return jsonb_build_object('ok',false,'error','QUANTITY_LIMIT','source_id',v_source_id);
+    end if;
+    if v_phase not in ('COMMERCIAL_F1_PREP_ACT','COMMERCIAL_F2_INTERVENTION','COMMERCIAL_F3_CONTINUITY') then
+      return jsonb_build_object('ok',false,'error','INVALID_PHASE','source_id',v_source_id,'phase_code',v_phase);
+    end if;
+
+    select * into v_role_policy
+    from public.aos_wa4_process_role_policy_v1 r
+    where r.role_code=v_role;
+    if v_role_policy.role_code is null then
+      return jsonb_build_object('ok',false,'error','INVALID_COMPONENT_ROLE','source_id',v_source_id,'role',v_role);
+    end if;
+    if v_role_policy.requires_authorized_plan and not p_authorized_plan then
+      return jsonb_build_object('ok',false,'error','AUTHORIZED_PLAN_REQUIRED','source_id',v_source_id,'role',v_role);
+    end if;
+
+    if v_source_type='CATALOG' then
+      if v_source_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+        return jsonb_build_object('ok',false,'error','INVALID_CATALOG_ID','source_id',v_source_id);
+      end if;
+      select * into v_ctx
+      from public.aos_wa4_process_entity_context_v1 c
+      where c.entity_id=v_source_id::uuid;
+      if v_ctx.entity_id is null then
+        return jsonb_build_object('ok',false,'error','CATALOG_ENTITY_NOT_FOUND','source_id',v_source_id);
+      end if;
+      if not (v_ctx.entity_type=any(v_role_policy.allowed_entity_types)) then
+        return jsonb_build_object('ok',false,'error','ROLE_ENTITY_TYPE_MISMATCH','source_id',v_source_id,'role',v_role,'entity_type',v_ctx.entity_type);
+      end if;
+      if not (v_phase=any(v_ctx.commercial_phase_codes)) then
+        return jsonb_build_object('ok',false,'error','PHASE_NOT_ALLOWED_FOR_ENTITY','source_id',v_source_id,'phase_code',v_phase);
+      end if;
+      if not coalesce(v_ctx.ready_for_quote,false) then
+        return jsonb_build_object('ok',false,'error','PRICE_NOT_READY','source_id',v_source_id,'price_state',v_ctx.price_state,'freshness_state',v_ctx.freshness_state);
+      end if;
+      v_unit:=v_ctx.quote_price;
+      v_subtotal:=round(v_unit*v_qty,2);
+      v_lines:=v_lines||jsonb_build_array(jsonb_build_object(
+        'source_type','CATALOG','source_id',v_source_id,'entity_type',v_ctx.entity_type,
+        'name',v_ctx.entity_name,'role',v_role,'phase_code',v_phase,'quantity',v_qty,
+        'unit_price',v_unit,'subtotal',v_subtotal,'price_evidence_ref',v_ctx.price_evidence_ref,
+        'clinical_scope_authority','AUTHORIZED_PLAN_OR_PROFESSIONAL','price_authority','aos_catalogo_servicios'
+      ));
+    elsif v_source_type='TOPPING' then
+      if v_role<>'TOPPING_ELIGIBLE' then
+        return jsonb_build_object('ok',false,'error','TOPPING_ROLE_REQUIRED','source_id',v_source_id);
+      end if;
+      select * into v_top
+      from public.aos_wa4_topping_authority_v1 t
+      where t.topping_id=v_source_id;
+      if v_top.topping_id is null then
+        return jsonb_build_object('ok',false,'error','TOPPING_NOT_FOUND','source_id',v_source_id);
+      end if;
+      if not coalesce(v_top.ready_for_consideration,false) then
+        return jsonb_build_object('ok',false,'error','TOPPING_NOT_READY','source_id',v_source_id);
+      end if;
+      v_unit:=v_top.precio;
+      v_subtotal:=round(v_unit*v_qty,2);
+      v_lines:=v_lines||jsonb_build_array(jsonb_build_object(
+        'source_type','TOPPING','source_id',v_source_id,'name',v_top.nombre,
+        'role',v_role,'phase_code',v_phase,'quantity',v_qty,'unit_price',v_unit,
+        'subtotal',v_subtotal,'benefit_mode',v_top.benefit_mode,
+        'price_evidence_ref',v_top.evidence_ref,'requires_context_approval',true,
+        'no_discount_semantics',true
+      ));
+    else
+      return jsonb_build_object('ok',false,'error','INVALID_SOURCE_TYPE','source_type',v_source_type);
+    end if;
+
+    v_total:=v_total+v_subtotal;
+    v_prev:=coalesce((v_phase_totals->>v_phase)::numeric,0);
+    v_phase_totals:=jsonb_set(v_phase_totals,array[v_phase],to_jsonb(round(v_prev+v_subtotal,2)),true);
+  end loop;
+
+  return jsonb_build_object(
+    'ok',true,
+    'currency','PEN',
+    'payment_mode',v_mode,
+    'canonical_total',round(v_total,2),
+    'phase_totals',v_phase_totals,
+    'progressive_view',case when v_mode='PROGRESSIVE' then v_phase_totals else null end,
+    'scope_preserved',true,
+    'discount_applied',false,
+    'price_fingerprint',public.aos_wa4_price_fingerprint_v1(),
+    'lines',v_lines,
+    'warnings',jsonb_build_array(
+      'Preview is read-only and does not create a quotation.',
+      'Payment mode does not alter clinical scope.',
+      'Required/alternative/dependent roles require authorized plan evidence.',
+      'Toppings are candidates only and are never auto-added.'
+    )
+  );
+end;
+$$;
+
+revoke all on function public.aos_wa4_quote_preview_v1(jsonb,text,boolean) from public,anon,authenticated;
+grant execute on function public.aos_wa4_quote_preview_v1(jsonb,text,boolean) to service_role;
+
+comment on view public.aos_wa4_price_authority_v1 is 'WA-4A.1C governed read model. Live catalog remains price authority; anomalous/stale prices fail closed.';
+comment on view public.aos_wa4_topping_authority_v1 is 'WA-4A.1C topping read model. Zero-price benefits are explicit candidates, never hidden discounts.';
+comment on table public.aos_wa4_process_templates_v1 is 'Structural Zi Vital process templates. Never patient-specific prescriptions and never price masters.';
+comment on function public.aos_wa4_quote_preview_v1(jsonb,text,boolean) is 'Private read-only quote preview. Uses live governed prices; does not create quote/payment/plan or mutate scope.';
+
+commit;

--- a/supabase/rollbacks/20260828033500_wa4a1c_treatment_pricing_architecture_v1.rollback.sql
+++ b/supabase/rollbacks/20260828033500_wa4a1c_treatment_pricing_architecture_v1.rollback.sql
@@ -1,0 +1,10 @@
+-- WA-4A.1C rollback. Does not touch canonical catalog/quotes/payments/WA-4A.1B.
+begin;
+drop function if exists public.aos_wa4_quote_preview_v1(jsonb,text,boolean);
+drop function if exists public.aos_wa4_price_fingerprint_v1();
+drop view if exists public.aos_wa4_process_entity_context_v1;
+drop view if exists public.aos_wa4_topping_authority_v1;
+drop view if exists public.aos_wa4_price_authority_v1;
+drop table if exists public.aos_wa4_process_templates_v1;
+drop table if exists public.aos_wa4_process_role_policy_v1;
+commit;


### PR DESCRIPTION
Builds the governed Zi Vital treatment/process/pricing architecture over certified WA-4A.1B semantics without creating a second price/quote/payment/plan master.

Scope:
- live catalog read-only price authority with stale/anomaly fail-closed state;
- topping authority separating paid add-ons from zero-price benefit candidates;
- 8 structural, non-prescriptive Domain/Approach process templates;
- 8 explicit component roles with no auto-assignment;
- private read-only quote preview with COMPLETE vs PROGRESSIVE phase view, scope/total preservation, no discounts and evidence fingerprints;
- exact 217-entity WA-4A.1B context reuse;
- no patient/lead/sales/REV mutation;
- no catalog/quote/payment/plan mutation;
- no Copilot/AI send/auto-reply/auto-routing activation;
- TEST-first / PROD-ready feature DDL only.

PROD discovery evidence: 167 services + 50 products; 20 active toppings; 284 quotes / 623 quote items; 7 offer-above-base price review rows; 0 active promotions, variants, service-product links or patient plan rows. Runtime catalog remains price authority; document examples never are.

Current exact head: `8354b65c5eaab022f7e4991e15ee48111205c799`.

Contract fix on this head:
- consume certified WA-4A.1B `mapping_confidence` (not nonexistent `confidence`);
- preserve WA-4A.1B `SERVICE|PRODUCT` semantics while exposing canonical catalog `SERVICIO|PRODUCTO` for pricing/role validation;
- no WA-4A.1B schema/source mutation.

Gates:
- Ascenda CI run `33139473108` = SUCCESS.
- Dedicated WA-4A.1C run `33139473110` remains QUEUED because GitHub has not assigned an eligible `self-hosted, Linux, X64, ascenda-zero-cost-v2` runner (`runner_id=0`).
- PROD readback confirms all WA-4A.1C feature objects absent; 167 services / 50 products / 20 toppings / 7 offer-above-base review rows preserved; pricing fingerprint `4f2bdff1a36dc1c621c237a8da655155` unchanged.

Merge is blocked until the dedicated exact-head DB/lint/rollback gate completes SUCCESS. WA-4B remains discovery-only until closeout.