### PR TITLE
WA-4C — Railway service-role env compatibility

### DIFF
--- a/.github/workflows/ascenda-ci.yml
+++ b/.github/workflows/ascenda-ci.yml
@@ -78,6 +78,16 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (Test-Path 'app/server-f4.js') { node --check app/server-f4.js }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (Test-Path 'app/server-wa4.js') { node --check app/server-wa4.js }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (Test-Path 'app/email-runtime-env-compat.cjs') { node --check app/email-runtime-env-compat.cjs }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: WA-4C Railway service-role env compatibility
+        shell: powershell
+        run: |
+          node ci/wa4c-runtime/env-compat.test.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Check public JavaScript syntax
         shell: powershell

--- a/app/email-runtime-env-compat.cjs
+++ b/app/email-runtime-env-compat.cjs
@@ -1,10 +1,14 @@
 'use strict'
 
-// Backend-only compatibility for the legacy Cartero transactional Email worker.
-// F4 strips SUPABASE_SERVICE_ROLE_KEY before spawning its legacy child, while
-// server.js/email-gateway already support `service_role` as the Railway alias.
-// Copy only inside the server process environment; no secret value is logged,
-// committed, serialized, or exposed to browser code.
+// Backend-only compatibility for Railway/Supabase service-role naming.
+// Existing Ascenda runtimes consume both the canonical
+// SUPABASE_SERVICE_ROLE_KEY name and the legacy Railway `service_role` alias.
+// Normalize only inside the server process environment; never log, serialize,
+// commit, or expose either secret value to browser code.
+// Preserve an explicitly configured value when both names already exist.
+if (!process.env.SUPABASE_SERVICE_ROLE_KEY && process.env.service_role) {
+  process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.service_role
+}
 if (!process.env.service_role && process.env.SUPABASE_SERVICE_ROLE_KEY) {
   process.env.service_role = process.env.SUPABASE_SERVICE_ROLE_KEY
 }

--- a/ci/wa4c-runtime/env-compat.test.js
+++ b/ci/wa4c-runtime/env-compat.test.js
@@ -1,0 +1,24 @@
+'use strict';
+const assert=require('assert');
+const path=require('path');
+const mod=path.resolve(__dirname,'../../app/email-runtime-env-compat.cjs');
+
+function run(env){
+  const prev={canonical:process.env.SUPABASE_SERVICE_ROLE_KEY,alias:process.env.service_role};
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.service_role;
+  if(Object.prototype.hasOwnProperty.call(env,'canonical'))process.env.SUPABASE_SERVICE_ROLE_KEY=env.canonical;
+  if(Object.prototype.hasOwnProperty.call(env,'alias'))process.env.service_role=env.alias;
+  delete require.cache[require.resolve(mod)];
+  require(mod);
+  const out={canonical:process.env.SUPABASE_SERVICE_ROLE_KEY,alias:process.env.service_role};
+  if(prev.canonical===undefined)delete process.env.SUPABASE_SERVICE_ROLE_KEY;else process.env.SUPABASE_SERVICE_ROLE_KEY=prev.canonical;
+  if(prev.alias===undefined)delete process.env.service_role;else process.env.service_role=prev.alias;
+  return out;
+}
+
+assert.deepStrictEqual(run({alias:'alias-secret'}),{canonical:'alias-secret',alias:'alias-secret'});
+assert.deepStrictEqual(run({canonical:'canonical-secret'}),{canonical:'canonical-secret',alias:'canonical-secret'});
+assert.deepStrictEqual(run({canonical:'canonical-secret',alias:'alias-secret'}),{canonical:'canonical-secret',alias:'alias-secret'});
+assert.deepStrictEqual(run({}),{canonical:undefined,alias:undefined});
+console.log('WA4C_ENV_COMPAT_PASS');


### PR DESCRIPTION
WA-4C runtime canary found a real production blocker: Railway runtime is healthy and Auth/2FA fails closed correctly, but `/api/wa4/health` reports `GROQ_KEY_NOT_CONFIGURED` because WA-4 reads only `SUPABASE_SERVICE_ROLE_KEY` while the established Railway alias is `service_role`.

This PR:
- normalizes `service_role -> SUPABASE_SERVICE_ROLE_KEY` and the reverse alias without overwriting explicitly configured values;
- keeps the mapping backend-only and never logs/serializes the secret;
- adds a focused four-case WA-4C env compatibility test;
- adds the compatibility test and WA-4 syntax/preload syntax checks to Ascenda CI.

Observed pre-fix runtime evidence:
- Railway `/health` HTTP 200: child chain alive/ready;
- `/api/wa4/health` HTTP 200 but `configured=false`, `copilot_ready=false`, `GROQ_KEY_NOT_CONFIGURED`;
- `/api/wa4/bootstrap` without token -> 403 `WA4_2FA_PANEL_REQUIRED`;
- `/api/wa4/.../suggest` without token -> 403 `WA4_2FA_PANEL_REQUIRED`.

Safety: no Copilot activation, no auto-reply, no auto-routing, no autonomous send. WA-4C remains fail-closed until exact-head CI + Railway deploy + fresh model-health canary pass.