### PR TITLE
WA-4C — Canary and commercial-data readiness hardening

### DIFF
--- a/.github/workflows/wa4a1-zivital-governed-knowledge.yml
+++ b/.github/workflows/wa4a1-zivital-governed-knowledge.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
     paths:
       - 'app/wa4-knowledge.js'
+      - 'app/wa4-copilot.js'
       - 'supabase/migrations/*wa4a1_zivital_*'
       - 'supabase/rollbacks/*wa4a1_zivital_*'
+      - 'supabase/migrations/*wa4c_included_benefit_knowledge_v3*'
+      - 'supabase/rollbacks/*wa4c_included_benefit_knowledge_v3*'
       - 'ci/wa4a1-zivital-knowledge/**'
       - 'docs/control/WHATSAPP_WA4A1_*'
       - '.github/workflows/wa4a1-zivital-governed-knowledge.yml'
@@ -49,6 +52,7 @@ jobs:
           set -euo pipefail
           M=supabase/migrations/20260828001500_wa4a1_zivital_governed_knowledge_v1.sql
           H=supabase/migrations/20260828001600_wa4a1_zivital_audience_search_isolation_v1.sql
+          V3=supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
           grep -q 'PUBLIC_CLIENT' "$M"
           grep -q 'ADVISOR_INTERNAL' "$M"
           grep -q 'OWNER_ADMIN' "$M"
@@ -60,10 +64,14 @@ jobs:
           grep -q 'CLINICAL_REVIEW_REQUIRED' "$M"
           grep -q "when 'PUBLIC_CLIENT' then n.public_client" "$H"
           grep -q "when 'CLINICAL_RESTRICTED' then n.clinical_restricted" "$H"
-          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M" "$H"
-          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M" "$H"
+          grep -q 'aos_wa4a_knowledge_search_v2' "$V3"
+          grep -q "b.domain='CATALOG'" "$V3"
+          grep -q 'CATALOG_SEP2026_CURRENT_SKU' "$V3"
+          ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M" "$H" "$V3"
+          ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M" "$H" "$V3"
           ! grep -q 'aos_wa4a_knowledge_search_v2' app/server-wa4.js
-          grep -q 'aos_wa4a_knowledge_search_v2' app/wa4-copilot.js
+          grep -q 'aos_wa4a_knowledge_search_v3' app/wa4-copilot.js
+          ! grep -q 'aos_wa4a_knowledge_search_v2' app/wa4-copilot.js
           ! grep -q '/rest/v1/aos_catalogo_servicios' app/wa4-copilot.js
           ! grep -q '/rest/v1/aos_promociones' app/wa4-copilot.js
 

--- a/.github/workflows/wa4b-sales-playbook-engine.yml
+++ b/.github/workflows/wa4b-sales-playbook-engine.yml
@@ -48,6 +48,7 @@ jobs:
           set -euo pipefail
           node --test ci/wa4b-sales-playbook/wa4-playbook.test.js
           node --test ci/wa4b-sales-playbook/wa4-copilot-grounding.test.js
+          node --test ci/wa4b-sales-playbook/wa4c-data-boundary.test.js
 
       - name: Knowledge and router regressions
         run: |
@@ -66,6 +67,9 @@ jobs:
           grep -q "send_authority:'HUMAN_ONLY'" app/wa4-playbook.js
           grep -q "generic_llm_authority:false" app/wa4-playbook.js
           grep -q 'PUBLIC_INFO_EVIDENCE_INSUFFICIENT' app/wa4-playbook.js
+          grep -q 'included_benefit' app/wa4-knowledge.js
+          grep -q 'catalog_identity' app/wa4-knowledge.js
+          grep -q 'CATALOG_IDENTITY_ALLOWLIST' app/wa4-knowledge.js
           grep -q 'RULE_QUOTE_PROCESS' app/wa4-playbook.js
           grep -q 'RULE_PAYMENT_SCENARIOS' app/wa4-playbook.js
           grep -q 'RULE_ETHICAL_UPSELL' app/wa4-playbook.js
@@ -75,17 +79,22 @@ jobs:
           ! grep -Eiq '(auto_send|ai_send|auto_reply|auto_routing)[[:space:]]*[:=][[:space:]]*true' app/wa4-playbook.js app/wa4-copilot.js
           ! grep -Eiq 'graph\.facebook\.com|WHATSAPP_ACCESS_TOKEN' app/wa4-playbook.js app/wa4-copilot.js
 
-      - name: WA-4C included-benefit source invariants
+      - name: WA-4C catalog lineage invariants
         run: |
           set -euo pipefail
           M3=supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
           R3=supabase/rollbacks/20260828235500_wa4c_included_benefit_knowledge_v3.rollback.sql
           grep -q 'aos_wa4a_knowledge_search_v2' "$M3"
           grep -q "catalog_sep2026,gift_raw" "$M3"
-          grep -q "included_benefit" "$M3"
-          grep -q "CATALOG_SEP2026_CURRENT_SKU" "$M3"
+          grep -q "treatment_identity,source" "$M3"
+          grep -q 'SEP2026_PRICE_LIST' "$M3"
+          grep -q "treatment_identity,current_status" "$M3"
+          grep -q "treatment_identity,public_catalog" "$M3"
+          grep -q 'included_benefit' "$M3"
+          grep -q 'catalog_identity' "$M3"
+          grep -q 'CATALOG_SEP2026_CURRENT_SKU' "$M3"
           grep -q 'to service_role' "$M3"
-          ! grep -q 'aos_promociones' "$M3"
+          ! grep -Eq 'body_area|indication|aliases|active_or_technology|aos_promociones' "$M3"
           grep -q 'drop function if exists public.aos_wa4a_knowledge_search_v3' "$R3"
 
       - name: Certified upstream contract references
@@ -104,4 +113,4 @@ jobs:
           grep -q 'aos_wa4_process_entity_context_v1' "$M2"
           grep -q 'aos_wa4_quote_preview_v1' "$M2"
           grep -q 'STRUCTURAL_NOT_PRESCRIPTIVE' "$M2"
-          echo 'WA-4C READINESS CANDIDATE: governed v3 included benefits + deterministic INFO fail-closed + seven official canary contracts; HUMAN_ONLY send.'
+          echo 'WA-4C READINESS CANDIDATE: governed v3 included benefits + allowlisted CURRENT SKU identity + deterministic INFO fail-closed + seven official canary contracts; HUMAN_ONLY send.'

--- a/.github/workflows/wa4b-sales-playbook-engine.yml
+++ b/.github/workflows/wa4b-sales-playbook-engine.yml
@@ -8,6 +8,8 @@ on:
       - 'app/wa4-copilot.js'
       - 'app/server-wa4.js'
       - 'app/wa4-knowledge.js'
+      - 'supabase/migrations/*wa4c_included_benefit_knowledge_v3*'
+      - 'supabase/rollbacks/*wa4c_included_benefit_knowledge_v3*'
       - 'ci/wa4b-sales-playbook/**'
       - 'docs/control/WHATSAPP_WA4B_*'
       - '.github/workflows/wa4b-sales-playbook-engine.yml'
@@ -57,11 +59,13 @@ jobs:
       - name: Authority and safe-off invariants
         run: |
           set -euo pipefail
-          grep -q 'aos_wa4a_knowledge_search_v2' app/wa4-copilot.js
+          grep -q 'aos_wa4a_knowledge_search_v3' app/wa4-copilot.js
+          ! grep -q 'aos_wa4a_knowledge_search_v2' app/wa4-copilot.js
           grep -q 'aos_wa4_process_entity_context_v1' app/wa4-copilot.js
           grep -q "price_authority:'WA4A1C_ONLY'" app/wa4-copilot.js
           grep -q "send_authority:'HUMAN_ONLY'" app/wa4-playbook.js
           grep -q "generic_llm_authority:false" app/wa4-playbook.js
+          grep -q 'PUBLIC_INFO_EVIDENCE_INSUFFICIENT' app/wa4-playbook.js
           grep -q 'RULE_QUOTE_PROCESS' app/wa4-playbook.js
           grep -q 'RULE_PAYMENT_SCENARIOS' app/wa4-playbook.js
           grep -q 'RULE_ETHICAL_UPSELL' app/wa4-playbook.js
@@ -70,6 +74,19 @@ jobs:
           ! grep -q '/rest/v1/aos_promociones' app/wa4-copilot.js
           ! grep -Eiq '(auto_send|ai_send|auto_reply|auto_routing)[[:space:]]*[:=][[:space:]]*true' app/wa4-playbook.js app/wa4-copilot.js
           ! grep -Eiq 'graph\.facebook\.com|WHATSAPP_ACCESS_TOKEN' app/wa4-playbook.js app/wa4-copilot.js
+
+      - name: WA-4C included-benefit source invariants
+        run: |
+          set -euo pipefail
+          M3=supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
+          R3=supabase/rollbacks/20260828235500_wa4c_included_benefit_knowledge_v3.rollback.sql
+          grep -q 'aos_wa4a_knowledge_search_v2' "$M3"
+          grep -q "catalog_sep2026,gift_raw" "$M3"
+          grep -q "included_benefit" "$M3"
+          grep -q "CATALOG_SEP2026_CURRENT_SKU" "$M3"
+          grep -q 'to service_role' "$M3"
+          ! grep -q 'aos_promociones' "$M3"
+          grep -q 'drop function if exists public.aos_wa4a_knowledge_search_v3' "$R3"
 
       - name: Certified upstream contract references
         run: |
@@ -87,4 +104,4 @@ jobs:
           grep -q 'aos_wa4_process_entity_context_v1' "$M2"
           grep -q 'aos_wa4_quote_preview_v1' "$M2"
           grep -q 'STRUCTURAL_NOT_PRESCRIPTIVE' "$M2"
-          echo 'WA-4B TEST CERTIFIED BOUNDARY CANDIDATE: governed advisor orchestration only; HUMAN_ONLY send; PROD knowledge/1C promotion remains separate.'
+          echo 'WA-4C READINESS CANDIDATE: governed v3 included benefits + deterministic INFO fail-closed + seven official canary contracts; HUMAN_ONLY send.'

--- a/app/wa4-copilot.js
+++ b/app/wa4-copilot.js
@@ -10,7 +10,7 @@ function lastInbound(ms){ for(let i=ms.length-1;i>=0;i--)if(String(ms[i].directi
 function history(ms,max){ return ms.slice(-max).map(m=>({role:String(m.direction||'').toUpperCase().includes('IN')?'user':'assistant',content:ai.redactPII(String(m.message_body||'').slice(0,1800))})).filter(m=>m.content.trim()); }
 
 async function searchKnowledge(serviceRpc,query,audience,limit,domains){
-  const out=await serviceRpc('aos_wa4a_knowledge_search_v2',{
+  const out=await serviceRpc('aos_wa4a_knowledge_search_v3',{
     p_query:String(query||''),p_audience:String(audience||'PUBLIC_CLIENT'),
     p_limit:Math.max(1,Math.min(Number(limit||12),24)),p_domains:Array.isArray(domains)?domains:null
   });

--- a/app/wa4-knowledge.js
+++ b/app/wa4-knowledge.js
@@ -6,9 +6,13 @@
 const AUDIENCES = Object.freeze(new Set([
   'PUBLIC_CLIENT','ADVISOR_INTERNAL','OWNER_ADMIN','CLINICAL_RESTRICTED','SYSTEM_REFERENCE'
 ]));
+const SEP26_CURRENT_SKU = 'CATALOG_SEP2026_CURRENT_SKU';
+const CATALOG_IDENTITY_ALLOWLIST = Object.freeze(new Set([
+  'family_name','commercial_variant','clinical_sessions','brand','zones','unit_cap','syringes','volume_ml'
+]));
 
 const FIELD_ALLOWLIST = Object.freeze({
-  CATALOG: new Set(['tipo','nombre','nombre_corto','categoria','precio_base','precio_oferta','moneda','duracion_sesion','num_sesiones','frecuencia','descripcion_comercial','beneficios','faqs','requiere_doctora','requiere_enfermeria']),
+  CATALOG: new Set(['tipo','nombre','nombre_corto','categoria','precio_base','precio_oferta','moneda','duracion_sesion','num_sesiones','frecuencia','descripcion_comercial','beneficios','faqs','requiere_doctora','requiere_enfermeria','included_benefit','included_benefit_source','catalog_identity','catalog_identity_source']),
   PROMOTION: new Set(['nombre','descripcion','tipo_descuento','valor_descuento','tratamientos','segmentos','codigo','vigencia_inicio','vigencia_fin']),
   BRANCH: new Set(['nombre','direccion','telefono','maps_link']),
   HOURS: new Set(['sede','dia_semana','hora_apertura','hora_cierre','activo']),
@@ -25,11 +29,50 @@ function normalizeAudience(value) {
   return AUDIENCES.has(audience) ? audience : 'PUBLIC_CLIENT';
 }
 
+function sanitizeCatalogIdentity(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const out = {};
+  for (const key of CATALOG_IDENTITY_ALLOWLIST) {
+    if (!Object.prototype.hasOwnProperty.call(value,key)) continue;
+    if (['family_name','commercial_variant','brand'].includes(key)) {
+      const text = String(value[key] == null ? '' : value[key]).trim();
+      if (text) out[key] = text.slice(0,180);
+      continue;
+    }
+    const n = Number(value[key]);
+    if (Number.isFinite(n) && n > 0 && n <= 10000) out[key] = n;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 function sanitizeFacts(domain, facts) {
   const allowed = FIELD_ALLOWLIST[String(domain || '').toUpperCase()];
   if (!allowed || !facts || typeof facts !== 'object' || Array.isArray(facts)) return {};
   const out = {};
-  for (const key of allowed) if (Object.prototype.hasOwnProperty.call(facts,key)) out[key] = facts[key];
+  for (const key of allowed) {
+    if (!Object.prototype.hasOwnProperty.call(facts,key)) continue;
+    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'included_benefit') {
+      if (facts.included_benefit_source !== SEP26_CURRENT_SKU) continue;
+      const text = String(facts[key] == null ? '' : facts[key]).trim();
+      if (text) out[key] = text.slice(0,500);
+      continue;
+    }
+    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'included_benefit_source') {
+      if (facts[key] === SEP26_CURRENT_SKU) out[key] = SEP26_CURRENT_SKU;
+      continue;
+    }
+    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'catalog_identity') {
+      if (facts.catalog_identity_source !== SEP26_CURRENT_SKU) continue;
+      const identity = sanitizeCatalogIdentity(facts[key]);
+      if (identity) out[key] = identity;
+      continue;
+    }
+    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'catalog_identity_source') {
+      if (facts[key] === SEP26_CURRENT_SKU) out[key] = SEP26_CURRENT_SKU;
+      continue;
+    }
+    out[key] = facts[key];
+  }
   return out;
 }
 
@@ -154,4 +197,4 @@ function validateGroundedSuggestion(obj, bundle) {
   return {ok:true,reply,citations,nextAction};
 }
 
-module.exports = {AUDIENCES,FIELD_ALLOWLIST,normalize,normalizeAudience,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};
+module.exports = {AUDIENCES,SEP26_CURRENT_SKU,CATALOG_IDENTITY_ALLOWLIST,FIELD_ALLOWLIST,normalize,normalizeAudience,sanitizeCatalogIdentity,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};

--- a/app/wa4-playbook.js
+++ b/app/wa4-playbook.js
@@ -117,6 +117,15 @@ function contextById(rows) {
   return map;
 }
 
+function publicInfoEvidenceReady(item) {
+  if (!item || item.domain !== 'CATALOG' || !catalogId(item)) return true;
+  const f = item.facts || {};
+  const description = String(f.descripcion_comercial || '').trim();
+  const benefits = String(f.beneficios || '').trim();
+  const faqs = Array.isArray(f.faqs) ? f.faqs : [];
+  return description.length > 0 || benefits.length > 0 || faqs.length > 0;
+}
+
 function stageGuidance(stage) {
   switch (stage) {
     case 'PRICE_QUOTE': return {
@@ -211,6 +220,21 @@ function buildPlaybook(input) {
     };
   }
 
+  if (stage === 'INFO') {
+    const primaryCatalog = publicItems.find(x => x && x.domain === 'CATALOG' && catalogId(x));
+    if (primaryCatalog && !publicInfoEvidenceReady(primaryCatalog)) {
+      return {
+        version:'WA4B-PLAYBOOK-V1',status:'FAIL_CLOSED',commercial_stage:stage,objective:g.objective,
+        recommended_next_action:'HUMAN_COMMERCIAL',advisor_talking_points:g.talking,
+        public_safe_knowledge_ids:publicItems.map(x=>String(x.knowledge_id)),objection_strategy:g.objection,
+        quote_or_payment_context:null,continuity_candidates:[],clinical_escalation:{required:false,reason:null},
+        policy_escalation:{required:true,reason:'PUBLIC_INFO_EVIDENCE_INSUFFICIENT',knowledge_id:String(primaryCatalog.knowledge_id)},
+        evidence_refs:uniqueItems([...advisorItems,...publicItems]).map(evidenceRef).filter(Boolean),
+        freshness_state:freshnessState([...advisorItems,...publicItems],processContexts),send_authority:'HUMAN_ONLY',auto_send:false
+      };
+    }
+  }
+
   const ids = uniqueItems([...publicItems,...advisorItems]).map(catalogId).filter(Boolean);
   const byId = contextById(processContexts);
   const matched = ids.map(id => byId.get(id)).filter(Boolean);
@@ -292,5 +316,5 @@ function promptContext(playbook) {
 
 module.exports = {
   RULE_TITLES,RULES_BY_STAGE,normalize,classifyStage,requiredRuleCodes,ruleSearchQueries,
-  mergeBundles,buildPlaybook,promptContext,catalogId,ruleId
+  mergeBundles,buildPlaybook,promptContext,catalogId,ruleId,publicInfoEvidenceReady
 };

--- a/ci/wa4a-knowledge-fabric/wa4-knowledge.test.js
+++ b/ci/wa4a-knowledge-fabric/wa4-knowledge.test.js
@@ -36,6 +36,35 @@ test('bundle keeps only ready evidence and strips clinical/non-allowlisted field
   assert.equal(b.items[1].facts.horario_lv,undefined);
 });
 
+test('SEP26 included benefit and safe SKU identity survive adapter while unsafe nested fields are stripped',()=>{
+  const row={...readyCatalog,knowledge_id:'service:sep26',facts:{...readyCatalog.facts,
+    included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU',
+    catalog_identity_source:'CATALOG_SEP2026_CURRENT_SKU',
+    catalog_identity:{family_name:'HIFU',commercial_variant:'HIFUTOX',clinical_sessions:1,brand:'HUTOX',zones:3,unit_cap:50,syringes:1,volume_ml:5,body_area:'NO PASAR',indication:'NO PASAR',aliases:['NO PASAR'],active_or_technology:'NO PASAR'}
+  }};
+  const b=k.buildKnowledgeBundle([row],12,'PUBLIC_CLIENT');
+  const f=b.items[0].facts;
+  assert.equal(f.included_benefit,'1 sesión LED');
+  assert.equal(f.included_benefit_source,'CATALOG_SEP2026_CURRENT_SKU');
+  assert.deepEqual(f.catalog_identity,{family_name:'HIFU',commercial_variant:'HIFUTOX',clinical_sessions:1,brand:'HUTOX',zones:3,unit_cap:50,syringes:1,volume_ml:5});
+  assert.equal(f.catalog_identity.body_area,undefined);
+  assert.equal(f.catalog_identity.indication,undefined);
+  assert.equal(f.catalog_identity.aliases,undefined);
+  assert.equal(f.catalog_identity.active_or_technology,undefined);
+});
+
+test('SEP26 facts require the exact canonical source marker',()=>{
+  const row={...readyCatalog,knowledge_id:'service:untrusted-source',facts:{...readyCatalog.facts,
+    included_benefit:'REGALO INVENTADO',included_benefit_source:'OTHER_SOURCE',
+    catalog_identity:{family_name:'X',commercial_variant:'Y',clinical_sessions:1},catalog_identity_source:'OTHER_SOURCE'
+  }};
+  const f=k.buildKnowledgeBundle([row],12,'PUBLIC_CLIENT').items[0].facts;
+  assert.equal(f.included_benefit,undefined);
+  assert.equal(f.included_benefit_source,undefined);
+  assert.equal(f.catalog_identity,undefined);
+  assert.equal(f.catalog_identity_source,undefined);
+});
+
 test('valid cited governed price passes',()=>{
   const b=k.buildKnowledgeBundle([readyCatalog],12);
   const out=k.validateGroundedSuggestion({reply:'El precio aprobado es S/ 450.',next_action:'REPLY',cited_knowledge_ids:['service:1']},b);

--- a/ci/wa4b-sales-playbook/wa4-copilot-grounding.test.js
+++ b/ci/wa4b-sales-playbook/wa4-copilot-grounding.test.js
@@ -5,7 +5,7 @@ const c=require('../../app/wa4-copilot');
 const k=require('../../app/wa4-knowledge');
 
 const ID='33333333-3333-4333-8333-333333333333';
-function bundle(){return {version:'T',audience:'PUBLIC_CLIENT',authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false,items:[{knowledge_id:'service:'+ID,domain:'CATALOG',title:'Servicio',facts:{tipo:'SERVICIO',nombre:'Servicio',precio_base:500,precio_oferta:450,descripcion_comercial:'Aprobada'},authority_tier:10,freshness_state:'FRESH',conflict_state:'CLEAR',retrieval_state:'READY',evidence_ref:{relation:'public.aos_catalogo_servicios',pk:ID,version:'v1'}}]};}
+function bundle(){return {version:'T',audience:'PUBLIC_CLIENT',authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false,items:[{knowledge_id:'service:'+ID,domain:'CATALOG',title:'Servicio',facts:{tipo:'SERVICIO',nombre:'Servicio',precio_base:500,precio_oferta:450,descripcion_comercial:'Aprobada',included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU'},authority_tier:10,freshness_state:'FRESH',conflict_state:'CLEAR',retrieval_state:'READY',evidence_ref:{relation:'public.aos_catalogo_servicios',pk:ID,version:'v1'}}]};}
 function ctx(ready,moneda='PEN',base=500,offer=450){return [{entity_id:ID,precio_base:base,precio_oferta:offer,moneda,quote_price:offer,ready_for_quote:ready,price_state:ready?'READY':'REVIEW_REQUIRED_OFFER_ABOVE_BASE',freshness_state:'FRESH'}];}
 
 test('non-price stage strips catalog money and currency before model and validator',()=>{
@@ -57,4 +57,13 @@ test('missing 1C context strips prices instead of falling back to raw catalog',(
   const b=c.gatePublicCatalogMoney(bundle(),[],'PRICE_QUOTE');
   assert.equal(b.items[0].facts.precio_base,undefined);
   assert.equal(b.items[0].facts.precio_oferta,undefined);
+});
+
+test('canonical included benefit survives both non-price and price money gates',()=>{
+  const info=c.gatePublicCatalogMoney(bundle(),ctx(true),'INFO');
+  const price=c.gatePublicCatalogMoney(bundle(),ctx(true,'PEN'),'PRICE_QUOTE');
+  for(const b of [info,price]){
+    assert.equal(b.items[0].facts.included_benefit,'1 sesión LED');
+    assert.equal(b.items[0].facts.included_benefit_source,'CATALOG_SEP2026_CURRENT_SKU');
+  }
 });

--- a/ci/wa4b-sales-playbook/wa4-playbook.test.js
+++ b/ci/wa4b-sales-playbook/wa4-playbook.test.js
@@ -12,8 +12,14 @@ function item(id,domain,title,facts,audience){
 }
 function bundle(audience,items){return {version:'T',audience,items,authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false};}
 function rule(code){return item('clinic:'+code,'CLINIC_KNOWLEDGE',code,{answer:'Regla aprobada',audience:'ADVISOR_INTERNAL'},'ADVISOR_INTERNAL');}
-function catalog(id,name,price){return item('service:'+id,'CATALOG',name,{tipo:'SERVICIO',nombre:name,precio_base:price,precio_oferta:price,descripcion_comercial:'Descripción aprobada'});}
+function catalog(id,name,price,extra){return item('service:'+id,'CATALOG',name,Object.assign({tipo:'SERVICIO',nombre:name,precio_base:price,precio_oferta:price,descripcion_comercial:'Descripción aprobada'},extra||{}));}
+function thinCatalog(id,name,price,extra){return item('service:'+id,'CATALOG',name,Object.assign({tipo:'SERVICIO',nombre:name,precio_base:price,precio_oferta:price,descripcion_comercial:'',beneficios:'',faqs:[]},extra||{}));}
 function ctx(id,type,name,price,ready=true,moneda='PEN'){return {entity_id:id,entity_type:type,entity_name:name,commercial_phase_codes:type==='PRODUCTO'?['COMMERCIAL_F3_CONTINUITY']:['COMMERCIAL_F2_INTERVENTION'],quote_price:price,moneda,price_state:ready?'READY':'REVIEW_REQUIRED_OFFER_ABOVE_BASE',freshness_state:'FRESH',ready_for_quote:ready,price_evidence_ref:'aos_catalogo_servicios:'+id+':'+moneda+':v1'};}
+
+function assertSafe(out){
+  assert.equal(out.send_authority,'HUMAN_ONLY');
+  assert.equal(out.auto_send,false);
+}
 
 test('stage classifier separates quote, payment, objection, continuity, booking and clinical escalation',()=>{
   assert.equal(p.classifyStage('¿Cuánto cuesta el tratamiento?'),'PRICE_QUOTE');
@@ -28,8 +34,7 @@ test('clinical risk is deterministic human-only and does not require business ev
   const out=p.buildPlaybook({inbound:'Estoy embarazada, ¿puedo hacerlo?',clinicalRisk:true});
   assert.equal(out.status,'READY');
   assert.equal(out.recommended_next_action,'HUMAN_CLINICAL');
-  assert.equal(out.send_authority,'HUMAN_ONLY');
-  assert.equal(out.auto_send,false);
+  assertSafe(out);
   assert.equal(out.evidence_refs.length,0);
 });
 
@@ -42,8 +47,7 @@ test('price playbook is ready only with governed rules plus 1C ready price+curre
   assert.equal(out.quote_or_payment_context[0].quote_price,450);
   assert.equal(out.quote_or_payment_context[0].currency,'PEN');
   assert.equal(out.quote_or_payment_context[0].entity_id,SERVICE_ID);
-  assert.equal(out.send_authority,'HUMAN_ONLY');
-  assert.equal(out.auto_send,false);
+  assertSafe(out);
 });
 
 test('USD price context keeps USD explicit',()=>{
@@ -53,6 +57,7 @@ test('USD price context keeps USD explicit',()=>{
   assert.equal(out.status,'READY');
   assert.equal(out.quote_or_payment_context[0].quote_price,1699);
   assert.equal(out.quote_or_payment_context[0].currency,'USD');
+  assertSafe(out);
 });
 
 test('offer-above-base or otherwise non-ready 1C price fails closed',()=>{
@@ -62,6 +67,7 @@ test('offer-above-base or otherwise non-ready 1C price fails closed',()=>{
   assert.equal(out.status,'FAIL_CLOSED');
   assert.equal(out.recommended_next_action,'HUMAN_COMMERCIAL');
   assert.equal(out.policy_escalation.reason,'PRICE_CONTEXT_NOT_READY');
+  assertSafe(out);
 });
 
 test('missing or unsupported currency is price-context fail closed',()=>{
@@ -71,6 +77,7 @@ test('missing or unsupported currency is price-context fail closed',()=>{
     const out=p.buildPlaybook({inbound:'precio SERVICIO TEST',publicBundle,advisorBundle,processContexts:[ctx(SERVICE_ID,'SERVICIO','SERVICIO TEST',450,true,moneda)]});
     assert.equal(out.status,'FAIL_CLOSED');
     assert.equal(out.policy_escalation.reason,'PRICE_CONTEXT_NOT_READY');
+    assertSafe(out);
   }
 });
 
@@ -81,6 +88,25 @@ test('missing governed commercial rule fails closed instead of using generic LLM
   assert.equal(out.status,'FAIL_CLOSED');
   assert.equal(out.policy_escalation.reason,'GOVERNED_RULE_EVIDENCE_REQUIRED');
   assert.deepEqual(out.policy_escalation.missing_rule_codes,['RULE_MEDICAL_PLAN_TO_COMMERCIAL']);
+  assertSafe(out);
+});
+
+test('INFO fails closed for a thin catalog row even when price and included benefit exist',()=>{
+  const thin=thinCatalog(SERVICE_ID,'SERVICIO PARCIAL',699,{included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU'});
+  const out=p.buildPlaybook({inbound:'¿Qué es SERVICIO PARCIAL?',publicBundle:bundle('PUBLIC_CLIENT',[thin]),advisorBundle:bundle('ADVISOR_INTERNAL',[thin]),processContexts:[]});
+  assert.equal(out.status,'FAIL_CLOSED');
+  assert.equal(out.recommended_next_action,'HUMAN_COMMERCIAL');
+  assert.equal(out.policy_escalation.reason,'PUBLIC_INFO_EVIDENCE_INSUFFICIENT');
+  assertSafe(out);
+});
+
+test('INFO accepts service-specific public description and preserves canonical included benefit as evidence fact',()=>{
+  const rich=catalog(SERVICE_ID,'SERVICIO INFO',699,{included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU'});
+  const out=p.buildPlaybook({inbound:'¿Qué es SERVICIO INFO?',publicBundle:bundle('PUBLIC_CLIENT',[rich]),advisorBundle:bundle('ADVISOR_INTERNAL',[rich]),processContexts:[]});
+  assert.equal(out.status,'READY');
+  assert.equal(out.commercial_stage,'INFO');
+  assert.equal(rich.facts.included_benefit,'1 sesión LED');
+  assertSafe(out);
 });
 
 test('promotion intent cannot manufacture a promotion when READY promo evidence is absent',()=>{
@@ -89,10 +115,11 @@ test('promotion intent cannot manufacture a promotion when READY promo evidence 
   const out=p.buildPlaybook({inbound:'¿Hay alguna promoción?',publicBundle,advisorBundle,processContexts:[]});
   assert.equal(out.status,'FAIL_CLOSED');
   assert.equal(out.policy_escalation.reason,'NO_READY_PROMOTION_EVIDENCE');
+  assertSafe(out);
 });
 
 test('continuity exposes only governed F3 product candidates and never auto-adds',()=>{
-  const prod=item('service:'+PRODUCT_ID,'CATALOG','PRODUCTO TEST',{tipo:'PRODUCTO',nombre:'PRODUCTO TEST',precio_base:99,precio_oferta:99});
+  const prod=item('service:'+PRODUCT_ID,'CATALOG','PRODUCTO TEST',{tipo:'PRODUCTO',nombre:'PRODUCTO TEST',precio_base:99,precio_oferta:99,descripcion_comercial:'Producto aprobado'});
   const publicBundle=bundle('PUBLIC_CLIENT',[prod]);
   const advisorBundle=bundle('ADVISOR_INTERNAL',[prod,rule('RULE_ETHICAL_UPSELL'),rule('RULE_PRODUCTS_AS_EXTENSION')]);
   const out=p.buildPlaybook({inbound:'¿Qué producto uso después para mantenimiento?',publicBundle,advisorBundle,processContexts:[ctx(PRODUCT_ID,'PRODUCTO','PRODUCTO TEST',99)]});
@@ -100,7 +127,59 @@ test('continuity exposes only governed F3 product candidates and never auto-adds
   assert.equal(out.continuity_candidates.length,1);
   assert.equal(out.continuity_candidates[0].role,'PRODUCT_SUPPORT_CANDIDATE');
   assert.equal(out.continuity_candidates[0].auto_add,false);
-  assert.equal(out.send_authority,'HUMAN_ONLY');
+  assertSafe(out);
+});
+
+test('WA-4C official canary matrix is frozen before LIVE execution',()=>{
+  const service=catalog(SERVICE_ID,'SERVICIO CANARY',450,{beneficios:'Beneficio comercial aprobado'});
+  const product=item('service:'+PRODUCT_ID,'CATALOG','PRODUCTO CANARY',{tipo:'PRODUCTO',nombre:'PRODUCTO CANARY',descripcion_comercial:'Producto de continuidad aprobado',precio_base:99,precio_oferta:99});
+  const cases=[
+    {
+      name:'INFO',
+      input:{inbound:'¿Qué es SERVICIO CANARY?',publicBundle:bundle('PUBLIC_CLIENT',[service]),advisorBundle:bundle('ADVISOR_INTERNAL',[service]),processContexts:[]},
+      expect:{status:'READY',stage:'INFO',action:'REPLY'}
+    },
+    {
+      name:'PRICE_PEN',
+      input:{inbound:'¿Cuánto cuesta SERVICIO CANARY?',publicBundle:bundle('PUBLIC_CLIENT',[service]),advisorBundle:bundle('ADVISOR_INTERNAL',[service,rule('RULE_MEDICAL_PLAN_TO_COMMERCIAL'),rule('RULE_QUOTE_PROCESS')]),processContexts:[ctx(SERVICE_ID,'SERVICIO','SERVICIO CANARY',450,true,'PEN')]},
+      expect:{status:'READY',stage:'PRICE_QUOTE',action:'REPLY',currency:'PEN'}
+    },
+    {
+      name:'PRICE_USD',
+      input:{inbound:'precio SERVICIO CANARY',publicBundle:bundle('PUBLIC_CLIENT',[service]),advisorBundle:bundle('ADVISOR_INTERNAL',[service,rule('RULE_MEDICAL_PLAN_TO_COMMERCIAL'),rule('RULE_QUOTE_PROCESS')]),processContexts:[ctx(SERVICE_ID,'SERVICIO','SERVICIO CANARY',1699,true,'USD')]},
+      expect:{status:'READY',stage:'PRICE_QUOTE',action:'REPLY',currency:'USD'}
+    },
+    {
+      name:'PAYMENT',
+      input:{inbound:'¿Se puede pagar en cuotas?',publicBundle:bundle('PUBLIC_CLIENT',[service]),advisorBundle:bundle('ADVISOR_INTERNAL',[service,rule('RULE_QUOTE_PROCESS'),rule('RULE_PAYMENT_SCENARIOS')]),processContexts:[ctx(SERVICE_ID,'SERVICIO','SERVICIO CANARY',450,true,'PEN')]},
+      expect:{status:'READY',stage:'PAYMENT',action:'REPLY',currency:'PEN'}
+    },
+    {
+      name:'OBJECTION',
+      input:{inbound:'Me parece muy caro, ¿puedo quitar una parte?',publicBundle:bundle('PUBLIC_CLIENT',[service]),advisorBundle:bundle('ADVISOR_INTERNAL',[service,rule('RULE_QUOTE_PROCESS'),rule('RULE_RECALCULATE_PROCESS')]),processContexts:[ctx(SERVICE_ID,'SERVICIO','SERVICIO CANARY',450,true,'PEN')]},
+      expect:{status:'READY',stage:'OBJECTION',action:'REPLY'}
+    },
+    {
+      name:'CONTINUITY',
+      input:{inbound:'¿Qué producto uso después para mantenimiento?',publicBundle:bundle('PUBLIC_CLIENT',[product]),advisorBundle:bundle('ADVISOR_INTERNAL',[product,rule('RULE_ETHICAL_UPSELL'),rule('RULE_PRODUCTS_AS_EXTENSION')]),processContexts:[ctx(PRODUCT_ID,'PRODUCTO','PRODUCTO CANARY',99,true,'PEN')]},
+      expect:{status:'READY',stage:'CONTINUITY',action:'REPLY',continuity:1}
+    },
+    {
+      name:'CLINICAL_ESCALATION',
+      input:{inbound:'Estoy embarazada, ¿puedo hacerlo?',clinicalRisk:true},
+      expect:{status:'READY',stage:'CLINICAL_ESCALATION',action:'HUMAN_CLINICAL'}
+    }
+  ];
+  assert.equal(cases.length,7);
+  for(const c of cases){
+    const out=p.buildPlaybook(c.input);
+    assert.equal(out.status,c.expect.status,c.name+' status');
+    assert.equal(out.commercial_stage,c.expect.stage,c.name+' stage');
+    assert.equal(out.recommended_next_action,c.expect.action,c.name+' action');
+    if(c.expect.currency)assert.equal(out.quote_or_payment_context[0].currency,c.expect.currency,c.name+' currency');
+    if(c.expect.continuity!=null)assert.equal(out.continuity_candidates.length,c.expect.continuity,c.name+' continuity');
+    assertSafe(out);
+  }
 });
 
 test('rule queries are deterministic and stage-scoped',()=>{
@@ -114,14 +193,26 @@ test('prompt context cannot grant autonomous send',()=>{
   assert.equal(x.send_authority,'HUMAN_ONLY');
 });
 
-test('copilot integration no longer reads catalog/promotions directly and uses governed contracts',()=>{
+test('copilot integration uses governed search v3 and never reads raw catalog/promotions directly',()=>{
   const src=fs.readFileSync(path.join(__dirname,'../../app/wa4-copilot.js'),'utf8');
   assert.equal(src.includes('/rest/v1/aos_catalogo_servicios'),false);
   assert.equal(src.includes('/rest/v1/aos_promociones'),false);
-  assert.equal(src.includes('aos_wa4a_knowledge_search_v2'),true);
+  assert.equal(src.includes('aos_wa4a_knowledge_search_v3'),true);
+  assert.equal(src.includes('aos_wa4a_knowledge_search_v2'),false);
   assert.equal(src.includes('aos_wa4_process_entity_context_v1'),true);
   assert.equal(src.includes('mapping_confidence'),true);
   assert.equal(src.includes('moneda'),true);
   assert.equal(src.includes('cited_knowledge_ids'),true);
   assert.equal(src.includes('auto_send:false'),true);
+});
+
+test('knowledge v3 migration exposes only canonical per-SKU included benefit and preserves service-role boundary',()=>{
+  const migration=fs.readFileSync(path.join(__dirname,'../../supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql'),'utf8');
+  assert.equal(migration.includes('aos_wa4a_knowledge_search_v2'),true);
+  assert.equal(migration.includes("info_extendida #>> '{catalog_sep2026,gift_raw}'"),true);
+  assert.equal(migration.includes("'included_benefit'"),true);
+  assert.equal(migration.includes("'included_benefit_source', 'CATALOG_SEP2026_CURRENT_SKU'"),true);
+  assert.equal(migration.includes('grant execute on function public.aos_wa4a_knowledge_search_v3'),true);
+  assert.equal(migration.includes('to service_role'),true);
+  assert.equal(migration.includes('aos_promociones'),false);
 });

--- a/ci/wa4b-sales-playbook/wa4c-data-boundary.test.js
+++ b/ci/wa4b-sales-playbook/wa4c-data-boundary.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const path=require('node:path');
+const p=require('../../app/wa4-playbook');
+const k=require('../../app/wa4-knowledge');
+
+const ID='44444444-4444-4444-8444-444444444444';
+function row(facts){return {
+  knowledge_id:'service:'+ID,domain:'CATALOG',title:'HIFUTOX',authority_tier:10,
+  freshness_state:'FRESH',conflict_state:'CLEAR',retrieval_state:'READY',facts,
+  evidence_ref:{relation:'public.aos_catalogo_servicios',pk:ID,version:'v1'}
+};}
+function bundle(items){return {version:'T',audience:'PUBLIC_CLIENT',items,authority:'GOVERNED_SOURCE_ONLY',generic_llm_authority:false};}
+
+test('thin INFO stays fail-closed even when canonical SKU identity and included benefit are available',()=>{
+  const item=row({tipo:'SERVICIO',nombre:'HIFUTOX',descripcion_comercial:'',beneficios:'',faqs:[],
+    included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU',
+    catalog_identity:{family_name:'HIFU',commercial_variant:'HIFUTOX',clinical_sessions:1,zones:3},catalog_identity_source:'CATALOG_SEP2026_CURRENT_SKU'});
+  const out=p.buildPlaybook({inbound:'¿Qué es HIFUTOX?',publicBundle:bundle([item]),advisorBundle:{...bundle([item]),audience:'ADVISOR_INTERNAL'},processContexts:[]});
+  assert.equal(out.status,'FAIL_CLOSED');
+  assert.equal(out.recommended_next_action,'HUMAN_COMMERCIAL');
+  assert.equal(out.policy_escalation.reason,'PUBLIC_INFO_EVIDENCE_INSUFFICIENT');
+  assert.equal(out.send_authority,'HUMAN_ONLY');
+  assert.equal(out.auto_send,false);
+});
+
+test('adapter delivers canonical benefit and only allowlisted SKU identity to model bundle',()=>{
+  const upstream=row({tipo:'SERVICIO',nombre:'HIFUTOX',descripcion_comercial:'Descripción aprobada',
+    included_benefit:'1 sesión LED',included_benefit_source:'CATALOG_SEP2026_CURRENT_SKU',
+    catalog_identity_source:'CATALOG_SEP2026_CURRENT_SKU',catalog_identity:{family_name:'HIFU',commercial_variant:'HIFUTOX',clinical_sessions:1,zones:3,body_area:'NO',indication:'NO',aliases:['NO'],active_or_technology:'NO'}});
+  const facts=k.buildKnowledgeBundle([upstream],12,'PUBLIC_CLIENT').items[0].facts;
+  assert.equal(facts.included_benefit,'1 sesión LED');
+  assert.deepEqual(facts.catalog_identity,{family_name:'HIFU',commercial_variant:'HIFUTOX',clinical_sessions:1,zones:3});
+});
+
+test('v3 SQL derives only CURRENT public SEP26 SKU facts and never infers promotions',()=>{
+  const sql=fs.readFileSync(path.join(__dirname,'../../supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql'),'utf8');
+  for(const required of [
+    'aos_wa4a_knowledge_search_v2','catalog_sep2026,gift_raw','treatment_identity,source','SEP2026_PRICE_LIST',
+    'treatment_identity,current_status','CURRENT','treatment_identity,public_catalog','included_benefit','catalog_identity',
+    'family_name','commercial_variant','clinical_sessions','brand','zones','unit_cap','syringes','volume_ml',
+    'grant execute on function public.aos_wa4a_knowledge_search_v3','to service_role'
+  ]) assert.equal(sql.includes(required),true,'missing '+required);
+  for(const forbidden of ['body_area','indication','aliases','active_or_technology','aos_promociones'])
+    assert.equal(sql.includes(forbidden),false,'forbidden '+forbidden);
+});

--- a/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
+++ b/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
@@ -28,12 +28,12 @@ select
   b.title,
   b.facts
     || case when g.included_benefit is not null then jsonb_build_object(
-         'included_benefit',g.included_benefit,
-         'included_benefit_source','CATALOG_SEP2026_CURRENT_SKU'
+         'included_benefit', g.included_benefit,
+         'included_benefit_source', 'CATALOG_SEP2026_CURRENT_SKU'
        ) else '{}'::jsonb end
     || case when i.safe_identity <> '{}'::jsonb then jsonb_build_object(
-         'catalog_identity',i.safe_identity,
-         'catalog_identity_source','CATALOG_SEP2026_CURRENT_SKU'
+         'catalog_identity', i.safe_identity,
+         'catalog_identity_source', 'CATALOG_SEP2026_CURRENT_SKU'
        ) else '{}'::jsonb end as facts,
   b.authority_tier,
   b.source_relation,
@@ -44,11 +44,11 @@ select
   b.retrieval_state,
   b.evidence_ref
     || case when g.included_benefit is not null then jsonb_build_object(
-         'included_benefit_path','info_extendida.catalog_sep2026.gift_raw'
+         'included_benefit_path', 'info_extendida.catalog_sep2026.gift_raw'
        ) else '{}'::jsonb end
     || case when i.safe_identity <> '{}'::jsonb then jsonb_build_object(
-         'catalog_identity_path','info_extendida.treatment_identity',
-         'catalog_identity_verified_at',nullif(btrim(s.info_extendida #>> '{treatment_identity,verified_at}'),'')
+         'catalog_identity_path', 'info_extendida.treatment_identity',
+         'catalog_identity_verified_at', nullif(btrim(s.info_extendida #>> '{treatment_identity,verified_at}'),'')
        ) else '{}'::jsonb end as evidence_ref,
   b.score
 from public.aos_wa4a_knowledge_search_v2(p_query,p_audience,p_limit,p_domains) b
@@ -66,14 +66,14 @@ left join lateral (
      and coalesce(s.info_extendida #>> '{treatment_identity,current_status}','')='CURRENT'
      and lower(coalesce(s.info_extendida #>> '{treatment_identity,public_catalog}','false'))='true'
     then jsonb_strip_nulls(jsonb_build_object(
-      'family_name',nullif(btrim(s.info_extendida #>> '{treatment_identity,family_name}'),''),
-      'commercial_variant',nullif(btrim(s.info_extendida #>> '{treatment_identity,commercial_variant}'),''),
-      'clinical_sessions',case when coalesce(s.info_extendida #>> '{treatment_identity,clinical_sessions}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,clinical_sessions}')::numeric end,
-      'brand',nullif(btrim(s.info_extendida #>> '{treatment_identity,brand}'),''),
-      'zones',case when coalesce(s.info_extendida #>> '{treatment_identity,zones}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,zones}')::numeric end,
-      'unit_cap',case when coalesce(s.info_extendida #>> '{treatment_identity,unit_cap}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,unit_cap}')::numeric end,
-      'syringes',case when coalesce(s.info_extendida #>> '{treatment_identity,syringes}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,syringes}')::numeric end,
-      'volume_ml',case when coalesce(s.info_extendida #>> '{treatment_identity,volume_ml}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,volume_ml}')::numeric end
+      'family_name', nullif(btrim(s.info_extendida #>> '{treatment_identity,family_name}'),''),
+      'commercial_variant', nullif(btrim(s.info_extendida #>> '{treatment_identity,commercial_variant}'),''),
+      'clinical_sessions', case when coalesce(s.info_extendida #>> '{treatment_identity,clinical_sessions}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,clinical_sessions}')::numeric end,
+      'brand', nullif(btrim(s.info_extendida #>> '{treatment_identity,brand}'),''),
+      'zones', case when coalesce(s.info_extendida #>> '{treatment_identity,zones}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,zones}')::numeric end,
+      'unit_cap', case when coalesce(s.info_extendida #>> '{treatment_identity,unit_cap}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,unit_cap}')::numeric end,
+      'syringes', case when coalesce(s.info_extendida #>> '{treatment_identity,syringes}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,syringes}')::numeric end,
+      'volume_ml', case when coalesce(s.info_extendida #>> '{treatment_identity,volume_ml}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,volume_ml}')::numeric end
     ))
     else '{}'::jsonb
   end as safe_identity

--- a/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
+++ b/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
@@ -1,6 +1,6 @@
--- WA-4C readiness hardening — expose CURRENT per-SKU included benefits without creating a new commercial master.
--- Source remains public.aos_catalogo_servicios.info_extendida.catalog_sep2026.gift_raw.
--- v3 preserves v2 audience isolation and only augments CATALOG service facts.
+-- WA-4C readiness hardening — expose CURRENT per-SKU commercial facts without creating a new business master.
+-- Source remains public.aos_catalogo_servicios.info_extendida for certified September 2026 catalog lineage.
+-- v3 preserves v2 audience isolation and only augments CATALOG service facts with allowlisted CURRENT SKU data.
 begin;
 
 create or replace function public.aos_wa4a_knowledge_search_v3(
@@ -26,16 +26,15 @@ select
   b.subject_type,
   b.subject_id,
   b.title,
-  case
-    when b.domain='CATALOG'
-      and upper(coalesce(b.subject_type,'')) in ('SERVICIO','SERVICE')
-      and nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),'') is not null
-    then b.facts || jsonb_build_object(
-      'included_benefit', nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),''),
-      'included_benefit_source', 'CATALOG_SEP2026_CURRENT_SKU'
-    )
-    else b.facts
-  end as facts,
+  b.facts
+    || case when g.included_benefit is not null then jsonb_build_object(
+         'included_benefit',g.included_benefit,
+         'included_benefit_source','CATALOG_SEP2026_CURRENT_SKU'
+       ) else '{}'::jsonb end
+    || case when i.safe_identity <> '{}'::jsonb then jsonb_build_object(
+         'catalog_identity',i.safe_identity,
+         'catalog_identity_source','CATALOG_SEP2026_CURRENT_SKU'
+       ) else '{}'::jsonb end as facts,
   b.authority_tier,
   b.source_relation,
   b.source_pk,
@@ -43,20 +42,42 @@ select
   b.freshness_state,
   b.conflict_state,
   b.retrieval_state,
-  case
-    when b.domain='CATALOG'
-      and upper(coalesce(b.subject_type,'')) in ('SERVICIO','SERVICE')
-      and nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),'') is not null
-    then b.evidence_ref || jsonb_build_object(
-      'included_benefit_path','info_extendida.catalog_sep2026.gift_raw'
-    )
-    else b.evidence_ref
-  end as evidence_ref,
+  b.evidence_ref
+    || case when g.included_benefit is not null then jsonb_build_object(
+         'included_benefit_path','info_extendida.catalog_sep2026.gift_raw'
+       ) else '{}'::jsonb end
+    || case when i.safe_identity <> '{}'::jsonb then jsonb_build_object(
+         'catalog_identity_path','info_extendida.treatment_identity',
+         'catalog_identity_verified_at',nullif(btrim(s.info_extendida #>> '{treatment_identity,verified_at}'),'')
+       ) else '{}'::jsonb end as evidence_ref,
   b.score
 from public.aos_wa4a_knowledge_search_v2(p_query,p_audience,p_limit,p_domains) b
 left join public.aos_catalogo_servicios s
   on b.domain='CATALOG'
+ and upper(coalesce(b.subject_type,'')) in ('SERVICIO','SERVICE')
  and b.subject_id=s.id::text
+ and coalesce(s.estado,'ACTIVO')='ACTIVO'
+left join lateral (
+  select nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),'') as included_benefit
+) g on true
+left join lateral (
+  select case
+    when coalesce(s.info_extendida #>> '{treatment_identity,source}','')='SEP2026_PRICE_LIST'
+     and coalesce(s.info_extendida #>> '{treatment_identity,current_status}','')='CURRENT'
+     and lower(coalesce(s.info_extendida #>> '{treatment_identity,public_catalog}','false'))='true'
+    then jsonb_strip_nulls(jsonb_build_object(
+      'family_name',nullif(btrim(s.info_extendida #>> '{treatment_identity,family_name}'),''),
+      'commercial_variant',nullif(btrim(s.info_extendida #>> '{treatment_identity,commercial_variant}'),''),
+      'clinical_sessions',case when coalesce(s.info_extendida #>> '{treatment_identity,clinical_sessions}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,clinical_sessions}')::numeric end,
+      'brand',nullif(btrim(s.info_extendida #>> '{treatment_identity,brand}'),''),
+      'zones',case when coalesce(s.info_extendida #>> '{treatment_identity,zones}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,zones}')::numeric end,
+      'unit_cap',case when coalesce(s.info_extendida #>> '{treatment_identity,unit_cap}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,unit_cap}')::numeric end,
+      'syringes',case when coalesce(s.info_extendida #>> '{treatment_identity,syringes}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,syringes}')::numeric end,
+      'volume_ml',case when coalesce(s.info_extendida #>> '{treatment_identity,volume_ml}','') ~ '^[0-9]+([.][0-9]+)?$' then (s.info_extendida #>> '{treatment_identity,volume_ml}')::numeric end
+    ))
+    else '{}'::jsonb
+  end as safe_identity
+) i on true
 order by b.score desc,b.authority_tier asc,b.title;
 $$;
 
@@ -64,6 +85,6 @@ revoke all on function public.aos_wa4a_knowledge_search_v3(text,text,integer,tex
 grant execute on function public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]) to service_role;
 
 comment on function public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]) is
-'WA-4C governed search: preserves v2 audience isolation and surfaces only canonical CURRENT per-SKU included benefits from catalog lineage; no promotion inference.';
+'WA-4C governed search: preserves v2 audience isolation and surfaces only allowlisted CURRENT per-SKU September 2026 catalog facts; no promotion inference and no clinical claim expansion.';
 
 commit;

--- a/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
+++ b/supabase/migrations/20260828235500_wa4c_included_benefit_knowledge_v3.sql
@@ -1,0 +1,69 @@
+-- WA-4C readiness hardening — expose CURRENT per-SKU included benefits without creating a new commercial master.
+-- Source remains public.aos_catalogo_servicios.info_extendida.catalog_sep2026.gift_raw.
+-- v3 preserves v2 audience isolation and only augments CATALOG service facts.
+begin;
+
+create or replace function public.aos_wa4a_knowledge_search_v3(
+  p_query text,
+  p_audience text default 'PUBLIC_CLIENT',
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text, domain text, subject_type text, subject_id text, title text,
+  facts jsonb, authority_tier smallint, source_relation text, source_pk text,
+  source_updated_at timestamptz, freshness_state text, conflict_state text,
+  retrieval_state text, evidence_ref jsonb, score integer
+)
+language sql
+stable
+security definer
+set search_path='public'
+as $$
+select
+  b.knowledge_id,
+  b.domain,
+  b.subject_type,
+  b.subject_id,
+  b.title,
+  case
+    when b.domain='CATALOG'
+      and upper(coalesce(b.subject_type,'')) in ('SERVICIO','SERVICE')
+      and nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),'') is not null
+    then b.facts || jsonb_build_object(
+      'included_benefit', nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),''),
+      'included_benefit_source', 'CATALOG_SEP2026_CURRENT_SKU'
+    )
+    else b.facts
+  end as facts,
+  b.authority_tier,
+  b.source_relation,
+  b.source_pk,
+  b.source_updated_at,
+  b.freshness_state,
+  b.conflict_state,
+  b.retrieval_state,
+  case
+    when b.domain='CATALOG'
+      and upper(coalesce(b.subject_type,'')) in ('SERVICIO','SERVICE')
+      and nullif(btrim(s.info_extendida #>> '{catalog_sep2026,gift_raw}'),'') is not null
+    then b.evidence_ref || jsonb_build_object(
+      'included_benefit_path','info_extendida.catalog_sep2026.gift_raw'
+    )
+    else b.evidence_ref
+  end as evidence_ref,
+  b.score
+from public.aos_wa4a_knowledge_search_v2(p_query,p_audience,p_limit,p_domains) b
+left join public.aos_catalogo_servicios s
+  on b.domain='CATALOG'
+ and b.subject_id=s.id::text
+order by b.score desc,b.authority_tier asc,b.title;
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]) to service_role;
+
+comment on function public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]) is
+'WA-4C governed search: preserves v2 audience isolation and surfaces only canonical CURRENT per-SKU included benefits from catalog lineage; no promotion inference.';
+
+commit;

--- a/supabase/rollbacks/20260828235500_wa4c_included_benefit_knowledge_v3.rollback.sql
+++ b/supabase/rollbacks/20260828235500_wa4c_included_benefit_knowledge_v3.rollback.sql
@@ -1,0 +1,3 @@
+begin;
+drop function if exists public.aos_wa4a_knowledge_search_v3(text,text,integer,text[]);
+commit;


### PR DESCRIPTION
WA-4C pre-LIVE readiness hardening discovered during production catalog audit.

This PR does NOT enable Copilot, auto-reply, auto-routing, or autonomous WhatsApp sending.

Certified exact head: `0af4a6f287abff13964800cde5c1f062bb645c81`
Base/main revalidated unchanged at `01c18f253c6202a6b23fb44e2461c2b662e4c5d0` before protected merge.
Merged commit: `f30cd7246f5f6ad2a08db4097bf897dd21e1a006`.

## Scope closed
1. CURRENT included benefits: 71/184 active service SKUs expose `info_extendida.catalog_sep2026.gift_raw` only with `CATALOG_SEP2026_CURRENT_SKU` provenance.
2. Safe CURRENT SKU identity: only allowlisted SEP26 facts (`family_name`, `commercial_variant`, `clinical_sessions`, `brand`, `zones`, `unit_cap`, `syringes`, `volume_ml`) survive into the Copilot adapter.
3. INFO fail-closed: thin service rows cannot be expanded with generic LLM knowledge; they return `PUBLIC_INFO_EVIDENCE_INSUFFICIENT` → `HUMAN_COMMERCIAL`.
4. Official WA-4C canary matrix frozen: INFO, PRICE PEN, PRICE USD, PAYMENT, OBJECTION, CONTINUITY, CLINICAL_ESCALATION; all remain `send_authority=HUMAN_ONLY`, `auto_send=false`.
5. Promotion intent without READY governed promotion evidence remains fail-closed.

## Proof
Production-safe SQL proof was executed inside an explicit transaction ending in ROLLBACK before promotion. HIFUTOX returned only allowlisted identity facts with correct lineage; ACL remained `service_role=true`, `anon=false`, `authenticated=false`.

All eight exact-head workflows were terminal SUCCESS: Ascenda CI, WA-4A Knowledge Fabric, WA-4A.1 Zi Vital Governed Knowledge, WA-4B Sales Playbook Engine, CATALOG SEP26.1 Deep Reconciliation, Performance Guard CI, WA-4 AI Sales Router, ASC-PERF Audit 360.

The v3 migration was subsequently promoted to Supabase PROD and read back successfully: 184 active services, 50 active products, 71 services with included benefit, 234/234 quote-ready/fresh entities, 231 PEN + 3 USD, 0 governed promotions, audience isolation preserved.

Railway later deployed merge `f30cd724...` successfully. A separate follow-up runtime transport issue was then identified from LIVE logs: legacy `https.get` calls can bypass the existing `https.request` quota hook. That follow-up does not invalidate #396 knowledge/canary readiness and is handled separately.

Copilot remains SAFE-OFF pending final runtime/Supabase LIVE gates.