### PR TITLE
AGV2 L2: 30-minute slot + duration/capacity authority

### DIFF
--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -67,7 +67,25 @@ jobs:
           # Compact FULL LOCAL intentionally omits the Equipo skills array. The real
           # production schema has it; add only the missing TEST compatibility column.
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];"
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql
+          # Reuse the real hierarchy DDL/functions. Its terminal 234-service coverage
+          # assertion is valid only against the complete production catalog, not this
+          # deliberately reduced FULL LOCAL catalog, so omit that assertion in TEST.
+          python3 - <<'PY'
+          from pathlib import Path
+          src = Path('supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql').read_text()
+          needle = "'WA4C_SKILL_HIERARCHY_UNMAPPED_ACTIVE_SERVICES:%'"
+          pos = src.find(needle)
+          if pos < 0:
+              raise SystemExit('L2_TEST_SKILL_ASSERTION_MARKER_NOT_FOUND')
+          start = src.rfind('\ndo $$', 0, pos)
+          end = src.find('\n$$;', pos)
+          if start < 0 or end < 0:
+              raise SystemExit('L2_TEST_SKILL_ASSERTION_BLOCK_NOT_FOUND')
+          end += len('\n$$;')
+          out = src[:start] + "\n-- TEST ONLY: global production catalog coverage assertion omitted here.\n" + src[end:]
+          Path('/tmp/wa4c-professional-skill-hierarchy-l2-test.sql').write_text(out)
+          PY
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f /tmp/wa4c-professional-skill-hierarchy-l2-test.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -53,8 +53,21 @@ jobs:
           echo 'AGV2_L2_LOCAL_PORT_CONTENTION' >&2
           exit 1
 
-      - name: Build isolated CURRENT substrate
-        run: bash ci/wa4c-full-local/bootstrap.sh
+      - name: Build isolated CURRENT + certified L1/L2 prerequisites
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          # Rehydrate the canonical booking/procedure authority that is intentionally
+          # outside the compact WA full-local fixture. This remains TEST-only.
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831235500_wa4c_catalog_capability_reconciliation_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
 
       - name: L2 timing and capacity canaries
         run: |

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -61,13 +61,15 @@ jobs:
 
           # FULL LOCAL intentionally keeps a compact catalog. Add only deterministic
           # TEST representatives needed to exercise L2 procedure-specific timing.
+          # Use exact names here because booking normalization is created later in this
+          # same TEST bootstrap; these rows are synthetic and deterministic.
           psql "$DB" -X -v ON_ERROR_STOP=1 <<'SQL'
           insert into public.aos_catalogo_servicios(
             nombre,nombre_corto,tipo,categoria,estado,requiere_doctora,requiere_enfermeria,precio_base,precio_oferta,moneda
           )
           select 'CELLBOOSTER GLOW x1','CELLBOOSTER GLOW x1','SERVICIO','BIOREVITALIZACION FACIAL','ACTIVO',true,false,100,90,'PEN'
           where not exists (
-            select 1 from public.aos_catalogo_servicios where public.aos_booking_norm_v1(nombre)=public.aos_booking_norm_v1('CELLBOOSTER GLOW x1')
+            select 1 from public.aos_catalogo_servicios where nombre='CELLBOOSTER GLOW x1'
           );
 
           insert into public.aos_catalogo_servicios(
@@ -75,7 +77,7 @@ jobs:
           )
           select 'FACIAL COREANO','FACIAL COREANO','SERVICIO','FACIALES','ACTIVO',false,true,100,90,'PEN'
           where not exists (
-            select 1 from public.aos_catalogo_servicios where public.aos_booking_norm_v1(nombre)=public.aos_booking_norm_v1('FACIAL COREANO')
+            select 1 from public.aos_catalogo_servicios where nombre='FACIAL COREANO'
           );
           SQL
 

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -88,9 +88,20 @@ jobs:
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831235500_wa4c_catalog_capability_reconciliation_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
 
-          # Compact FULL LOCAL intentionally omits the Equipo skills array. The real
-          # production schema has it; add only the missing TEST compatibility column.
-          psql "$DB" -X -v ON_ERROR_STOP=1 -c "alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];"
+          # Compact FULL LOCAL intentionally omits columns that exist in the real Team/
+          # catalog schemas. Add only TEST compatibility required by the certified
+          # production migrations reused below; no production semantics are changed.
+          psql "$DB" -X -v ON_ERROR_STOP=1 <<'SQL'
+          alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];
+          alter table public.aos_catalogo_categorias add column if not exists tipo text default 'SERVICIO';
+          alter table public.aos_catalogo_categorias add column if not exists icono text;
+          alter table public.aos_catalogo_categorias add column if not exists rol_profesional text default 'AMBOS';
+          alter table public.aos_catalogo_categorias add column if not exists estado text default 'ACTIVO';
+          alter table public.aos_catalogo_categorias add column if not exists orden integer default 0;
+          alter table public.aos_catalogo_categorias add column if not exists updated_at timestamptz default now();
+          create unique index if not exists ux_aos_catalogo_categorias_nombre_l2_test
+            on public.aos_catalogo_categorias(nombre);
+          SQL
 
           # Rehydrate the already-certified service→skill authority that supplies the
           # exact CELLBOOSTER/FACIALES mappings used by the production procedure hierarchy.

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -1,0 +1,75 @@
+name: ASCENDA AGV2 L2 Slot Authority
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*slot_authority*'
+      - 'ci/agv2-slot-authority/**'
+      - '.github/workflows/agv2-slot-authority.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agv2-slot-authority-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: ZERO-COST · 30m grid + duration + capacity authority
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Static L2 business contract
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          node --test ci/agv2-slot-authority/slot-authority-contract.test.js
+
+      - name: Wait for isolated local ports
+        run: |
+          set -euo pipefail
+          ports='60200 60201 60202'
+          for i in $(seq 1 60); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'AGV2_L2_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+
+      - name: Build isolated CURRENT substrate
+        run: bash ci/wa4c-full-local/bootstrap.sh
+
+      - name: L2 timing and capacity canaries
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/agv2-slot-authority/slot-authority-canary.sql 2>&1 | tee /tmp/agv2-l2-canary.txt
+          grep -q 'AGV2_L2_SLOT_AUTHORITY_CANARY_PASS' /tmp/agv2-l2-canary.txt
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_booking_operations_v2")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_events_v2")" = '0'
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/agv2-l2-lint.txt
+          if grep -q '\[ERROR\]' /tmp/agv2-l2-lint.txt; then exit 1; fi
+
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -58,18 +58,46 @@ jobs:
           set -euo pipefail
           bash ci/wa4c-full-local/bootstrap.sh
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+
+          # FULL LOCAL intentionally keeps a compact catalog. Add only deterministic
+          # TEST representatives needed to exercise L2 procedure-specific timing.
+          psql "$DB" -X -v ON_ERROR_STOP=1 <<'SQL'
+          insert into public.aos_catalogo_servicios(
+            nombre,nombre_corto,tipo,categoria,estado,requiere_doctora,requiere_enfermeria,precio_base,precio_oferta,moneda
+          )
+          select 'CELLBOOSTER GLOW x1','CELLBOOSTER GLOW x1','SERVICIO','BIOREVITALIZACION FACIAL','ACTIVO',true,false,100,90,'PEN'
+          where not exists (
+            select 1 from public.aos_catalogo_servicios where public.aos_booking_norm_v1(nombre)=public.aos_booking_norm_v1('CELLBOOSTER GLOW x1')
+          );
+
+          insert into public.aos_catalogo_servicios(
+            nombre,nombre_corto,tipo,categoria,estado,requiere_doctora,requiere_enfermeria,precio_base,precio_oferta,moneda
+          )
+          select 'FACIAL COREANO','FACIAL COREANO','SERVICIO','FACIALES','ACTIVO',false,true,100,90,'PEN'
+          where not exists (
+            select 1 from public.aos_catalogo_servicios where public.aos_booking_norm_v1(nombre)=public.aos_booking_norm_v1('FACIAL COREANO')
+          );
+          SQL
+
           # Rehydrate the canonical booking/procedure authority that is intentionally
           # outside the compact WA full-local fixture. This remains TEST-only.
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831235500_wa4c_catalog_capability_reconciliation_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+
           # Compact FULL LOCAL intentionally omits the Equipo skills array. The real
           # production schema has it; add only the missing TEST compatibility column.
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];"
-          # Reuse the real hierarchy DDL/functions. Its terminal 234-service coverage
-          # assertion is valid only against the complete production catalog, not this
-          # deliberately reduced FULL LOCAL catalog, so omit that assertion in TEST.
+
+          # Rehydrate the already-certified service→skill authority that supplies the
+          # exact CELLBOOSTER/FACIALES mappings used by the production procedure hierarchy.
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003000_wa4c_team_skill_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003500_wa4c_team_skill_catalog_classification_v3.sql
+
+          # Reuse the real hierarchy DDL/functions. Its terminal complete-production-
+          # catalog coverage assertion is invalid against this deliberately compact
+          # fixture, so omit only that assertion in TEST; procedure/capability logic is real.
           python3 - <<'PY'
           from pathlib import Path
           src = Path('supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql').read_text()

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -157,7 +157,7 @@ jobs:
           grep -q 'AGV2_L2_SLOT_AUTHORITY_CANARY_PASS' /tmp/agv2-l2-canary.txt
           test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_booking_operations_v2")" = '0'
           test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_events_v2")" = '0'
-          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/agv2-l2-lint.txt
+          (cd ci/wa4c-full-local && supabase db lint --local --schema public --level error) 2>&1 | tee /tmp/agv2-l2-lint.txt
           if grep -q '\[ERROR\]' /tmp/agv2-l2-lint.txt; then exit 1; fi
 
       - name: Cleanup local Supabase

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -80,14 +80,23 @@ jobs:
             select 1 from public.aos_catalogo_servicios where nombre='FACIAL COREANO'
           );
 
-          -- PROD resolves HIDROFACIAL through the governed FACIALES category. The
-          -- compact synthetic catalog uses a placeholder category, so align only
-          -- these deterministic TEST rows with the observed production semantics.
+          -- PROD resolves these SKUs through category FACIALES plus the governed
+          -- HIDROFACIAL parent skill. The compact fixture intentionally omits part of
+          -- that authority, so mirror the observed production semantics in TEST only.
           update public.aos_catalogo_servicios
              set categoria='FACIALES'
            where upper(coalesce(estado,'ACTIVO'))='ACTIVO'
              and upper(coalesce(tipo,'SERVICIO'))='SERVICIO'
              and upper(nombre) like 'HIDROFACIAL%';
+
+          insert into public.aos_cat_tratamientos(
+            tratamiento,estado,orden,ultima_edicion,editado_por,categoria,requiere_doctora,requiere_enfermeria
+          ) values (
+            'HIDROFACIAL','ACTIVO',320,now(),'L2_TEST_PROD_PARITY','FACIAL',false,true
+          )
+          on conflict(tratamiento) do update
+          set estado='ACTIVO',categoria='FACIAL',requiere_doctora=false,
+              requiere_enfermeria=true,ultima_edicion=now(),editado_por='L2_TEST_PROD_PARITY';
           SQL
 
           # Rehydrate the canonical booking/procedure authority that is intentionally

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -64,6 +64,9 @@ jobs:
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831235500_wa4c_catalog_capability_reconciliation_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          # Compact FULL LOCAL intentionally omits the Equipo skills array. The real
+          # production schema has it; add only the missing TEST compatibility column.
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];"
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901123000_agv2_slot_authority_v2.sql

--- a/.github/workflows/agv2-slot-authority.yml
+++ b/.github/workflows/agv2-slot-authority.yml
@@ -79,6 +79,15 @@ jobs:
           where not exists (
             select 1 from public.aos_catalogo_servicios where nombre='FACIAL COREANO'
           );
+
+          -- PROD resolves HIDROFACIAL through the governed FACIALES category. The
+          -- compact synthetic catalog uses a placeholder category, so align only
+          -- these deterministic TEST rows with the observed production semantics.
+          update public.aos_catalogo_servicios
+             set categoria='FACIALES'
+           where upper(coalesce(estado,'ACTIVO'))='ACTIVO'
+             and upper(coalesce(tipo,'SERVICIO'))='SERVICIO'
+             and upper(nombre) like 'HIDROFACIAL%';
           SQL
 
           # Rehydrate the canonical booking/procedure authority that is intentionally

--- a/ci/agv2-slot-authority/slot-authority-canary.sql
+++ b/ci/agv2-slot-authority/slot-authority-canary.sql
@@ -1,0 +1,50 @@
+\set ON_ERROR_STOP on
+
+-- Critical families must resolve governed timing from active catalog rows.
+do $$
+declare
+  v_id uuid;
+  v jsonb;
+  v_cap text;
+begin
+  foreach v_cap in array array['TOXINA','HIFU','HIDROFACIAL','CRIOLIPOLISIS'] loop
+    select s.id into v_id
+    from public.aos_catalogo_servicios s
+    where upper(coalesce(s.estado,'ACTIVO'))='ACTIVO'
+      and upper(coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+      and public.aos_booking_capability_for_service_v1(s.id)=v_cap
+    order by s.nombre limit 1;
+    if v_id is null then raise exception 'L2_CANARY_CAPABILITY_NOT_FOUND:%',v_cap; end if;
+    v:=public.aos_booking_timing_for_service_v2(v_id);
+    if coalesce((v->>'ok')::boolean,false) is not true then raise exception 'L2_TIMING_NOT_READY:%:%',v_cap,v; end if;
+    if (v->>'reservation_grid_min')::int<>30 or (v->>'soft_capacity')::int<>5 or (v->>'overflow_capacity')::int<>6 then
+      raise exception 'L2_CAPACITY_CONTRACT_BAD:%:%',v_cap,v;
+    end if;
+    if coalesce((v->>'duration_blocks_future_booking')::boolean,true) is true then raise exception 'L2_DURATION_BLOCKING_BAD:%',v_cap; end if;
+  end loop;
+
+  select s.id into v_id
+  from public.aos_catalogo_servicios s
+  where upper(coalesce(s.estado,'ACTIVO'))='ACTIVO'
+    and upper(coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+    and public.aos_booking_procedure_for_service_v1(s.id)->>'procedure_key'='CELLBOOSTER GLOW'
+  order by s.nombre limit 1;
+  if v_id is null then raise exception 'L2_CELLBOOSTER_NOT_FOUND'; end if;
+  v:=public.aos_booking_timing_for_service_v2(v_id);
+  if (v->>'execution_default_min')::int<>30 then raise exception 'L2_CELLBOOSTER_DURATION_BAD:%',v; end if;
+
+  select s.id into v_id
+  from public.aos_catalogo_servicios s
+  where upper(coalesce(s.estado,'ACTIVO'))='ACTIVO'
+    and upper(coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+    and public.aos_booking_procedure_for_service_v1(s.id)->>'procedure_key'='FACIAL COREANO'
+  order by s.nombre limit 1;
+  if v_id is not null then
+    v:=public.aos_booking_timing_for_service_v2(v_id);
+    if (v->>'execution_min_min')::int<>90 or (v->>'execution_max_min')::int<>120 then raise exception 'L2_COREANO_DURATION_BAD:%',v; end if;
+  end if;
+end
+$$;
+
+-- No test may create a real appointment. L2 is timing/availability authority only.
+select 'AGV2_L2_SLOT_AUTHORITY_CANARY_PASS' as result;

--- a/ci/agv2-slot-authority/slot-authority-contract.test.js
+++ b/ci/agv2-slot-authority/slot-authority-contract.test.js
@@ -1,0 +1,41 @@
+const fs=require('fs');
+const assert=require('assert');
+const {test}=require('node:test');
+
+const sql=fs.readFileSync('supabase/migrations/20260901123000_agv2_slot_authority_v2.sql','utf8');
+
+function must(re,msg){assert.match(sql,re,msg);}
+
+test('L2 freezes 30-minute grid and 5/6 capacity without duration slot blocking',()=>{
+  must(/reservation_grid_min[^\n]*default 30/i,'30-min grid missing');
+  must(/soft_capacity[^\n]*default 5/i,'soft capacity 5 missing');
+  must(/overflow_capacity[^\n]*default 6/i,'overflow capacity 6 missing');
+  must(/duration_blocks_future_booking boolean not null default false/i,'duration must not consume future slots');
+  must(/autonomous_overflow_enabled boolean not null default false/i,'autonomous overflow must start safe-off');
+});
+
+test('clinical timing is procedure-aware and fail-closed',()=>{
+  must(/aos_booking_timing_authority_v2/,'timing table missing');
+  must(/aos_booking_procedure_for_service_v1/,'procedure resolver missing');
+  must(/TIMING_AUTHORITY_MISSING/,'missing timing must fail closed');
+  must(/HARD_RESOURCE_AUTHORITY_NOT_WIRED/,'hard resource constraint must fail closed until wired');
+});
+
+test('critical canary families have explicit business timing',()=>{
+  must(/\('TOXINA','\*',15,30,30,0\)/,'toxina timing missing');
+  must(/\('HIFU','\*',45,60,60,0\)/,'HIFU timing missing');
+  must(/\('HIDROFACIAL','\*',60,60,60,0\)/,'hidrofacial timing missing');
+  must(/\('CRIOLIPOLISIS','\*',90,90,90,0\)/,'criolipolisis timing missing');
+  must(/CELLBOOSTER GLOW',30,30,30,0/,'Cellbooster timing missing');
+});
+
+test('AGV2 BOOK/REBOOK selected slot consumes L2 authority but live V1 availability is not replaced',()=>{
+  must(/create or replace function public\.aos_booking_slot_authority_v2/i,'L2 slot authority missing');
+  must(/v_av:=coalesce\(public\.aos_booking_slot_authority_v2/i,'AGV2 selected slot not wired to L2');
+  assert.doesNotMatch(sql,/create or replace function public\.aos_booking_availability_v2\s*\(/i,'live V1/public availability must remain untouched in L2 dormant rollout');
+});
+
+test('safe-off autonomous boundary remains intact',()=>{
+  assert.doesNotMatch(sql,/(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)\s*=\s*true/i);
+  assert.doesNotMatch(sql,/autonomous_overflow_enabled\s*=\s*true/i);
+});

--- a/ci/wa4c-full-local/booking_fixture.sql
+++ b/ci/wa4c-full-local/booking_fixture.sql
@@ -61,9 +61,17 @@ create table if not exists public.aos_horarios_personal(
 
 -- Compact governed treatment authority required by the canonical booking capability resolver.
 -- This remains TEST-only: the selected synthetic service is mirrored 1:1 as its own capability.
+-- Keep the production-facing metadata columns used by Team Skill Authority so downstream
+-- certification exercises the real migration shape instead of a schema-truncated stub.
 create table if not exists public.aos_cat_tratamientos(
   tratamiento text primary key,
-  estado text default 'ACTIVO'
+  estado text default 'ACTIVO',
+  orden integer not null default 0,
+  ultima_edicion timestamptz default now(),
+  editado_por text,
+  categoria text,
+  requiere_doctora boolean not null default false,
+  requiere_enfermeria boolean not null default false
 );
 
 create table if not exists public.aos_pacientes(

--- a/supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
+++ b/supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
@@ -1,0 +1,368 @@
+-- ASCENDA OS · AGV2 L2 — Slot Authority V2
+-- Business authority: 30-minute reservation grid, soft capacity 5, overflow 6.
+-- Clinical duration controls valid start-time fit, but does NOT consume/block later reservation slots.
+-- Existing V1/public availability remains untouched; AGV2 V2 selected-slot authority is rewired here.
+begin;
+
+create table if not exists public.aos_booking_timing_authority_v2 (
+  capability text not null,
+  procedure_key text not null default '*',
+  execution_min_min integer not null check (execution_min_min > 0),
+  execution_max_min integer not null check (execution_max_min >= execution_min_min),
+  execution_default_min integer not null check (execution_default_min between execution_min_min and execution_max_min),
+  prep_default_min integer not null default 0 check (prep_default_min >= 0),
+  reservation_grid_min integer not null default 30 check (reservation_grid_min = 30),
+  soft_capacity integer not null default 5 check (soft_capacity >= 1),
+  overflow_capacity integer not null default 6 check (overflow_capacity >= soft_capacity),
+  autonomous_overflow_enabled boolean not null default false,
+  duration_blocks_future_booking boolean not null default false,
+  hard_resource_constraint boolean not null default false,
+  resource_key text null,
+  active boolean not null default true,
+  evidence_ref text not null default 'BUSINESS_REVALIDATION_2026-09-01',
+  updated_at timestamptz not null default now(),
+  primary key(capability,procedure_key),
+  check (hard_resource_constraint is false or resource_key is not null)
+);
+
+revoke all on table public.aos_booking_timing_authority_v2 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_booking_timing_authority_v2 to service_role;
+
+-- Capability defaults. Procedure overrides below win over '*'.
+insert into public.aos_booking_timing_authority_v2
+(capability,procedure_key,execution_min_min,execution_max_min,execution_default_min,prep_default_min)
+values
+('CONSULTA MEDICA','*',20,30,30,0),
+('TOXINA','*',15,30,30,0),
+('ACIDO HIALURONICO','*',60,60,60,0),
+('BIOESTIMULADOR','*',60,60,60,0),
+('HIFU','*',45,60,60,0),
+('HIDROFACIAL','*',60,60,60,0),
+('CRIOLIPOLISIS','*',90,90,90,0),
+('ENZIMAS CORPORALES','*',45,45,45,0),
+('ENZIMAS FACIALES','*',45,45,45,0),
+('GLUTEOS','*',90,90,90,0),
+('PRP CAPILAR','*',45,60,60,0),
+('CAPILAR','*',30,60,60,0),
+('MESOTERAPIA CAPILAR','*',30,60,60,0),
+('RADIOFRECUENCIA FRACCIONADA','*',45,60,60,0),
+('CARBOXITERAPIA','*',45,60,60,0),
+('DETOX','*',25,40,40,0),
+('EXOSOMAS','*',60,60,60,0),
+('EXOSOMAS CAPILARES','*',60,60,60,0),
+('HIDROENZIMAS','*',45,45,45,0),
+('MESOTERAPIA CORPORAL','*',45,45,45,0),
+('MESOTERAPIA FACIAL','*',60,60,60,0),
+('MICRONEEDLING FACIAL','*',60,60,60,0),
+('NANO GLOW','*',45,60,60,0),
+('PEELINGS','*',30,30,30,0),
+('PEPTONAS','*',30,45,45,0),
+('PINK INTIMATE','*',45,60,60,0),
+('PQ AGE','*',30,45,45,0),
+('VITAMINAS','*',45,60,60,0),
+('BIOREVITALIZACION FACIAL','*',45,60,60,0),
+('FACIALES','*',20,60,60,0)
+on conflict(capability,procedure_key) do update set
+ execution_min_min=excluded.execution_min_min,
+ execution_max_min=excluded.execution_max_min,
+ execution_default_min=excluded.execution_default_min,
+ prep_default_min=excluded.prep_default_min,
+ reservation_grid_min=30,
+ soft_capacity=5,
+ overflow_capacity=6,
+ autonomous_overflow_enabled=false,
+ duration_blocks_future_booking=false,
+ active=true,
+ evidence_ref='BUSINESS_REVALIDATION_2026-09-01',
+ updated_at=now();
+
+-- Explicit procedure timings supplied by clinic operations.
+insert into public.aos_booking_timing_authority_v2
+(capability,procedure_key,execution_min_min,execution_max_min,execution_default_min,prep_default_min)
+values
+('BIOREVITALIZACION FACIAL','ACIDO SUCCINICO AMBER',30,30,30,0),
+('BIOREVITALIZACION FACIAL','ACIDO TRANEXAMICO',30,30,30,0),
+('BIOREVITALIZACION FACIAL','CELLBOOSTER GLOW',30,30,30,0),
+('BIOREVITALIZACION FACIAL','CELLBOOSTER LIFT',30,30,30,0),
+('BIOREVITALIZACION FACIAL','MESOGLOW',45,60,60,0),
+('BIOREVITALIZACION FACIAL','NANOPLASMA FACIAL',45,60,60,0),
+('BIOREVITALIZACION FACIAL','PINK GLOW ROSTRO',45,60,60,0),
+('FACIALES','FACIAL CELULAS MADRE',20,30,30,0),
+('FACIALES','FACIAL COREANO',90,120,120,0),
+('FACIALES','FACIAL DIAMANTE',60,60,60,0),
+('FACIALES','HIDROVITAL PASCOE',60,60,60,0),
+('FACIALES','MASCARILLA ESTHEMAX',15,20,20,0),
+('FACIALES','MASCARILLA Q10',15,20,20,0),
+('FACIALES','SKIN PREP',15,20,20,0),
+('BIOESTIMULADOR','POWERFILL GLUTEOS',90,90,90,0),
+('GLUTEOS','AH SKINFILL GLUTEOS',90,90,90,0)
+on conflict(capability,procedure_key) do update set
+ execution_min_min=excluded.execution_min_min,
+ execution_max_min=excluded.execution_max_min,
+ execution_default_min=excluded.execution_default_min,
+ prep_default_min=excluded.prep_default_min,
+ reservation_grid_min=30,
+ soft_capacity=5,
+ overflow_capacity=6,
+ autonomous_overflow_enabled=false,
+ duration_blocks_future_booking=false,
+ active=true,
+ evidence_ref='BUSINESS_REVALIDATION_2026-09-01',
+ updated_at=now();
+
+create or replace function public.aos_booking_timing_for_service_v2(p_treatment_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_proc jsonb;
+  v_row public.aos_booking_timing_authority_v2%rowtype;
+begin
+  v_proc:=public.aos_booking_procedure_for_service_v1(p_treatment_id);
+  if v_proc is null then
+    return jsonb_build_object('ok',false,'status','PROCEDURE_UNMAPPED','requires_human',true);
+  end if;
+
+  select * into v_row
+  from public.aos_booking_timing_authority_v2 t
+  where t.active=true
+    and public.aos_booking_norm_v1(t.capability)=public.aos_booking_norm_v1(v_proc->>'capability')
+    and t.procedure_key in (v_proc->>'procedure_key','*')
+  order by case when t.procedure_key=v_proc->>'procedure_key' then 0 else 1 end
+  limit 1;
+
+  if not found then
+    return jsonb_build_object(
+      'ok',false,'status','TIMING_AUTHORITY_MISSING','requires_human',true,
+      'capability',v_proc->>'capability','procedure_key',v_proc->>'procedure_key','procedure_name',v_proc->>'procedure_name'
+    );
+  end if;
+
+  if v_row.hard_resource_constraint and v_row.resource_key is not null then
+    return jsonb_build_object(
+      'ok',false,'status','HARD_RESOURCE_AUTHORITY_NOT_WIRED','requires_human',true,
+      'resource_key',v_row.resource_key,'capability',v_proc->>'capability','procedure_key',v_proc->>'procedure_key'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,'status','TIMING_READY',
+    'capability',v_proc->>'capability','procedure_key',v_proc->>'procedure_key','procedure_name',v_proc->>'procedure_name',
+    'execution_min_min',v_row.execution_min_min,'execution_max_min',v_row.execution_max_min,'execution_default_min',v_row.execution_default_min,
+    'prep_default_min',v_row.prep_default_min,'reservation_grid_min',v_row.reservation_grid_min,
+    'soft_capacity',v_row.soft_capacity,'overflow_capacity',v_row.overflow_capacity,
+    'autonomous_overflow_enabled',v_row.autonomous_overflow_enabled,
+    'duration_blocks_future_booking',v_row.duration_blocks_future_booking,
+    'hard_resource_constraint',v_row.hard_resource_constraint,'resource_key',v_row.resource_key,
+    'evidence_ref',v_row.evidence_ref
+  );
+end
+$$;
+
+-- Dormant AGV2 slot resolver with the real 30-minute commercial grid and 5/6 capacity model.
+create or replace function public.aos_booking_slot_authority_v2(
+  p_treatment_id uuid,
+  p_fecha date,
+  p_sede text,
+  p_profesional_id text default null
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_t public.aos_catalogo_servicios%rowtype;
+  v_timing jsonb;
+  v_proc jsonb;
+  v_site text;
+  v_doc_allowed boolean;
+  v_nurse_allowed boolean;
+  v_doc_latest date;
+  v_nurse_latest date;
+  v_exec int;
+  v_soft int;
+  v_over int;
+  v_step interval:=interval '30 minutes';
+  v_slots jsonb:='[]'::jsonb;
+  v_providers jsonb:='[]'::jsonb;
+  v_p record;
+  v_h record;
+  v_time time;
+  v_min_start time;
+  v_max_end time;
+  v_members int;
+  v_names jsonb;
+  v_occupied int;
+begin
+  v_site:=upper(replace(trim(coalesce(p_sede,'')),'_',' '));
+  if p_fecha is null or v_site not in ('SAN ISIDRO','PUEBLO LIBRE') then
+    return jsonb_build_object('ok',false,'status','INVALID_DATE_OR_SITE');
+  end if;
+  if p_fecha<current_date or extract(isodow from p_fecha)=7 then
+    return jsonb_build_object('ok',false,'status',case when p_fecha<current_date then 'DATE_IN_PAST' else 'SUNDAY_CLOSED' end);
+  end if;
+
+  select * into v_t from public.aos_catalogo_servicios
+  where id=p_treatment_id and upper(coalesce(estado,'ACTIVO'))='ACTIVO' and upper(coalesce(tipo,'SERVICIO'))='SERVICIO';
+  if not found then return jsonb_build_object('ok',false,'status','TREATMENT_NOT_ACTIVE'); end if;
+
+  v_timing:=public.aos_booking_timing_for_service_v2(v_t.id);
+  if coalesce((v_timing->>'ok')::boolean,false) is not true then return v_timing; end if;
+  v_proc:=public.aos_booking_procedure_for_service_v1(v_t.id);
+  v_exec:=(v_timing->>'execution_default_min')::int;
+  v_soft:=(v_timing->>'soft_capacity')::int;
+  v_over:=(v_timing->>'overflow_capacity')::int;
+  v_doc_allowed:=coalesce(v_t.requiere_doctora,false);
+  v_nurse_allowed:=coalesce(v_t.requiere_enfermeria,false);
+
+  if v_doc_allowed then select max(fecha) into v_doc_latest from public.aos_horarios_personal where activo=true and upper(coalesce(rol,''))='DOCTORA'; end if;
+  if v_nurse_allowed then select max(fecha) into v_nurse_latest from public.aos_horarios_personal where activo=true and upper(coalesce(rol,''))='ENFERMERIA'; end if;
+  if (v_doc_allowed and (v_doc_latest is null or v_doc_latest<p_fecha)) and (not v_nurse_allowed or p_profesional_id is not null) then
+    return jsonb_build_object('ok',false,'status','SCHEDULE_SOURCE_STALE','requires_human',true,'role','DOCTORA');
+  end if;
+  if v_nurse_allowed and p_profesional_id is null and (v_nurse_latest is null or v_nurse_latest<p_fecha) and not v_doc_allowed then
+    return jsonb_build_object('ok',false,'status','SCHEDULE_SOURCE_STALE','requires_human',true,'role','ENFERMERIA');
+  end if;
+
+  if v_doc_allowed and v_doc_latest>=p_fecha then
+    for v_p in
+      select p.* from public.aos_perfiles_profesional p
+      where coalesce(p.visible,true)=true and upper(coalesce(p.tipo,''))='DOCTORA'
+        and (p_profesional_id is null or p.id::text=p_profesional_id)
+        and public.aos_professional_can_service_v1(p.id::text,v_t.id)
+        and exists(select 1 from public.aos_horarios_personal h where h.activo=true and h.fecha=p_fecha and upper(h.sede)=v_site and upper(coalesce(h.rol,''))='DOCTORA' and public.aos_booking_norm_v1(h.personal) like '%'||public.aos_booking_profile_key_v1(p.nombre_publico)||'%')
+      order by p.orden nulls last,p.nombre_publico
+    loop
+      v_providers:=v_providers||jsonb_build_array(jsonb_build_object('id',v_p.id,'name',v_p.nombre_publico,'role','DOCTORA'));
+      for v_h in
+        select h.* from public.aos_horarios_personal h
+        where h.activo=true and h.fecha=p_fecha and upper(h.sede)=v_site and upper(coalesce(h.rol,''))='DOCTORA'
+          and public.aos_booking_norm_v1(h.personal) like '%'||public.aos_booking_profile_key_v1(v_p.nombre_publico)||'%'
+      loop
+        v_time:=v_h.hora_inicio::time;
+        while v_time + make_interval(mins=>v_exec) <= v_h.hora_fin::time loop
+          select count(*) into v_occupied from public.aos_agenda_citas a
+          where a.fecha_cita=p_fecha and upper(coalesce(a.sede,''))=v_site
+            and substring(coalesce(a.hora_cita,'') from 1 for 5)=to_char(v_time,'HH24:MI')
+            and upper(coalesce(a.tipo_atencion,''))='DOCTORA'
+            and upper(coalesce(a.estado_cita,'')) not in ('CANCELADA','CANCELADO');
+          if v_occupied<v_soft then
+            v_slots:=v_slots||jsonb_build_array(jsonb_build_object(
+              'hora',to_char(v_time,'HH24:MI'),'sede',v_site,'disponible',true,
+              'ocupadas',v_occupied,'libres',v_soft-v_occupied,'capacidad',v_soft,'overflow_capacity',v_over,'overflow_available',v_occupied<v_over,
+              'professional_id',v_p.id,'professional_name',v_p.nombre_publico,'role','DOCTORA','mode','EXACT_PROVIDER',
+              'execution_default_min',v_exec,'duration_blocks_future_booking',false,
+              'procedure_key',v_proc->>'procedure_key','procedure_name',v_proc->>'procedure_name'
+            ));
+          end if;
+          v_time:=v_time+v_step;
+        end loop;
+      end loop;
+    end loop;
+  end if;
+
+  if v_nurse_allowed and p_profesional_id is null and v_nurse_latest>=p_fecha then
+    select min(h.hora_inicio::time),max(h.hora_fin::time) into v_min_start,v_max_end
+    from public.aos_perfiles_profesional p join public.aos_horarios_personal h
+      on h.activo=true and h.fecha=p_fecha and upper(h.sede)=v_site and upper(coalesce(h.rol,''))='ENFERMERIA'
+     and public.aos_booking_norm_v1(h.personal) like '%'||public.aos_booking_profile_key_v1(p.nombre_publico)||'%'
+    where coalesce(p.visible,true)=true and upper(coalesce(p.tipo,''))='ENFERMERIA' and public.aos_professional_can_service_v1(p.id::text,v_t.id);
+
+    if v_min_start is not null and v_max_end is not null then
+      v_time:=v_min_start;
+      while v_time+make_interval(mins=>v_exec)<=v_max_end loop
+        select count(distinct p.id),coalesce(jsonb_agg(distinct p.nombre_publico),'[]'::jsonb) into v_members,v_names
+        from public.aos_perfiles_profesional p join public.aos_horarios_personal h
+          on h.activo=true and h.fecha=p_fecha and upper(h.sede)=v_site and upper(coalesce(h.rol,''))='ENFERMERIA'
+         and public.aos_booking_norm_v1(h.personal) like '%'||public.aos_booking_profile_key_v1(p.nombre_publico)||'%'
+        where coalesce(p.visible,true)=true and upper(coalesce(p.tipo,''))='ENFERMERIA'
+          and public.aos_professional_can_service_v1(p.id::text,v_t.id)
+          and v_time>=h.hora_inicio::time and v_time+make_interval(mins=>v_exec)<=h.hora_fin::time;
+        if coalesce(v_members,0)>0 then
+          select count(*) into v_occupied from public.aos_agenda_citas a
+          where a.fecha_cita=p_fecha and upper(coalesce(a.sede,''))=v_site
+            and substring(coalesce(a.hora_cita,'') from 1 for 5)=to_char(v_time,'HH24:MI')
+            and upper(coalesce(a.tipo_atencion,''))='ENFERMERIA'
+            and upper(coalesce(a.estado_cita,'')) not in ('CANCELADA','CANCELADO');
+          if v_occupied<v_soft then
+            v_slots:=v_slots||jsonb_build_array(jsonb_build_object(
+              'hora',to_char(v_time,'HH24:MI'),'sede',v_site,'disponible',true,
+              'ocupadas',v_occupied,'libres',v_soft-v_occupied,'capacidad',v_soft,'overflow_capacity',v_over,'overflow_available',v_occupied<v_over,
+              'member_count',v_members,'member_names',v_names,'professional_id',null,'professional_name','Enfermería','role','ENFERMERIA','mode','SITE_POOL',
+              'execution_default_min',v_exec,'duration_blocks_future_booking',false,
+              'procedure_key',v_proc->>'procedure_key','procedure_name',v_proc->>'procedure_name'
+            ));
+          end if;
+        end if;
+        v_time:=v_time+v_step;
+      end loop;
+    end if;
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,'status',case when jsonb_array_length(v_slots)>0 then 'REAL_SLOTS_READY' else 'NO_REAL_SLOTS' end,
+    'treatment_id',v_t.id,'treatment',v_t.nombre,'capability',v_proc->>'capability','procedure',v_proc,'timing',v_timing,
+    'fecha',p_fecha,'sede',v_site,'eligible_professionals',v_providers,'slots',v_slots
+  );
+end
+$$;
+
+-- V2 BOOK/REBOOK uses L2 authority; V1/public surfaces remain unchanged until their own rollout gate.
+create or replace function public.aos_booking_resolve_selected_slot_v2(
+  p_treatment_id uuid,p_date date,p_site text,p_time time,p_professional_id text default null,p_slot_role text default null
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_av jsonb; v_slot jsonb; v_role text:=upper(btrim(coalesce(p_slot_role,''))); v_prof text:=nullif(btrim(coalesce(p_professional_id,'')),'');
+begin
+  v_av:=coalesce(public.aos_booking_slot_authority_v2(p_treatment_id,p_date,p_site,v_prof),'{}'::jsonb);
+  if coalesce((v_av->>'ok')::boolean,false) is not true then
+    return jsonb_build_object('ok',false,'error','AGV2_AUTHORITY_BLOCKED','authority_status',coalesce(v_av->>'status','UNKNOWN'),'requires_human',true,'authority',v_av);
+  end if;
+  if v_role='' then
+    if v_prof is not null then v_role:='DOCTORA'; else v_role:='ENFERMERIA'; end if;
+  end if;
+  if v_role not in ('DOCTORA','ENFERMERIA') then return jsonb_build_object('ok',false,'error','AGV2_SLOT_ROLE_REQUIRED'); end if;
+  if v_role='DOCTORA' and v_prof is null then return jsonb_build_object('ok',false,'error','AGV2_EXACT_PROVIDER_REQUIRED'); end if;
+  if v_role='ENFERMERIA' then v_prof:=null; end if;
+
+  select s into v_slot from jsonb_array_elements(coalesce(v_av->'slots','[]'::jsonb)) s
+  where s->>'hora'=to_char(p_time,'HH24:MI') and upper(coalesce(s->>'role',''))=v_role
+    and coalesce((s->>'disponible')::boolean,false)=true
+    and (v_role='ENFERMERIA' or s->>'professional_id'=v_prof)
+  limit 1;
+  if v_slot is null then return jsonb_build_object('ok',false,'error','AGV2_SLOT_NO_LONGER_AVAILABLE','requires_reselection',true); end if;
+
+  return jsonb_build_object(
+    'ok',true,'role',v_role,'booking_mode',case when v_role='DOCTORA' then 'EXACT_PROVIDER' else 'SITE_POOL' end,
+    'professional_id',case when v_role='DOCTORA' then v_prof else null end,
+    'professional_ref',case when v_role='DOCTORA' then v_prof else 'POOL:'||replace(upper(replace(btrim(p_site),'_',' ')),' ','_') end,
+    'professional_name',case when v_role='DOCTORA' then v_slot->>'professional_name' else 'Enfermería' end,
+    'site',upper(replace(btrim(p_site),'_',' ')),'date',p_date,'time',to_char(p_time,'HH24:MI'),
+    'capacity',(v_slot->>'capacidad')::int,'overflow_capacity',(v_slot->>'overflow_capacity')::int,
+    'execution_default_min',(v_slot->>'execution_default_min')::int,'authority_status',v_av->>'status'
+  );
+end
+$$;
+
+revoke all on function public.aos_booking_timing_for_service_v2(uuid) from public,anon,authenticated;
+revoke all on function public.aos_booking_slot_authority_v2(uuid,date,text,text) from public,anon,authenticated;
+revoke all on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) from public,anon,authenticated;
+grant execute on function public.aos_booking_timing_for_service_v2(uuid) to service_role;
+grant execute on function public.aos_booking_slot_authority_v2(uuid,date,text,text) to service_role;
+grant execute on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) to service_role;
+
+comment on table public.aos_booking_timing_authority_v2 is 'AGV2 L2 clinical execution timing and 30-minute commercial capacity authority. Duration does not consume later slots.';
+comment on function public.aos_booking_slot_authority_v2(uuid,date,text,text) is 'Dormant AGV2 slot authority: 30-min grid, soft 5/overflow 6, clinical duration only validates start-time fit.';
+
+commit;

--- a/supabase/rollbacks/20260901123000_agv2_slot_authority_v2_rollback.sql
+++ b/supabase/rollbacks/20260901123000_agv2_slot_authority_v2_rollback.sql
@@ -1,0 +1,58 @@
+begin;
+
+-- Restore L1 selected-slot authority to the existing WA/public availability V2.
+create or replace function public.aos_booking_resolve_selected_slot_v2(
+  p_treatment_id uuid,
+  p_date date,
+  p_site text,
+  p_time time,
+  p_professional_id text default null,
+  p_slot_role text default null
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path='pg_catalog','public','extensions','pg_temp'
+as $$
+declare
+  v_t public.aos_catalogo_servicios%rowtype;
+  v_site text;
+  v_role text;
+  v_prof text:=nullif(btrim(coalesce(p_professional_id,'')),'');
+  v_av jsonb;
+  v_slot jsonb;
+  v_doc boolean;
+  v_nurse boolean;
+begin
+  select * into v_t from public.aos_catalogo_servicios
+  where id=p_treatment_id and upper(coalesce(estado,'ACTIVO'))='ACTIVO' and upper(coalesce(tipo,'SERVICIO'))='SERVICIO';
+  if not found then return jsonb_build_object('ok',false,'error','AGV2_TREATMENT_NOT_ACTIVE'); end if;
+  v_site:=upper(replace(btrim(coalesce(p_site,'')),'_',' '));
+  if p_date is null or p_time is null or v_site not in ('SAN ISIDRO','PUEBLO LIBRE') then return jsonb_build_object('ok',false,'error','AGV2_DATE_TIME_SITE_INVALID'); end if;
+  if p_date<current_date then return jsonb_build_object('ok',false,'error','AGV2_DATE_IN_PAST'); end if;
+  if extract(isodow from p_date)=7 then return jsonb_build_object('ok',false,'error','AGV2_SUNDAY_CLOSED'); end if;
+  v_doc:=coalesce(v_t.requiere_doctora,false); v_nurse:=coalesce(v_t.requiere_enfermeria,false); v_role:=upper(btrim(coalesce(p_slot_role,'')));
+  if v_role='' then if v_doc and v_nurse then v_role:=case when v_prof is null then 'ENFERMERIA' else 'DOCTORA' end; elsif v_doc then v_role:='DOCTORA'; elsif v_nurse then v_role:='ENFERMERIA'; end if; end if;
+  if v_role not in ('DOCTORA','ENFERMERIA') then return jsonb_build_object('ok',false,'error','AGV2_SLOT_ROLE_REQUIRED'); end if;
+  if v_role='DOCTORA' and not v_doc then return jsonb_build_object('ok',false,'error','AGV2_ROLE_NOT_ALLOWED'); end if;
+  if v_role='ENFERMERIA' and not v_nurse then return jsonb_build_object('ok',false,'error','AGV2_ROLE_NOT_ALLOWED'); end if;
+  if v_role='DOCTORA' and v_prof is null then return jsonb_build_object('ok',false,'error','AGV2_EXACT_PROVIDER_REQUIRED'); end if;
+  if v_role='ENFERMERIA' then v_prof:=null; end if;
+  v_av:=coalesce(public.aos_booking_availability_v2(v_t.id,p_date,v_site,v_prof),'{}'::jsonb);
+  if coalesce((v_av->>'ok')::boolean,false) is not true then return jsonb_build_object('ok',false,'error','AGV2_AUTHORITY_BLOCKED','authority_status',coalesce(v_av->>'status','UNKNOWN'),'requires_human',true); end if;
+  select s into v_slot from jsonb_array_elements(coalesce(v_av->'slots','[]'::jsonb)) s
+  where s->>'hora'=to_char(p_time,'HH24:MI') and upper(coalesce(s->>'role',''))=v_role and coalesce((s->>'disponible')::boolean,false)=true and (v_role='ENFERMERIA' or s->>'professional_id'=v_prof) limit 1;
+  if v_slot is null then return jsonb_build_object('ok',false,'error','AGV2_SLOT_NO_LONGER_AVAILABLE','requires_reselection',true); end if;
+  return jsonb_build_object('ok',true,'role',v_role,'booking_mode',case when v_role='DOCTORA' then 'EXACT_PROVIDER' else 'SITE_POOL' end,'professional_id',case when v_role='DOCTORA' then v_prof else null end,'professional_ref',case when v_role='DOCTORA' then v_prof else 'POOL:'||replace(v_site,' ','_') end,'professional_name',case when v_role='DOCTORA' then v_slot->>'professional_name' else 'Enfermería' end,'site',v_site,'date',p_date,'time',to_char(p_time,'HH24:MI'),'authority_status',v_av->>'status');
+end
+$$;
+
+revoke all on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) from public,anon,authenticated;
+grant execute on function public.aos_booking_resolve_selected_slot_v2(uuid,date,text,time,text,text) to service_role;
+
+drop function if exists public.aos_booking_slot_authority_v2(uuid,date,text,text);
+drop function if exists public.aos_booking_timing_for_service_v2(uuid);
+drop table if exists public.aos_booking_timing_authority_v2;
+
+commit;


### PR DESCRIPTION
Implements WA-AUTO L2 as an additive/dormant authority on top of merged AGV2 L1.

Business contract frozen from clinic operations:
- 30-minute commercial reservation grid.
- soft capacity 5 appointments per slot; overflow ceiling 6.
- autonomous overflow starts OFF.
- clinical execution duration validates whether a treatment can start before the staff attention window closes, but does not consume/block later commercial booking slots.
- prep/anesthesia is modeled separately and remains 0 unless explicitly governed; ~30 min can be configured per procedure when confirmed.
- hard machine/cabin/resource constraints fail closed until a concrete resource authority is wired.
- existing V1/public availability remains untouched; only dormant AGV2 selected-slot authority is rewired.

Includes procedure/capability timing seeds, critical canaries (Toxina, Cellbooster, HIFU, Hidrofacial, Criolipólisis), local lint and rollback. No production appointment mutation and no autonomous send activation.