### PR TITLE
AGV2: freeze booking rules + unified Agenda/WhatsApp contract

### DIFF
--- a/.github/workflows/agv2-unified-booking-contract.yml
+++ b/.github/workflows/agv2-unified-booking-contract.yml
@@ -1,0 +1,106 @@
+name: ASCENDA AGV2 Unified Booking Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/control/AGV2_*'
+      - 'supabase/migrations/*agv2*'
+      - 'supabase/rollbacks/*agv2*'
+      - 'ci/agv2/**'
+      - '.github/workflows/agv2-unified-booking-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agv2-unified-booking-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: ZERO-COST · Agenda + WhatsApp transactional BOOK/REBOOK
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Static AGV2 contract
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          node --check ci/agv2/unified-booking-contract.test.js
+          node --test ci/agv2/unified-booking-contract.test.js
+          grep -q 'BUSINESS_FROZEN' docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md
+          ! grep -Eqi '(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)[[:space:]]*=[[:space:]]*true' supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+
+      - name: Wait for isolated local ports
+        run: |
+          set -euo pipefail
+          ports='60200 60201 60202'
+          for i in $(seq 1 60); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'AGV2_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+
+      - name: Build isolated booking substrate
+        run: bash ci/wa4c-full-local/bootstrap.sh
+
+      - name: Apply CURRENT booking authority + AGV2 migration in TEST only
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003000_wa4c_team_skill_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003500_wa4c_team_skill_catalog_classification_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
+
+      - name: AGV2 BOOK + idempotency + ownership + REBOOK canary
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/agv2/unified-booking-canary.sql 2>&1 | tee /tmp/agv2-canary.txt
+          grep -q 'AGV2_UNIFIED_BOOKING_CANARY_PASS' /tmp/agv2-canary.txt
+
+      - name: Schema and safety assertions
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_booking_operations_v2') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_agenda_events_v2') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_agenda_commit_booking_v2(text,text,jsonb)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa4_commit_booking_v2(uuid,text,uuid,jsonb)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_booking_operations_v2 where operation_type='BOOK'")" = '1'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_booking_operations_v2 where operation_type='REBOOK'")" = '1'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_events_v2 where event_type='BOOKED'")" = '1'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_events_v2 where event_type='RESCHEDULED'")" = '1'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_routing_control_v1 where human_send_enabled=true and ai_send_enabled=false and auto_routing_enabled=false")" = '1'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_ai_control_v1 where copilot_enabled=true and auto_reply_enabled=false")" = '1'
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/agv2-lint.txt
+          if grep -q '\[ERROR\]' /tmp/agv2-lint.txt; then exit 1; fi
+          echo 'AGV2-2 UNIFIED TRANSACTIONAL BOOKING CONTRACT PASS' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/.github/workflows/agv2-unified-booking-contract.yml
+++ b/.github/workflows/agv2-unified-booking-contract.yml
@@ -61,15 +61,16 @@ jobs:
       - name: Build isolated booking substrate
         run: bash ci/wa4c-full-local/bootstrap.sh
 
-      - name: Apply CURRENT booking authority + AGV2 migration in TEST only
+      - name: Apply certified booking substrate + AGV2 migration in TEST only
         run: |
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          # The full-local bootstrap deliberately contains a compact booking fixture rather than
+          # Admin/Equipo's production-only skill-master table. Apply only the booking migrations
+          # needed by this transactional canary; Team/Professional hierarchy is independently
+          # regression-tested and the exact-head WA-4C FULL LOCAL gate must also remain green.
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003000_wa4c_team_skill_authority_v2.sql
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003500_wa4c_team_skill_catalog_classification_v3.sql
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
 

--- a/.github/workflows/agv2-unified-booking-contract.yml
+++ b/.github/workflows/agv2-unified-booking-contract.yml
@@ -66,9 +66,11 @@ jobs:
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
           # The full-local bootstrap deliberately contains a compact booking fixture rather than
-          # Admin/Equipo's production-only skill-master table. Apply only the booking migrations
-          # needed by this transactional canary; Team/Professional hierarchy is independently
-          # regression-tested and the exact-head WA-4C FULL LOCAL gate must also remain green.
+          # Admin/Equipo's production-only skill-master table. Rehydrate only canonical booking
+          # authority required by this transactional canary; this stays TEST-only and does not
+          # alter production semantics. Team/Professional hierarchy is independently regression-
+          # tested and the exact-head WA-4C FULL LOCAL gate must also remain green.
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql

--- a/.github/workflows/agv2-unified-booking-contract.yml
+++ b/.github/workflows/agv2-unified-booking-contract.yml
@@ -84,6 +84,7 @@ jobs:
           grep -q 'AGV2_UNIFIED_BOOKING_CANARY_PASS' /tmp/agv2-canary.txt
 
       - name: Schema and safety assertions
+        working-directory: ci/wa4c-full-local
         run: |
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'

--- a/.github/workflows/wa4c-full-local-integration.yml
+++ b/.github/workflows/wa4c-full-local-integration.yml
@@ -28,7 +28,10 @@ on:
       - 'app/public/wa-shell-integration.js'
       - 'supabase/migrations/*wa4*'
       - 'supabase/rollbacks/*wa4*'
+      - 'supabase/migrations/*agv2*'
+      - 'supabase/rollbacks/*agv2*'
       - 'ci/wa4c-full-local/**'
+      - 'ci/agv2/**'
       - '.github/workflows/wa4c-full-local-integration.yml'
   workflow_dispatch:
 
@@ -89,13 +92,17 @@ jobs:
           node --check ci/wa4c-full-local/run-canaries.js
           node --check ci/wa4c-full-local/run-booking-canary.js
           node --check ci/wa4c-full-local/run-conversation-beta.js
+          node --check ci/agv2/unified-booking-contract.test.js
           bash -n ci/wa4c-full-local/bootstrap.sh
           grep -q "ASCENDA_FULL_LOCAL" ci/wa4c-full-local/local-network-preload.cjs
           grep -q "production_network_mutation: false" ci/wa4c-full-local/local-network-preload.cjs
           grep -q "modern_api_key_bearer_removed: true" ci/wa4c-full-local/local-supabase-auth-preload.cjs
           grep -q "apikey_preserved: true" ci/wa4c-full-local/local-supabase-auth-preload.cjs
-          ! grep -Eq 'ituyqwstonmhnfshnaqz|SUPABASE_ACCESS_TOKEN' ci/wa4c-full-local/*.js ci/wa4c-full-local/*.sh ci/wa4c-full-local/*.sql
-          ! grep -Eq '(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)[[:space:]]*=[[:space:]]*true' ci/wa4c-full-local/*.sql
+          ! grep -Eq 'ituyqwstonmhnfshnaqz|SUPABASE_ACCESS_TOKEN' ci/wa4c-full-local/*.js ci/wa4c-full-local/*.sh ci/wa4c-full-local/*.sql ci/agv2/*
+          ! grep -Eq '(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)[[:space:]]*=[[:space:]]*true' ci/wa4c-full-local/*.sql supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+
+      - name: AGV2 static transactional contract
+        run: node --test ci/agv2/unified-booking-contract.test.js
 
       - name: Conversation Runtime V2 deterministic regression corpus
         run: |

--- a/ci/agv2/unified-booking-canary.sql
+++ b/ci/agv2/unified-booking-canary.sql
@@ -1,0 +1,182 @@
+-- TEST ONLY. Synthetic AGV2 BOOK/REBOOK canary. Never apply to PROD.
+\set ON_ERROR_STOP on
+
+-- Align synthetic provider with the fixture treatment under the CURRENT capability hierarchy.
+update public.aos_perfiles_profesional p
+set servicios=array[public.aos_booking_capability_for_service_v1(f.treatment_id)]::text[]
+from public.aos_wa4c_booking_test_fixture f
+where f.id=1 and p.id='wa4c-doctor-1';
+
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_name,phone_number_id,state,box_id,owner_user_id,
+  ownership_version,contact_address,contact_address_type,opened_at,updated_at
+) values (
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+  'agv2-local:51933333333','51933333333','Cliente AGV2 QA','local-phone-id','AI_COPILOT',
+  '77777777-7777-4777-8777-777777777777'::uuid,'44444444-4444-4444-8444-444444444444'::uuid,
+  1,'51933333333','PHONE',now(),now()
+) on conflict(id) do update set
+  state='AI_COPILOT',owner_user_id='44444444-4444-4444-8444-444444444444'::uuid,
+  box_id='77777777-7777-4777-8777-777777777777'::uuid,updated_at=now();
+
+insert into public.aos_wa_assignments_v1(
+  id,conversation_id,box_id,owner_user_id,state,assigned_at,claimed_at,assigned_by
+) values (
+  'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid,
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+  '77777777-7777-4777-8777-777777777777'::uuid,
+  '44444444-4444-4444-8444-444444444444'::uuid,
+  'ACTIVE',now(),now(),'11111111-1111-4111-8111-111111111111'::uuid
+) on conflict(id) do update set state='ACTIVE',owner_user_id=excluded.owner_user_id,updated_at=now();
+
+-- Conflict identity fixture.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_name,phone_number_id,state,box_id,owner_user_id,
+  ownership_version,contact_address,contact_address_type,opened_at,updated_at
+) values (
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'::uuid,
+  'agv2-local:51922222222','51922222222','Cliente Conflict QA','local-phone-id','AI_COPILOT',
+  '77777777-7777-4777-8777-777777777777'::uuid,'44444444-4444-4444-8444-444444444444'::uuid,
+  1,'51922222222','PHONE',now(),now()
+) on conflict(id) do update set state='AI_COPILOT',owner_user_id='44444444-4444-4444-8444-444444444444'::uuid,updated_at=now();
+
+insert into public.aos_wa_assignments_v1(
+  id,conversation_id,box_id,owner_user_id,state,assigned_at,claimed_at,assigned_by
+) values (
+  'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'::uuid,
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'::uuid,
+  '77777777-7777-4777-8777-777777777777'::uuid,
+  '44444444-4444-4444-8444-444444444444'::uuid,
+  'ACTIVE',now(),now(),'11111111-1111-4111-8111-111111111111'::uuid
+) on conflict(id) do update set state='ACTIVE',owner_user_id=excluded.owner_user_id,updated_at=now();
+
+do $$
+declare
+  f public.aos_wa4c_booking_test_fixture%rowtype;
+  r jsonb;
+  replay jsonb;
+  mismatch jsonb;
+  rebook jsonb;
+  conflict_r jsonb;
+  not_owner jsonb;
+  invalid_agenda jsonb;
+  aid text;
+  payload jsonb;
+  p2 jsonb;
+  n int;
+begin
+  select * into f from public.aos_wa4c_booking_test_fixture where id=1;
+  if not found then raise exception 'AGV2_CANARY_FIXTURE_MISSING'; end if;
+
+  payload:=jsonb_build_object(
+    'treatment_id',f.treatment_id,
+    'professional_id',f.professional_id,
+    'slot_role','DOCTORA',
+    'site','SAN_ISIDRO',
+    'date',f.target_date,
+    'time','10:00',
+    'name','Cliente',
+    'last_name','AGV2 QA',
+    'appointment_type','CONSULTA NUEVA'
+  );
+
+  r:=public.aos_wa4_commit_booking_v2(
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'agv2-local-book-00000001',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    payload
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'status'<>'BOOKED' then
+    raise exception 'AGV2_CANARY_BOOK_FAILED %',r;
+  end if;
+  aid:=r->>'appointment_id';
+  if coalesce(aid,'')='' then raise exception 'AGV2_CANARY_APPOINTMENT_ID_MISSING'; end if;
+
+  replay:=public.aos_wa4_commit_booking_v2(
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'agv2-local-book-00000001',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    payload
+  );
+  if coalesce((replay->>'idempotent_replay')::boolean,false) is not true or replay->>'appointment_id'<>aid then
+    raise exception 'AGV2_CANARY_IDEMPOTENCY_REPLAY_FAILED %',replay;
+  end if;
+
+  mismatch:=public.aos_wa4_commit_booking_v2(
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'agv2-local-book-00000001',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    jsonb_set(payload,'{time}','"11:30"'::jsonb)
+  );
+  if mismatch->>'error'<>'AGV2_IDEMPOTENCY_MISMATCH' then
+    raise exception 'AGV2_CANARY_IDEMPOTENCY_MISMATCH_NOT_BLOCKED %',mismatch;
+  end if;
+
+  not_owner:=public.aos_wa4_commit_booking_v2(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'agv2-local-book-not-owner',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    jsonb_set(payload,'{time}','"11:30"'::jsonb)
+  );
+  if not_owner->>'error'<>'WA4_BOOKING_NOT_CONVERSATION_OWNER' then
+    raise exception 'AGV2_CANARY_OWNERSHIP_NOT_BLOCKED %',not_owner;
+  end if;
+
+  conflict_r:=public.aos_wa4_commit_booking_v2(
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'agv2-local-book-conflict',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'::uuid,
+    jsonb_set(payload,'{time}','"11:30"'::jsonb)
+  );
+  if conflict_r->>'error'<>'AGV2_IDENTITY_CONFLICT' then
+    raise exception 'AGV2_CANARY_IDENTITY_CONFLICT_NOT_BLOCKED %',conflict_r;
+  end if;
+
+  p2:=jsonb_build_object(
+    'site','SAN_ISIDRO','date',f.target_date,'time','10:30',
+    'professional_id',f.professional_id,'slot_role','DOCTORA','reason','Cambio solicitado por QA'
+  );
+  rebook:=public.aos_wa4_rebook_booking_v2(
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'agv2-local-rebook-000001',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    aid,p2
+  );
+  if coalesce((rebook->>'ok')::boolean,false) is not true or rebook->>'status'<>'REBOOKED' or rebook->>'appointment_id'<>aid then
+    raise exception 'AGV2_CANARY_REBOOK_FAILED %',rebook;
+  end if;
+
+  select count(*) into n from public.aos_agenda_citas where id=aid;
+  if n<>1 then raise exception 'AGV2_CANARY_REBOOK_DUPLICATED_APPOINTMENT %',n; end if;
+  if not exists(select 1 from public.aos_agenda_citas where id=aid and left(hora_cita,5)='10:30' and estado_cita='PENDIENTE') then
+    raise exception 'AGV2_CANARY_REBOOK_DID_NOT_MUTATE_SAME_APPOINTMENT';
+  end if;
+  select count(*) into n from public.aos_agenda_events_v2 where appointment_id=aid and event_type in ('BOOKED','RESCHEDULED');
+  if n<>2 then raise exception 'AGV2_CANARY_EVENT_LEDGER_BAD_COUNT %',n; end if;
+  select count(*) into n from public.aos_booking_operations_v2 where appointment_id=aid and operation_type in ('BOOK','REBOOK');
+  if n<>2 then raise exception 'AGV2_CANARY_OPERATION_LEDGER_BAD_COUNT %',n; end if;
+  if not exists(select 1 from public.aos_wa4_booking_actions_v1 where agenda_id=aid and status='BOOKED') then
+    raise exception 'AGV2_CANARY_LEGACY_WA_LEDGER_NOT_PRESERVED';
+  end if;
+
+  begin
+    update public.aos_agenda_events_v2 set reason='tamper' where appointment_id=aid;
+    raise exception 'AGV2_CANARY_APPEND_ONLY_NOT_ENFORCED';
+  exception when others then
+    if sqlerrm not like '%AGV2_EVENT_LEDGER_APPEND_ONLY%' then raise; end if;
+  end;
+
+  invalid_agenda:=public.aos_agenda_commit_booking_v2('invalid-token','agv2-invalid-agenda-0001',payload||jsonb_build_object('phone','51944444444'));
+  if invalid_agenda->>'error'<>'AGENDA_2FA_PANEL_REQUIRED' then
+    raise exception 'AGV2_CANARY_AGENDA_STRONG_SESSION_NOT_ENFORCED %',invalid_agenda;
+  end if;
+
+  if to_regprocedure('public.aos_wa4_commit_booking_v1(uuid,text,uuid,jsonb)') is null then
+    raise exception 'AGV2_CANARY_WA_V1_COMPAT_REMOVED';
+  end if;
+
+  raise notice 'AGV2_UNIFIED_BOOKING_CANARY_PASS appointment_id=%',aid;
+end
+$$;
+
+select 'AGV2_UNIFIED_BOOKING_CANARY_PASS' as result;

--- a/ci/agv2/unified-booking-contract.test.js
+++ b/ci/agv2/unified-booking-contract.test.js
@@ -44,7 +44,7 @@ test('rebooking mutates the same appointment and appends history',()=>{
   assert.match(mig,/event_type[^\n]*RESCHEDULED|,'RESCHEDULED'/);
   assert.match(mig,/AGV2_EVENT_LEDGER_APPEND_ONLY/);
   assert.doesNotMatch(mig,/delete from public\.aos_agenda_citas/i);
-  assert.match(contract,/same logical appointment/i);
+  assert.match(contract,/mismo `appointment_id`|mismo appointment/i);
 });
 
 test('Agenda uses strong session authority and WA preserves HUMAN_ONLY ownership',()=>{

--- a/ci/agv2/unified-booking-contract.test.js
+++ b/ci/agv2/unified-booking-contract.test.js
@@ -1,0 +1,73 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const path=require('node:path');
+
+const ROOT=path.resolve(__dirname,'../..');
+const mig=fs.readFileSync(path.join(ROOT,'supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql'),'utf8');
+const rb=fs.readFileSync(path.join(ROOT,'supabase/rollbacks/20260901013500_agv2_unified_transactional_booking_contract_v1_rollback.sql'),'utf8');
+const frozen=fs.readFileSync(path.join(ROOT,'docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md'),'utf8');
+const contract=fs.readFileSync(path.join(ROOT,'docs/control/AGV2_2_TRANSACTIONAL_BOOKING_CONTRACT.md'),'utf8');
+
+test('AGV2-1 business decisions are frozen',()=>{
+  assert.match(frozen,/Estado: `BUSINESS_FROZEN`/);
+  assert.match(frozen,/primera disponibilidad real/i);
+  assert.match(frozen,/mismo appointment lógico/i);
+  assert.match(frozen,/hasta \*\*3 fechas\*\*/);
+  assert.match(frozen,/hasta \*\*5 slots\*\*/);
+  assert.match(frozen,/DNI.*Opcional/is);
+  assert.match(frozen,/No hardcodear “evaluación gratuita”/);
+});
+
+test('shared BOOK and REBOOK authority is additive and channel-neutral',()=>{
+  for(const token of [
+    'aos_booking_operations_v2','aos_agenda_events_v2',
+    'aos_booking_resolve_selected_slot_v2','aos_booking_commit_core_v2','aos_booking_rebook_core_v2',
+    'aos_agenda_commit_booking_v2','aos_agenda_rebook_v2',
+    'aos_wa4_commit_booking_v2','aos_wa4_rebook_booking_v2'
+  ]) assert.ok(mig.includes(token),`missing ${token}`);
+  assert.match(mig,/operation_type text not null check \(operation_type in \('BOOK','REBOOK'\)\)/);
+  assert.match(mig,/channel text not null check \(channel in \('AGENDA','WHATSAPP'\)\)/);
+  assert.doesNotMatch(mig,/create or replace function public\.aos_wa4_commit_booking_v1\(/);
+});
+
+test('slot is checked, locked and checked again before write',()=>{
+  const calls=(mig.match(/aos_booking_resolve_selected_slot_v2\(v_t\.id,v_date,v_site,v_time/g)||[]).length;
+  assert.ok(calls>=4,`expected repeated BOOK+REBOOK revalidation, got ${calls}`);
+  assert.match(mig,/pg_advisory_xact_lock\(hashtextextended\('agv2-slot:'/);
+  assert.match(mig,/AGV2_SLOT_NO_LONGER_AVAILABLE/);
+  assert.doesNotMatch(mig,/force[_ ]?booking|override[_ ]?capacity/i);
+});
+
+test('rebooking mutates the same appointment and appends history',()=>{
+  assert.match(mig,/update public\.aos_agenda_citas[\s\S]*where id=p_appointment_id;/);
+  assert.match(mig,/event_type[^\n]*RESCHEDULED|,'RESCHEDULED'/);
+  assert.match(mig,/AGV2_EVENT_LEDGER_APPEND_ONLY/);
+  assert.doesNotMatch(mig,/delete from public\.aos_agenda_citas/i);
+  assert.match(contract,/same logical appointment/i);
+});
+
+test('Agenda uses strong session authority and WA preserves HUMAN_ONLY ownership',()=>{
+  assert.match(mig,/aos_app_actor_v3\(p_token,'advisor-agenda',false\)/);
+  assert.match(mig,/aos_app_actor_v3\(p_token,'admin-agenda',true\)/);
+  assert.match(mig,/AGENDA_2FA_PANEL_REQUIRED/);
+  assert.match(mig,/v_conv\.owner_user_id is distinct from p_actor_id/);
+  assert.match(mig,/aos_wa_assignments_v1[\s\S]*state='ACTIVE'/);
+  assert.match(mig,/HUMAN_ACTIVE','AI_COPILOT/);
+});
+
+test('identity conflicts fail closed and optional data does not become invented authority',()=>{
+  assert.match(mig,/aos_rev_resolve_patient_identity_v2\('PHONE'/);
+  assert.match(mig,/AGV2_IDENTITY_CONFLICT/);
+  assert.match(mig,/AGV2_EMAIL_INVALID/);
+  assert.doesNotMatch(mig,/DNI_REQUIRED/);
+  assert.match(contract,/Email y DNI no son bloqueantes/);
+});
+
+test('core has no provider side-effect send and rollback removes only additive surfaces',()=>{
+  assert.doesNotMatch(mig,/sendAgentEmail|graph\.facebook|messages\/send|resend\.com/i);
+  for(const token of ['aos_wa4_commit_booking_v2','aos_agenda_commit_booking_v2','aos_booking_operations_v2','aos_agenda_events_v2']){
+    assert.ok(rb.includes(token),`rollback missing ${token}`);
+  }
+  assert.doesNotMatch(rb,/aos_wa4_commit_booking_v1/);
+});

--- a/ci/wa4c-full-local/booking_fixture.sql
+++ b/ci/wa4c-full-local/booking_fixture.sql
@@ -55,7 +55,15 @@ create table if not exists public.aos_horarios_personal(
   hora_inicio text not null,
   hora_fin text not null,
   sede text not null,
+  rol text,
   activo boolean default true
+);
+
+-- Compact governed treatment authority required by the canonical booking capability resolver.
+-- This remains TEST-only: the selected synthetic service is mirrored 1:1 as its own capability.
+create table if not exists public.aos_cat_tratamientos(
+  tratamiento text primary key,
+  estado text default 'ACTIVO'
 );
 
 create table if not exists public.aos_pacientes(
@@ -84,6 +92,7 @@ end
 $$;
 
 grant select,insert,update on public.aos_agenda_citas,public.aos_perfiles_profesional,public.aos_horarios_personal,public.aos_pacientes to service_role;
+grant select on public.aos_cat_tratamientos to service_role;
 grant execute on function public.aos_rev_resolve_patient_identity_v2(text,text) to service_role;
 
 insert into public.aos_perfiles_profesional(id,codigo_asesor,nombre_publico,sede,tipo,visible,orden)
@@ -93,15 +102,15 @@ on conflict(id) do update set visible=true,sede='TODAS',tipo='DOCTORA',nombre_pu
 with d as (
   select current_date + case extract(isodow from current_date)::int when 6 then 2 when 7 then 1 else 1 end as target_date
 )
-insert into public.aos_horarios_personal(personal,fecha,hora_inicio,hora_fin,sede,activo)
-select 'DRA. TEST',target_date,'10:00','12:00','SAN ISIDRO',true from d;
+insert into public.aos_horarios_personal(personal,fecha,hora_inicio,hora_fin,sede,rol,activo)
+select 'DRA. TEST',target_date,'10:00','12:00','SAN ISIDRO','DOCTORA',true from d;
 
 -- Keep the freshness watermark beyond the target date.
 with d as (
   select current_date + case extract(isodow from current_date)::int when 6 then 2 when 7 then 1 else 1 end + 7 as future_date
 )
-insert into public.aos_horarios_personal(personal,fecha,hora_inicio,hora_fin,sede,activo)
-select 'DRA. TEST',future_date,'10:00','12:00','SAN ISIDRO',true from d;
+insert into public.aos_horarios_personal(personal,fecha,hora_inicio,hora_fin,sede,rol,activo)
+select 'DRA. TEST',future_date,'10:00','12:00','SAN ISIDRO','DOCTORA',true from d;
 
 create table if not exists public.aos_wa4c_booking_test_fixture(
   id integer primary key,
@@ -126,6 +135,15 @@ update public.aos_catalogo_servicios s
 set requiere_doctora=true,requiere_enfermeria=false
 from public.aos_wa4c_booking_test_fixture f
 where f.id=1 and s.id=f.treatment_id;
+
+-- Mirror the exact selected service into the compact treatment authority so the
+-- canonical capability resolver is exercised rather than stubbed.
+insert into public.aos_cat_tratamientos(tratamiento,estado)
+select s.nombre,'ACTIVO'
+from public.aos_catalogo_servicios s
+join public.aos_wa4c_booking_test_fixture f on f.treatment_id=s.id
+where f.id=1
+on conflict(tratamiento) do update set estado='ACTIVO';
 
 grant select on public.aos_wa4c_booking_test_fixture to service_role;
 

--- a/docs/control/AGENDA_V2_CURRENT.md
+++ b/docs/control/AGENDA_V2_CURRENT.md
@@ -2,7 +2,7 @@
 
 Fecha de apertura: 2026-09-01
 Baseline: `main@66ac1bfaa92465f061c243578607388926970c32`
-Estado: `INVENTORY_AND_ARCHITECTURE`
+Estado: `AGV2-0_INVENTORY_ACTIVE`
 Mutación PROD: `NO`
 
 ## Objetivo
@@ -48,6 +48,68 @@ Esto permite combinaciones que deberían derivarse de autoridad clínica y dispo
 
 `agenda-governed-status-v1.js` solo sustituyó el guardado de estado legacy por una operación atómica gobernada. Creación, edición y reprogramación todavía requieren reconciliación/migración.
 
+## AGV2-0 — mapa inicial de superficies de escritura
+
+La cita canónica no se escribe únicamente desde `agenda.js`. El inventario de repo confirma múltiples superficies legacy:
+
+| Superficie | Ruta observada | Riesgo / decisión V2 |
+| --- | --- | --- |
+| `app/public/agenda.js` | PATCH directo de `aos_agenda_citas` | edición debe migrar a frontera gobernada |
+| `app/public/agenda.js` | DELETE directo de `aos_agenda_citas` | eliminación física debe salir del browser; preferir cancelación/state machine salvo caso administrativo explícito |
+| `app/public/agenda.js` | reprogramación por `PATCH original + POST nueva` en paralelo | no atómico; migrar a una sola transacción de rebook |
+| `app/public/citas.js` / `citas.html` | PATCH/DELETE directos | deben consumir la misma autoridad que Agenda V2 |
+| `app/public/citas.html` | reprogramación directa PATCH + POST | segunda ruta legacy de booking; eliminar divergencia |
+| `app/public/calls.js` / `calls.html` | POST de cita desde Call Center legacy | ya existe Loop6 governed runtime; mantener únicamente ruta gobernada/postload |
+| `app/public/attendance.html` | puede crear `aos_agenda_citas` directamente | revisar ownership: asistencia no debe inventar booking fuera del contrato canónico |
+| `app/public/admin-agenda.html` | POST/DELETE directo de `aos_horarios_personal` | horarios requieren frontera administrativa y auditoría propias |
+
+Principio AGV2: no corregir cada pantalla con reglas distintas. Todas las superficies que creen/reprogramen/editen una cita deben converger en un único contrato transaccional.
+
+## Boundary de seguridad encontrado en PROD
+
+`aos_agenda_citas` tiene RLS habilitado, pero conserva políticas legacy permisivas `ALL / true` para `anon` y `authenticated`. Además, los roles `anon` y `authenticated` conservan privilegios de tabla incluyendo `SELECT/INSERT/UPDATE/DELETE`.
+
+Esto significa que la seguridad efectiva actual depende parcialmente de triggers de runtime/origen y de que la UI use rutas gobernadas; no existe todavía un boundary de tabla suficientemente cerrado para Agenda V2.
+
+Agenda V2 debe eliminar esta dependencia gradualmente y sin romper Call Center, WhatsApp, asistencia o integraciones legacy:
+
+1. inventariar cada writer legítimo;
+2. darle RPC/función gobernada propia o consolidada;
+3. certificar cada writer;
+4. retirar writes directos del browser;
+5. recién entonces endurecer grants/RLS de la tabla canónica.
+
+No revocar ACL/RLS en PROD durante AGV2-0: podría cortar writers existentes no reconciliados.
+
+## Triggers y side-effects actuales de `aos_agenda_citas`
+
+El ledger tiene side-effects que obligan a que Create/Rebook/State sean transacciones diseñadas, no simples PATCH/POST:
+
+- Loop6 guard para INSERT de origen `CITA_MANUAL` / `CALL_CENTER*`.
+- WA-4 governed booking guard para INSERT/UPDATE de origen `WHATSAPP`.
+- dedupe de agenda en INSERT.
+- cleanup de llamadas legacy para ciertas citas manuales.
+- notificaciones en INSERT y en cambios de `estado_cita`.
+- asignación de historia clínica al pasar a `ASISTIO`.
+- autocreación/enriquecimiento de paciente desde la cita.
+- auditoría general INSERT/UPDATE/DELETE.
+- dirty marker de Revenue/Sentinel.
+
+Por lo tanto, una operación de Agenda V2 debe preservar deliberadamente los side-effects válidos y retirar los accidentales/duplicados solo con pruebas.
+
+## Status authority CURRENT
+
+`aos_agenda_set_status_v1(...)` ya implementa una frontera fuerte para estados:
+
+- exige sesión 2FA válida para `advisor-agenda` o `admin-agenda`;
+- acepta solo `PENDIENTE`, `CITA CONFIRMADA`, `ASISTIO`, `EFECTIVA`, `NO ASISTIO`, `CANCELADA`;
+- bloquea la fila con `FOR UPDATE`;
+- para `ASISTIO/EFECTIVA` exige autoridad de profesional clínico y crea/actualiza `aos_atenciones`;
+- al volver a `PENDIENTE/CITA CONFIRMADA`, preserva atención si ya existen notas clínicas y limpia solo cuando no existen;
+- registra auditoría `AGENDA_STATUS_GOVERNED`.
+
+AGV2-3 debe construir la state machine sobre esta base y definir explícitamente qué transiciones entre estados son legales; el RPC actual valida el estado destino, pero todavía no congela una matriz completa `estado anterior → estado nuevo`.
+
 ## Booking authority ya disponible
 
 `aos_booking_availability_v2` actualmente:
@@ -65,6 +127,18 @@ Reglas técnicas CURRENT a debatir antes de congelar como regla comercial de Age
 - domingo no agendable en `aos_agendar_publica_v2`.
 
 Estas reglas existen hoy, pero NO quedan congeladas como política de negocio por este documento.
+
+## Patrón transaccional reutilizable
+
+`aos_agendar_publica_v2` ya demuestra varias piezas correctas que AGV2-2 puede reutilizar conceptualmente:
+
+- advisory lock de booking;
+- llamada a la autoridad de disponibilidad dentro de la operación;
+- revalidación del slot inmediatamente antes de insertar;
+- fallo `SLOT_NO_LONGER_AVAILABLE` si cambió la disponibilidad;
+- resolución de profesional exacto o pool según rol.
+
+No reutilizar ciegamente sus semánticas de token/origen/atribución porque son de agenda pública; el booking interno necesita actor 2FA, owner/asesor y origen interno explícitos.
 
 ## Contrato objetivo Agenda V2
 
@@ -106,6 +180,20 @@ Eliminar lecturas duplicadas, fijar ownership de vistas día/semana/mes y medir 
 
 ### AGV2-7 — LIVE Certification
 Con sesión 2FA real y horario laboral: crear, reprogramar y cambiar estado de citas reales allowlisted; validar readback, atribución, capacidad, auditoría y side-effects.
+
+## Próximo gate de arquitectura
+
+Antes de escribir AGV2-2 hay que cerrar AGV2-1 con decisión humana sobre estas reglas de negocio que el código actual no debe imponer por accidente:
+
+- duración/capacidad por procedimiento, no solo por rol;
+- cuándo se exige profesional exacto y cuándo pool;
+- si una cita puede cambiar de tratamiento sin rebooking;
+- reglas de reprogramación y conservación de historial/origen;
+- cancelación vs eliminación física;
+- estados y transiciones válidas;
+- qué datos del paciente son obligatorios al agendar;
+- ownership de la cita: asesor, sede, canal y atribución;
+- horarios especiales, bloqueos, feriados y excepciones.
 
 ## Gate aplazado hasta horario laboral
 

--- a/docs/control/AGENDA_V2_CURRENT.md
+++ b/docs/control/AGENDA_V2_CURRENT.md
@@ -1,0 +1,114 @@
+# ASCENDA OS · AGENDA V2 — CURRENT
+
+Fecha de apertura: 2026-09-01
+Baseline: `main@66ac1bfaa92465f061c243578607388926970c32`
+Estado: `INVENTORY_AND_ARCHITECTURE`
+Mutación PROD: `NO`
+
+## Objetivo
+
+Evolucionar Agenda desde el runtime legacy hacia una operación gobernada, rápida y coherente con la autoridad de booking ya certificada por WA-4C, sin crear una segunda verdad de disponibilidad, profesionales, tratamientos o citas.
+
+## Autoridades que se preservan
+
+1. `public.aos_agenda_citas` permanece como ledger canónico de citas.
+2. `public.aos_booking_availability_v2(...)` es la autoridad actual de disponibilidad real.
+3. La elegibilidad clínica sigue la cadena canónica:
+   `servicio → procedimiento → capability/skill → profesional → horario por fecha/sede → slot/capacidad`.
+4. `public.aos_professional_can_service_v1(...)` gobierna si un profesional puede realizar el tratamiento/procedimiento.
+5. `public.aos_horarios_personal` es la fuente date-specific usada actualmente por `aos_agenda_dia` y `aos_booking_availability_v2`.
+6. El cambio de estado ya está gobernado por `public.aos_agenda_set_status_v1(...)` con sesión fuerte/2FA y permisos de Agenda.
+7. HUMAN_ONLY / SAFE-OFF de WhatsApp no cambia por este workstream.
+
+## Readback PROD al abrir Agenda V2
+
+- `aos_horarios_personal`: 525 filas, 520 activas.
+- Cobertura date-specific observada: `2026-04-11 → 2026-09-30`.
+- `aos_turnos`: 0 filas; no debe asumirse como fuente vigente de disponibilidad sin nueva evidencia.
+- Existen además `aos_horarios_profesional` y `aos_config_horarios`, pero Agenda V2 no debe mezclar fuentes hasta reconciliar ownership y propósito.
+
+## Estado legacy confirmado
+
+`app/public/agenda.html` + `app/public/agenda.js` siguen siendo la UI/runtime principal.
+
+El modal Nueva/Editar permite escoger manualmente, entre otros:
+- paciente / teléfono / DNI / correo;
+- asesor;
+- sede;
+- tipo de atención;
+- doctora;
+- fecha;
+- hora libre;
+- tratamiento;
+- tipo de cita;
+- estado;
+- observación.
+
+Esto permite combinaciones que deberían derivarse de autoridad clínica y disponibilidad, no de decisiones manuales independientes.
+
+`agenda-governed-status-v1.js` solo sustituyó el guardado de estado legacy por una operación atómica gobernada. Creación, edición y reprogramación todavía requieren reconciliación/migración.
+
+## Booking authority ya disponible
+
+`aos_booking_availability_v2` actualmente:
+- valida tratamiento activo y tipo SERVICIO;
+- resuelve capability y procedimiento;
+- valida profesional mediante `aos_professional_can_service_v1`;
+- exige horario real de `aos_horarios_personal` para la fecha y sede;
+- descuenta ocupación real de `aos_agenda_citas`;
+- falla cerrado si la fuente de horarios está stale;
+- devuelve únicamente slots reales disponibles.
+
+Reglas técnicas CURRENT a debatir antes de congelar como regla comercial de Agenda V2:
+- DOCTORA: slot de 30 min, capacidad 1, profesional exacto.
+- ENFERMERIA: pool por sede, slot de 45 min, capacidad técnica actual `2 × enfermeras elegibles presentes`.
+- domingo no agendable en `aos_agendar_publica_v2`.
+
+Estas reglas existen hoy, pero NO quedan congeladas como política de negocio por este documento.
+
+## Contrato objetivo Agenda V2
+
+La creación/reprogramación no debe permitir inventar disponibilidad. Flujo objetivo:
+
+1. Identidad del paciente.
+2. Tratamiento/servicio exacto.
+3. Sistema resuelve procedimiento y rol clínico elegible.
+4. Sede.
+5. Fecha.
+6. Profesionales elegibles y/o pool según regla clínica.
+7. Slot REAL retornado por la autoridad de booking.
+8. Tipo de cita / contexto clínico-operativo.
+9. Revalidación transaccional del slot.
+10. Escritura idempotente de la cita con actor, origen y atribución preservados.
+
+## Fases propuestas
+
+### AGV2-0 — Inventory / Truth Map
+Mapear UI, RPC, tablas, triggers, estados, side-effects, fuentes de horarios y todas las rutas que crean/editan/reprograman/eliminan citas.
+
+### AGV2-1 — Canonical Booking Contract
+Congelar campos obligatorios, reglas de rol, sede, fecha, capacidad, profesional, origen, owner, identidad e idempotencia.
+
+### AGV2-2 — Governed Create/Rebook
+Crear una única frontera transaccional para alta y reprogramación desde Agenda, con 2FA/permisos y revalidación de slot. El browser deja de hacer cadenas directas de writes.
+
+### AGV2-3 — Appointment State Machine
+Formalizar transiciones válidas y sus responsables: pendiente, confirmada, asistió, efectiva, no asistió, cancelada y reprogramada, incluyendo efectos clínicos y de auditoría.
+
+### AGV2-4 — Agenda UX V2
+Rehacer Nueva/Reprogramar como flujo guiado por autoridad real; reducir campos manuales redundantes e impedir combinaciones incompatibles.
+
+### AGV2-5 — Notifications / Side Effects
+Separar confirmaciones, recordatorios, email/WhatsApp y no-show de la transacción core de booking. Un fallo de mensajería nunca debe corromper una cita ya confirmada.
+
+### AGV2-6 — Performance / Read Architecture
+Eliminar lecturas duplicadas, fijar ownership de vistas día/semana/mes y medir latencia/carga de RPCs críticos.
+
+### AGV2-7 — LIVE Certification
+Con sesión 2FA real y horario laboral: crear, reprogramar y cambiar estado de citas reales allowlisted; validar readback, atribución, capacidad, auditoría y side-effects.
+
+## Gate aplazado hasta horario laboral
+
+No fabricar citas PROD para cerrar el workstream. El smoke real de creación/reprogramación y cambio de estado se ejecutará con una sesión legítima de usuario de Agenda durante horario laboral.
+
+Hasta ese gate se permite: inventario read-only, contratos, pruebas locales, diseño de migraciones/UI y canaries sintéticos locales.

--- a/docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md
+++ b/docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md
@@ -1,0 +1,165 @@
+# ASCENDA OS · AGV2-1 — Conversational Booking Contract (DRAFT)
+
+Fecha: 2026-09-01
+Baseline main: `66ac1bfaa92465f061c243578607388926970c32`
+Estado: `DRAFT_FOR_BUSINESS_FREEZE`
+Mutación PROD: `NO`
+
+## Objetivo
+
+Definir cómo una conversación de WhatsApp pasa de intención comercial a una cita real, gobernada y auditable, sin duplicar la autoridad de tratamientos, profesionales, horarios o disponibilidad.
+
+## Principio rector
+
+El usuario no debe decidir manualmente datos que ASCENDA ya puede resolver desde autoridad canónica.
+
+Cadena:
+
+`contexto/campaña → tratamiento/intención → procedimiento/capability → profesional(es) elegibles → sede → horario date-specific → slot real → confirmación explícita → commit gobernado`
+
+## Interacción comercial
+
+La conversación no debe convertirse en un formulario largo. Primero responde lo que el prospecto pregunta, con economía de mensajes, y orienta a una cita/evaluación cuando sea apropiado.
+
+No hardcodear “evaluación gratuita” globalmente. Solo ofrecerla como gratuita cuando la autoridad comercial vigente del tratamiento/campaña lo permita; de lo contrario usar el precio/condición canónica de consulta.
+
+Para tratamientos genéricos (p.ej. TOXINA, MESOTERAPIA, HIFU), no inundar al prospecto con subvariantes no solicitadas. Resolver primero su intención y presentar detalles adicionales únicamente cuando sean necesarios para responder o elegir correctamente el servicio.
+
+## Inicio del modo booking
+
+Cuando el usuario expresa intención inequívoca de agendar, el runtime entra en un estado de booking explícito. Copy objetivo natural, no coercitivo:
+
+> Perfecto, te ayudo a agendar. Te pediré unos datos rápidos y luego te mostraré los horarios realmente disponibles.
+
+No exigir que el usuario responda con un formato rígido. El sistema debe tolerar lenguaje natural y repreguntar solo el campo faltante o ambiguo.
+
+## Datos y fricción
+
+### Tratamiento
+
+Si ya quedó resuelto por conversación/campaña y la confianza es suficiente, no volver a preguntarlo. Si existe ambigüedad material, aclararla antes de consultar disponibilidad.
+
+### Nombre completo
+
+Solicitar nombres y apellidos en una sola interacción. Preservar también el valor textual completo recibido; separar campos cuando sea posible y pedir aclaración solo si es realmente necesario para persistencia canónica.
+
+### WhatsApp / teléfono
+
+El número inbound de la conversación es la identidad de contacto primaria. No volver a pedirlo por defecto. Si el negocio necesita un teléfono alternativo, debe solicitarse como opcional y explícitamente diferente al WhatsApp actual.
+
+### Email
+
+Recomendado, pero no bloqueante para una cita normal. Explicar el valor: confirmación y recordatorios por correo. Validar sintaxis antes de guardar. El booking debe poder cerrarse aunque el usuario no quiera dejar email.
+
+### DNI / documento
+
+No convertirlo en requisito de booking sin una regla legal/operativa explícita. Puede solicitarse opcionalmente o completarse después/en clínica. Un prospecto que no entregue DNI no debe perder un slot si el resto del contrato permite identificarlo de forma suficiente.
+
+### Sede
+
+Debe resolverse antes de consultar slots, porque la disponibilidad es sede-específica. Si el contexto ya determina sede, puede confirmarse en vez de repreguntarse.
+
+### Profesional / rol clínico
+
+No preguntar “doctora o enfermería” cuando el tratamiento ya determina capability/rol. El sistema resuelve profesionales elegibles usando `aos_booking_availability_v2` + `aos_professional_can_service_v1` + horario date-specific.
+
+Si solo existe un profesional elegible con horario real, no presentar una falsa elección; informar el profesional en la propuesta/confirmación. Si existen varios, se puede ofrecer preferencia o primera disponibilidad según la política que se congele.
+
+### Fecha y hora
+
+Nunca aceptar una hora como disponibilidad por simple texto sin validarla. Primero consultar autoridad real; luego presentar fechas/slots válidos. El usuario puede elegir mediante botones/listas interactivas o lenguaje natural, pero el backend siempre valida contra la misma autoridad.
+
+## Uso de botones/listas en WhatsApp
+
+Usar interacción estructurada únicamente donde reduce fricción y las opciones son discretas: sede, fecha disponible, slot disponible y confirmación/reprogramación. No reemplazar con botones la conversación abierta de preguntas, objeciones, síntomas, tratamiento o precio.
+
+Los botones son aceleradores, no un requisito: si el usuario escribe “mañana a las 4”, el sistema debe interpretar la intención, comprobar si ese slot existe y responder con resultado o alternativas.
+
+## Confirmación previa al commit
+
+Antes de escribir la cita, presentar un resumen mínimo: tratamiento, sede, fecha, hora y profesional/pool cuando aplique. El usuario debe realizar una acción afirmativa inequívoca.
+
+Luego el commit debe revalidar el slot de forma transaccional e idempotente. Si el slot dejó de estar libre, no crear la cita y ofrecer nuevas opciones.
+
+## Post-booking
+
+Tras commit exitoso:
+
+1. `aos_agenda_citas` refleja la cita con origen/atribución correctos.
+2. El ledger de booking conserva `conversation_id`, actor/origen e idempotencia.
+3. WhatsApp confirma dentro del flujo permitido.
+4. Si existe email válido, se encola confirmación transaccional por email.
+5. Un fallo de WhatsApp/email posterior NO revierte ni corrompe una cita confirmada; las notificaciones son side-effects/outbox.
+6. La cita queda disponible para recordatorios y seguimiento posterior.
+
+## Reprogramación conversacional
+
+El sistema debe detectar intención de reprogramar en lenguaje natural: “no podré ir”, “se me complicó”, “puede ser otro día”, “quiero mover mi cita”, etc. Las expresiones reales aportadas por operación se convertirán en canaries/corpus de regresión.
+
+Flujo objetivo:
+
+`mensaje → RESCHEDULE_INTENT → resolver cita activa del paciente/conversación → si hay ambigüedad preguntar cuál → conservar tratamiento/reglas clínicas → consultar nuevos slots reales → elección → confirmación explícita → rebook transaccional`
+
+No borrar silenciosamente la cita anterior ni crear una nueva sin vínculo. Debe preservarse historial de reprogramación y evitar doble conteo de “citas generadas”.
+
+AGV2-1 debe congelar si se usará:
+
+- un mismo appointment lógico + event ledger de cambios, o
+- fila anterior marcada `REAGENDADA/REPROGRAMADA` + nueva fila vinculada por relación explícita.
+
+La métrica debe distinguir `booking_created` de `rebooking`.
+
+## Continuidad y seguimiento
+
+La conversación de WhatsApp debe mantener el contexto del mismo número/conversación. Una respuesta a un recordatorio no abre un lead nuevo si la identidad canónica permite asociarla al mismo paciente/cita.
+
+El seguimiento posterior puede ofrecer reprogramación o recuperar riesgo de no-show, pero ninguna modificación de agenda se realiza sin una confirmación explícita del usuario.
+
+## Email transaccional
+
+La infraestructura actual ya contempla clases como `confirmacion_cita`, `recordatorio_manana`, `recordatorio_hoy`, `reprogramacion` y `no_asistencia`. AGV2 no debe enviar correo dentro de la transacción de booking. Debe persistir un evento/outbox y permitir que el worker de email lo despache y audite por separado.
+
+## Economía de conversación / WhatsApp Cost Intelligence
+
+Objetivo adicional: poder saber cuánto costó una conversación hasta cada outcome.
+
+Fuentes CURRENT existentes:
+
+- `aos_wa_messages_v1`: `conversation_id`, dirección, estado, `pricing_category`, `pricing_model`, `billable`.
+- `aos_wa_ai_runs_v1`: tokens, modelo, latencia y `estimated_cost_usd`.
+- `aos_wa_attribution_touchpoints_v1`: campaña/anuncio/origen y paciente canónico.
+- `aos_wa4_booking_actions_v1`: vínculo de conversación con el commit de booking.
+
+Para costo exacto de Meta falta una autoridad de pricing versionada por fecha/mercado/categoría y/o persistir el costo efectivo por evento. `billable=true/false` por sí solo no es un importe.
+
+### Popup objetivo por conversación
+
+Mostrar como mínimo:
+
+- mensajes inbound/outbound;
+- mensajes Meta billables/no billables/unknown;
+- costo Meta acumulado;
+- consumo IA y costo IA estimado;
+- costo total de conversación;
+- cita generada/reprogramada;
+- asistió/no-show;
+- venta y facturación atribuida cuando exista;
+- costo por booking, costo por asistencia y costo de conversación hasta venta.
+
+A nivel agregado, permitir cortes por campaña/anuncio, orgánico, tratamiento, bot/humano y periodo.
+
+## Datos CURRENT verificados al redactar este draft
+
+- Dra. Carolina Zimic tiene horario date-specific vigente observado en septiembre.
+- Dra. Pamela y Dra. Yessica están visibles como perfiles, pero no presentan horario date-specific futuro en el readback actual; por tanto no deben aparecer como disponibilidad real mientras eso siga así.
+- El sistema de email ya registra envíos recientes de `confirmacion_cita`, `recordatorio_manana`, `recordatorio_hoy`, `bienvenida` y `no_asistencia`.
+- El ledger WA ya contiene campos de pricing/billable, pero la muestra actual todavía tiene eventos con pricing desconocido y no existen aún AI cost runs persistidos en PROD.
+
+## Pendientes de freeze empresarial
+
+1. Si la cita debe preguntar preferencia profesional cuando existen varios elegibles o priorizar primera disponibilidad.
+2. Regla exacta de “evaluación gratuita” por tratamiento/campaña/consulta.
+3. Modelo canónico de reprogramación (same logical appointment + event ledger vs linked rows).
+4. Cuándo pedir DNI y en qué casos sí sería obligatorio.
+5. Política de email: confirmación, recordatorios, reprogramación y evitar duplicación con bienvenida.
+6. Cantidad máxima de fechas/slots a mostrar en una interacción antes de paginar/listar.

--- a/docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md
+++ b/docs/control/AGV2_1_CONVERSATIONAL_BOOKING_CONTRACT_DRAFT.md
@@ -1,8 +1,8 @@
-# ASCENDA OS · AGV2-1 — Conversational Booking Contract (DRAFT)
+# ASCENDA OS · AGV2-1 — Conversational Booking Contract
 
-Fecha: 2026-09-01
-Baseline main: `66ac1bfaa92465f061c243578607388926970c32`
-Estado: `DRAFT_FOR_BUSINESS_FREEZE`
+Fecha de freeze: 2026-09-01
+Baseline main de apertura: `66ac1bfaa92465f061c243578607388926970c32`
+Estado: `BUSINESS_FROZEN`
 Mutación PROD: `NO`
 
 ## Objetivo
@@ -13,153 +13,162 @@ Definir cómo una conversación de WhatsApp pasa de intención comercial a una c
 
 El usuario no debe decidir manualmente datos que ASCENDA ya puede resolver desde autoridad canónica.
 
-Cadena:
+Cadena canónica:
 
 `contexto/campaña → tratamiento/intención → procedimiento/capability → profesional(es) elegibles → sede → horario date-specific → slot real → confirmación explícita → commit gobernado`
 
+Agenda interna y WhatsApp deben converger en la misma autoridad transaccional de booking. La UI y la conversación pueden ser distintas; las reglas y el commit no.
+
 ## Interacción comercial
 
-La conversación no debe convertirse en un formulario largo. Primero responde lo que el prospecto pregunta, con economía de mensajes, y orienta a una cita/evaluación cuando sea apropiado.
+La conversación no debe convertirse en un formulario largo. Primero responde exactamente lo que el prospecto pregunta, con economía de mensajes, y orienta a cita/evaluación cuando sea apropiado.
 
-No hardcodear “evaluación gratuita” globalmente. Solo ofrecerla como gratuita cuando la autoridad comercial vigente del tratamiento/campaña lo permita; de lo contrario usar el precio/condición canónica de consulta.
+No hardcodear “evaluación gratuita”. Solo comunicar gratuidad cuando la autoridad comercial vigente del tratamiento/campaña/consulta la confirme. Si la autoridad no lo puede demostrar, se comunica el precio/condición canónica o se evita afirmar gratuidad.
 
-Para tratamientos genéricos (p.ej. TOXINA, MESOTERAPIA, HIFU), no inundar al prospecto con subvariantes no solicitadas. Resolver primero su intención y presentar detalles adicionales únicamente cuando sean necesarios para responder o elegir correctamente el servicio.
+Para tratamientos genéricos como TOXINA, MESOTERAPIA o HIFU, no inundar al prospecto con subvariantes no solicitadas. Resolver primero intención y presentar variantes solo cuando sean necesarias para contestar, cotizar o elegir correctamente el servicio.
 
 ## Inicio del modo booking
 
-Cuando el usuario expresa intención inequívoca de agendar, el runtime entra en un estado de booking explícito. Copy objetivo natural, no coercitivo:
+Cuando el usuario expresa intención inequívoca de agendar, el runtime entra en estado explícito de booking.
+
+Copy objetivo natural:
 
 > Perfecto, te ayudo a agendar. Te pediré unos datos rápidos y luego te mostraré los horarios realmente disponibles.
 
-No exigir que el usuario responda con un formato rígido. El sistema debe tolerar lenguaje natural y repreguntar solo el campo faltante o ambiguo.
+No exigir formato rígido. El sistema tolera lenguaje natural y repregunta únicamente el campo faltante o ambiguo.
 
 ## Datos y fricción
 
 ### Tratamiento
 
-Si ya quedó resuelto por conversación/campaña y la confianza es suficiente, no volver a preguntarlo. Si existe ambigüedad material, aclararla antes de consultar disponibilidad.
+Si ya quedó resuelto por conversación/campaña con confianza suficiente, no volver a preguntarlo. Si existe ambigüedad material, aclararla antes de disponibilidad.
 
 ### Nombre completo
 
-Solicitar nombres y apellidos en una sola interacción. Preservar también el valor textual completo recibido; separar campos cuando sea posible y pedir aclaración solo si es realmente necesario para persistencia canónica.
+Solicitar nombres y apellidos en una sola interacción cuando aún no estén confiablemente disponibles. Para una identidad canónica ya conocida, reutilizar lo existente y solo completar faltantes. Al commit debe existir nombre y apellido suficientes para la cita; no duplicar preguntas si la autoridad ya los posee.
 
 ### WhatsApp / teléfono
 
-El número inbound de la conversación es la identidad de contacto primaria. No volver a pedirlo por defecto. Si el negocio necesita un teléfono alternativo, debe solicitarse como opcional y explícitamente diferente al WhatsApp actual.
+El número inbound de la conversación es la identidad de contacto primaria para WhatsApp. No volver a pedirlo por defecto. Un teléfono alternativo es opcional y debe presentarse explícitamente como diferente al WhatsApp actual.
 
 ### Email
 
-Recomendado, pero no bloqueante para una cita normal. Explicar el valor: confirmación y recordatorios por correo. Validar sintaxis antes de guardar. El booking debe poder cerrarse aunque el usuario no quiera dejar email.
+Recomendado, no bloqueante. Explicar su utilidad: confirmación y recordatorios por correo. Validar sintaxis antes de persistir. Rechazar un email inválido como dato, pero no cancelar el booking si el usuario prefiere continuar sin email.
 
 ### DNI / documento
 
-No convertirlo en requisito de booking sin una regla legal/operativa explícita. Puede solicitarse opcionalmente o completarse después/en clínica. Un prospecto que no entregue DNI no debe perder un slot si el resto del contrato permite identificarlo de forma suficiente.
+Opcional durante el booking normal. Puede completarse después o en clínica. Solo podrá convertirse en obligatorio para un servicio concreto si en el futuro existe una regla legal/operativa versionada en la autoridad canónica; nunca por inferencia del bot.
 
 ### Sede
 
-Debe resolverse antes de consultar slots, porque la disponibilidad es sede-específica. Si el contexto ya determina sede, puede confirmarse en vez de repreguntarse.
+Debe resolverse antes de consultar slots porque disponibilidad es sede-específica. Si campaña/contexto ya determina sede, confirmar en lugar de repreguntar.
 
 ### Profesional / rol clínico
 
-No preguntar “doctora o enfermería” cuando el tratamiento ya determina capability/rol. El sistema resuelve profesionales elegibles usando `aos_booking_availability_v2` + `aos_professional_can_service_v1` + horario date-specific.
+No preguntar “doctora o enfermería” cuando el tratamiento ya determina capability/rol. El sistema resuelve elegibilidad mediante `aos_booking_availability_v2`, `aos_professional_can_service_v1`, skills/procedimientos y horario date-specific.
 
-Si solo existe un profesional elegible con horario real, no presentar una falsa elección; informar el profesional en la propuesta/confirmación. Si existen varios, se puede ofrecer preferencia o primera disponibilidad según la política que se congele.
+Regla congelada de elección profesional:
+
+1. Por defecto priorizar la **primera disponibilidad real** compatible con tratamiento, sede y fecha/preferencia temporal del paciente.
+2. Si solo existe un profesional elegible con horario real, no presentar una falsa elección: se informa quién atenderá en la propuesta/confirmación.
+3. Si existen varios elegibles, no forzar una pregunta adicional. Se ofrece primera disponibilidad; si el paciente expresa preferencia por profesional, esa preferencia se respeta únicamente si el profesional es elegible y tiene slot real.
+4. Agenda interna sí puede exponer un filtro opcional de profesional para operación, pero el backend valida la misma autoridad.
+
+### Tipo de cita
+
+Para un prospecto nuevo que llega por interés comercial, WhatsApp usa por defecto `CONSULTA NUEVA`, salvo que contexto canónico demuestre que corresponde `APLICACION` o `CONTROL`. El bot no debe convertir automáticamente “quiero toxina/HIFU/etc.” en APLICACION.
 
 ### Fecha y hora
 
-Nunca aceptar una hora como disponibilidad por simple texto sin validarla. Primero consultar autoridad real; luego presentar fechas/slots válidos. El usuario puede elegir mediante botones/listas interactivas o lenguaje natural, pero el backend siempre valida contra la misma autoridad.
+Nunca aceptar una hora como disponible por simple texto sin validarla. Primero consultar autoridad real; luego presentar fechas/slots válidos. Si el usuario escribe “mañana a las 4”, interpretar intención y comprobar el slot; si no existe, ofrecer alternativas reales.
 
-## Uso de botones/listas en WhatsApp
+## Botones y listas
 
-Usar interacción estructurada únicamente donde reduce fricción y las opciones son discretas: sede, fecha disponible, slot disponible y confirmación/reprogramación. No reemplazar con botones la conversación abierta de preguntas, objeciones, síntomas, tratamiento o precio.
+Usar interacción estructurada solo cuando reduce fricción y las opciones son discretas: sede, fecha, slot, confirmar y reprogramar. Preguntas abiertas, objeciones, síntomas, tratamiento y precio siguen siendo conversacionales.
 
-Los botones son aceleradores, no un requisito: si el usuario escribe “mañana a las 4”, el sistema debe interpretar la intención, comprobar si ese slot existe y responder con resultado o alternativas.
+Regla congelada de paginación WhatsApp:
+
+- mostrar inicialmente hasta **3 fechas** próximas relevantes;
+- al elegir fecha, mostrar inicialmente hasta **5 slots** reales, ordenados cronológicamente;
+- incluir `Ver más`/lista adicional cuando existan más opciones;
+- la Agenda interna puede mostrar más resultados por pantalla, pero consume la misma lista canónica y nunca genera horarios propios.
+
+Los botones son aceleradores, no requisito. El texto libre sigue siendo válido y siempre se revalida.
 
 ## Confirmación previa al commit
 
-Antes de escribir la cita, presentar un resumen mínimo: tratamiento, sede, fecha, hora y profesional/pool cuando aplique. El usuario debe realizar una acción afirmativa inequívoca.
+Antes de escribir la cita mostrar resumen mínimo:
 
-Luego el commit debe revalidar el slot de forma transaccional e idempotente. Si el slot dejó de estar libre, no crear la cita y ofrecer nuevas opciones.
+- tratamiento;
+- sede;
+- fecha;
+- hora;
+- profesional exacto cuando aplique o modalidad de atención/pool cuando corresponda.
 
-## Post-booking
+Debe existir una acción afirmativa inequívoca del usuario/operador. Después el commit vuelve a validar el slot dentro de la transacción. Si dejó de estar disponible, no crea la cita y exige reselección.
 
-Tras commit exitoso:
+## Reprogramación — modelo congelado
 
-1. `aos_agenda_citas` refleja la cita con origen/atribución correctos.
-2. El ledger de booking conserva `conversation_id`, actor/origen e idempotencia.
-3. WhatsApp confirma dentro del flujo permitido.
-4. Si existe email válido, se encola confirmación transaccional por email.
-5. Un fallo de WhatsApp/email posterior NO revierte ni corrompe una cita confirmada; las notificaciones son side-effects/outbox.
-6. La cita queda disponible para recordatorios y seguimiento posterior.
+Se adopta **un mismo appointment lógico (`aos_agenda_citas.id`) + event ledger append-only**.
 
-## Reprogramación conversacional
+Reprogramar NO crea una segunda cita lógica ni elimina la anterior. Actualiza fecha/hora/sede/profesional del mismo appointment bajo lock transaccional y registra un evento `RESCHEDULED` con snapshot anterior/nuevo, actor, canal, conversación y motivo cuando exista.
 
-El sistema debe detectar intención de reprogramar en lenguaje natural: “no podré ir”, “se me complicó”, “puede ser otro día”, “quiero mover mi cita”, etc. Las expresiones reales aportadas por operación se convertirán en canaries/corpus de regresión.
+Consecuencias:
 
-Flujo objetivo:
+- `booking_created` y `rebooking` son métricas distintas;
+- no se inflan citas generadas;
+- se conserva trazabilidad completa;
+- el tratamiento no cambia durante una reprogramación. Cambiar tratamiento es una edición clínica/comercial diferente y debe volver a resolver autoridad.
 
-`mensaje → RESCHEDULE_INTENT → resolver cita activa del paciente/conversación → si hay ambigüedad preguntar cuál → conservar tratamiento/reglas clínicas → consultar nuevos slots reales → elección → confirmación explícita → rebook transaccional`
+El sistema debe detectar intención de reprogramar en lenguaje natural y resolver la cita activa por identidad/conversación. Si hay más de una candidata, pregunta cuál antes de mutar.
 
-No borrar silenciosamente la cita anterior ni crear una nueva sin vínculo. Debe preservarse historial de reprogramación y evitar doble conteo de “citas generadas”.
+## Post-booking y notificaciones
 
-AGV2-1 debe congelar si se usará:
+El commit de booking/rebooking termina primero. Email y WhatsApp son side-effects posteriores y nunca forman parte de la transacción core.
 
-- un mismo appointment lógico + event ledger de cambios, o
-- fila anterior marcada `REAGENDADA/REPROGRAMADA` + nueva fila vinculada por relación explícita.
+Política congelada:
 
-La métrica debe distinguir `booking_created` de `rebooking`.
+1. con email válido, encolar `confirmacion_cita` después de BOOK;
+2. con email válido, encolar `reprogramacion` después de REBOOK;
+3. mantener recordatorios transaccionales `recordatorio_manana` y `recordatorio_hoy` según scheduler vigente, evitando doble envío por clave idempotente;
+4. `bienvenida` es un evento de relación/onboarding y no se dispara por cada cita; nunca debe duplicar una confirmación;
+5. `no_asistencia` pertenece al flujo posterior de estado/no-show, no al commit de booking;
+6. un fallo de Resend/Meta nunca revierte la cita confirmada; el side-effect se reintenta por separado.
 
-## Continuidad y seguimiento
+## Continuidad
 
-La conversación de WhatsApp debe mantener el contexto del mismo número/conversación. Una respuesta a un recordatorio no abre un lead nuevo si la identidad canónica permite asociarla al mismo paciente/cita.
+La conversación mantiene contexto del mismo número/conversación. Una respuesta a recordatorio no abre un lead nuevo cuando la identidad canónica permite asociarla a paciente/cita existente. Ninguna modificación de agenda se ejecuta sin confirmación explícita.
 
-El seguimiento posterior puede ofrecer reprogramación o recuperar riesgo de no-show, pero ninguna modificación de agenda se realiza sin una confirmación explícita del usuario.
+## WhatsApp Cost Intelligence
 
-## Email transaccional
+El recorrido objetivo debe permitir:
 
-La infraestructura actual ya contempla clases como `confirmacion_cita`, `recordatorio_manana`, `recordatorio_hoy`, `reprogramacion` y `no_asistencia`. AGV2 no debe enviar correo dentro de la transacción de booking. Debe persistir un evento/outbox y permitir que el worker de email lo despache y audite por separado.
+`campaña/anuncio → conversación → mensajes/costo Meta → AI runs/costo IA → BOOK/REBOOK → asistencia/no-show → venta → facturación`
 
-## Economía de conversación / WhatsApp Cost Intelligence
+Fuentes CURRENT:
 
-Objetivo adicional: poder saber cuánto costó una conversación hasta cada outcome.
+- `aos_wa_messages_v1`: conversación, dirección, estado, pricing category/model y billable;
+- `aos_wa_ai_runs_v1`: tokens, modelo, latencia y costo IA estimado;
+- `aos_wa_attribution_touchpoints_v1`: campaña/anuncio/origen/paciente;
+- `aos_wa4_booking_actions_v1`: vínculo booking-conversación.
 
-Fuentes CURRENT existentes:
+Costo Meta exacto requiere autoridad de pricing versionada y/o costo efectivo por evento; `billable` por sí solo no es importe.
 
-- `aos_wa_messages_v1`: `conversation_id`, dirección, estado, `pricing_category`, `pricing_model`, `billable`.
-- `aos_wa_ai_runs_v1`: tokens, modelo, latencia y `estimated_cost_usd`.
-- `aos_wa_attribution_touchpoints_v1`: campaña/anuncio/origen y paciente canónico.
-- `aos_wa4_booking_actions_v1`: vínculo de conversación con el commit de booking.
+Popup objetivo por conversación: mensajes, billable/non-billable/unknown, costo Meta, costo IA, costo total, BOOK/REBOOK, asistencia/no-show, venta/facturación atribuida, costo por booking/asistencia/venta.
 
-Para costo exacto de Meta falta una autoridad de pricing versionada por fecha/mercado/categoría y/o persistir el costo efectivo por evento. `billable=true/false` por sí solo no es un importe.
+## Reglas comerciales cerradas
 
-### Popup objetivo por conversación
+1. Profesional: primera disponibilidad por defecto; preferencia solo cuando el paciente la expresa y es válida.
+2. Evaluación gratuita: solo si autoridad comercial la demuestra; nunca hardcoded.
+3. Reprogramación: mismo appointment + event ledger append-only.
+4. DNI: opcional salvo futura regla canónica explícita.
+5. Email: opcional para booking; confirmación/reprogramación/recordatorios como side-effects idempotentes; bienvenida separada.
+6. Opciones WhatsApp: 3 fechas iniciales y 5 slots iniciales, con `Ver más`.
+7. Tipo de cita comercial inbound: `CONSULTA NUEVA` por defecto salvo contexto canónico contrario.
+8. Teléfono WhatsApp: reutilizar inbound; no repreguntar por defecto.
 
-Mostrar como mínimo:
+## Gate
 
-- mensajes inbound/outbound;
-- mensajes Meta billables/no billables/unknown;
-- costo Meta acumulado;
-- consumo IA y costo IA estimado;
-- costo total de conversación;
-- cita generada/reprogramada;
-- asistió/no-show;
-- venta y facturación atribuida cuando exista;
-- costo por booking, costo por asistencia y costo de conversación hasta venta.
+`AGV2-1 = BUSINESS FROZEN`.
 
-A nivel agregado, permitir cortes por campaña/anuncio, orgánico, tratamiento, bot/humano y periodo.
-
-## Datos CURRENT verificados al redactar este draft
-
-- Dra. Carolina Zimic tiene horario date-specific vigente observado en septiembre.
-- Dra. Pamela y Dra. Yessica están visibles como perfiles, pero no presentan horario date-specific futuro en el readback actual; por tanto no deben aparecer como disponibilidad real mientras eso siga así.
-- El sistema de email ya registra envíos recientes de `confirmacion_cita`, `recordatorio_manana`, `recordatorio_hoy`, `bienvenida` y `no_asistencia`.
-- El ledger WA ya contiene campos de pricing/billable, pero la muestra actual todavía tiene eventos con pricing desconocido y no existen aún AI cost runs persistidos en PROD.
-
-## Pendientes de freeze empresarial
-
-1. Si la cita debe preguntar preferencia profesional cuando existen varios elegibles o priorizar primera disponibilidad.
-2. Regla exacta de “evaluación gratuita” por tratamiento/campaña/consulta.
-3. Modelo canónico de reprogramación (same logical appointment + event ledger vs linked rows).
-4. Cuándo pedir DNI y en qué casos sí sería obligatorio.
-5. Política de email: confirmación, recordatorios, reprogramación y evitar duplicación con bienvenida.
-6. Cantidad máxima de fechas/slots a mostrar en una interacción antes de paginar/listar.
+Cualquier cambio posterior de estas reglas requiere una versión nueva del contrato y regresión de Agenda + WhatsApp.

--- a/docs/control/AGV2_2_TRANSACTIONAL_BOOKING_CONTRACT.md
+++ b/docs/control/AGV2_2_TRANSACTIONAL_BOOKING_CONTRACT.md
@@ -1,0 +1,215 @@
+# ASCENDA OS · AGV2-2 — Unified Transactional Booking Contract
+
+Fecha: 2026-09-01
+Baseline de diseño: `main@66ac1bfaa92465f061c243578607388926970c32`
+Depende de: `AGV2-1 = BUSINESS FROZEN`
+Estado: `IMPLEMENTATION_IN_PROGRESS`
+
+## Objetivo
+
+Construir una sola frontera transaccional para crear y reprogramar citas desde:
+
+- Agenda interna;
+- WhatsApp Revenue Hub.
+
+La UI o el canal no son autoridad de disponibilidad. Ambos deben consumir el mismo core de booking y el mismo ledger de eventos.
+
+## Invariantes
+
+1. `aos_agenda_citas` sigue siendo el ledger canónico CURRENT de la cita.
+2. Un BOOK crea exactamente un appointment lógico.
+3. Un REBOOK modifica el mismo `appointment_id`; no duplica la cita.
+4. Cada mutación se registra en un event ledger append-only.
+5. Toda operación exige `idempotency_key` y request hash.
+6. Toda selección de slot se revalida bajo lock antes de escribir.
+7. Tratamiento debe ser ACTIVO y `tipo=SERVICIO`.
+8. Rol/profesional deben derivarse de authority, no de texto libre.
+9. `AMBOS` significa una ruta clínica elegible u otra, nunca ambos profesionales obligatorios.
+10. El teléfono debe poder resolver identidad; `IDENTITY_CONFLICT` falla cerrado.
+11. Email y DNI no son bloqueantes según AGV2-1.
+12. Email/WhatsApp de confirmación no se ejecutan dentro de la transacción core.
+13. WhatsApp mantiene HUMAN_ONLY / SAFE-OFF: el wrapper conserva ownership y active assignment.
+14. Agenda interna exige sesión fuerte/2FA y permiso de Agenda.
+15. Un mismo contrato lógico gobierna ambos canales; wrappers solo autentican/derivan contexto.
+
+## Modelo
+
+### `aos_booking_operations_v2`
+
+Ledger idempotente de operaciones BOOK/REBOOK.
+
+Campos esenciales:
+
+- `id`;
+- `idempotency_key` UNIQUE;
+- `request_hash`;
+- `operation_type` (`BOOK`,`REBOOK`);
+- `channel` (`AGENDA`,`WHATSAPP`);
+- `actor_id`;
+- `conversation_id` nullable;
+- `appointment_id`;
+- `treatment_id`;
+- `professional_ref`;
+- `site`, `appointment_date`, `appointment_time`;
+- `identity_state`;
+- `campaign_source`, `ad_id`, `lead_id`;
+- `status`;
+- `response`;
+- timestamps.
+
+Un replay con misma key + mismo hash devuelve el mismo resultado. Misma key + otro payload falla cerrado.
+
+### `aos_agenda_events_v2`
+
+Event ledger append-only del appointment.
+
+Eventos iniciales:
+
+- `BOOKED`;
+- `RESCHEDULED`.
+
+Cada evento conserva snapshot anterior/nuevo y contexto de actor/canal/conversación. AGV2-3 ampliará la máquina de estados sin alterar el historial de booking.
+
+## Payload BOOK
+
+Campos de autoridad:
+
+- `treatment_id` requerido;
+- `site` requerido;
+- `date` requerido;
+- `time` requerido;
+- `professional_id` requerido para ruta `DOCTORA`;
+- `slot_role` recomendado y requerido conceptualmente para servicios AMBOS; compatibilidad temporal: si falta, se infiere DOCTORA con professional_id y ENFERMERIA sin professional_id;
+- `appointment_type` default `CONSULTA NUEVA`;
+- `name`, `last_name` completables desde identidad canónica;
+- `email` opcional;
+- `dni` opcional.
+
+Agenda añade teléfono en payload. WhatsApp lo deriva de la conversación y no confía en un número enviado por el browser/runtime.
+
+## Resolución de slot
+
+1. normalizar sede;
+2. cargar tratamiento activo;
+3. resolver rol elegido compatible con el tratamiento;
+4. validar provider exacto para DOCTORA o SITE_POOL para ENFERMERIA;
+5. consultar `aos_booking_availability_v2`;
+6. verificar que el slot exacto está `disponible=true`;
+7. adquirir advisory lock por provider/pool + fecha + hora + sede;
+8. consultar nuevamente autoridad;
+9. solo entonces escribir.
+
+No existe camino `force=true`, override de capacidad o hora inventada en este contrato.
+
+## Identidad
+
+La identidad primaria se resuelve por teléfono con `aos_rev_resolve_patient_identity_v2`.
+
+- `MATCH`: reutilizar paciente canónico y completar datos faltantes.
+- `UNRESOLVED`: permitir BOOK con identidad mínima si nombre+apellido y teléfono son suficientes.
+- `IDENTITY_CONFLICT`: falla cerrado y requiere humano.
+- cualquier estado inesperado: falla cerrado.
+
+No fusionar pacientes dentro del commit de booking.
+
+## Wrapper Agenda
+
+`aos_agenda_commit_booking_v2(token, idempotency_key, payload)`:
+
+- valida `advisor-agenda` o `admin-agenda` mediante `aos_app_actor_v3`;
+- exige sesión fuerte/2FA según autoridad vigente;
+- deriva actor/código;
+- acepta teléfono del formulario/paciente;
+- llama al core;
+- no escribe `aos_agenda_citas` directamente desde browser.
+
+## Wrapper WhatsApp
+
+`aos_wa4_commit_booking_v1(actor_id, idempotency_key, conversation_id, payload)` se mantiene como contrato de compatibilidad, pero delega en el core V2.
+
+Antes de delegar conserva:
+
+- conversación existente;
+- owner exacto;
+- estado `HUMAN_ACTIVE`/`AI_COPILOT`;
+- assignment ACTIVE;
+- trusted phone de conversación;
+- campaña/ad/lead del contexto WA.
+
+No envía mensajes ni fabrica una llamada de Call Center.
+
+## REBOOK
+
+Core separado sobre el mismo modelo:
+
+- lock de appointment;
+- teléfono/contexto deben pertenecer al appointment cuando canal=WHATSAPP;
+- tratamiento se conserva;
+- consultar nuevo slot con la misma autoridad;
+- adquirir lock de nuevo slot;
+- update atómico del mismo `aos_agenda_citas.id`;
+- registrar `RESCHEDULED` con snapshots before/after;
+- escribir operación idempotente `REBOOK`;
+- volver a `PENDIENTE` temporalmente hasta que AGV2-3 congele una semántica distinta de estado post-rebook.
+
+Cambiar tratamiento NO es REBOOK.
+
+## Resultado estándar
+
+Éxito BOOK:
+
+```json
+{
+  "ok": true,
+  "status": "BOOKED",
+  "appointment_id": "...",
+  "operation_id": "...",
+  "idempotent_replay": false,
+  "site": "SAN ISIDRO",
+  "date": "2026-09-02",
+  "time": "12:30",
+  "professional_role": "DOCTORA",
+  "booking_mode": "EXACT_PROVIDER",
+  "professional_id": "...",
+  "professional_name": "...",
+  "identity_state": "MATCH"
+}
+```
+
+REBOOK usa `status=REBOOKED` e incluye snapshot nuevo. Los códigos de error son estables y machine-readable.
+
+## Side-effects
+
+El core solo emite evento persistido. AGV2-5 será responsable de convertir `BOOKED/RESCHEDULED` en intenciones idempotentes de:
+
+- email;
+- WhatsApp template/message;
+- recordatorios;
+- notificaciones internas.
+
+Esto evita que un proveedor externo convierta un BOOK exitoso en error o duplicado.
+
+## Compatibilidad y rollout
+
+1. Implementar tablas + core + wrappers en migración aditiva.
+2. Mantener firmas de WA existentes.
+3. Ejecutar full local y canaries actuales sin regresión.
+4. Agregar canaries AGV2 de BOOK Agenda sintético local, BOOK WhatsApp y REBOOK.
+5. Merge exact-head.
+6. Aplicar PROD solo desde lineage fusionado.
+7. No cambiar todavía UI legacy hasta AGV2-4.
+8. Smoke LIVE con sesión real y horario laboral se reserva para AGV2-7.
+
+## Gate AGV2-2
+
+Se considera implementado técnicamente cuando:
+
+- migración local rebuild PASS;
+- idempotency PASS;
+- slot race/revalidation PASS;
+- Agenda strong-session wrapper PASS;
+- WA ownership/assignment wrapper PASS;
+- BOOK y REBOOK event ledger PASS;
+- mismo appointment en REBOOK PASS;
+- full WA-4C canaries sin regresión PASS;
+- rollback disponible.

--- a/docs/control/AGV2_2_TRANSACTIONAL_BOOKING_CONTRACT.md
+++ b/docs/control/AGV2_2_TRANSACTIONAL_BOOKING_CONTRACT.md
@@ -125,9 +125,11 @@ No fusionar pacientes dentro del commit de booking.
 
 ## Wrapper WhatsApp
 
-`aos_wa4_commit_booking_v1(actor_id, idempotency_key, conversation_id, payload)` se mantiene como contrato de compatibilidad, pero delega en el core V2.
+Durante la implementación/certificación se introduce `aos_wa4_commit_booking_v2(actor_id, idempotency_key, conversation_id, payload)` como wrapper nuevo sobre el core V2.
 
-Antes de delegar conserva:
+El contrato productivo existente `aos_wa4_commit_booking_v1(...)` **permanece intacto y live** hasta que AGV2-2 pase los gates y una fase posterior conecte explícitamente el runtime a V2. No se hace reemplazo silencioso durante esta migración aditiva.
+
+El wrapper V2, antes de delegar, conserva:
 
 - conversación existente;
 - owner exacto;
@@ -191,12 +193,12 @@ Esto evita que un proveedor externo convierta un BOOK exitoso en error o duplica
 
 ## Compatibilidad y rollout
 
-1. Implementar tablas + core + wrappers en migración aditiva.
-2. Mantener firmas de WA existentes.
+1. Implementar tablas + core + wrappers V2 en migración aditiva.
+2. Mantener `aos_wa4_commit_booking_v1` sin cambios durante certificación.
 3. Ejecutar full local y canaries actuales sin regresión.
-4. Agregar canaries AGV2 de BOOK Agenda sintético local, BOOK WhatsApp y REBOOK.
+4. Agregar canaries AGV2 de BOOK Agenda sintético local, BOOK WhatsApp V2 y REBOOK.
 5. Merge exact-head.
-6. Aplicar PROD solo desde lineage fusionado.
+6. Aplicar PROD solo desde lineage fusionado; V2 queda dormante hasta wiring explícito.
 7. No cambiar todavía UI legacy hasta AGV2-4.
 8. Smoke LIVE con sesión real y horario laboral se reserva para AGV2-7.
 

--- a/supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+++ b/supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
@@ -1,0 +1,698 @@
+-- ASCENDA OS · AGV2-2 — Unified Transactional Booking Contract V1
+-- Additive/dormant rollout: creates a shared BOOK/REBOOK core for Agenda + WhatsApp.
+-- Existing live WA v1 commit remains untouched until the V2 contract is certified/wired.
+
+begin;
+
+create table if not exists public.aos_booking_operations_v2 (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  request_hash text not null,
+  operation_type text not null check (operation_type in ('BOOK','REBOOK')),
+  channel text not null check (channel in ('AGENDA','WHATSAPP')),
+  actor_id uuid not null,
+  conversation_id uuid null,
+  appointment_id text not null,
+  treatment_id uuid not null,
+  professional_ref text not null,
+  site text not null,
+  appointment_date date not null,
+  appointment_time time not null,
+  identity_state text not null,
+  campaign_source text null,
+  ad_id text null,
+  lead_id text null,
+  status text not null,
+  response jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_aos_booking_operations_v2_appointment
+  on public.aos_booking_operations_v2(appointment_id,created_at desc);
+create index if not exists idx_aos_booking_operations_v2_conversation
+  on public.aos_booking_operations_v2(conversation_id,created_at desc)
+  where conversation_id is not null;
+
+create table if not exists public.aos_agenda_events_v2 (
+  id uuid primary key default gen_random_uuid(),
+  operation_id uuid not null references public.aos_booking_operations_v2(id),
+  appointment_id text not null,
+  event_type text not null check (event_type in ('BOOKED','RESCHEDULED')),
+  actor_id uuid not null,
+  channel text not null check (channel in ('AGENDA','WHATSAPP')),
+  conversation_id uuid null,
+  reason text null,
+  before_snapshot jsonb null,
+  after_snapshot jsonb not null,
+  created_at timestamptz not null default now(),
+  unique(operation_id,event_type)
+);
+
+create index if not exists idx_aos_agenda_events_v2_appointment
+  on public.aos_agenda_events_v2(appointment_id,created_at desc);
+
+create or replace function public.aos_agenda_events_v2_append_only_guard()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+begin
+  raise exception using errcode='P0001',message='AGV2_EVENT_LEDGER_APPEND_ONLY';
+end
+$$;
+
+drop trigger if exists trg_aos_agenda_events_v2_append_only on public.aos_agenda_events_v2;
+create trigger trg_aos_agenda_events_v2_append_only
+before update or delete on public.aos_agenda_events_v2
+for each row execute function public.aos_agenda_events_v2_append_only_guard();
+
+revoke all on table public.aos_booking_operations_v2 from public,anon,authenticated;
+revoke all on table public.aos_agenda_events_v2 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_booking_operations_v2 to service_role;
+grant select,insert on table public.aos_agenda_events_v2 to service_role;
+
+-- Resolve one chosen slot against the same authority consumed by WA/public booking.
+create or replace function public.aos_booking_resolve_selected_slot_v2(
+  p_treatment_id uuid,
+  p_date date,
+  p_site text,
+  p_time time,
+  p_professional_id text default null,
+  p_slot_role text default null
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_t public.aos_catalogo_servicios%rowtype;
+  v_site text;
+  v_role text;
+  v_prof text:=nullif(btrim(coalesce(p_professional_id,'')),'');
+  v_av jsonb;
+  v_slot jsonb;
+  v_doc boolean;
+  v_nurse boolean;
+begin
+  select * into v_t
+  from public.aos_catalogo_servicios
+  where id=p_treatment_id
+    and upper(coalesce(estado,'ACTIVO'))='ACTIVO'
+    and upper(coalesce(tipo,'SERVICIO'))='SERVICIO';
+  if not found then return jsonb_build_object('ok',false,'error','AGV2_TREATMENT_NOT_ACTIVE'); end if;
+
+  v_site:=upper(replace(btrim(coalesce(p_site,'')),'_',' '));
+  if p_date is null or p_time is null or v_site not in ('SAN ISIDRO','PUEBLO LIBRE') then
+    return jsonb_build_object('ok',false,'error','AGV2_DATE_TIME_SITE_INVALID');
+  end if;
+  if p_date<current_date then return jsonb_build_object('ok',false,'error','AGV2_DATE_IN_PAST'); end if;
+  if extract(isodow from p_date)=7 then return jsonb_build_object('ok',false,'error','AGV2_SUNDAY_CLOSED'); end if;
+
+  v_doc:=coalesce(v_t.requiere_doctora,false);
+  v_nurse:=coalesce(v_t.requiere_enfermeria,false);
+  v_role:=upper(btrim(coalesce(p_slot_role,'')));
+
+  if v_role='' then
+    if v_doc and v_nurse then v_role:=case when v_prof is null then 'ENFERMERIA' else 'DOCTORA' end;
+    elsif v_doc then v_role:='DOCTORA';
+    elsif v_nurse then v_role:='ENFERMERIA';
+    end if;
+  end if;
+
+  if v_role not in ('DOCTORA','ENFERMERIA') then
+    return jsonb_build_object('ok',false,'error','AGV2_SLOT_ROLE_REQUIRED');
+  end if;
+  if v_role='DOCTORA' and not v_doc then return jsonb_build_object('ok',false,'error','AGV2_ROLE_NOT_ALLOWED'); end if;
+  if v_role='ENFERMERIA' and not v_nurse then return jsonb_build_object('ok',false,'error','AGV2_ROLE_NOT_ALLOWED'); end if;
+  if v_role='DOCTORA' and v_prof is null then return jsonb_build_object('ok',false,'error','AGV2_EXACT_PROVIDER_REQUIRED'); end if;
+  if v_role='ENFERMERIA' then v_prof:=null; end if;
+
+  v_av:=coalesce(public.aos_booking_availability_v2(v_t.id,p_date,v_site,v_prof),'{}'::jsonb);
+  if coalesce((v_av->>'ok')::boolean,false) is not true then
+    return jsonb_build_object(
+      'ok',false,'error','AGV2_AUTHORITY_BLOCKED',
+      'authority_status',coalesce(v_av->>'status','UNKNOWN'),
+      'requires_human',true
+    );
+  end if;
+
+  select s into v_slot
+  from jsonb_array_elements(coalesce(v_av->'slots','[]'::jsonb)) s
+  where s->>'hora'=to_char(p_time,'HH24:MI')
+    and upper(coalesce(s->>'role',''))=v_role
+    and coalesce((s->>'disponible')::boolean,false)=true
+    and (v_role='ENFERMERIA' or s->>'professional_id'=v_prof)
+  limit 1;
+
+  if v_slot is null then
+    return jsonb_build_object('ok',false,'error','AGV2_SLOT_NO_LONGER_AVAILABLE','requires_reselection',true);
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,
+    'role',v_role,
+    'booking_mode',case when v_role='DOCTORA' then 'EXACT_PROVIDER' else 'SITE_POOL' end,
+    'professional_id',case when v_role='DOCTORA' then v_prof else null end,
+    'professional_ref',case when v_role='DOCTORA' then v_prof else 'POOL:'||replace(v_site,' ','_') end,
+    'professional_name',case when v_role='DOCTORA' then v_slot->>'professional_name' else 'Enfermería' end,
+    'site',v_site,
+    'date',p_date,
+    'time',to_char(p_time,'HH24:MI'),
+    'authority_status',v_av->>'status'
+  );
+end
+$$;
+
+-- Shared BOOK core. Wrappers authenticate the channel; core owns identity, slot and commit invariants.
+create or replace function public.aos_booking_commit_core_v2(
+  p_context jsonb,
+  p_idempotency_key text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_existing public.aos_booking_operations_v2%rowtype;
+  v_actor uuid;
+  v_channel text;
+  v_conv uuid;
+  v_phone text;
+  v_phone_norm text;
+  v_contact_name text;
+  v_campaign text;
+  v_ad text;
+  v_lead text;
+  v_lead_bigint bigint:=null;
+  v_hash text;
+  v_t public.aos_catalogo_servicios%rowtype;
+  v_treatment_id uuid;
+  v_site text;
+  v_date date;
+  v_time time;
+  v_prof text;
+  v_slot_role text;
+  v_slot jsonb;
+  v_prof_ref text;
+  v_prof_name text;
+  v_role text;
+  v_booking_mode text;
+  v_identity jsonb:='{}'::jsonb;
+  v_identity_state text:='UNRESOLVED';
+  v_canonical text;
+  v_patient public.aos_pacientes%rowtype;
+  v_name text;
+  v_last text;
+  v_dni text;
+  v_email text;
+  v_type text;
+  v_agenda_id text;
+  v_op_id uuid:=gen_random_uuid();
+  v_response jsonb;
+  v_source text;
+  v_actor_code text;
+begin
+  if p_context is null or jsonb_typeof(p_context)<>'object' or p_payload is null or jsonb_typeof(p_payload)<>'object' then
+    return jsonb_build_object('ok',false,'error','AGV2_CONTEXT_OR_PAYLOAD_INVALID');
+  end if;
+  if coalesce(length(btrim(p_idempotency_key)),0)<16 or length(p_idempotency_key)>160 then
+    return jsonb_build_object('ok',false,'error','AGV2_IDEMPOTENCY_KEY_INVALID');
+  end if;
+
+  begin v_actor:=(p_context->>'actor_id')::uuid;
+  exception when others then return jsonb_build_object('ok',false,'error','AGV2_ACTOR_INVALID'); end;
+  v_channel:=upper(btrim(coalesce(p_context->>'channel','')));
+  if v_channel not in ('AGENDA','WHATSAPP') then return jsonb_build_object('ok',false,'error','AGV2_CHANNEL_INVALID'); end if;
+  begin v_conv:=nullif(p_context->>'conversation_id','')::uuid; exception when others then return jsonb_build_object('ok',false,'error','AGV2_CONVERSATION_INVALID'); end;
+
+  v_phone:=coalesce(nullif(btrim(p_context->>'contact_number'),''),nullif(btrim(p_payload->>'phone'),''));
+  v_phone_norm:=regexp_replace(coalesce(v_phone,''),'[^0-9]','','g');
+  if length(v_phone_norm)<7 then return jsonb_build_object('ok',false,'error','AGV2_TRUSTED_PHONE_REQUIRED'); end if;
+  v_contact_name:=nullif(btrim(p_context->>'contact_name'),'');
+  v_campaign:=nullif(btrim(p_context->>'campaign_source'),'');
+  v_ad:=nullif(btrim(p_context->>'ad_id'),'');
+  v_lead:=nullif(btrim(p_context->>'lead_id'),'');
+  v_actor_code:=nullif(btrim(p_context->>'actor_code'),'');
+
+  perform pg_advisory_xact_lock(hashtextextended('agv2-op:'||p_idempotency_key,0));
+  v_hash:=encode(digest(convert_to(v_channel||'|'||coalesce(v_conv::text,'')||'|'||v_actor::text||'|'||p_payload::text,'UTF8'),'sha256'),'hex');
+  select * into v_existing from public.aos_booking_operations_v2 where idempotency_key=p_idempotency_key;
+  if found then
+    if v_existing.request_hash<>v_hash then return jsonb_build_object('ok',false,'error','AGV2_IDEMPOTENCY_MISMATCH'); end if;
+    return jsonb_set(v_existing.response,'{idempotent_replay}','true'::jsonb,true);
+  end if;
+
+  v_identity:=coalesce(public.aos_rev_resolve_patient_identity_v2('PHONE',v_phone_norm),'{}'::jsonb);
+  v_identity_state:=upper(coalesce(v_identity->>'status','UNRESOLVED'));
+  if v_identity_state='IDENTITY_CONFLICT' then return jsonb_build_object('ok',false,'error','AGV2_IDENTITY_CONFLICT','requires_human',true); end if;
+  if v_identity_state not in ('MATCH','UNRESOLVED') then
+    return jsonb_build_object('ok',false,'error','AGV2_IDENTITY_NOT_READY','identity_state',v_identity_state,'requires_human',true);
+  end if;
+  if v_identity_state='MATCH' then
+    v_canonical:=nullif(btrim(v_identity->>'canonical_patient_id'),'');
+    if v_canonical is null then return jsonb_build_object('ok',false,'error','AGV2_CANONICAL_ID_MISSING','requires_human',true); end if;
+    select * into v_patient from public.aos_pacientes where "ID_PACIENTE"::text=v_canonical limit 1;
+    if not found then return jsonb_build_object('ok',false,'error','AGV2_CANONICAL_TARGET_MISSING','requires_human',true); end if;
+  end if;
+
+  begin v_treatment_id:=(p_payload->>'treatment_id')::uuid;
+  exception when others then return jsonb_build_object('ok',false,'error','AGV2_TREATMENT_ID_INVALID'); end;
+  select * into v_t from public.aos_catalogo_servicios
+  where id=v_treatment_id and upper(coalesce(estado,'ACTIVO'))='ACTIVO' and upper(coalesce(tipo,'SERVICIO'))='SERVICIO';
+  if not found then return jsonb_build_object('ok',false,'error','AGV2_TREATMENT_NOT_ACTIVE'); end if;
+
+  v_site:=upper(replace(btrim(coalesce(p_payload->>'site','')),'_',' '));
+  begin v_date:=(p_payload->>'date')::date; v_time:=(p_payload->>'time')::time;
+  exception when others then return jsonb_build_object('ok',false,'error','AGV2_DATE_TIME_INVALID'); end;
+  v_prof:=nullif(btrim(p_payload->>'professional_id'),'');
+  v_slot_role:=nullif(upper(btrim(p_payload->>'slot_role')),'');
+
+  v_slot:=public.aos_booking_resolve_selected_slot_v2(v_t.id,v_date,v_site,v_time,v_prof,v_slot_role);
+  if coalesce((v_slot->>'ok')::boolean,false) is not true then return v_slot; end if;
+  v_prof_ref:=v_slot->>'professional_ref';
+  v_prof_name:=v_slot->>'professional_name';
+  v_role:=v_slot->>'role';
+  v_booking_mode:=v_slot->>'booking_mode';
+
+  -- Lock the exact provider/pool slot and re-read availability inside the same transaction.
+  perform pg_advisory_xact_lock(hashtextextended('agv2-slot:'||v_prof_ref||':'||v_date::text||':'||to_char(v_time,'HH24:MI')||':'||v_site,0));
+  v_slot:=public.aos_booking_resolve_selected_slot_v2(v_t.id,v_date,v_site,v_time,case when v_role='DOCTORA' then v_prof else null end,v_role);
+  if coalesce((v_slot->>'ok')::boolean,false) is not true then return v_slot; end if;
+
+  v_name:=nullif(btrim(p_payload->>'name'),'');
+  v_last:=nullif(btrim(p_payload->>'last_name'),'');
+  v_dni:=nullif(btrim(p_payload->>'dni'),'');
+  v_email:=nullif(lower(btrim(p_payload->>'email')),'');
+  if v_identity_state='MATCH' then
+    v_name:=coalesce(v_name,nullif(btrim(v_patient."Nombres"),''));
+    v_last:=coalesce(v_last,nullif(btrim(v_patient."Apellidos"),''));
+    v_dni:=coalesce(v_dni,nullif(btrim(v_patient."N° documento"),''));
+    v_email:=coalesce(v_email,nullif(lower(btrim(v_patient."Email")),''));
+  end if;
+  v_name:=coalesce(v_name,v_contact_name);
+  if v_name is null then return jsonb_build_object('ok',false,'error','AGV2_NAME_REQUIRED'); end if;
+  if v_channel='AGENDA' and coalesce(v_last,'')='' then return jsonb_build_object('ok',false,'error','AGV2_LAST_NAME_REQUIRED'); end if;
+  if v_email is not null and v_email !~* '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$' then
+    return jsonb_build_object('ok',false,'error','AGV2_EMAIL_INVALID','email_optional',true);
+  end if;
+
+  v_type:=upper(btrim(coalesce(p_payload->>'appointment_type','CONSULTA NUEVA')));
+  if v_type not in ('CONSULTA NUEVA','APLICACION','CONTROL') then return jsonb_build_object('ok',false,'error','AGV2_APPOINTMENT_TYPE_INVALID'); end if;
+  if v_lead is not null and v_lead~'^[0-9]+$' then v_lead_bigint:=v_lead::bigint; end if;
+
+  v_source:=case
+    when v_channel='WHATSAPP' and (v_ad is not null or upper(coalesce(v_campaign,'')) like '%META%') then 'WHATSAPP_META'
+    when v_channel='WHATSAPP' then 'WHATSAPP_ORGANIC'
+    else 'AGENDA_INTERNAL'
+  end;
+
+  v_agenda_id:=gen_random_uuid()::text;
+  if v_channel='WHATSAPP' then perform set_config('aos.wa4_governed_booking_write','1',true); end if;
+
+  insert into public.aos_agenda_citas(
+    id,fecha_cita,tratamiento,tipo_cita,sede,numero,nombre,apellido,dni,correo,
+    asesor,id_asesor,estado_cita,obs,ts_creado,ts_actualizado,hora_cita,etiqueta_campana,
+    doctora,tipo_atencion,origen_cita,numero_limpio,origen,lead_id_origen,llamada_id_origen
+  ) values (
+    v_agenda_id,v_date,v_t.nombre,v_type,v_site,v_phone,v_name,coalesce(v_last,''),v_dni,v_email,
+    case when v_channel='WHATSAPP' then 'WHATSAPP' else coalesce(v_actor_code,'AGENDA') end,
+    v_actor::text,'PENDIENTE',case when v_role='ENFERMERIA' then 'AGV2_BOOKING_MODE=SITE_POOL' else null end,
+    now(),now(),to_char(v_time,'HH24:MI'),v_campaign,
+    case when v_role='DOCTORA' then v_prof_name else null end,v_role,
+    case when v_channel='WHATSAPP' then 'WHATSAPP' else 'AGENDA_V2' end,
+    v_phone_norm,v_source,v_lead_bigint,null
+  );
+
+  v_response:=jsonb_build_object(
+    'ok',true,'status','BOOKED','appointment_id',v_agenda_id,'agenda_id',v_agenda_id,
+    'operation_id',v_op_id,'idempotent_replay',false,'confirmation_allowed',true,
+    'identity_state',v_identity_state,'site',v_site,'date',v_date,'time',to_char(v_time,'HH24:MI'),
+    'professional_role',v_role,'booking_mode',v_booking_mode,
+    'professional_id',case when v_role='DOCTORA' then v_prof else null end,
+    'professional_name',v_prof_name,'source',v_source
+  );
+
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,conversation_id,appointment_id,
+    treatment_id,professional_ref,site,appointment_date,appointment_time,identity_state,
+    campaign_source,ad_id,lead_id,status,response
+  ) values (
+    v_op_id,p_idempotency_key,v_hash,'BOOK',v_channel,v_actor,v_conv,v_agenda_id,
+    v_t.id,v_prof_ref,v_site,v_date,v_time,v_identity_state,v_campaign,v_ad,v_lead,'BOOKED',v_response
+  );
+
+  insert into public.aos_agenda_events_v2(
+    operation_id,appointment_id,event_type,actor_id,channel,conversation_id,before_snapshot,after_snapshot
+  ) values (
+    v_op_id,v_agenda_id,'BOOKED',v_actor,v_channel,v_conv,null,
+    jsonb_build_object(
+      'appointment_id',v_agenda_id,'treatment_id',v_t.id,'treatment',v_t.nombre,
+      'site',v_site,'date',v_date,'time',to_char(v_time,'HH24:MI'),
+      'role',v_role,'professional_ref',v_prof_ref,'professional_name',v_prof_name,
+      'status','PENDIENTE','source',v_source
+    )
+  );
+
+  -- Preserve the existing WA booking attribution ledger for downstream analytics/canaries.
+  if v_channel='WHATSAPP' and v_conv is not null then
+    insert into public.aos_wa4_booking_actions_v1(
+      idempotency_key,request_hash,conversation_id,actor_id,agenda_id,treatment_id,professional_id,
+      site,appointment_date,appointment_time,identity_state,source_channel,campaign_source,ad_id,lead_id,status
+    ) values (
+      p_idempotency_key,v_hash,v_conv,v_actor,v_agenda_id,v_t.id,v_prof_ref,
+      v_site,v_date,v_time,v_identity_state,'WHATSAPP',v_campaign,v_ad,v_lead,'BOOKED'
+    ) on conflict(idempotency_key) do nothing;
+  end if;
+
+  return v_response;
+end
+$$;
+
+-- Same logical appointment + append-only event ledger REBOOK.
+create or replace function public.aos_booking_rebook_core_v2(
+  p_context jsonb,
+  p_idempotency_key text,
+  p_appointment_id text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_existing public.aos_booking_operations_v2%rowtype;
+  v_actor uuid;
+  v_channel text;
+  v_conv uuid;
+  v_phone text;
+  v_phone_norm text;
+  v_hash text;
+  v_cita public.aos_agenda_citas%rowtype;
+  v_t public.aos_catalogo_servicios%rowtype;
+  v_treatment_id uuid;
+  v_site text;
+  v_date date;
+  v_time time;
+  v_prof text;
+  v_role text;
+  v_slot jsonb;
+  v_prof_ref text;
+  v_prof_name text;
+  v_booking_mode text;
+  v_identity jsonb:='{}'::jsonb;
+  v_identity_state text:='UNRESOLVED';
+  v_op_id uuid:=gen_random_uuid();
+  v_before jsonb;
+  v_after jsonb;
+  v_response jsonb;
+  v_reason text;
+  v_campaign text;
+  v_ad text;
+  v_lead text;
+begin
+  if p_context is null or jsonb_typeof(p_context)<>'object' or p_payload is null or jsonb_typeof(p_payload)<>'object' then
+    return jsonb_build_object('ok',false,'error','AGV2_CONTEXT_OR_PAYLOAD_INVALID');
+  end if;
+  if coalesce(length(btrim(p_idempotency_key)),0)<16 or length(p_idempotency_key)>160 then return jsonb_build_object('ok',false,'error','AGV2_IDEMPOTENCY_KEY_INVALID'); end if;
+  if coalesce(btrim(p_appointment_id),'')='' then return jsonb_build_object('ok',false,'error','AGV2_APPOINTMENT_REQUIRED'); end if;
+
+  begin v_actor:=(p_context->>'actor_id')::uuid; exception when others then return jsonb_build_object('ok',false,'error','AGV2_ACTOR_INVALID'); end;
+  v_channel:=upper(btrim(coalesce(p_context->>'channel','')));
+  if v_channel not in ('AGENDA','WHATSAPP') then return jsonb_build_object('ok',false,'error','AGV2_CHANNEL_INVALID'); end if;
+  begin v_conv:=nullif(p_context->>'conversation_id','')::uuid; exception when others then return jsonb_build_object('ok',false,'error','AGV2_CONVERSATION_INVALID'); end;
+  v_phone:=coalesce(nullif(btrim(p_context->>'contact_number'),''),nullif(btrim(p_payload->>'phone'),''));
+  v_phone_norm:=regexp_replace(coalesce(v_phone,''),'[^0-9]','','g');
+  v_campaign:=nullif(btrim(p_context->>'campaign_source'),'');
+  v_ad:=nullif(btrim(p_context->>'ad_id'),'');
+  v_lead:=nullif(btrim(p_context->>'lead_id'),'');
+  v_reason:=nullif(btrim(p_payload->>'reason'),'');
+
+  perform pg_advisory_xact_lock(hashtextextended('agv2-op:'||p_idempotency_key,0));
+  v_hash:=encode(digest(convert_to(v_channel||'|'||coalesce(v_conv::text,'')||'|'||v_actor::text||'|'||p_appointment_id||'|'||p_payload::text,'UTF8'),'sha256'),'hex');
+  select * into v_existing from public.aos_booking_operations_v2 where idempotency_key=p_idempotency_key;
+  if found then
+    if v_existing.request_hash<>v_hash then return jsonb_build_object('ok',false,'error','AGV2_IDEMPOTENCY_MISMATCH'); end if;
+    return jsonb_set(v_existing.response,'{idempotent_replay}','true'::jsonb,true);
+  end if;
+
+  select * into v_cita from public.aos_agenda_citas where id=p_appointment_id for update;
+  if not found then return jsonb_build_object('ok',false,'error','AGV2_APPOINTMENT_NOT_FOUND'); end if;
+  if upper(coalesce(v_cita.estado_cita,'PENDIENTE')) not in ('PENDIENTE','CITA CONFIRMADA') then
+    return jsonb_build_object('ok',false,'error','AGV2_REBOOK_STATE_BLOCKED','current_status',v_cita.estado_cita);
+  end if;
+  if v_channel='WHATSAPP' then
+    if length(v_phone_norm)<7 or v_phone_norm<>regexp_replace(coalesce(v_cita.numero_limpio,v_cita.numero,''),'[^0-9]','','g') then
+      return jsonb_build_object('ok',false,'error','AGV2_REBOOK_APPOINTMENT_IDENTITY_MISMATCH','requires_human',true);
+    end if;
+  end if;
+
+  if length(v_phone_norm)>=7 then
+    v_identity:=coalesce(public.aos_rev_resolve_patient_identity_v2('PHONE',v_phone_norm),'{}'::jsonb);
+    v_identity_state:=upper(coalesce(v_identity->>'status','UNRESOLVED'));
+    if v_identity_state='IDENTITY_CONFLICT' then return jsonb_build_object('ok',false,'error','AGV2_IDENTITY_CONFLICT','requires_human',true); end if;
+    if v_identity_state not in ('MATCH','UNRESOLVED') then return jsonb_build_object('ok',false,'error','AGV2_IDENTITY_NOT_READY','requires_human',true); end if;
+  end if;
+
+  select treatment_id into v_treatment_id
+  from public.aos_booking_operations_v2
+  where appointment_id=p_appointment_id
+  order by created_at asc
+  limit 1;
+  if v_treatment_id is null then
+    select treatment_id into v_treatment_id from public.aos_wa4_booking_actions_v1 where agenda_id=p_appointment_id order by created_at asc limit 1;
+  end if;
+  if v_treatment_id is null then
+    select id into v_treatment_id from public.aos_catalogo_servicios
+    where upper(btrim(nombre))=upper(btrim(coalesce(v_cita.tratamiento,'')))
+      and upper(coalesce(estado,'ACTIVO'))='ACTIVO' and upper(coalesce(tipo,'SERVICIO'))='SERVICIO'
+    order by created_at desc nulls last limit 1;
+  end if;
+  if v_treatment_id is null then return jsonb_build_object('ok',false,'error','AGV2_REBOOK_TREATMENT_UNRESOLVED','requires_human',true); end if;
+  select * into v_t from public.aos_catalogo_servicios where id=v_treatment_id;
+
+  v_site:=upper(replace(btrim(coalesce(p_payload->>'site','')),'_',' '));
+  begin v_date:=(p_payload->>'date')::date; v_time:=(p_payload->>'time')::time;
+  exception when others then return jsonb_build_object('ok',false,'error','AGV2_DATE_TIME_INVALID'); end;
+  v_prof:=nullif(btrim(p_payload->>'professional_id'),'');
+  v_role:=nullif(upper(btrim(p_payload->>'slot_role')),'');
+
+  if v_site=upper(replace(btrim(coalesce(v_cita.sede,'')),'_',' '))
+     and v_date=v_cita.fecha_cita
+     and to_char(v_time,'HH24:MI')=left(coalesce(v_cita.hora_cita,''),5)
+     and (
+       (upper(coalesce(v_cita.tipo_atencion,''))='ENFERMERIA' and coalesce(v_role,'ENFERMERIA')='ENFERMERIA')
+       or (upper(coalesce(v_cita.tipo_atencion,''))='DOCTORA' and upper(coalesce(v_cita.doctora,''))=upper(coalesce((select nombre_publico from public.aos_perfiles_profesional where id=v_prof limit 1),'')))
+     ) then
+    return jsonb_build_object('ok',true,'status','NO_CHANGE','appointment_id',p_appointment_id,'idempotent_replay',false);
+  end if;
+
+  v_slot:=public.aos_booking_resolve_selected_slot_v2(v_t.id,v_date,v_site,v_time,v_prof,v_role);
+  if coalesce((v_slot->>'ok')::boolean,false) is not true then return v_slot; end if;
+  v_prof_ref:=v_slot->>'professional_ref';v_prof_name:=v_slot->>'professional_name';v_role:=v_slot->>'role';v_booking_mode:=v_slot->>'booking_mode';
+
+  perform pg_advisory_xact_lock(hashtextextended('agv2-slot:'||v_prof_ref||':'||v_date::text||':'||to_char(v_time,'HH24:MI')||':'||v_site,0));
+  v_slot:=public.aos_booking_resolve_selected_slot_v2(v_t.id,v_date,v_site,v_time,case when v_role='DOCTORA' then v_prof else null end,v_role);
+  if coalesce((v_slot->>'ok')::boolean,false) is not true then return v_slot; end if;
+
+  v_before:=jsonb_build_object(
+    'appointment_id',v_cita.id,'treatment',v_cita.tratamiento,'site',v_cita.sede,'date',v_cita.fecha_cita,
+    'time',left(coalesce(v_cita.hora_cita,''),5),'role',v_cita.tipo_atencion,'professional_name',v_cita.doctora,
+    'status',v_cita.estado_cita
+  );
+
+  if upper(coalesce(v_cita.origen_cita,''))='WHATSAPP' then perform set_config('aos.wa4_governed_booking_write','1',true); end if;
+  update public.aos_agenda_citas
+  set fecha_cita=v_date,
+      hora_cita=to_char(v_time,'HH24:MI'),
+      sede=v_site,
+      doctora=case when v_role='DOCTORA' then v_prof_name else null end,
+      tipo_atencion=v_role,
+      estado_cita='PENDIENTE',
+      ts_actualizado=now()
+  where id=p_appointment_id;
+
+  v_after:=jsonb_build_object(
+    'appointment_id',p_appointment_id,'treatment_id',v_t.id,'treatment',v_t.nombre,'site',v_site,'date',v_date,
+    'time',to_char(v_time,'HH24:MI'),'role',v_role,'professional_ref',v_prof_ref,'professional_name',v_prof_name,
+    'booking_mode',v_booking_mode,'status','PENDIENTE'
+  );
+
+  v_response:=jsonb_build_object(
+    'ok',true,'status','REBOOKED','appointment_id',p_appointment_id,'operation_id',v_op_id,
+    'idempotent_replay',false,'confirmation_allowed',true,'identity_state',v_identity_state,
+    'site',v_site,'date',v_date,'time',to_char(v_time,'HH24:MI'),'professional_role',v_role,
+    'booking_mode',v_booking_mode,'professional_id',case when v_role='DOCTORA' then v_prof else null end,
+    'professional_name',v_prof_name
+  );
+
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,conversation_id,appointment_id,
+    treatment_id,professional_ref,site,appointment_date,appointment_time,identity_state,
+    campaign_source,ad_id,lead_id,status,response
+  ) values (
+    v_op_id,p_idempotency_key,v_hash,'REBOOK',v_channel,v_actor,v_conv,p_appointment_id,
+    v_t.id,v_prof_ref,v_site,v_date,v_time,v_identity_state,v_campaign,v_ad,v_lead,'REBOOKED',v_response
+  );
+
+  insert into public.aos_agenda_events_v2(
+    operation_id,appointment_id,event_type,actor_id,channel,conversation_id,reason,before_snapshot,after_snapshot
+  ) values (v_op_id,p_appointment_id,'RESCHEDULED',v_actor,v_channel,v_conv,v_reason,v_before,v_after);
+
+  return v_response;
+end
+$$;
+
+-- Internal Agenda wrapper: strong session / Agenda permission, no direct browser write.
+create or replace function public.aos_agenda_commit_booking_v2(
+  p_token text,
+  p_idempotency_key text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_actor uuid;
+  v_code text;
+  v_ctx jsonb;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'advisor-agenda',false);
+  if v_actor is null then v_actor:=public.aos_app_actor_v3(p_token,'admin-agenda',true); end if;
+  if v_actor is null then return jsonb_build_object('ok',false,'error','AGENDA_2FA_PANEL_REQUIRED'); end if;
+  select codigo_asesor into v_code from public.aos_usuarios where id=v_actor and activo=true;
+  v_ctx:=jsonb_build_object(
+    'actor_id',v_actor,'actor_code',coalesce(v_code,'AGENDA'),'channel','AGENDA',
+    'contact_number',p_payload->>'phone','contact_name',concat_ws(' ',p_payload->>'name',p_payload->>'last_name')
+  );
+  return public.aos_booking_commit_core_v2(v_ctx,p_idempotency_key,p_payload);
+end
+$$;
+
+create or replace function public.aos_agenda_rebook_v2(
+  p_token text,
+  p_idempotency_key text,
+  p_appointment_id text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_actor uuid;
+  v_code text;
+  v_cita public.aos_agenda_citas%rowtype;
+  v_ctx jsonb;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'advisor-agenda',false);
+  if v_actor is null then v_actor:=public.aos_app_actor_v3(p_token,'admin-agenda',true); end if;
+  if v_actor is null then return jsonb_build_object('ok',false,'error','AGENDA_2FA_PANEL_REQUIRED'); end if;
+  select * into v_cita from public.aos_agenda_citas where id=p_appointment_id;
+  if not found then return jsonb_build_object('ok',false,'error','AGV2_APPOINTMENT_NOT_FOUND'); end if;
+  select codigo_asesor into v_code from public.aos_usuarios where id=v_actor and activo=true;
+  v_ctx:=jsonb_build_object(
+    'actor_id',v_actor,'actor_code',coalesce(v_code,'AGENDA'),'channel','AGENDA',
+    'contact_number',coalesce(v_cita.numero_limpio,v_cita.numero),'contact_name',concat_ws(' ',v_cita.nombre,v_cita.apellido)
+  );
+  return public.aos_booking_rebook_core_v2(v_ctx,p_idempotency_key,p_appointment_id,p_payload);
+end
+$$;
+
+-- WA V2 wrappers. They preserve HUMAN_ONLY ownership/assignment before entering the shared core.
+create or replace function public.aos_wa4_commit_booking_v2(
+  p_actor_id uuid,
+  p_idempotency_key text,
+  p_conversation_id uuid,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_ctx jsonb;
+begin
+  if p_actor_id is null or p_conversation_id is null then return jsonb_build_object('ok',false,'error','WA4_BOOKING_ACTOR_AND_CONVERSATION_REQUIRED'); end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id for update;
+  if not found then return jsonb_build_object('ok',false,'error','WA4_BOOKING_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.owner_user_id is distinct from p_actor_id then return jsonb_build_object('ok',false,'error','WA4_BOOKING_NOT_CONVERSATION_OWNER'); end if;
+  if upper(coalesce(v_conv.state,'')) not in ('HUMAN_ACTIVE','AI_COPILOT') then return jsonb_build_object('ok',false,'error','WA4_BOOKING_CONVERSATION_STATE_BLOCKED'); end if;
+  if not exists(select 1 from public.aos_wa_assignments_v1 a where a.conversation_id=p_conversation_id and a.owner_user_id=p_actor_id and a.state='ACTIVE') then
+    return jsonb_build_object('ok',false,'error','WA4_BOOKING_ACTIVE_ASSIGNMENT_REQUIRED');
+  end if;
+  if coalesce(regexp_replace(v_conv.contact_number,'[^0-9]','','g'),'')='' then return jsonb_build_object('ok',false,'error','WA4_BOOKING_TRUSTED_PHONE_REQUIRED'); end if;
+  v_ctx:=jsonb_build_object(
+    'actor_id',p_actor_id,'channel','WHATSAPP','conversation_id',p_conversation_id,
+    'contact_number',v_conv.contact_number,'contact_name',v_conv.contact_name,
+    'campaign_source',v_conv.campaign_source,'ad_id',v_conv.ad_id,'lead_id',v_conv.lead_id
+  );
+  return public.aos_booking_commit_core_v2(v_ctx,p_idempotency_key,p_payload);
+end
+$$;
+
+create or replace function public.aos_wa4_rebook_booking_v2(
+  p_actor_id uuid,
+  p_idempotency_key text,
+  p_conversation_id uuid,
+  p_appointment_id text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_ctx jsonb;
+begin
+  if p_actor_id is null or p_conversation_id is null then return jsonb_build_object('ok',false,'error','WA4_REBOOK_ACTOR_AND_CONVERSATION_REQUIRED'); end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id for update;
+  if not found then return jsonb_build_object('ok',false,'error','WA4_REBOOK_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.owner_user_id is distinct from p_actor_id then return jsonb_build_object('ok',false,'error','WA4_REBOOK_NOT_CONVERSATION_OWNER'); end if;
+  if upper(coalesce(v_conv.state,'')) not in ('HUMAN_ACTIVE','AI_COPILOT') then return jsonb_build_object('ok',false,'error','WA4_REBOOK_CONVERSATION_STATE_BLOCKED'); end if;
+  if not exists(select 1 from public.aos_wa_assignments_v1 a where a.conversation_id=p_conversation_id and a.owner_user_id=p_actor_id and a.state='ACTIVE') then
+    return jsonb_build_object('ok',false,'error','WA4_REBOOK_ACTIVE_ASSIGNMENT_REQUIRED');
+  end if;
+  v_ctx:=jsonb_build_object(
+    'actor_id',p_actor_id,'channel','WHATSAPP','conversation_id',p_conversation_id,
+    'contact_number',v_conv.contact_number,'contact_name',v_conv.contact_name,
+    'campaign_source',v_conv.campaign_source,'ad_id',v_conv.ad_id,'lead_id',v_conv.lead_id
+  );
+  return public.aos_booking_rebook_core_v2(v_ctx,p_idempotency_key,p_appointment_id,p_payload);
+end
+$$;
+
+revoke all on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) from public,anon,authenticated;
+revoke all on function public.aos_booking_commit_core_v2(jsonb,text,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_booking_rebook_core_v2(jsonb,text,text,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_wa4_commit_booking_v2(uuid,text,uuid,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_wa4_rebook_booking_v2(uuid,text,uuid,text,jsonb) from public,anon,authenticated;
+grant execute on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) to service_role;
+grant execute on function public.aos_booking_commit_core_v2(jsonb,text,jsonb) to service_role;
+grant execute on function public.aos_booking_rebook_core_v2(jsonb,text,text,jsonb) to service_role;
+grant execute on function public.aos_wa4_commit_booking_v2(uuid,text,uuid,jsonb) to service_role;
+grant execute on function public.aos_wa4_rebook_booking_v2(uuid,text,uuid,text,jsonb) to service_role;
+
+revoke all on function public.aos_agenda_commit_booking_v2(text,text,jsonb) from public;
+revoke all on function public.aos_agenda_rebook_v2(text,text,text,jsonb) from public;
+grant execute on function public.aos_agenda_commit_booking_v2(text,text,jsonb) to anon,authenticated,service_role;
+grant execute on function public.aos_agenda_rebook_v2(text,text,text,jsonb) to anon,authenticated,service_role;
+
+comment on table public.aos_booking_operations_v2 is 'AGV2-2 idempotent BOOK/REBOOK operation ledger shared by Agenda and WhatsApp.';
+comment on table public.aos_agenda_events_v2 is 'AGV2-2 append-only appointment event ledger. REBOOK preserves the same logical appointment id.';
+comment on function public.aos_agenda_commit_booking_v2(text,text,jsonb) is 'AGV2-2 strong-session Agenda BOOK wrapper over unified transactional authority.';
+comment on function public.aos_wa4_commit_booking_v2(uuid,text,uuid,jsonb) is 'AGV2-2 HUMAN_ONLY WhatsApp BOOK wrapper over unified transactional authority; v1 remains live until rollout certification.';
+
+commit;

--- a/supabase/rollbacks/20260901013500_agv2_unified_transactional_booking_contract_v1_rollback.sql
+++ b/supabase/rollbacks/20260901013500_agv2_unified_transactional_booking_contract_v1_rollback.sql
@@ -1,0 +1,16 @@
+-- Rollback AGV2-2 additive transactional contract V1.
+begin;
+
+drop function if exists public.aos_wa4_rebook_booking_v2(uuid,text,uuid,text,jsonb);
+drop function if exists public.aos_wa4_commit_booking_v2(uuid,text,uuid,jsonb);
+drop function if exists public.aos_agenda_rebook_v2(text,text,text,jsonb);
+drop function if exists public.aos_agenda_commit_booking_v2(text,text,jsonb);
+drop function if exists public.aos_booking_rebook_core_v2(jsonb,text,text,jsonb);
+drop function if exists public.aos_booking_commit_core_v2(jsonb,text,jsonb);
+drop function if exists public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text);
+drop trigger if exists trg_aos_agenda_events_v2_append_only on public.aos_agenda_events_v2;
+drop function if exists public.aos_agenda_events_v2_append_only_guard();
+drop table if exists public.aos_agenda_events_v2;
+drop table if exists public.aos_booking_operations_v2;
+
+commit;


### PR DESCRIPTION
## Scope

Closes the remaining AGV2-1 business decisions and implements the additive AGV2-2 transactional BOOK/REBOOK contract shared by internal Agenda and WhatsApp.

### AGV2-1 — BUSINESS FROZEN
- first real availability by default; provider preference only when explicitly requested and valid
- no hardcoded free evaluation
- same logical appointment + append-only event ledger for rebooking
- DNI optional unless future explicit canonical rule
- email optional; confirmation/rebooking/reminders are post-commit side effects
- WhatsApp initially shows up to 3 dates and 5 slots, with more on demand
- inbound commercial booking defaults to CONSULTA NUEVA unless canonical context says otherwise
- inbound WhatsApp phone is reused instead of re-asked

### AGV2-2 — additive transactional contract
- `aos_booking_operations_v2` idempotent BOOK/REBOOK ledger
- `aos_agenda_events_v2` append-only appointment event ledger
- shared slot resolver + BOOK core + REBOOK core
- Agenda wrappers require strong app session/2FA and Agenda permission
- WhatsApp V2 wrappers preserve HUMAN_ONLY owner + active assignment
- slot authority checked before and after advisory lock
- identity conflict fails closed
- REBOOK updates the same `aos_agenda_citas.id`; does not create a second appointment
- no email/Meta provider send inside the DB transaction
- existing `aos_wa4_commit_booking_v1` remains untouched/live until V2 rollout certification
- rollback included

### Tests
- static AGV2 contract test
- synthetic local BOOK / idempotency / ownership / identity-conflict / REBOOK canary
- dedicated self-hosted Linux zero-cost workflow
- WA-4C FULL LOCAL path expanded to include AGV2 regression

## Safety
- No PROD appointment mutation in this PR.
- No live UI/WhatsApp wiring yet.
- HUMAN_ONLY / SAFE-OFF unchanged.
- Business-hours LIVE booking smoke remains deferred to AGV2-7.