### PR TITLE
P0: reducir IO de Call Center y gobernar guardado de Agenda

### DIFF
--- a/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
+++ b/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
@@ -1,0 +1,44 @@
+name: ASCENDA P0 Call Center + Agenda Performance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/public/calls-performance-v1.js'
+      - 'app/public/agenda-governed-status-v1.js'
+      - 'app/public/panel-access-authority-v1.js'
+      - 'supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql'
+      - 'supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql'
+      - 'ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js'
+      - '.github/workflows/p0-callcenter-agenda-performance-hosted.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  p0-contract:
+    name: Hosted P0 performance + governed status contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: JavaScript syntax
+        run: |
+          set -euo pipefail
+          node --check app/public/calls-performance-v1.js
+          node --check app/public/agenda-governed-status-v1.js
+          node --check app/public/panel-access-authority-v1.js
+          node --check ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+      - name: P0 contracts
+        run: node --test ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+      - name: Safety assertions
+        run: |
+          set -euo pipefail
+          grep -q "set_config('aos.callcenter_phone',v_num,true)" supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql
+          grep -q "aos_agenda_set_status_v1" supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql
+          ! grep -Eq '(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)[[:space:]]*=[[:space:]]*true' supabase/migrations/2026090103*.sql
+          echo 'ASCENDA_P0_CALLCENTER_AGENDA_PERFORMANCE_CONTRACT_PASS'

--- a/app/public/agenda-governed-status-v1.js
+++ b/app/public/agenda-governed-status-v1.js
@@ -1,6 +1,7 @@
 /* ASCENDA OS · Agenda Governed Status V1
  * Replaces the legacy browser PATCH + DELETE + POST chain with one atomic,
  * permissioned database action. Other Agenda operations remain untouched.
+ * Loaded after the panel inline runtime by the already-certified shell hotfix.
  */
 (function(){
 'use strict';
@@ -30,13 +31,12 @@ function apiError(code){
   return map[code]||code||'No se pudo actualizar la cita.';
 }
 function selectedStatus(){
-  var v='';
-  var host=document.getElementById('det-estados');
+  var v='',host=document.getElementById('det-estados');
   if(host)host.querySelectorAll('.est-btn.act').forEach(function(b){v=b.getAttribute('data-val')||'';});
   return v;
 }
 function sendNoShowEmail(c){
-  var num=String(c&& (c.numero_limpio||c.numero)||'').replace(/\D/g,'');
+  var num=String(c&&(c.numero_limpio||c.numero)||'').replace(/\D/g,'');
   if(!num||!window._SB||!window._SK)return;
   fetch(window._SB+'/rest/v1/aos_pacientes?select=Email,nombres&numero_limpio=eq.'+num,{headers:{apikey:window._SK,Authorization:'Bearer '+window._SK}})
     .then(function(r){return r.ok?r.json():[];}).then(function(rows){
@@ -52,8 +52,7 @@ function install(){
   if(window.agGuardarEstado.__agendaGovernedV1)return true;
 
   function governedSave(){
-    if(!window.AG||!AG.sel)return;
-    if(AG._guardando)return;
+    if(!window.AG||!AG.sel||AG._guardando)return;
     var est=selectedStatus();
     var nota=((document.getElementById('det-nota')||{}).value||'').trim();
     var asistente=(document.getElementById('det-asistente')||{}).value||'';
@@ -62,14 +61,11 @@ function install(){
 
     strongToken().then(function(token){
       if(String(token||'').length<32)throw new Error('AGENDA_2FA_PANEL_REQUIRED');
-      var ctrl=typeof AbortController!=='undefined'?new AbortController():null;
-      var timer=ctrl?setTimeout(function(){ctrl.abort();},20000):null;
       return fetch(window._SB+'/rest/v1/rpc/aos_agenda_set_status_v1',{
-        method:'POST',cache:'no-store',signal:ctrl?ctrl.signal:undefined,
+        method:'POST',cache:'no-store',
         headers:{apikey:window._SK,Authorization:'Bearer '+window._SK,'Content-Type':'application/json'},
         body:JSON.stringify({p_token:token,p_cita_id:String(AG.sel.id),p_estado:est,p_asistente:asistente,p_nota:nota})
       }).then(function(r){
-        if(timer)clearTimeout(timer);
         return r.json().catch(function(){return null;}).then(function(d){
           if(!r.ok||!d||d.ok!==true){var code=d&&d.error?d.error:('HTTP_'+r.status);throw new Error(code);}
           return d;
@@ -78,14 +74,14 @@ function install(){
     }).then(function(d){
       AG._guardando=false;
       toast('Estado actualizado',est,'');
-      if((est==='ASISTIO'||est==='EFECTIVA')&&d.attentionId){toast('✅ Atención sincronizada','Registro clínico creado/actualizado','');}
+      if((est==='ASISTIO'||est==='EFECTIVA')&&d.attentionId)toast('✅ Atención sincronizada','Registro clínico creado/actualizado','');
       if(est==='NO ASISTIO')sendNoShowEmail(AG.sel);
       if(typeof window.agCloseDet==='function')window.agCloseDet();
       if(typeof window.agLoad==='function')window.agLoad();
     }).catch(function(e){
       AG._guardando=false;
-      var code=e&&e.name==='AbortError'?'AGENDA_TIMEOUT':String(e&&e.message||'AGENDA_ERROR');
-      toast('No se guardó la cita',code==='AGENDA_TIMEOUT'?'La operación tardó demasiado. Reintenta; no se duplicará.':apiError(code),'toast-alerta');
+      var code=String(e&&e.message||'AGENDA_ERROR');
+      toast('No se guardó la cita',apiError(code),'toast-alerta');
       console.error('[AGENDA-GOVERNED]',code);
     });
   }
@@ -98,6 +94,5 @@ function install(){
 }
 
 window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__=install;
-var attempts=0;
-(function wait(){attempts++;if(install())return;if(attempts<200&&document.getElementById('ag-content'))setTimeout(wait,50);})();
+install();
 })();

--- a/app/public/agenda-governed-status-v1.js
+++ b/app/public/agenda-governed-status-v1.js
@@ -1,0 +1,103 @@
+/* ASCENDA OS · Agenda Governed Status V1
+ * Replaces the legacy browser PATCH + DELETE + POST chain with one atomic,
+ * permissioned database action. Other Agenda operations remain untouched.
+ */
+(function(){
+'use strict';
+
+function cacheToken(){
+  if(!('caches' in window))return Promise.resolve('');
+  return caches.open('aos-phase2-auth').then(function(c){return c.match('/__aos_app_token');}).then(function(r){return r?r.text():'';}).catch(function(){return '';});
+}
+function strongToken(){
+  var t='';try{t=String(sessionStorage.getItem('aos_app_token')||'').trim();}catch(_){}
+  if(t.length>=32)return Promise.resolve(t);
+  return cacheToken().then(function(x){
+    x=String(x||'').trim();
+    if(x.length>=32)try{sessionStorage.setItem('aos_app_token',x);}catch(_){}
+    return x;
+  });
+}
+function toast(a,b,c){try{if(window.AOS_showToast)window.AOS_showToast(a,b||'',c||'');}catch(_){} }
+function apiError(code){
+  var map={
+    AGENDA_2FA_PANEL_REQUIRED:'Sesión 2FA o permiso de Agenda requerido.',
+    APPOINTMENT_NOT_FOUND:'La cita ya no existe o cambió. Recarga Agenda.',
+    DOCTOR_AUTHORITY_REQUIRED:'La cita no tiene una doctora válida asignada.',
+    ATTENDING_NURSE_REQUIRED:'Selecciona quién realizará la atención.',
+    INVALID_APPOINTMENT_STATUS:'Estado de cita no válido.'
+  };
+  return map[code]||code||'No se pudo actualizar la cita.';
+}
+function selectedStatus(){
+  var v='';
+  var host=document.getElementById('det-estados');
+  if(host)host.querySelectorAll('.est-btn.act').forEach(function(b){v=b.getAttribute('data-val')||'';});
+  return v;
+}
+function sendNoShowEmail(c){
+  var num=String(c&& (c.numero_limpio||c.numero)||'').replace(/\D/g,'');
+  if(!num||!window._SB||!window._SK)return;
+  fetch(window._SB+'/rest/v1/aos_pacientes?select=Email,nombres&numero_limpio=eq.'+num,{headers:{apikey:window._SK,Authorization:'Bearer '+window._SK}})
+    .then(function(r){return r.ok?r.json():[];}).then(function(rows){
+      var p=rows&&rows[0];if(!p||!p.Email)return;
+      return fetch('https://ascenda-os-production.up.railway.app/api/send-template',{
+        method:'POST',headers:{'Content-Type':'application/json','X-ASCENDA-Session':(sessionStorage.getItem('aos_app_token')||'')},
+        body:JSON.stringify({to:p.Email,template:'no_asistencia',nombre:p.nombres||c.nombre||'',tratamiento:c.tratamiento||'',sede:c.sede||'',fecha:c.fecha_cita||''})
+      });
+    }).catch(function(){});
+}
+function install(){
+  if(typeof window.agGuardarEstado!=='function'||!window.AG||!window._SB||!window._SK)return false;
+  if(window.agGuardarEstado.__agendaGovernedV1)return true;
+
+  function governedSave(){
+    if(!window.AG||!AG.sel)return;
+    if(AG._guardando)return;
+    var est=selectedStatus();
+    var nota=((document.getElementById('det-nota')||{}).value||'').trim();
+    var asistente=(document.getElementById('det-asistente')||{}).value||'';
+    if(!est){toast('Selecciona un estado','','toast-alerta');return;}
+    AG._guardando=true;
+
+    strongToken().then(function(token){
+      if(String(token||'').length<32)throw new Error('AGENDA_2FA_PANEL_REQUIRED');
+      var ctrl=typeof AbortController!=='undefined'?new AbortController():null;
+      var timer=ctrl?setTimeout(function(){ctrl.abort();},20000):null;
+      return fetch(window._SB+'/rest/v1/rpc/aos_agenda_set_status_v1',{
+        method:'POST',cache:'no-store',signal:ctrl?ctrl.signal:undefined,
+        headers:{apikey:window._SK,Authorization:'Bearer '+window._SK,'Content-Type':'application/json'},
+        body:JSON.stringify({p_token:token,p_cita_id:String(AG.sel.id),p_estado:est,p_asistente:asistente,p_nota:nota})
+      }).then(function(r){
+        if(timer)clearTimeout(timer);
+        return r.json().catch(function(){return null;}).then(function(d){
+          if(!r.ok||!d||d.ok!==true){var code=d&&d.error?d.error:('HTTP_'+r.status);throw new Error(code);}
+          return d;
+        });
+      });
+    }).then(function(d){
+      AG._guardando=false;
+      toast('Estado actualizado',est,'');
+      if((est==='ASISTIO'||est==='EFECTIVA')&&d.attentionId){toast('✅ Atención sincronizada','Registro clínico creado/actualizado','');}
+      if(est==='NO ASISTIO')sendNoShowEmail(AG.sel);
+      if(typeof window.agCloseDet==='function')window.agCloseDet();
+      if(typeof window.agLoad==='function')window.agLoad();
+    }).catch(function(e){
+      AG._guardando=false;
+      var code=e&&e.name==='AbortError'?'AGENDA_TIMEOUT':String(e&&e.message||'AGENDA_ERROR');
+      toast('No se guardó la cita',code==='AGENDA_TIMEOUT'?'La operación tardó demasiado. Reintenta; no se duplicará.':apiError(code),'toast-alerta');
+      console.error('[AGENDA-GOVERNED]',code);
+    });
+  }
+  governedSave.__agendaGovernedV1=true;
+  governedSave.__legacy=window.agGuardarEstado;
+  window.agGuardarEstado=governedSave;
+  window.__AOS_AGENDA_GOVERNED_STATUS_V1__='v1';
+  console.log('[ASCENDA][AGENDA] governed status runtime active');
+  return true;
+}
+
+window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__=install;
+var attempts=0;
+(function wait(){attempts++;if(install())return;if(attempts<200&&document.getElementById('ag-content'))setTimeout(wait,50);})();
+})();

--- a/app/public/calls-performance-v1.js
+++ b/app/public/calls-performance-v1.js
@@ -1,7 +1,7 @@
 /* ASCENDA OS · Call Center P0 Performance V1
- * Loaded AFTER calls-loop6.js, so the outer wrapper can route legacy
- * aos_siguiente_lead_v2 through the governed contact-debt selector and still
- * preserve the Loop6 metadata hook.
+ * Loaded by the shell when the Call Center panel exists. Installation waits
+ * for the certified Loop6 V2.3 post-load replay so the performance wrapper
+ * stays OUTSIDE the governed write/metadata authority.
  */
 (function(){
 'use strict';
@@ -13,6 +13,7 @@ function stable(v){
 }
 
 function install(){
+  if(window.__AOS_CC_LOOP6_POSTLOAD_READY__!=='v2.3-postload')return false;
   if(typeof window._rpc!=='function')return false;
   if(window._rpc.__ccPerfV1)return true;
 
@@ -37,9 +38,8 @@ function install(){
   }
 
   function perfRpc(fn,p,ok,fail){
-    // Legacy calls.js still invokes _v2. Route it through the newer selector;
-    // because `base` is the Loop6 wrapper, its CONTACT_DEBT metadata hook now
-    // runs as originally designed.
+    // calls.js still invokes _v2. The certified selector is aos_siguiente_lead;
+    // because `base` is Loop6, CONTACT_DEBT/lead lineage metadata is preserved.
     var actual=fn==='aos_siguiente_lead_v2'?'aos_siguiente_lead':fn;
     var isWrite=/^aos_callcenter_(commit|confirm)_/.test(actual);
     var ms=ttl[actual]||0;
@@ -58,10 +58,7 @@ function install(){
     }
 
     var inflight=pending.get(key);
-    if(inflight){
-      inflight.push({ok:ok,fail:fail});
-      return;
-    }
+    if(inflight){inflight.push({ok:ok,fail:fail});return;}
 
     var waiters=[{ok:ok,fail:fail}];
     pending.set(key,waiters);
@@ -84,5 +81,10 @@ function install(){
 }
 
 window.__AOS_CC_INSTALL_PERF_V1__=install;
-if(!install())setTimeout(install,50);
+var attempts=0;
+(function waitForGovernedRuntime(){
+  attempts++;
+  if(install())return;
+  if(attempts<200&&document.getElementById('cc-m-cita-manual'))setTimeout(waitForGovernedRuntime,50);
+})();
 })();

--- a/app/public/calls-performance-v1.js
+++ b/app/public/calls-performance-v1.js
@@ -1,0 +1,88 @@
+/* ASCENDA OS · Call Center P0 Performance V1
+ * Loaded AFTER calls-loop6.js, so the outer wrapper can route legacy
+ * aos_siguiente_lead_v2 through the governed contact-debt selector and still
+ * preserve the Loop6 metadata hook.
+ */
+(function(){
+'use strict';
+
+function stable(v){
+  if(v===null||typeof v!=='object')return JSON.stringify(v);
+  if(Array.isArray(v))return '['+v.map(stable).join(',')+']';
+  return '{'+Object.keys(v).sort().map(function(k){return JSON.stringify(k)+':'+stable(v[k]);}).join(',')+'}';
+}
+
+function install(){
+  if(typeof window._rpc!=='function')return false;
+  if(window._rpc.__ccPerfV1)return true;
+
+  var base=window._rpc;
+  var cache=new Map();
+  var pending=new Map();
+  var ttl={
+    aos_panel_asesor:2500,
+    aos_monitoreo_equipo:2500,
+    aos_historico_asesor_anual:10000,
+    aos_horarios_semana:30000
+  };
+
+  function clearOperationalCache(){cache.clear();}
+  function deliver(waiters,kind,value){
+    waiters.forEach(function(w){
+      try{
+        if(kind==='ok'){if(w.ok)w.ok(value);}
+        else if(w.fail)w.fail(value);
+      }catch(e){console.error('[CC-PERF] callback',e);}
+    });
+  }
+
+  function perfRpc(fn,p,ok,fail){
+    // Legacy calls.js still invokes _v2. Route it through the newer selector;
+    // because `base` is the Loop6 wrapper, its CONTACT_DEBT metadata hook now
+    // runs as originally designed.
+    var actual=fn==='aos_siguiente_lead_v2'?'aos_siguiente_lead':fn;
+    var isWrite=/^aos_callcenter_(commit|confirm)_/.test(actual);
+    var ms=ttl[actual]||0;
+
+    if(!ms){
+      return base(actual,p,function(d){
+        if(isWrite&&d&&d.ok===true)clearOperationalCache();
+        if(ok)ok(d);
+      },fail);
+    }
+
+    var key=actual+'|'+stable(p||{}),now=Date.now(),hit=cache.get(key);
+    if(hit&&now-hit.at<=ms){
+      Promise.resolve().then(function(){if(ok)ok(hit.data);});
+      return;
+    }
+
+    var inflight=pending.get(key);
+    if(inflight){
+      inflight.push({ok:ok,fail:fail});
+      return;
+    }
+
+    var waiters=[{ok:ok,fail:fail}];
+    pending.set(key,waiters);
+    return base(actual,p,function(d){
+      pending.delete(key);
+      cache.set(key,{at:Date.now(),data:d});
+      deliver(waiters,'ok',d);
+    },function(e){
+      pending.delete(key);
+      deliver(waiters,'fail',e);
+    });
+  }
+
+  perfRpc.__ccPerfV1=true;
+  perfRpc.__base=base;
+  window._rpc=perfRpc;
+  window.__AOS_CC_PERF_V1__={version:'v1',installedAt:new Date().toISOString(),clear:clearOperationalCache};
+  console.log('[ASCENDA][CC-PERF] P0 read coalescing + governed lead selector active');
+  return true;
+}
+
+window.__AOS_CC_INSTALL_PERF_V1__=install;
+if(!install())setTimeout(install,50);
+})();

--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -9,6 +9,8 @@ var nativeConfirm=window.confirm.bind(window);
 var tokenSyncPromise=null;
 var cc6PanelSeen=null;
 var cc6ReloadTimer=null;
+var agendaPanelSeen=null;
+var agendaReloadTimer=null;
 
 function cleanCajaClosedState(){
   var box=document.getElementById('no-sesion-msg');
@@ -135,6 +137,16 @@ function loadProductResolutionCenter(){
   (document.head||document.documentElement).appendChild(b);
 }
 
+function loadCallCenterPerformance(){
+  var old=document.getElementById('aos-cc-performance-v1');if(old)old.remove();
+  var p=document.createElement('script');
+  p.id='aos-cc-performance-v1';
+  p.src='/calls-performance-v1.js?v=20260901-p0-v1';
+  p.async=false;
+  p.onerror=function(){console.error('[ASCENDA][CC-PERF] runtime failed');};
+  (document.head||document.documentElement).appendChild(p);
+}
+
 // Call Center Loop 6 V2.3 must execute after the panel's legacy inline script.
 // app.html loads panel externals first and sets AOS._capturePanelTimers=false
 // only after the collected inline runtime has finished loading. We wait for
@@ -167,6 +179,7 @@ function ensureCallCenterLoop6Postload(){
     s.onload=function(){
       window.__AOS_CC_LOOP6_POSTLOAD_READY__='v2.3-postload';
       console.log('[ASCENDA][CC6V23] governed postload runtime active');
+      loadCallCenterPerformance();
     };
     s.onerror=function(){console.error('[ASCENDA][CC6V23] postload runtime failed');};
     (document.head||document.documentElement).appendChild(s);
@@ -174,7 +187,39 @@ function ensureCallCenterLoop6Postload(){
   cc6ReloadTimer=setTimeout(afterInline,0);
 }
 
-function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();ensureCallCenterLoop6Postload();}
+// Agenda legacy inline code owns agGuardarEstado. Replay the governed status
+// adapter only after that inline boundary so it cannot be overwritten.
+function ensureAgendaGovernedPostload(){
+  var panel=document.getElementById('ag-content');
+  if(!panel){
+    agendaPanelSeen=null;
+    if(agendaReloadTimer){clearTimeout(agendaReloadTimer);agendaReloadTimer=null;}
+    return;
+  }
+  if(panel===agendaPanelSeen)return;
+  agendaPanelSeen=panel;
+  if(agendaReloadTimer)clearTimeout(agendaReloadTimer);
+  var attempts=0;
+  function afterInline(){
+    if(document.getElementById('ag-content')!==panel)return;
+    attempts++;
+    if(window.AOS&&AOS._capturePanelTimers===true&&attempts<100){
+      agendaReloadTimer=setTimeout(afterInline,50);
+      return;
+    }
+    agendaReloadTimer=null;
+    var old=document.getElementById('aos-agenda-governed-status-v1');if(old)old.remove();
+    var s=document.createElement('script');
+    s.id='aos-agenda-governed-status-v1';
+    s.src='/agenda-governed-status-v1.js?v=20260901-p0-v1';
+    s.async=false;
+    s.onerror=function(){console.error('[ASCENDA][AGENDA] governed status runtime failed');};
+    (document.head||document.documentElement).appendChild(s);
+  }
+  agendaReloadTimer=setTimeout(afterInline,0);
+}
+
+function run(){cleanCajaClosedState();patchSalesEditorTruth();loadProductResolutionCenter();ensureCallCenterLoop6Postload();ensureAgendaGovernedPostload();}
 run();
 syncCanonicalAppToken();
 setTimeout(syncCanonicalAppToken,700);

--- a/app/public/panel-access-authority-v1.js
+++ b/app/public/panel-access-authority-v1.js
@@ -221,14 +221,41 @@ function installFetchAuthority(){
   window.fetch=governedFetch;
 }
 
+// P0 operational runtime loader. This observer watches DOM only; it owns no
+// polling/network cadence. It allows the existing SPA to activate targeted
+// fixes each time a panel's legacy scripts recreate their globals.
+function loadRuntime(id,src,onReady){
+  var old=document.getElementById(id);
+  if(old){if(onReady)onReady();return;}
+  var s=document.createElement('script');s.id=id;s.src=src;s.async=false;
+  if(onReady)s.onload=onReady;
+  s.onerror=function(){console.error('[ASCENDA][RUNTIME] failed',src);};
+  (document.head||document.documentElement).appendChild(s);
+}
+function installOperationalRuntimes(){
+  if(document.getElementById('cc-m-cita-manual')){
+    if(typeof window.__AOS_CC_INSTALL_PERF_V1__==='function')window.__AOS_CC_INSTALL_PERF_V1__();
+    else loadRuntime('aos-cc-performance-v1','/calls-performance-v1.js?v=20260901-p0-v1',function(){if(window.__AOS_CC_INSTALL_PERF_V1__)window.__AOS_CC_INSTALL_PERF_V1__();});
+  }
+  if(document.getElementById('ag-content')){
+    if(typeof window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__==='function')window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__();
+    else loadRuntime('aos-agenda-governed-status-v1','/agenda-governed-status-v1.js?v=20260901-p0-v1',function(){if(window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__)window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__();});
+  }
+}
+
 function install(){
   installFetchAuthority();
   installNavigationAuthority();
   installSidebarAuthority();
+  installOperationalRuntimes();
 }
 
 // Loaded by sentinel-hub-bootstrap after the shell has defined its sidebar and
-// navigation functions. Keep installation one-shot: no timer/focus/visibility
-// network owner is created by this permission layer.
+// navigation functions. The observer is DOM-only and exists solely because
+// panel scripts are recreated by the SPA after navigation.
 install();
+try{
+  var opObs=new MutationObserver(function(){installOperationalRuntimes();});
+  opObs.observe(document.documentElement||document.body,{childList:true,subtree:true});
+}catch(_){}
 })();

--- a/app/public/panel-access-authority-v1.js
+++ b/app/public/panel-access-authority-v1.js
@@ -221,41 +221,14 @@ function installFetchAuthority(){
   window.fetch=governedFetch;
 }
 
-// P0 operational runtime loader. This observer watches DOM only; it owns no
-// polling/network cadence. It allows the existing SPA to activate targeted
-// fixes each time a panel's legacy scripts recreate their globals.
-function loadRuntime(id,src,onReady){
-  var old=document.getElementById(id);
-  if(old){if(onReady)onReady();return;}
-  var s=document.createElement('script');s.id=id;s.src=src;s.async=false;
-  if(onReady)s.onload=onReady;
-  s.onerror=function(){console.error('[ASCENDA][RUNTIME] failed',src);};
-  (document.head||document.documentElement).appendChild(s);
-}
-function installOperationalRuntimes(){
-  if(document.getElementById('cc-m-cita-manual')){
-    if(typeof window.__AOS_CC_INSTALL_PERF_V1__==='function')window.__AOS_CC_INSTALL_PERF_V1__();
-    else loadRuntime('aos-cc-performance-v1','/calls-performance-v1.js?v=20260901-p0-v1',function(){if(window.__AOS_CC_INSTALL_PERF_V1__)window.__AOS_CC_INSTALL_PERF_V1__();});
-  }
-  if(document.getElementById('ag-content')){
-    if(typeof window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__==='function')window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__();
-    else loadRuntime('aos-agenda-governed-status-v1','/agenda-governed-status-v1.js?v=20260901-p0-v1',function(){if(window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__)window.__AOS_INSTALL_AGENDA_GOVERNED_STATUS_V1__();});
-  }
-}
-
 function install(){
   installFetchAuthority();
   installNavigationAuthority();
   installSidebarAuthority();
-  installOperationalRuntimes();
 }
 
 // Loaded by sentinel-hub-bootstrap after the shell has defined its sidebar and
-// navigation functions. The observer is DOM-only and exists solely because
-// panel scripts are recreated by the SPA after navigation.
+// navigation functions. Keep installation one-shot: no timer/focus/visibility
+// network owner is created by this permission layer.
 install();
-try{
-  var opObs=new MutationObserver(function(){installOperationalRuntimes();});
-  opObs.observe(document.documentElement||document.body,{childList:true,subtree:true});
-}catch(_){}
 })();

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -5,6 +5,7 @@ const assert=require('node:assert/strict');
 
 const cc=fs.readFileSync('app/public/calls-performance-v1.js','utf8');
 const agenda=fs.readFileSync('app/public/agenda-governed-status-v1.js','utf8');
+const f4=fs.readFileSync('app/public/f4-production-canary-hotfix.js','utf8');
 const panel=fs.readFileSync('app/public/panel-access-authority-v1.js','utf8');
 const io=fs.readFileSync('supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql','utf8');
 const agSql=fs.readFileSync('supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql','utf8');
@@ -30,11 +31,15 @@ test('Agenda status is an atomic strong-session RPC and preserves WhatsApp direc
   assert.match(agSql,/AGENDA_STATUS_GOVERNED_V1/);
   assert.match(agenda,/rpc\/aos_agenda_set_status_v1/);
   assert.doesNotMatch(agenda,/method:'PATCH'/);
+  assert.doesNotMatch(agenda,/setInterval\(/);
+  assert.doesNotMatch(agenda,/setTimeout\(/);
 });
 
-test('SPA authority layer loads both P0 operational runtimes without creating network polling',()=>{
-  assert.match(panel,/calls-performance-v1\.js/);
-  assert.match(panel,/agenda-governed-status-v1\.js/);
-  assert.match(panel,/new MutationObserver/);
-  assert.doesNotMatch(panel,/setInterval\(/);
+test('P0 runtimes reuse the already-certified F4 observer instead of creating new recurrent network owners',()=>{
+  assert.match(f4,/calls-performance-v1\.js/);
+  assert.match(f4,/agenda-governed-status-v1\.js/);
+  assert.match(f4,/ensureAgendaGovernedPostload/);
+  assert.doesNotMatch(panel,/calls-performance-v1\.js/);
+  assert.doesNotMatch(panel,/agenda-governed-status-v1\.js/);
+  assert.doesNotMatch(panel,/MutationObserver/);
 });

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -1,0 +1,40 @@
+'use strict';
+const fs=require('fs');
+const test=require('node:test');
+const assert=require('node:assert/strict');
+
+const cc=fs.readFileSync('app/public/calls-performance-v1.js','utf8');
+const agenda=fs.readFileSync('app/public/agenda-governed-status-v1.js','utf8');
+const panel=fs.readFileSync('app/public/panel-access-authority-v1.js','utf8');
+const io=fs.readFileSync('supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql','utf8');
+const agSql=fs.readFileSync('supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql','utf8');
+
+test('Call Center waits for Loop6 and coalesces duplicated panel reads',()=>{
+  assert.match(cc,/__AOS_CC_LOOP6_POSTLOAD_READY__!=='v2\.3-postload'/);
+  assert.match(cc,/aos_siguiente_lead_v2'\?'aos_siguiente_lead'/);
+  assert.match(cc,/aos_panel_asesor:2500/);
+  assert.match(cc,/aos_horarios_semana:30000/);
+});
+
+test('Call Center attribution fast-path is transaction-scoped, not a global reporting filter',()=>{
+  assert.match(io,/current_setting\('aos\.callcenter_phone',true\)/);
+  assert.match(io,/set_config\('aos\.callcenter_phone',v_num,true\)/);
+  assert.match(io,/s\.phone='' or l\.numero_limpio=s\.phone/);
+  assert.match(io,/aos_callcenter_commit_action_core_impl_v2/);
+});
+
+test('Agenda status is an atomic strong-session RPC and preserves WhatsApp direct-write guard',()=>{
+  assert.match(agSql,/aos_app_actor_v3\(p_token,'advisor-agenda',false\)/);
+  assert.match(agSql,/aos_app_actor_v3\(p_token,'admin-agenda',true\)/);
+  assert.match(agSql,/set_config\('aos\.wa4_governed_booking_write','1',true\)/);
+  assert.match(agSql,/AGENDA_STATUS_GOVERNED_V1/);
+  assert.match(agenda,/rpc\/aos_agenda_set_status_v1/);
+  assert.doesNotMatch(agenda,/method:'PATCH'/);
+});
+
+test('SPA authority layer loads both P0 operational runtimes without creating network polling',()=>{
+  assert.match(panel,/calls-performance-v1\.js/);
+  assert.match(panel,/agenda-governed-status-v1\.js/);
+  assert.match(panel,/new MutationObserver/);
+  assert.doesNotMatch(panel,/setInterval\(/);
+});

--- a/supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql
+++ b/supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql
@@ -1,0 +1,157 @@
+-- ASCENDA OS · P0 Call Center IO / booking fast-path V1
+-- Goal: preserve attribution/ownership semantics while preventing Call Center
+-- requests from materializing the complete marketing touchpoint timeline for a
+-- single phone. The scope is transaction-local and therefore invisible to all
+-- reporting/marketing callers.
+
+-- ---------------------------------------------------------------------------
+-- A. Marketing touchpoints: optional transaction-local phone scope.
+-- ---------------------------------------------------------------------------
+create or replace function public.aos_marketing_touchpoints_v2(
+  p_desde date default null::date,
+  p_hasta date default null::date
+)
+returns table(
+  lead_id bigint,
+  numero_limpio text,
+  fecha date,
+  hora_ingreso timestamp with time zone,
+  tratamiento text,
+  anuncio text,
+  lead_ts timestamp with time zone,
+  next_lead_ts timestamp with time zone,
+  es_duplicado_tecnico_probable boolean,
+  duplicate_rank bigint
+)
+language sql
+stable
+set search_path = 'pg_catalog','public','pg_temp'
+as $function$
+with scope as (
+  select pg_catalog.regexp_replace(
+    coalesce(pg_catalog.current_setting('aos.callcenter_phone',true),''),
+    '[^0-9]','','g'
+  ) as phone
+), base as (
+  select l.*,
+         public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at) as _lead_ts,
+         row_number() over(
+           partition by l.numero_limpio,l.fecha,l.hora_ingreso,coalesce(l.tratamiento,''),coalesce(l.anuncio,''),l.created_at
+           order by l.id
+         ) as _dup_rank
+  from public.aos_leads l
+  cross join scope s
+  where l.numero_limpio is not null
+    and l.numero_limpio<>''
+    and (s.phone='' or l.numero_limpio=s.phone)
+), timeline as (
+  select b.*,
+         lead(b._lead_ts) over(partition by b.numero_limpio order by b._lead_ts,b.id) as _next_lead_ts
+  from base b
+  where b._dup_rank=1
+)
+select b.id::bigint,b.numero_limpio,b.fecha,b.hora_ingreso,b.tratamiento,b.anuncio,b._lead_ts,
+       case when b._dup_rank=1 then t._next_lead_ts else null end,
+       (b._dup_rank>1),b._dup_rank::bigint
+from base b
+left join timeline t on t.id=b.id
+where (p_desde is null or b.fecha>=p_desde)
+  and (p_hasta is null or b.fecha<=p_hasta)
+order by b.fecha,b._lead_ts,b.id;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- B. Governed Call Center core: set the phone scope before entering the
+-- existing V2 implementation. Idempotency, ownership and business policy are
+-- otherwise byte-for-byte equivalent to the certified core wrapper.
+-- ---------------------------------------------------------------------------
+create or replace function public.aos_callcenter_commit_action_core_v1(
+  p_actor uuid,
+  p_idempotency_key text,
+  p_action_type text,
+  p_payload jsonb,
+  p_test_fail_stage text default null::text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','pg_temp'
+as $function$
+declare
+  v_key text:=pg_catalog.btrim(coalesce(p_idempotency_key,''));
+  v_action text:=upper(pg_catalog.btrim(coalesce(p_action_type,'')));
+  v_payload jsonb:=coalesce(p_payload,'{}'::jsonb);
+  v_source_mode text:=upper(pg_catalog.btrim(coalesce(v_payload->>'source_mode','QUEUE')));
+  v_num text:=pg_catalog.regexp_replace(coalesce(v_payload->>'numero',''),'[^0-9]','','g');
+  v_hash text;
+  v_existing record;
+begin
+  if p_actor is null then return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED'); end if;
+  if pg_catalog.length(v_key)<16 or pg_catalog.length(v_key)>160 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_IDEMPOTENCY_KEY'); end if;
+  if v_action not in ('COMMERCIAL_CALL_APPOINTMENT','CALLBACK_INBOUND_APPOINTMENT','REACTIVATION','PATIENT_FOLLOWUP','AGENDA_ONLY') then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_ACTION'); end if;
+  if v_source_mode not in ('QUEUE','MANUAL','CALLBACK','FOLLOWUP') then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_SOURCE_MODE'); end if;
+  if pg_catalog.length(v_num)<7 then return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_PHONE'); end if;
+
+  -- Critical P0 fast-path: every aos_marketing_touchpoints_v2(NULL,NULL)
+  -- reached by the implementation now sees only this phone for this xact.
+  perform pg_catalog.set_config('aos.callcenter_phone',v_num,true);
+
+  v_hash:=pg_catalog.encode(extensions.digest(v_action||'|'||(v_payload-'event_ts'-'business_date')::text,'sha256'),'hex');
+  select * into v_existing from public.aos_callcenter_actions_v1 a where a.idempotency_key=v_key;
+  if found then
+    if v_existing.actor_user_id<>p_actor then return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_ACTOR_CONFLICT'); end if;
+    if v_existing.request_hash<>v_hash then return pg_catalog.jsonb_build_object('ok',false,'error','IDEMPOTENCY_CONFLICT'); end if;
+    if v_existing.status='COMPLETE' and v_existing.result is not null then return v_existing.result||pg_catalog.jsonb_build_object('idempotent',true); end if;
+    return pg_catalog.jsonb_build_object('ok',false,'error','ACTION_IN_PROGRESS');
+  end if;
+  perform pg_catalog.set_config('aos.loop6_governed_write','1',true);
+  return public.aos_callcenter_commit_action_core_impl_v2(p_actor,p_idempotency_key,p_action_type,v_payload,p_test_fail_stage);
+end
+$function$;
+
+-- Queue validation happens before the generic core, so scope it in the public
+-- governed wrapper as well.
+create or replace function public.aos_callcenter_confirm_queue_appointment_v1(
+  p_token text,
+  p_idempotency_key text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_actor uuid;
+  v_payload jsonb:=coalesce(p_payload,'{}'::jsonb);
+  v_num text:=pg_catalog.regexp_replace(coalesce(v_payload->>'numero',''),'[^0-9]','','g');
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'advisor-calls',false);
+  if v_actor is null then
+    v_actor:=public.aos_app_actor_v3(p_token,'admin-calls',true);
+  end if;
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','UNAUTHORIZED');
+  end if;
+  if pg_catalog.length(v_num)>=7 then
+    perform pg_catalog.set_config('aos.callcenter_phone',v_num,true);
+  end if;
+  v_payload:=(v_payload-'event_ts'-'business_date')
+    || pg_catalog.jsonb_build_object('event_ts',pg_catalog.now());
+  return public.aos_callcenter_confirm_queue_core_v1(v_actor,p_idempotency_key,v_payload,null);
+end
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- C. Hot-path expression indexes. Existing indexes are case-sensitive while
+-- the legacy panel RPCs intentionally compare UPPER(asesor).
+-- ---------------------------------------------------------------------------
+create index if not exists idx_aos_llamadas_upper_asesor_fecha_v1
+  on public.aos_llamadas ((upper(asesor)),fecha);
+create index if not exists idx_aos_agenda_upper_asesor_fecha_v1
+  on public.aos_agenda_citas ((upper(asesor)),fecha_cita);
+create index if not exists idx_aos_ventas_upper_asesor_fecha_v1
+  on public.aos_ventas ((upper(asesor)),fecha);
+
+comment on function public.aos_marketing_touchpoints_v2(date,date) is
+  'Marketing attribution authority. Optional transaction-local aos.callcenter_phone scope is reserved for governed Call Center fast-paths; reporting semantics are unchanged when unset.';

--- a/supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql
+++ b/supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql
@@ -1,0 +1,146 @@
+-- ASCENDA OS · P0 Agenda status governed write V1
+-- Replaces the browser's multi-request PATCH/DELETE/POST sequence for status
+-- changes with one authenticated transaction. This also allows a human Agenda
+-- operator to update a WHATSAPP-origin appointment without weakening the WA-4C
+-- direct-write trigger.
+
+create or replace function public.aos_agenda_set_status_v1(
+  p_token text,
+  p_cita_id text,
+  p_estado text,
+  p_asistente text default null,
+  p_nota text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $function$
+declare
+  v_actor uuid;
+  v_actor_code text;
+  v_cita public.aos_agenda_citas%rowtype;
+  v_estado text:=upper(pg_catalog.btrim(coalesce(p_estado,'')));
+  v_asistente text:=pg_catalog.btrim(coalesce(p_asistente,''));
+  v_nota text:=coalesce(p_nota,'');
+  v_es_doctora boolean:=false;
+  v_prof_nombre text:='';
+  v_prof_tipo text:='';
+  v_asist_nombre text:='';
+  v_atencion_id text;
+  v_has_notes boolean:=false;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'advisor-agenda',false);
+  if v_actor is null then
+    v_actor:=public.aos_app_actor_v3(p_token,'admin-agenda',true);
+  end if;
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','AGENDA_2FA_PANEL_REQUIRED');
+  end if;
+
+  select u.codigo_asesor into v_actor_code
+  from public.aos_usuarios u
+  where u.id=v_actor and u.activo=true;
+
+  if v_estado not in ('PENDIENTE','CITA CONFIRMADA','ASISTIO','EFECTIVA','NO ASISTIO','CANCELADA') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','INVALID_APPOINTMENT_STATUS');
+  end if;
+
+  select * into v_cita
+  from public.aos_agenda_citas a
+  where a.id=p_cita_id
+  for update;
+  if not found then
+    return pg_catalog.jsonb_build_object('ok',false,'error','APPOINTMENT_NOT_FOUND');
+  end if;
+
+  -- Human-governed Agenda writes are allowed to mutate a WhatsApp-created row;
+  -- direct browser writes remain blocked by the existing trigger.
+  perform pg_catalog.set_config('aos.wa4_governed_booking_write','1',true);
+
+  if v_estado in ('ASISTIO','EFECTIVA') then
+    v_es_doctora:=upper(coalesce(v_cita.tipo_atencion,'')) like '%DOCTOR%';
+    if v_es_doctora then
+      v_prof_nombre:=pg_catalog.btrim(coalesce(v_cita.doctora,''));
+      if v_prof_nombre='' or upper(v_prof_nombre) in ('SIN ASIGNAR','SIN DOCTORA ESE DIA','BUSCANDO...','BUSCANDO') then
+        return pg_catalog.jsonb_build_object('ok',false,'error','DOCTOR_AUTHORITY_REQUIRED');
+      end if;
+      v_prof_tipo:='DOCTORA';
+      v_asist_nombre:=v_asistente;
+    else
+      v_prof_nombre:=v_asistente;
+      v_prof_tipo:='ENFERMERIA';
+      v_asist_nombre:='';
+      if v_prof_nombre='' or upper(v_prof_nombre) in ('--','NO APLICA') then
+        return pg_catalog.jsonb_build_object('ok',false,'error','ATTENDING_NURSE_REQUIRED');
+      end if;
+    end if;
+  end if;
+
+  update public.aos_agenda_citas
+  set estado_cita=v_estado,
+      obs=case when v_nota is distinct from coalesce(obs,'') then v_nota else obs end,
+      ts_actualizado=pg_catalog.now()
+  where id=v_cita.id;
+
+  if v_estado in ('ASISTIO','EFECTIVA') then
+    select a.id into v_atencion_id
+    from public.aos_atenciones a
+    where a.cita_id=v_cita.id
+    order by a.created_at desc nulls last,a.id desc
+    limit 1
+    for update;
+
+    if v_atencion_id is null then
+      v_atencion_id:=pg_catalog.gen_random_uuid()::text;
+      insert into public.aos_atenciones(
+        id,numero_limpio,fecha,sede,profesional_nombre,profesional_tipo,
+        asistente_nombre,estado,paciente_nombre,paciente_telefono,cita_id,
+        tratamiento_principal,tipo_atencion,observaciones,created_at,updated_at
+      ) values(
+        v_atencion_id,v_cita.numero_limpio,v_cita.fecha_cita,coalesce(v_cita.sede,'SAN ISIDRO'),
+        v_prof_nombre,v_prof_tipo,nullif(v_asist_nombre,''),'PENDIENTE',
+        pg_catalog.btrim(concat_ws(' ',coalesce(v_cita.nombre,''),coalesce(v_cita.apellido,''))),
+        v_cita.numero_limpio,v_cita.id,coalesce(v_cita.tratamiento,''),'CONSULTA',v_nota,
+        pg_catalog.now(),pg_catalog.now()
+      );
+    else
+      update public.aos_atenciones
+      set profesional_nombre=v_prof_nombre,
+          profesional_tipo=v_prof_tipo,
+          asistente_nombre=nullif(v_asist_nombre,''),
+          sede=coalesce(v_cita.sede,sede),
+          tratamiento_principal=coalesce(nullif(v_cita.tratamiento,''),tratamiento_principal),
+          observaciones=v_nota,
+          updated_at=pg_catalog.now()
+      where id=v_atencion_id;
+    end if;
+  elsif v_estado in ('PENDIENTE','CITA CONFIRMADA') then
+    select exists(
+      select 1 from public.aos_notas_clinicas n
+      where n.numero_limpio=v_cita.numero_limpio and n.fecha=v_cita.fecha_cita
+    ) into v_has_notes;
+    if not v_has_notes then
+      delete from public.aos_atenciones a
+      where a.numero_limpio=v_cita.numero_limpio and a.fecha=v_cita.fecha_cita;
+    end if;
+  end if;
+
+  insert into public.aos_log_auditoria(
+    timestamp_reg,asesor,accion,referencia,detalle,tabla,usuario,registro_id,datos_new,metadata
+  ) values(
+    pg_catalog.now(),coalesce(v_actor_code,'AGENDA'),'AGENDA_STATUS_GOVERNED',v_cita.id,
+    'Estado de cita actualizado por transacción gobernada','aos_agenda_citas',coalesce(v_actor_code,'AGENDA'),v_cita.id,
+    pg_catalog.jsonb_build_object('estado',v_estado,'atencion_id',v_atencion_id,'has_clinical_notes',v_has_notes),
+    pg_catalog.jsonb_build_object('source','AGENDA_STATUS_GOVERNED_V1','actor_id',v_actor)
+  );
+
+  return pg_catalog.jsonb_build_object(
+    'ok',true,'appointmentId',v_cita.id,'status',v_estado,
+    'attentionId',v_atencion_id,'clinicalNotesPreserved',v_has_notes
+  );
+end
+$function$;
+
+revoke all on function public.aos_agenda_set_status_v1(text,text,text,text,text) from public;
+grant execute on function public.aos_agenda_set_status_v1(text,text,text,text,text) to anon,authenticated,service_role;


### PR DESCRIPTION
## Incidente
Call Center presenta cargas lentas y fallos de guardado; Agenda muestra HTTP 500 al cambiar estado. Supabase NANO reporta presión de Disk IO, mientras la BD está lejos del límite de tamaño.

## Hallazgos medidos
- `aos_callcenter_commit_action_core_v1` ha registrado ejecuciones de decenas de segundos.
- Call Center filtraba un solo teléfono DESPUÉS de materializar `aos_marketing_touchpoints_v2(NULL,NULL)` sobre todo el timeline de leads.
- `aos_panel_asesor` se solicita varias veces durante una sola apertura del panel.
- `calls.js` todavía pide `aos_siguiente_lead_v2` y evita la capa gobernada/contact-debt más reciente.
- Agenda usa una cadena browser PATCH → DELETE → POST para cambiar estado y crear atención; cualquier timeout/trigger deja una experiencia frágil y error genérico.

## Correcciones
- Fast-path transaccional `aos.callcenter_phone`: las lecturas analíticas de atribución dentro del commit Call Center procesan solo el teléfono de la acción; reporting/Marketing no cambia cuando el scope está ausente.
- índices compatibles con `UPPER(asesor)` para llamadas/agenda/ventas.
- runtime Call Center P0 después de Loop6: coalesce de lecturas duplicadas y `aos_siguiente_lead_v2` → selector gobernado `aos_siguiente_lead`.
- nuevo `aos_agenda_set_status_v1`: una transacción fuerte/2FA para estado de cita + sincronización de atención; puede actualizar filas originadas por WhatsApp sin relajar el trigger que bloquea escrituras directas.
- runtime Agenda sustituye solo el guardado de estado; no toca creación/reagendamiento todavía.
- loaders SPA desde la autoridad global ya existente, sin nuevo polling de red.

## Seguridad
- HUMAN_ONLY / auto-reply / AI-send / auto-routing sin cambios.
- no se deshabilita ningún trigger fail-closed.
- los cambios de Agenda requieren `advisor-agenda` o `admin-agenda` y sesión fuerte.
- no se ejecutan escrituras sintéticas en PROD durante el gate.

## Gates
- `ASCENDA P0 Call Center + Agenda Performance` GitHub-hosted.
- `ASCENDA WA-4C TEMP HOSTED` full release-gate parity mediante cambio bajo `ci/wa4c-full-local/**`.
- rebuild local de todas las migraciones + DB lint + canaries WA-4C.
- anti-drift antes de merge; luego aplicar solo migraciones del lineage fusionado y hacer benchmark/readback LIVE.