### PR TITLE
WA-4C — Close legacy https.get quota breaker bypass

### DIFF
--- a/app/supabase-quota-circuit-preload.cjs
+++ b/app/supabase-quota-circuit-preload.cjs
@@ -55,10 +55,21 @@ if (!global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__) {
     return req;
   };
 
+  // Node's native https.get() closes over its internal request implementation;
+  // replacing https.request alone does not guarantee that legacy get() callers
+  // traverse the patched export. Route every get() through the patched request
+  // explicitly, then end it to preserve normal https.get semantics.
+  https.get = function aosQuotaAwareGet() {
+    const req = https.request.apply(https, arguments);
+    req.end();
+    return req;
+  };
+
   global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__ = {
     installed: true,
     host: configuredHost,
     scope: 'ALL_CONFIGURED_SUPABASE_RUNTIME_REQUESTS',
+    transports: ['https.request', 'https.get'],
     snapshot: function() { return circuit.snapshot(); }
   };
 }

--- a/ci/performance/wa-supabase-quota-circuit-contract.js
+++ b/ci/performance/wa-supabase-quota-circuit-contract.js
@@ -47,7 +47,8 @@ async function coreContract() {
 
 async function preloadContract() {
   const https = require('https');
-  const original = https.request;
+  const originalRequest = https.request;
+  const originalGet = https.get;
   let network = 0;
   let status = 402;
 
@@ -90,10 +91,27 @@ async function preloadContract() {
     });
   }
 
+  function callGet(userAgent, hostname) {
+    return new Promise(function(resolve) {
+      const req = https.get({
+        hostname: hostname || 'ituyqwstonmhnfshnaqz.supabase.co',
+        path: '/rest/v1/aos_agentes?activo=eq.true',
+        headers: { 'User-Agent': userAgent }
+      }, function(res) {
+        res.on('end', function() { resolve({ status: res.statusCode }); });
+      });
+      req.on('error', function(e) { resolve({ error: e }); });
+    });
+  }
+
   const first = await call('AscendaOS-Phase-S/1.0');
   assert.strictEqual(first.status, 402, 'first upstream 402 must be observable by caller');
   assert.strictEqual(network, 1, 'first Supabase call must reach network');
   assert.strictEqual(global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__.snapshot().open, true, 'preload circuit did not open');
+
+  const legacyGet = await callGet('legacy-no-tag');
+  assert(legacyGet.error && legacyGet.error.code === 'SUPABASE_QUOTA_BLOCKED', 'legacy https.get must share the Supabase quota circuit');
+  assert.strictEqual(network, 1, 'legacy https.get escaped to network while circuit was open');
 
   const supabaseAgents = [
     'AscendaOS-Phase-S/1.0',
@@ -113,10 +131,17 @@ async function preloadContract() {
   assert.strictEqual(network, 1, 'blocked Supabase calls escaped to network');
 
   const external = await call('AscendaOS-WA-Gateway/1.0', 'graph.facebook.com');
-  assert.strictEqual(external.status, 402, 'non-Supabase host must preserve base transport behavior');
-  assert.strictEqual(network, 2, 'external host was incorrectly intercepted by Supabase quota circuit');
+  assert.strictEqual(external.status, 402, 'non-Supabase host must preserve base request behavior');
+  assert.strictEqual(network, 2, 'external request host was incorrectly intercepted');
 
-  https.request = original;
+  const externalGet = await callGet('legacy-no-tag', 'graph.facebook.com');
+  assert.strictEqual(externalGet.status, 402, 'non-Supabase https.get must preserve base transport behavior');
+  assert.strictEqual(network, 3, 'external https.get host was incorrectly intercepted');
+
+  assert.deepStrictEqual(global.__AOS_WA_SUPABASE_QUOTA_PRELOAD__.transports, ['https.request', 'https.get'], 'preload transport coverage metadata mismatch');
+
+  https.request = originalRequest;
+  https.get = originalGet;
 }
 
 function staticContract() {
@@ -126,6 +151,8 @@ function staticContract() {
   assert(railway.includes('--require ./supabase-quota-circuit-preload.cjs'), 'Railway quota preload missing');
   assert(preload.includes("scope: 'ALL_CONFIGURED_SUPABASE_RUNTIME_REQUESTS'"), 'project-wide Supabase quota scope missing');
   assert(preload.includes('isConfiguredSupabaseRequest(args, configuredHost)'), 'Supabase host classifier missing');
+  assert(preload.includes('https.get = function aosQuotaAwareGet'), 'legacy https.get quota transport hook missing');
+  assert(preload.includes("transports: ['https.request', 'https.get']"), 'quota transport coverage metadata missing');
   assert(target.includes("host === String(configuredHost || '').toLowerCase()"), 'quota circuit must remain scoped to the configured Supabase host');
   assert(!preload.includes('userAgentRe'), 'quota circuit must not depend on runtime User-Agent');
   assert(preload.includes('configuredHost'), 'Supabase host scoping missing');


### PR DESCRIPTION
Follow-up runtime hardening discovered from LIVE Supabase logs after #395/#396 deployment.

Root cause: the quota preload patched `https.request`, but legacy runtime reads still use `https.get`. Node's native `https.get` may bypass a replaced exported `https.request`, so repeated legacy `aos_agentes` GETs continued reaching the restricted Supabase project during HTTP 402.

Change:
- route exported `https.get()` explicitly through the already quota-aware patched `https.request()` and call `end()` to preserve normal GET semantics;
- keep host scoping to the configured Supabase project only;
- keep external hosts untouched;
- add direct contract coverage proving legacy Supabase `https.get` short-circuits while external `https.get` still uses base transport;
- expose non-sensitive transport coverage metadata `['https.request','https.get']`.

No Supabase schema/data mutation. No Copilot activation. Safety unchanged: HUMAN_ONLY, ai_send=false, auto_reply=false, auto_routing=false.

LIVE evidence before this PR: Supabase API logs still showed `GET /rest/v1/aos_agentes` HTTP 402 approximately every minute after the final #396 runtime deployment, while Auth/Data API remain Fair Use restricted. This PR is intended to remove that remaining transport escape before quota reset and official WA-4C LIVE canaries.