### PR TITLE
Hotfix: restore governed Call Center appointment writes

### DIFF
--- a/.github/workflows/callcenter-governed-runtime-guard.yml
+++ b/.github/workflows/callcenter-governed-runtime-guard.yml
@@ -1,0 +1,82 @@
+name: ASCENDA Call Center Governed Runtime Guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/public/app.html'
+      - 'app/public/calls.html'
+      - 'app/public/calls.js'
+      - 'app/public/calls-loop6.js'
+      - 'app/public/f4-production-canary-hotfix.js'
+      - 'supabase/migrations/*loop6*'
+      - '.github/workflows/callcenter-governed-runtime-guard.yml'
+  push:
+    branches: [main, 'fix/**']
+    paths:
+      - 'app/public/app.html'
+      - 'app/public/calls.html'
+      - 'app/public/calls.js'
+      - 'app/public/calls-loop6.js'
+      - 'app/public/f4-production-canary-hotfix.js'
+      - 'supabase/migrations/*loop6*'
+      - '.github/workflows/callcenter-governed-runtime-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: callcenter-governed-runtime-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  hosted-contract:
+    name: Hosted governed-write contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Syntax
+        run: |
+          set -euo pipefail
+          node --check app/public/f4-production-canary-hotfix.js
+          node --check app/public/calls-loop6.js
+
+      - name: Call Center postload + fail-closed contract
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const assert = require('assert');
+          const app = fs.readFileSync('app/public/app.html','utf8');
+          const calls = fs.readFileSync('app/public/calls.html','utf8');
+          const loop6 = fs.readFileSync('app/public/calls-loop6.js','utf8');
+          const bridge = fs.readFileSync('app/public/f4-production-canary-hotfix.js','utf8');
+          const guard = fs.readFileSync('supabase/migrations/20260822011500_mkt_loop6_legacy_bypass_guard_v22.sql','utf8');
+
+          assert(app.includes('AOS._capturePanelTimers = true'), 'panel-loader start marker missing');
+          assert(app.includes('AOS._capturePanelTimers = false'), 'panel-loader completion marker missing');
+          assert(app.indexOf('if (extSrcs.length)') < app.indexOf('else if (allInline.length)'), 'expected external-before-inline loader contract changed');
+
+          assert(calls.includes('/calls-loop6.js?v=20260821-loop6-v2.3'), 'Loop6 panel runtime reference missing');
+          assert(loop6.includes("window.__AOS_CC_LOOP6_V2__='v2.3'"), 'Loop6 V2.3 marker missing');
+          assert(loop6.includes('aos_callcenter_confirm_queue_appointment_v1'), 'governed queue RPC missing');
+          assert(loop6.includes('aos_callcenter_commit_action_v1'), 'governed manual RPC missing');
+          assert(loop6.includes('window.guardarCitaManual=function'), 'governed manual handler override missing');
+          assert(loop6.includes('window.ccConfirmarCita=function'), 'governed queue handler override missing');
+
+          assert(bridge.includes('ensureCallCenterLoop6Postload'), 'postload bridge missing');
+          assert(bridge.includes('AOS._capturePanelTimers===true'), 'bridge must wait for inline panel runtime completion');
+          assert(bridge.includes('/calls-loop6.js?v=20260901-loop6-v2.3-postload'), 'postload governed runtime source missing');
+          assert(bridge.includes("window.__AOS_CC_LOOP6_POSTLOAD_READY__='v2.3-postload'"), 'postload readiness marker missing');
+
+          assert(guard.includes('AOS_LOOP6_RUNTIME_REQUIRED'), 'fail-closed trigger error missing');
+          assert(guard.includes("set_config('aos.loop6_governed_write','1',true)"), 'governed write marker missing');
+          assert(guard.includes("v_origin='CITA_MANUAL' or v_origin like 'CALL_CENTER%'"), 'legacy agenda bypass guard missing');
+
+          console.log('CALLCENTER_GOVERNED_RUNTIME_GUARD_PASS');
+          NODE

--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -136,10 +136,9 @@ function loadProductResolutionCenter(){
 }
 
 // Call Center Loop 6 V2.3 must execute after the panel's legacy inline script.
-// app.html intentionally loads panel externals before inline code, so the first
-// calls-loop6.js execution can be overwritten by legacy function declarations.
-// This bridge replays the governed runtime after the panel has settled, keeping
-// direct CALL_CENTER/CITA_MANUAL PostgREST writes fail-closed.
+// app.html loads panel externals first and sets AOS._capturePanelTimers=false
+// only after the collected inline runtime has finished loading. We wait for
+// that exact loader boundary, then replay the certified governed handlers.
 function ensureCallCenterLoop6Postload(){
   var panel=document.getElementById('cc-m-cita-manual');
   if(!panel){
@@ -150,9 +149,15 @@ function ensureCallCenterLoop6Postload(){
   if(panel===cc6PanelSeen)return;
   cc6PanelSeen=panel;
   if(cc6ReloadTimer)clearTimeout(cc6ReloadTimer);
-  cc6ReloadTimer=setTimeout(function(){
-    cc6ReloadTimer=null;
+  var attempts=0;
+  function afterInline(){
     if(document.getElementById('cc-m-cita-manual')!==panel)return;
+    attempts++;
+    if(window.AOS&&AOS._capturePanelTimers===true&&attempts<100){
+      cc6ReloadTimer=setTimeout(afterInline,50);
+      return;
+    }
+    cc6ReloadTimer=null;
     var old=document.getElementById('aos-cc6-postload-runtime');
     if(old)old.remove();
     var s=document.createElement('script');
@@ -165,7 +170,8 @@ function ensureCallCenterLoop6Postload(){
     };
     s.onerror=function(){console.error('[ASCENDA][CC6V23] postload runtime failed');};
     (document.head||document.documentElement).appendChild(s);
-  },120);
+  }
+  cc6ReloadTimer=setTimeout(afterInline,0);
 }
 
 function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();ensureCallCenterLoop6Postload();}

--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -7,6 +7,8 @@ window.__AOS_F4_PRODUCTION_CANARY_P0__=true;
 var previousFetch=window.fetch.bind(window);
 var nativeConfirm=window.confirm.bind(window);
 var tokenSyncPromise=null;
+var cc6PanelSeen=null;
+var cc6ReloadTimer=null;
 
 function cleanCajaClosedState(){
   var box=document.getElementById('no-sesion-msg');
@@ -132,7 +134,41 @@ function loadProductResolutionCenter(){
   b.onerror=function(){console.error('[REV-PRC1] auth bridge failed to load');};
   (document.head||document.documentElement).appendChild(b);
 }
-function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();}
+
+// Call Center Loop 6 V2.3 must execute after the panel's legacy inline script.
+// app.html intentionally loads panel externals before inline code, so the first
+// calls-loop6.js execution can be overwritten by legacy function declarations.
+// This bridge replays the governed runtime after the panel has settled, keeping
+// direct CALL_CENTER/CITA_MANUAL PostgREST writes fail-closed.
+function ensureCallCenterLoop6Postload(){
+  var panel=document.getElementById('cc-m-cita-manual');
+  if(!panel){
+    cc6PanelSeen=null;
+    if(cc6ReloadTimer){clearTimeout(cc6ReloadTimer);cc6ReloadTimer=null;}
+    return;
+  }
+  if(panel===cc6PanelSeen)return;
+  cc6PanelSeen=panel;
+  if(cc6ReloadTimer)clearTimeout(cc6ReloadTimer);
+  cc6ReloadTimer=setTimeout(function(){
+    cc6ReloadTimer=null;
+    if(document.getElementById('cc-m-cita-manual')!==panel)return;
+    var old=document.getElementById('aos-cc6-postload-runtime');
+    if(old)old.remove();
+    var s=document.createElement('script');
+    s.id='aos-cc6-postload-runtime';
+    s.src='/calls-loop6.js?v=20260901-loop6-v2.3-postload';
+    s.async=false;
+    s.onload=function(){
+      window.__AOS_CC_LOOP6_POSTLOAD_READY__='v2.3-postload';
+      console.log('[ASCENDA][CC6V23] governed postload runtime active');
+    };
+    s.onerror=function(){console.error('[ASCENDA][CC6V23] postload runtime failed');};
+    (document.head||document.documentElement).appendChild(s);
+  },120);
+}
+
+function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();ensureCallCenterLoop6Postload();}
 run();
 syncCanonicalAppToken();
 setTimeout(syncCanonicalAppToken,700);


### PR DESCRIPTION
## Incident
Mireya reported `Error guardando` when creating a manual appointment from Call Center. Production reproduction confirmed the browser was still reaching the legacy direct `aos_agenda_citas` / `aos_llamadas` PostgREST path, which is correctly rejected by `trg_000_aos_loop6_governed_agenda_v22` with `AOS_LOOP6_RUNTIME_REQUIRED`.

## Root cause
`app.html` loads panel external scripts first and executes collected inline scripts afterwards. `calls-loop6.js` therefore installed the governed V2.3 handlers first, but the legacy inline `ccConfirmarCita` / `guardarCitaManual` declarations from `calls.html` overwrote them afterwards.

## Fix
Replay the already-certified `calls-loop6.js` runtime once the Call Center panel has settled. The bridge is scoped to `#cc-m-cita-manual`, deduplicated per panel instance, and preserves the existing governed RPCs:
- `aos_callcenter_prepare_action_v1`
- `aos_callcenter_confirm_queue_appointment_v1`
- `aos_callcenter_commit_action_v1`

## Safety
- No Supabase trigger is weakened or disabled.
- No direct CALL_CENTER/CITA_MANUAL write is re-enabled.
- No schema/data migration.
- No synthetic production appointment.
- Existing Sales/F4 behavior remains unchanged.

## Agenda incident
The separate Agenda HTTP 500 screenshot was investigated. An anon-role transaction can currently perform the same status transition successfully, and the reported appointment has a successful audit UPDATE followed by exactly one attention row seconds after the screenshot, indicating the Agenda action succeeded on retry rather than a persistent DB write regression.