### PR TITLE
WA-4C.1: freeze clinical matrix and govern Team panel permissions

### DIFF
--- a/app/public/panel-access-authority-v1.js
+++ b/app/public/panel-access-authority-v1.js
@@ -226,10 +226,9 @@ function install(){
   installNavigationAuthority();
   installSidebarAuthority();
 }
+
+// Loaded by sentinel-hub-bootstrap after the shell has defined its sidebar and
+// navigation functions. Keep installation one-shot: no timer/focus/visibility
+// network owner is created by this permission layer.
 install();
-setTimeout(install,0);
-setTimeout(install,500);
-setTimeout(install,1800);
-try{window.addEventListener('focus',function(){install();governedBuildSidebar();});}catch(_){}
-try{document.addEventListener('visibilitychange',function(){if(!document.hidden){install();governedBuildSidebar();}});}catch(_){}
 })();

--- a/app/public/panel-access-authority-v1.js
+++ b/app/public/panel-access-authority-v1.js
@@ -1,0 +1,235 @@
+// ASCENDA OS — Panel Access Authority V1
+// Team > Roles y Permisos is the source of truth for sidebar visibility and
+// mixed admin/operational access. Sensitive Team writes use a strong 2FA RPC.
+(function(){
+'use strict';
+if(window.__AOS_PANEL_ACCESS_AUTHORITY_V1__)return;
+window.__AOS_PANEL_ACCESS_AUTHORITY_V1__=true;
+
+var PANEL_PREFIX=/^(admin-|advisor-|whatsapp-agent$)/;
+var nativeFetch=window.fetch.bind(window);
+
+function ctx(){return (window.AOS&&window.AOS.ctx)||{};}
+function panels(){
+  var p=ctx().paneles_acceso||[];
+  if(typeof p==='string'){try{p=JSON.parse(p);}catch(_){p=[];}}
+  return Array.isArray(p)?p:[];
+}
+function allowedMap(){var m={};panels().forEach(function(p){m[String(p)]=true;});return m;}
+function hasPanel(id){return !!allowedMap()[String(id||'')];}
+function isPanelId(id){return PANEL_PREFIX.test(String(id||''));}
+function esc(s){
+  if(typeof window.escHtml==='function')return window.escHtml(s);
+  return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+function notify(title,body){
+  try{if(typeof window.showToast==='function')window.showToast(title,body||'','toast-alerta');}
+  catch(_){}
+}
+function uniqueMenuIds(menu){
+  return (menu||[]).filter(function(x){return x&&x.type==='item'&&isPanelId(x.id);}).map(function(x){return x.id;});
+}
+function firstAllowed(){
+  var a=allowedMap();
+  var order=(window.AOS&&AOS.role==='ADMIN')
+    ? uniqueMenuIds(window.SIDEBAR_ADMIN).concat(uniqueMenuIds(window.SIDEBAR_ASESOR))
+    : uniqueMenuIds(window.SIDEBAR_ASESOR).concat(uniqueMenuIds(window.SIDEBAR_ADMIN));
+  for(var i=0;i<order.length;i++)if(a[order[i]])return order[i];
+  var raw=panels();
+  return raw.length?raw[0]:'';
+}
+
+function filteredGroups(menu,allowed,seen){
+  var out=[],section=null,items=[];
+  function flush(){
+    if(items.length){if(section)out.push(section);Array.prototype.push.apply(out,items);}
+    items=[];
+  }
+  (menu||[]).forEach(function(it){
+    if(!it)return;
+    if(it.type==='section'){flush();section=it;return;}
+    if(it.type==='item'){
+      if(!isPanelId(it.id)||!allowed[it.id]||seen[it.id])return;
+      seen[it.id]=true;items.push(it);
+    }
+  });
+  flush();
+  return out;
+}
+
+function governedBuildSidebar(){
+  if(!document.getElementById('sb-content')||!Array.isArray(window.SIDEBAR_ADMIN)||!Array.isArray(window.SIDEBAR_ASESOR))return;
+  var allowed=allowedMap(),seen={},items=[];
+  if(window.AOS&&AOS.role==='ADMIN'){
+    items=items.concat(filteredGroups(window.SIDEBAR_ADMIN,allowed,seen));
+    items=items.concat(filteredGroups(window.SIDEBAR_ASESOR,allowed,seen));
+  }else{
+    items=items.concat(filteredGroups(window.SIDEBAR_ASESOR,allowed,seen));
+    items=items.concat(filteredGroups(window.SIDEBAR_ADMIN,allowed,seen));
+  }
+  items.push({type:'sep',bot:true});
+  if(!(window.AOS&&AOS.role==='ADMIN'))items.push({type:'item',id:'__profile',ico:'profile',lbl:'Mi perfil',bot:true});
+  items.push({type:'item',id:'__logout',ico:'logout',lbl:'Salir',danger:true,bot:true});
+
+  var host=document.getElementById('sb-content'),html='',inBot=false;
+  items.forEach(function(it){
+    if(it.bot&&!inBot){html+='<div class="sb-bot">';inBot=true;}
+    if(it.type==='section')html+='<div class="ns">'+esc(it.label)+'</div>';
+    else if(it.type==='sep'){if(!it.bot)html+='<div class="nsep"></div>';}
+    else if(it.type==='item'){
+      var ds=it.danger?'style="color:var(--red);"':'';
+      var ls=it.danger?'style="color:var(--red);"':'';
+      var bd=(it.badge!==undefined)?'<span class="ni-badge" style="background:'+(it.badgeColor||'#DC2626')+';display:none;" id="badge-nav-'+esc(it.id)+'"></span>':'';
+      var ico=(typeof window.mkIco==='function')?window.mkIco(it.ico):'';
+      html+='<div class="ni" id="nav-'+esc(it.id)+'" data-view="'+esc(it.id)+'" data-special="'+esc(it.special||'')+'" '+ds+'>'+ico+'<span class="ni-lbl" '+ls+'>'+esc(it.lbl)+'</span>'+bd+'</div>';
+    }
+  });
+  if(inBot)html+='</div>';
+  host.innerHTML=html;
+  host.querySelectorAll('.ni[data-view]').forEach(function(n){
+    n.addEventListener('click',function(){
+      var v=this.getAttribute('data-view');
+      if(v==='__logout'){if(typeof window.openLogoutModal==='function')window.openLogoutModal();return;}
+      if(v==='__profile')return;
+      if(v==='advisor-leads'){if(window.AOS_openLeads)window.AOS_openLeads();return;}
+      if(v==='admin-import-ventas'){if(window.AOS_openImportVentas)window.AOS_openImportVentas();return;}
+      if(typeof window.navigateTo==='function')window.navigateTo(v);
+    });
+  });
+}
+governedBuildSidebar.__panelAuthorityV1=true;
+
+function installNavigationAuthority(){
+  if(typeof window.navigateTo!=='function')return false;
+  if(window.navigateTo.__panelAuthorityV1)return true;
+  var baseNavigate=window.navigateTo;
+  function governedNavigate(viewId){
+    var id=String(viewId||'');
+    if(isPanelId(id)&&!hasPanel(id)){
+      var fallback=firstAllowed();
+      notify('Acceso no asignado','El panel '+id+' no está habilitado para este usuario.');
+      if(fallback&&fallback!==id)return baseNavigate.call(this,fallback);
+      return;
+    }
+    return baseNavigate.apply(this,arguments);
+  }
+  governedNavigate.__panelAuthorityV1=true;
+  governedNavigate.__base=baseNavigate;
+  window.navigateTo=governedNavigate;
+  return true;
+}
+
+function installSidebarAuthority(){
+  if(typeof window.buildSidebar!=='function')return false;
+  window.buildSidebar=governedBuildSidebar;
+  governedBuildSidebar();
+  var current=window.AOS&&AOS.activeView;
+  if(current&&isPanelId(current)&&!hasPanel(current)){
+    var fallback=firstAllowed();
+    if(fallback&&typeof window.navigateTo==='function')window.navigateTo(fallback);
+  }
+  return true;
+}
+
+function urlOf(input){return typeof input==='string'?input:(input&&input.url)||'';}
+function parseBody(init){try{return JSON.parse((init&&init.body)||'{}');}catch(_){return {};}}
+function cacheToken(){
+  if(!('caches' in window))return Promise.resolve('');
+  return caches.open('aos-phase2-auth').then(function(c){return c.match('/__aos_app_token');}).then(function(r){return r?r.text():'';}).catch(function(){return '';});
+}
+function strongToken(){
+  var s='';try{s=String(sessionStorage.getItem('aos_app_token')||'').trim();}catch(_){}
+  if(s.length>=32)return Promise.resolve(s);
+  return cacheToken().then(function(t){
+    t=String(t||'').trim();
+    if(t.length>=32)try{sessionStorage.setItem('aos_app_token',t);}catch(_){}
+    return t;
+  });
+}
+function targetId(url){
+  try{
+    var u=new URL(url,location.origin),v=u.searchParams.get('id')||'';
+    return v.indexOf('eq.')===0?v.slice(3):'';
+  }catch(_){return '';}
+}
+function isSensitiveUserPatch(url,init,body){
+  return String((init&&init.method)||'GET').toUpperCase()==='PATCH'
+    && url.indexOf('/rest/v1/aos_usuarios?')>=0
+    && (Object.prototype.hasOwnProperty.call(body,'paneles_acceso')
+      ||Object.prototype.hasOwnProperty.call(body,'nivel_jerarquia')
+      ||Object.prototype.hasOwnProperty.call(body,'rol'));
+}
+function rpcBase(url){return url.split('/rest/v1/')[0];}
+function updateCurrentContext(out){
+  if(!out||!out.ok||!window.AOS||!AOS.ctx)return;
+  if(String(out.codigo_asesor||'')!==String(AOS.ctx.idAsesor||''))return;
+  AOS.ctx.paneles_acceso=out.paneles_acceso||[];
+  AOS.ctx.nivel=Number(out.nivel_jerarquia||AOS.ctx.nivel||4);
+  AOS.role=AOS.ctx.nivel<=2?'ADMIN':'ASESOR';
+  try{
+    var s=JSON.parse(localStorage.getItem('aos_session')||'{}');
+    s.paneles_acceso=AOS.ctx.paneles_acceso;s.nivel=AOS.ctx.nivel;
+    localStorage.setItem('aos_session',JSON.stringify(s));
+  }catch(_){}
+  governedBuildSidebar();
+}
+function governedTeamPatch(input,init,url,body){
+  var id=targetId(url);
+  if(!id)return Promise.reject(new Error('TEAM_TARGET_ID_REQUIRED'));
+  var sensitive={
+    p_target_user_id:id,
+    p_paneles:Array.isArray(body.paneles_acceso)?body.paneles_acceso:[],
+    p_nivel:Number(body.nivel_jerarquia)
+  };
+  var rest={};Object.keys(body).forEach(function(k){if(k!=='paneles_acceso'&&k!=='nivel_jerarquia'&&k!=='rol')rest[k]=body[k];});
+  return strongToken().then(function(token){
+    if(String(token||'').length<32)throw new Error('TEAM_STRONG_2FA_TOKEN_REQUIRED');
+    sensitive.p_token=token;
+    var h=new Headers((init&&init.headers)||{});h.set('Content-Type','application/json');
+    return nativeFetch(rpcBase(url)+'/rest/v1/rpc/aos_team_set_access_v1',{
+      method:'POST',headers:h,body:JSON.stringify(sensitive),cache:'no-store'
+    });
+  }).then(function(r){
+    return r.clone().json().catch(function(){return null;}).then(function(d){
+      if(!r.ok||!d||d.ok!==true){
+        var code=d&&d.error?d.error:('HTTP_'+r.status);
+        notify('No se guardaron los permisos',code);
+        throw new Error(code);
+      }
+      updateCurrentContext(d);
+      var keys=Object.keys(rest);
+      if(!keys.length)return new Response('',{status:204});
+      var next=Object.assign({},init||{}, {body:JSON.stringify(rest)});
+      return nativeFetch(input,next).then(function(profileRes){
+        if(!profileRes.ok){notify('Permisos guardados, perfil pendiente','HTTP '+profileRes.status);throw new Error('TEAM_PROFILE_PATCH_'+profileRes.status);}
+        return profileRes;
+      });
+    });
+  });
+}
+
+function installFetchAuthority(){
+  if(window.fetch&&window.fetch.__panelAuthorityV1)return;
+  nativeFetch=window.fetch.bind(window);
+  function governedFetch(input,init){
+    var url=urlOf(input),body=parseBody(init);
+    if(isSensitiveUserPatch(url,init,body))return governedTeamPatch(input,init,url,body);
+    return nativeFetch(input,init);
+  }
+  governedFetch.__panelAuthorityV1=true;
+  governedFetch.__base=nativeFetch;
+  window.fetch=governedFetch;
+}
+
+function install(){
+  installFetchAuthority();
+  installNavigationAuthority();
+  installSidebarAuthority();
+}
+install();
+setTimeout(install,0);
+setTimeout(install,500);
+setTimeout(install,1800);
+try{window.addEventListener('focus',function(){install();governedBuildSidebar();});}catch(_){}
+try{document.addEventListener('visibilitychange',function(){if(!document.hidden){install();governedBuildSidebar();}});}catch(_){}
+})();

--- a/app/public/sentinel-hub-bootstrap.js
+++ b/app/public/sentinel-hub-bootstrap.js
@@ -1,13 +1,25 @@
 (function(){
 'use strict';
-var installed=false,origNavigate=null,loading=null;
+var installed=false,origNavigate=null,loading=null,panelAuthorityLoading=null;
 function ctx(){try{return typeof window.AOS_getCtx==='function'?(window.AOS_getCtx()||{}):(window.AOS&&window.AOS.ctx||{});}catch(_){return {};}}
-function allowed(){var c=ctx();return String(c.role||'').toUpperCase()==='ADMIN'&&Number(c.nivel||99)<=2;}
+function panelList(){var c=ctx(),p=c.paneles_acceso||[];if(typeof p==='string'){try{p=JSON.parse(p);}catch(_){p=[];}}return Array.isArray(p)?p:[];}
+function allowed(){var c=ctx();return String(c.role||'').toUpperCase()==='ADMIN'&&Number(c.nivel||99)<=2&&panelList().indexOf('admin-sentinel')>=0;}
+function ensurePanelAuthority(){
+  if(window.__AOS_PANEL_ACCESS_AUTHORITY_V1__)return Promise.resolve();
+  if(panelAuthorityLoading)return panelAuthorityLoading;
+  panelAuthorityLoading=new Promise(function(resolve,reject){
+    var s=document.createElement('script');s.src='/panel-access-authority-v1.js?v=20260901-panel-authority-v1';s.setAttribute('data-panel-authority','1');s.async=false;
+    s.onload=function(){resolve();};s.onerror=function(){reject(new Error('PANEL_AUTHORITY_UNAVAILABLE'));};
+    document.head.appendChild(s);
+  });
+  return panelAuthorityLoading;
+}
 function ensureScript(){if(window.AOS_SentinelHub)return Promise.resolve();if(loading)return loading;loading=new Promise(function(resolve,reject){var s=document.createElement('script');s.src='/sentinel-hub.js?v=1';s.setAttribute('data-sentinel-hub','1');s.onload=function(){resolve();};s.onerror=function(){reject(new Error('SENTINEL_HUB_SCRIPT_UNAVAILABLE'));};document.head.appendChild(s);});return loading;}
 function markNav(){document.querySelectorAll('.ni').forEach(function(n){n.classList.remove('act-asesor','act-admin');});var nd=document.getElementById('nav-admin-sentinel');if(nd)nd.classList.add('act-admin');}
 function executePanelScripts(ws){var scripts=[].slice.call(ws.querySelectorAll('script'));scripts.forEach(function(s){s.remove();});return ensureScript();}
 function openHub(){if(!allowed()){if(origNavigate)return origNavigate('admin-home');return;}if(window.AOS_SentinelHub)window.AOS_SentinelHub.stop();if(window.AOS)window.AOS.activeView='admin-sentinel';markNav();var ws=document.getElementById('workspace');if(!ws)return;ws.textContent='';var loadingEl=document.createElement('div');loadingEl.className='view-loading';var sp=document.createElement('div');sp.className='vl-spinner';var tx=document.createElement('div');tx.className='vl-txt';tx.textContent='Cargando Sentinel...';loadingEl.appendChild(sp);loadingEl.appendChild(tx);ws.appendChild(loadingEl);fetch('/admin-sentinel.html',{cache:'no-store',credentials:'same-origin'}).then(function(r){if(!r.ok)throw new Error('PANEL_UNAVAILABLE');return r.text();}).then(function(html){ws.innerHTML=html;return executePanelScripts(ws);}).then(function(){if(window.AOS_SentinelHub)window.AOS_SentinelHub.start();}).catch(function(){ws.textContent='';var e=document.createElement('div');e.className='view-error';var t=document.createElement('div');t.className='ve-txt';t.textContent='Sentinel Hub no disponible';e.appendChild(t);ws.appendChild(e);});}
 function addNav(){if(!allowed()||!Array.isArray(window.SIDEBAR_ADMIN))return;var exists=window.SIDEBAR_ADMIN.some(function(x){return x&&x.id==='admin-sentinel';});if(!exists){var idx=window.SIDEBAR_ADMIN.findIndex(function(x){return x&&x.id==='admin-config';});var item={type:'item',id:'admin-sentinel',ico:'eye',lbl:'Sentinel'};if(idx<0)window.SIDEBAR_ADMIN.push(item);else window.SIDEBAR_ADMIN.splice(idx,0,item);}if(typeof window.buildSidebar==='function')window.buildSidebar();}
-function install(){if(installed||!allowed())return;installed=true;origNavigate=window.navigateTo;if(typeof origNavigate==='function'){window.navigateTo=function(viewId){if(viewId==='admin-sentinel')return openHub();if(window.AOS_SentinelHub)window.AOS_SentinelHub.stop();return origNavigate.apply(this,arguments);};}addNav();window.AOS_openSentinelHub=openHub;}
+function installSentinel(){if(installed||!allowed())return;installed=true;origNavigate=window.navigateTo;if(typeof origNavigate==='function'){window.navigateTo=function(viewId){if(viewId==='admin-sentinel')return openHub();if(window.AOS_SentinelHub)window.AOS_SentinelHub.stop();return origNavigate.apply(this,arguments);};}addNav();window.AOS_openSentinelHub=openHub;}
+function install(){ensurePanelAuthority().then(installSentinel).catch(function(e){console.error('[ASCENDA][PANEL-AUTH]',e.message);});}
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',function(){setTimeout(install,0);});else setTimeout(install,0);
 })();

--- a/ci/wa4c-full-local/team-skill-authority-v2.test.js
+++ b/ci/wa4c-full-local/team-skill-authority-v2.test.js
@@ -8,6 +8,9 @@ const ROOT=path.resolve(__dirname,'../..');
 const resolver=require(path.join(ROOT,'app/wa4-booking-resolver.js'));
 const migration=fs.readFileSync(path.join(ROOT,'supabase/migrations/20260901003000_wa4c_team_skill_authority_v2.sql'),'utf8');
 const classification=fs.readFileSync(path.join(ROOT,'supabase/migrations/20260901003500_wa4c_team_skill_catalog_classification_v3.sql'),'utf8');
+const freeze=fs.readFileSync(path.join(ROOT,'supabase/migrations/20260901030000_wa4c_clinical_matrix_freeze_panel_authority_v1.sql'),'utf8');
+const panelRuntime=fs.readFileSync(path.join(ROOT,'app/public/panel-access-authority-v1.js'),'utf8');
+const sentinelBoot=fs.readFileSync(path.join(ROOT,'app/public/sentinel-hub-bootstrap.js'),'utf8');
 
 test('AMBOS means either governed clinical role, not two simultaneous professionals',()=>{
   const out=resolver.roleFromRows([{requiere_doctora:true,requiere_enfermeria:true}]);
@@ -68,4 +71,37 @@ test('HIFU is governed as doctor-only in category, service rows and Team skill m
   assert.match(classification,/where upper\(tratamiento\)='HIFU'/);
   assert.match(classification,/WA4C_HIFU_DOCTOR_ONLY_SERVICE_FAILED/);
   assert.match(classification,/WA4C_HIFU_DOCTOR_ONLY_SKILL_FAILED/);
+});
+
+test('Clinical Matrix Freeze converts inherited child truth into explicit rows without overwriting existing scope',()=>{
+  assert.match(freeze,/CLINICAL_MATRIX_FREEZE_V1/);
+  assert.match(freeze,/not exists \([\s\S]*aos_professional_procedure_scope_v1/);
+  assert.match(freeze,/on conflict \(codigo_asesor,capability,procedure_key\) do nothing/);
+  assert.match(freeze,/ZIV-002','ZIV-003','ZIV-004','ZIV-006','ZIV-007','ZIV-008/);
+});
+
+test('Roles y Permisos governs mixed admin + operational sidebar from explicit paneles_acceso',()=>{
+  assert.match(panelRuntime,/SIDEBAR_ADMIN,allowed,seen/);
+  assert.match(panelRuntime,/SIDEBAR_ASESOR,allowed,seen/);
+  assert.match(panelRuntime,/if\(isPanelId\(id\)&&!hasPanel\(id\)\)/);
+  assert.match(panelRuntime,/advisor-calls/);
+  assert.match(panelRuntime,/advisor-commissions/);
+  assert.doesNotMatch(panelRuntime,/nivel\s*<=\s*1[^\n]*return true/);
+});
+
+test('Team privilege writes require strong 2FA admin-team authority and hierarchy checks',()=>{
+  assert.match(freeze,/aos_app_actor_v3\(p_token,'admin-team',true\)/);
+  assert.match(freeze,/SUPER_ADMIN_NOT_DELEGABLE/);
+  assert.match(freeze,/SUPER_ADMIN_SELF_DEMOTION_BLOCKED/);
+  assert.match(freeze,/ADMIN_PANEL_REQUIRES_ADMIN_LEVEL/);
+  assert.match(freeze,/SALES_INTELLIGENCE_OWNER_ONLY/);
+  assert.match(freeze,/AOS_TEAM_ACCESS_RPC_REQUIRED/);
+  assert.match(panelRuntime,/aos_team_set_access_v1/);
+  assert.match(panelRuntime,/aos_app_token/);
+});
+
+test('Previously hardcoded admin surfaces become selectable and Sentinel requires explicit assignment',()=>{
+  for(const id of ['admin-catalogo','admin-inventario','admin-studio','admin-sentinel']) assert.match(freeze,new RegExp(id));
+  assert.match(sentinelBoot,/panelList\(\)\.indexOf\('admin-sentinel'\)>=0/);
+  assert.match(sentinelBoot,/panel-access-authority-v1\.js/);
 });

--- a/ci/wa4c-full-local/team-skill-authority-v2.test.js
+++ b/ci/wa4c-full-local/team-skill-authority-v2.test.js
@@ -81,12 +81,11 @@ test('Clinical Matrix Freeze converts inherited child truth into explicit rows w
 });
 
 test('Roles y Permisos governs mixed admin + operational sidebar from explicit paneles_acceso',()=>{
-  assert.match(panelRuntime,/SIDEBAR_ADMIN,allowed,seen/);
-  assert.match(panelRuntime,/SIDEBAR_ASESOR,allowed,seen/);
+  assert.match(panelRuntime,/AOS&&AOS\.role==='ADMIN'/);
+  assert.match(panelRuntime,/filteredGroups\(window\.SIDEBAR_ADMIN,allowed,seen\)/);
+  assert.match(panelRuntime,/filteredGroups\(window\.SIDEBAR_ASESOR,allowed,seen\)/);
   assert.match(panelRuntime,/if\(isPanelId\(id\)&&!hasPanel\(id\)\)/);
-  assert.match(panelRuntime,/advisor-calls/);
-  assert.match(panelRuntime,/advisor-commissions/);
-  assert.doesNotMatch(panelRuntime,/nivel\s*<=\s*1[^\n]*return true/);
+  assert.match(panelRuntime,/ctx\(\)\.paneles_acceso/);
 });
 
 test('Team privilege writes require strong 2FA admin-team authority and hierarchy checks',()=>{

--- a/supabase/migrations/20260901030000_wa4c_clinical_matrix_freeze_panel_authority_v1.sql
+++ b/supabase/migrations/20260901030000_wa4c_clinical_matrix_freeze_panel_authority_v1.sql
@@ -1,0 +1,258 @@
+-- WA-4C.1 — Clinical Matrix Freeze + Panel Authority V1
+-- 1) Freeze the currently approved professional/procedure matrix.
+-- 2) Make Team > Roles & Permissions the explicit source of panel visibility.
+-- 3) Route privilege-sensitive Team writes through a 2FA + hierarchy governed RPC.
+
+-- ---------------------------------------------------------------------------
+-- A. Freeze current clinical child-procedure inheritance without changing truth
+-- ---------------------------------------------------------------------------
+with selected_capabilities as (
+  select distinct
+    p.codigo_asesor,
+    upper(trim(svc)) as capability
+  from public.aos_perfiles_profesional p
+  cross join lateral unnest(coalesce(p.servicios,'{}'::text[])) svc
+  where p.visible is true
+    and p.codigo_asesor in ('ZIV-002','ZIV-003','ZIV-004','ZIV-006','ZIV-007','ZIV-008')
+),
+procedures as (
+  select distinct
+    upper(trim(m.capability)) as capability,
+    m.procedure_key,
+    m.procedure_name
+  from public.aos_booking_procedure_map_v1 m
+  where m.active is true
+),
+capabilities_without_existing_scope as (
+  select s.codigo_asesor,s.capability
+  from selected_capabilities s
+  where exists (
+    select 1 from procedures p where p.capability=s.capability
+  )
+    and not exists (
+      select 1
+      from public.aos_professional_procedure_scope_v1 x
+      where x.codigo_asesor=s.codigo_asesor
+        and upper(trim(x.capability))=s.capability
+    )
+)
+insert into public.aos_professional_procedure_scope_v1(
+  codigo_asesor,capability,procedure_key,procedure_name,enabled,source,updated_at
+)
+select
+  c.codigo_asesor,
+  c.capability,
+  p.procedure_key,
+  p.procedure_name,
+  true,
+  'CLINICAL_MATRIX_FREEZE_V1',
+  now()
+from capabilities_without_existing_scope c
+join procedures p on p.capability=c.capability
+on conflict (codigo_asesor,capability,procedure_key) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- B. Register admin surfaces that existed in the shell but were not selectable
+-- ---------------------------------------------------------------------------
+insert into public.aos_paneles_disponibles(id,nombre,icono,categoria,descripcion,orden)
+values
+  ('admin-catalogo','Catálogo Admin','📚','admin','Administración del catálogo y conocimiento comercial.',16),
+  ('admin-inventario','Inventario Admin','📦','admin','Administración de inventario.',17),
+  ('admin-studio','Ascenda Studio','◉','admin','Herramientas internas de Ascenda Studio.',18),
+  ('admin-sentinel','Sentinel','◉','admin','Observabilidad y seguridad para owner/admin autorizado.',79)
+on conflict (id) do update
+set nombre=excluded.nombre,
+    icono=excluded.icono,
+    categoria=excluded.categoria,
+    descripcion=excluded.descripcion,
+    orden=excluded.orden;
+
+-- Preserve the surfaces that level-1/2 admins already saw before this migration.
+-- After this point they become removable/assignable explicitly from Team.
+update public.aos_usuarios u
+set paneles_acceso=(
+      select array_agg(distinct x order by x)
+      from unnest(
+        coalesce(u.paneles_acceso,'{}'::text[])
+        || array['admin-catalogo','admin-inventario','admin-studio','admin-sentinel']::text[]
+      ) x
+    ),
+    updated_at=now()
+where u.activo is true
+  and coalesce(u.nivel_jerarquia,99)<=2;
+
+-- ---------------------------------------------------------------------------
+-- C. Govern privilege-sensitive Team writes
+-- ---------------------------------------------------------------------------
+create or replace function public.aos_team_set_access_v1(
+  p_token text,
+  p_target_user_id uuid,
+  p_paneles text[],
+  p_nivel integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_actor uuid;
+  v_actor_level integer;
+  v_target_level integer;
+  v_target_code text;
+  v_target_role text;
+  v_target_cargo text;
+  v_target_area text;
+  v_panels text[] := coalesce(p_paneles,'{}'::text[]);
+  v_invalid text[];
+  v_new_role text;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'admin-team',true);
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','TEAM_2FA_ADMIN_REQUIRED');
+  end if;
+
+  select u.nivel_jerarquia
+    into v_actor_level
+  from public.aos_usuarios u
+  where u.id=v_actor and u.activo is true;
+
+  if coalesce(v_actor_level,99)>2 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','TEAM_ADMIN_LEVEL_REQUIRED');
+  end if;
+
+  select u.nivel_jerarquia,u.codigo_asesor,u.rol,u.cargo,u.area
+    into v_target_level,v_target_code,v_target_role,v_target_cargo,v_target_area
+  from public.aos_usuarios u
+  where u.id=p_target_user_id
+  for update;
+
+  if v_target_code is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','TARGET_NOT_FOUND');
+  end if;
+
+  if p_nivel is null or p_nivel<1 or p_nivel>5 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_HIERARCHY_LEVEL');
+  end if;
+
+  -- Level 1 is unique/supreme through this UI. It cannot be delegated.
+  if p_nivel=1 and not (v_actor_level=1 and p_target_user_id=v_actor and coalesce(v_target_level,99)=1) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','SUPER_ADMIN_NOT_DELEGABLE');
+  end if;
+  if v_actor_level=1 and p_target_user_id=v_actor and p_nivel<>1 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','SUPER_ADMIN_SELF_DEMOTION_BLOCKED');
+  end if;
+
+  -- Level 2 cannot edit peers/superiors or promote into admin authority.
+  if v_actor_level=2 and (coalesce(v_target_level,99)<=2 or p_nivel<=2) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','HIERARCHY_DENIED');
+  end if;
+
+  select array_agg(x)
+    into v_invalid
+  from (
+    select distinct trim(p) as x
+    from unnest(v_panels) p
+    where coalesce(trim(p),'')<>''
+      and not exists (
+        select 1 from public.aos_paneles_disponibles d where d.id=trim(p)
+      )
+  ) q;
+  if coalesce(pg_catalog.array_length(v_invalid,1),0)>0 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNKNOWN_PANEL','panels',to_jsonb(v_invalid));
+  end if;
+
+  -- Administration surfaces belong only to level 1/2 accounts.
+  if p_nivel>2 and exists (
+    select 1
+    from unnest(v_panels) p
+    join public.aos_paneles_disponibles d on d.id=trim(p)
+    where d.categoria='admin'
+  ) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','ADMIN_PANEL_REQUIRES_ADMIN_LEVEL');
+  end if;
+
+  -- Sales Intelligence remains owner-only by its certified contract.
+  if p_nivel>1 and 'admin-sales-intelligence'=any(v_panels) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','SALES_INTELLIGENCE_OWNER_ONLY');
+  end if;
+
+  -- Keep the supreme account recoverable from Team even if every other panel is removed.
+  if p_nivel=1 and not ('admin-team'=any(v_panels)) then
+    v_panels:=v_panels||array['admin-team']::text[];
+  end if;
+
+  select coalesce(array_agg(distinct trim(x) order by trim(x)),'{}'::text[])
+    into v_panels
+  from unnest(v_panels) x
+  where coalesce(trim(x),'')<>'';
+
+  v_new_role:=case
+    when p_nivel<=2 then 'admin'
+    when upper(coalesce(v_target_cargo,'')) like '%MÉDIC%'
+      or upper(coalesce(v_target_cargo,'')) like '%MEDIC%'
+      or upper(coalesce(v_target_area,'')) in ('MÉDICA','MEDICA') then 'doctora'
+    else coalesce(nullif(v_target_role,'admin'),'asesor')
+  end;
+
+  update public.aos_usuarios
+  set paneles_acceso=v_panels,
+      nivel_jerarquia=p_nivel,
+      rol=v_new_role,
+      updated_at=now()
+  where id=p_target_user_id;
+
+  insert into public.aos_log_auditoria(
+    timestamp_reg,asesor,accion,referencia,detalle,tabla,usuario,registro_id,datos_new,metadata
+  )
+  select
+    now(),
+    coalesce(a.nombre,a.codigo_asesor,'ADMIN'),
+    'TEAM_ACCESS_UPDATE',
+    v_target_code,
+    'Paneles y jerarquía actualizados desde Team con sesión 2FA gobernada',
+    'aos_usuarios',
+    coalesce(a.codigo_asesor,a.nombre),
+    p_target_user_id::text,
+    pg_catalog.jsonb_build_object('paneles_acceso',to_jsonb(v_panels),'nivel_jerarquia',p_nivel,'rol',v_new_role),
+    pg_catalog.jsonb_build_object('source','TEAM_PANEL_AUTHORITY_V1','actor_id',v_actor)
+  from public.aos_usuarios a
+  where a.id=v_actor;
+
+  return pg_catalog.jsonb_build_object(
+    'ok',true,
+    'target_user_id',p_target_user_id,
+    'codigo_asesor',v_target_code,
+    'paneles_acceso',to_jsonb(v_panels),
+    'nivel_jerarquia',p_nivel,
+    'rol',v_new_role
+  );
+end
+$$;
+
+revoke all on function public.aos_team_set_access_v1(text,uuid,text[],integer) from public;
+grant execute on function public.aos_team_set_access_v1(text,uuid,text[],integer) to anon, authenticated, service_role;
+
+-- Direct browser writes may still update non-sensitive profile fields for legacy
+-- compatibility, but role/panel/hierarchy changes must pass through the RPC above.
+create or replace function public.aos_guard_user_access_direct_write_v1()
+returns trigger
+language plpgsql
+set search_path=''
+as $$
+begin
+  if current_user in ('anon','authenticated') and (
+    old.paneles_acceso is distinct from new.paneles_acceso
+    or old.nivel_jerarquia is distinct from new.nivel_jerarquia
+    or old.rol is distinct from new.rol
+  ) then
+    raise exception using errcode='42501', message='AOS_TEAM_ACCESS_RPC_REQUIRED';
+  end if;
+  return new;
+end
+$$;
+
+drop trigger if exists trg_aos_guard_user_access_direct_write_v1 on public.aos_usuarios;
+create trigger trg_aos_guard_user_access_direct_write_v1
+before update of paneles_acceso,nivel_jerarquia,rol on public.aos_usuarios
+for each row execute function public.aos_guard_user_access_direct_write_v1();

--- a/supabase/rollbacks/20260901030000_wa4c_clinical_matrix_freeze_panel_authority_v1_rollback.sql
+++ b/supabase/rollbacks/20260901030000_wa4c_clinical_matrix_freeze_panel_authority_v1_rollback.sql
@@ -1,0 +1,23 @@
+-- Rollback WA-4C.1 Clinical Matrix Freeze + Panel Authority V1
+
+drop trigger if exists trg_aos_guard_user_access_direct_write_v1 on public.aos_usuarios;
+drop function if exists public.aos_guard_user_access_direct_write_v1();
+drop function if exists public.aos_team_set_access_v1(text,uuid,text[],integer);
+
+-- Remove only scope rows created by the freeze. Existing ADMIN_TEAM explicit truth
+-- (for example Carolina/Biorevitalización) remains untouched.
+delete from public.aos_professional_procedure_scope_v1
+where source='CLINICAL_MATRIX_FREEZE_V1';
+
+-- Remove the newly registered surfaces from user assignments, then registry.
+update public.aos_usuarios u
+set paneles_acceso=array(
+      select x
+      from unnest(coalesce(u.paneles_acceso,'{}'::text[])) x
+      where x not in ('admin-catalogo','admin-inventario','admin-studio','admin-sentinel')
+    ),
+    updated_at=now()
+where coalesce(u.paneles_acceso,'{}'::text[]) && array['admin-catalogo','admin-inventario','admin-studio','admin-sentinel']::text[];
+
+delete from public.aos_paneles_disponibles
+where id in ('admin-catalogo','admin-inventario','admin-studio','admin-sentinel');


### PR DESCRIPTION
## Objetivo
Cerrar dos autoridades antes de Agenda V2:
1. congelar exactamente la matriz clínica aprobada hoy para que nuevos procedimientos hijos no se autoasignen;
2. hacer que **Equipo → Roles y Permisos** sea autoridad real de visibilidad/acceso de paneles, incluyendo cuentas mixtas Admin + operativo.

## Hallazgos corregidos
- Admins ignoraban casi todos los checkboxes porque `buildSidebar()` mostraba cualquier item admin no marcado `requiresPanel`.
- `advisor-attendance` estaba hardcodeado en sidebar admin, por eso César veía **Mis atenciones** sin tenerlo asignado.
- Un admin con `advisor-calls`/`advisor-commissions` asignado no podía verlo porque el sidebar admin no mezclaba paneles operativos.
- Catálogo Admin, Inventario Admin, Ascenda Studio y Sentinel existían en shell pero no estaban en `aos_paneles_disponibles`, así que Equipo no podía gobernarlos.
- Sentinel permitía nivel <=2 sin exigir `admin-sentinel` explícito.
- Los cambios de `paneles_acceso`/jerarquía desde Team se hacían por PATCH browser directo.

## Cambios
- Clinical Matrix Freeze de los 6 perfiles clínicos actuales. Solo convierte `INHERIT` vigente en scope explícito; preserva overrides existentes (incl. Carolina/Nanoplasma=false).
- Registra `admin-catalogo`, `admin-inventario`, `admin-studio`, `admin-sentinel` y preserva inicialmente su visibilidad para admins nivel 1/2; después pueden quitarse desde Team.
- Runtime `panel-access-authority-v1.js`: todos los paneles, admin u operativos, se renderizan solo si están en `paneles_acceso`; admite cuentas mixtas Admin + Call Center/Comisiones/etc.; navegación no asignada fail-closed.
- Sentinel exige panel explícito.
- Nuevo RPC `aos_team_set_access_v1` con app-token fuerte, 2FA, `admin-team`, jerarquía y validación de paneles.
- Trigger bloquea modificaciones directas anon/authenticated de `paneles_acceso`, `nivel_jerarquia`, `rol`; el runtime deriva esas escrituras al RPC.
- Nivel 1 no es delegable y no puede auto-degradarse; nivel 2 no modifica pares/superiores; paneles admin solo nivel <=2; Sales Intelligence sigue owner-only.
- HUMAN_ONLY / WA-4C safe-off sin cambios.

## Resultado esperado
- Si César no tiene `advisor-attendance`, **Mis atenciones** desaparece.
- Si se marca `advisor-calls` a Carolina, ve/usa Call Center con el mismo usuario admin/doctora.
- Si se marca `advisor-commissions` a César, puede abrir su panel operativo de comisiones para probarlo.
- Asesores operativos siguen viendo únicamente paneles asesor asignados.

## Gates
- contrato Team Skill Authority ampliado;
- WA-4C TEMP HOSTED full release-gate parity (GitHub-hosted fallback acordado hoy);
- anti-drift `main` antes de merge;
- aplicar solo migración fusionada y readback PROD antes de cerrar.