### PR TITLE
CATALOG SEP2026 — service/topping price currency foundation

### DIFF
--- a/supabase/migrations/20260828115000_catalog_price_currency_v1.sql
+++ b/supabase/migrations/20260828115000_catalog_price_currency_v1.sql
@@ -1,0 +1,29 @@
+-- CATALOG SEP2026 — explicit price currency
+-- Business price lists now contain PEN and USD. Never infer currency from numeric value.
+begin;
+
+alter table public.aos_catalogo_servicios
+  add column if not exists moneda text not null default 'PEN';
+
+alter table public.aos_catalogo_servicios
+  drop constraint if exists aos_catalogo_servicios_moneda_check;
+alter table public.aos_catalogo_servicios
+  add constraint aos_catalogo_servicios_moneda_check
+  check (moneda in ('PEN','USD'));
+
+comment on column public.aos_catalogo_servicios.moneda is
+  'ISO-like operational price currency for precio_base/precio_oferta. Current allowed values: PEN, USD.';
+
+alter table public.aos_catalogo_toppings
+  add column if not exists moneda text not null default 'PEN';
+
+alter table public.aos_catalogo_toppings
+  drop constraint if exists aos_catalogo_toppings_moneda_check;
+alter table public.aos_catalogo_toppings
+  add constraint aos_catalogo_toppings_moneda_check
+  check (moneda in ('PEN','USD'));
+
+comment on column public.aos_catalogo_toppings.moneda is
+  'Operational price currency for topping precio. Current allowed values: PEN, USD.';
+
+commit;


### PR DESCRIPTION
Dependency reconciliation required before WA-4C canaries. The September 2026 Zi Vital service price list contains mixed PEN/USD prices (3 current Glúteos entries are USD), while the canonical catalog previously stored numeric prices without explicit currency.

This PR adds an explicit `moneda` contract to `aos_catalogo_servicios` and `aos_catalogo_toppings`, defaulting existing rows to PEN and restricting values to PEN/USD. It does not change any price, catalog item, patient, quote, payment, revenue, WhatsApp send control, or AI setting.

After exact-head CI/merge, the September CSV business-content reconciliation will update/rename 154 existing services, insert 30 current services, inactivate 13 historical services, and reconcile current toppings from 20 to 9 without deleting history. WA-4A.1B/1C/4B will then be revalidated against the new catalog shape before WA-4C resumes.