### PR TITLE
AGV2 L3: durable confirmations + reminder outbox

### DIFF
--- a/.github/workflows/agv2-l3-delivery-outbox.yml
+++ b/.github/workflows/agv2-l3-delivery-outbox.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'supabase/migrations/*l3_delivery_outbox*'
+      - 'supabase/migrations/*agv2_l3_*'
       - 'supabase/rollbacks/*l3_delivery_outbox*'
       - 'ci/agv2-l3-delivery/**'
       - '.github/workflows/agv2-l3-delivery-outbox.yml'
@@ -128,6 +128,7 @@ jobs:
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193500_agv2_l3_active_revision_fix_v3.sql
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
 
       - name: L3 confirmation, reminder, rebook and idempotency canaries
@@ -149,6 +150,7 @@ jobs:
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql
           test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_agenda_delivery_outbox_v3') is null")" = 't'
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193500_agv2_l3_active_revision_fix_v3.sql
           test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true")" = '10'
 
       - name: Local DB lint and dormant boundary

--- a/.github/workflows/agv2-l3-delivery-outbox.yml
+++ b/.github/workflows/agv2-l3-delivery-outbox.yml
@@ -1,0 +1,167 @@
+name: ASCENDA AGV2 L3 Delivery Outbox
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*l3_delivery_outbox*'
+      - 'supabase/rollbacks/*l3_delivery_outbox*'
+      - 'ci/agv2-l3-delivery/**'
+      - '.github/workflows/agv2-l3-delivery-outbox.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agv2-l3-delivery-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: ZERO-COST · post-commit confirmations + reminders
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+
+      - name: Static L3 delivery contract
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          node --test ci/agv2-l3-delivery/delivery-outbox-contract.test.js
+
+      - name: Wait for isolated local ports
+        run: |
+          set -euo pipefail
+          ports='60200 60201 60202'
+          for i in $(seq 1 60); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'AGV2_L3_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+
+      - name: Build isolated CURRENT + certified L1/L2 prerequisites
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+
+          # FULL LOCAL is deliberately compact. Add deterministic representatives
+          # required by the already-certified L1/L2 migrations reused by L3.
+          psql "$DB" -X -v ON_ERROR_STOP=1 <<'SQL'
+          insert into public.aos_catalogo_servicios(
+            nombre,nombre_corto,tipo,categoria,estado,requiere_doctora,requiere_enfermeria,precio_base,precio_oferta,moneda
+          )
+          select 'CELLBOOSTER GLOW x1','CELLBOOSTER GLOW x1','SERVICIO','BIOREVITALIZACION FACIAL','ACTIVO',true,false,100,90,'PEN'
+          where not exists (select 1 from public.aos_catalogo_servicios where nombre='CELLBOOSTER GLOW x1');
+
+          insert into public.aos_catalogo_servicios(
+            nombre,nombre_corto,tipo,categoria,estado,requiere_doctora,requiere_enfermeria,precio_base,precio_oferta,moneda
+          )
+          select 'FACIAL COREANO','FACIAL COREANO','SERVICIO','FACIALES','ACTIVO',false,true,100,90,'PEN'
+          where not exists (select 1 from public.aos_catalogo_servicios where nombre='FACIAL COREANO');
+
+          update public.aos_catalogo_servicios
+             set categoria='FACIALES'
+           where upper(coalesce(estado,'ACTIVO'))='ACTIVO'
+             and upper(coalesce(tipo,'SERVICIO'))='SERVICIO'
+             and upper(nombre) like 'HIDROFACIAL%';
+
+          insert into public.aos_cat_tratamientos(
+            tratamiento,estado,orden,ultima_edicion,editado_por,categoria,requiere_doctora,requiere_enfermeria
+          ) values ('HIDROFACIAL','ACTIVO',320,now(),'L3_TEST_PROD_PARITY','FACIAL',false,true)
+          on conflict(tratamiento) do update
+          set estado='ACTIVO',categoria='FACIAL',requiere_doctora=false,
+              requiere_enfermeria=true,ultima_edicion=now(),editado_por='L3_TEST_PROD_PARITY';
+          SQL
+
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831235500_wa4c_catalog_capability_reconciliation_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+
+          psql "$DB" -X -v ON_ERROR_STOP=1 <<'SQL'
+          alter table public.aos_usuarios add column if not exists servicios text[] not null default '{}'::text[];
+          alter table public.aos_catalogo_categorias add column if not exists tipo text default 'SERVICIO';
+          alter table public.aos_catalogo_categorias add column if not exists icono text;
+          alter table public.aos_catalogo_categorias add column if not exists rol_profesional text default 'AMBOS';
+          alter table public.aos_catalogo_categorias add column if not exists estado text default 'ACTIVO';
+          alter table public.aos_catalogo_categorias add column if not exists orden integer default 0;
+          alter table public.aos_catalogo_categorias add column if not exists updated_at timestamptz default now();
+          create unique index if not exists ux_aos_catalogo_categorias_nombre_l3_test
+            on public.aos_catalogo_categorias(nombre);
+          SQL
+
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003000_wa4c_team_skill_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901003500_wa4c_team_skill_catalog_classification_v3.sql
+
+          python3 - <<'PY'
+          from pathlib import Path
+          src = Path('supabase/migrations/20260901012000_wa4c_professional_skill_hierarchy_v1.sql').read_text()
+          needle = "'WA4C_SKILL_HIERARCHY_UNMAPPED_ACTIVE_SERVICES:%'"
+          pos = src.find(needle)
+          if pos < 0:
+              raise SystemExit('L3_TEST_SKILL_ASSERTION_MARKER_NOT_FOUND')
+          start = src.rfind('\ndo $$', 0, pos)
+          end = src.find('\n$$;', pos)
+          if start < 0 or end < 0:
+              raise SystemExit('L3_TEST_SKILL_ASSERTION_BLOCK_NOT_FOUND')
+          end += len('\n$$;')
+          out = src[:start] + "\n-- TEST ONLY: global production catalog coverage assertion omitted here.\n" + src[end:]
+          Path('/tmp/wa4c-professional-skill-hierarchy-l3-test.sql').write_text(out)
+          PY
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f /tmp/wa4c-professional-skill-hierarchy-l3-test.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901123000_agv2_slot_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
+
+      - name: L3 confirmation, reminder, rebook and idempotency canaries
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/agv2-l3-delivery/delivery-outbox-canary.sql 2>&1 | tee /tmp/agv2-l3-canary.txt
+          grep -q 'AGV2_L3_DELIVERY_OUTBOX_CANARY_PASS' /tmp/agv2-l3-canary.txt
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_booking_operations_v2")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_events_v2")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_outbox_v3")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true")" = '10'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_template_registry_v3 where provider_verified=false")" = '6'
+
+      - name: L3 rollback compiles and re-applies cleanly
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_agenda_delivery_outbox_v3') is null")" = 't'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true")" = '10'
+
+      - name: Local DB lint and dormant boundary
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_agenda_delivery_outbox_v3 where state in ('READY','CLAIMED','ACCEPTED')")" = '0'
+          (cd ci/wa4c-full-local && supabase db lint --local --schema public --level error) 2>&1 | tee /tmp/agv2-l3-lint.txt
+          if grep -q '\[ERROR\]' /tmp/agv2-l3-lint.txt; then exit 1; fi
+
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/ci/agv2-l3-delivery/delivery-outbox-canary.sql
+++ b/ci/agv2-l3-delivery/delivery-outbox-canary.sql
@@ -1,0 +1,145 @@
+-- WA-AUTO L3 · TEST ONLY
+-- Proves event projection, idempotency, reminder materialization, rebook supersession and dormant boundary.
+
+begin;
+
+do $$
+declare
+  v_actor uuid:='00000000-0000-0000-0000-00000000c303'::uuid;
+  v_treatment uuid;
+  v_op1 uuid:=gen_random_uuid();
+  v_op2 uuid:=gen_random_uuid();
+  v_op3 uuid:=gen_random_uuid();
+  v_e1 uuid;
+  v_e2 uuid;
+  v_e3 uuid;
+  v_appt text:='agv2-l3-canary-primary';
+  v_appt_bad text:='agv2-l3-canary-malformed-email';
+  v_date date:=current_date+3;
+  v_new_date date:=current_date+5;
+  v_n integer;
+  v_r jsonb;
+begin
+  select treatment_id into v_treatment from public.aos_wa4c_booking_test_fixture where id=1;
+  if v_treatment is null then raise exception 'L3_CANARY_TREATMENT_FIXTURE_MISSING'; end if;
+
+  insert into public.aos_agenda_citas(
+    id,fecha_cita,tratamiento,tipo_cita,sede,numero,nombre,apellido,correo,asesor,id_asesor,
+    estado_cita,hora_cita,doctora,tipo_atencion,origen_cita,numero_limpio,origen
+  ) values (
+    v_appt,v_date,'L3 TEST SERVICE','CONSULTA NUEVA','SAN ISIDRO','51911111111','Paciente','L3',
+    'l3.canary@example.test','TEST','TEST','PENDIENTE','10:00','DRA. TEST','DOCTORA','AGENDA_V2','51911111111','AGENDA_INTERNAL'
+  );
+
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,appointment_id,treatment_id,
+    professional_ref,site,appointment_date,appointment_time,identity_state,status,response
+  ) values (
+    v_op1,'agv2-l3-canary-book-0001',repeat('a',64),'BOOK','AGENDA',v_actor,v_appt,v_treatment,
+    'wa4c-doctor-1','SAN ISIDRO',v_date,'10:00','UNRESOLVED','BOOKED','{}'::jsonb
+  );
+
+  insert into public.aos_agenda_events_v2(
+    operation_id,appointment_id,event_type,actor_id,channel,before_snapshot,after_snapshot
+  ) values (
+    v_op1,v_appt,'BOOKED',v_actor,'AGENDA',null,jsonb_build_object('appointment_id',v_appt,'date',v_date,'time','10:00')
+  ) returning id into v_e1;
+
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1;
+  if v_n<>2 then raise exception 'L3_BOOK_CONFIRMATION_INTENTS_EXPECTED_2:%',v_n; end if;
+  if exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and state<>'DORMANT') then
+    raise exception 'L3_BOOK_INTENT_NOT_DORMANT';
+  end if;
+  if not exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and channel='EMAIL' and provider='RESEND' and provider_template_verified=true and template_key='confirmacion_cita') then
+    raise exception 'L3_EMAIL_CONFIRMATION_CONTRACT_MISSING';
+  end if;
+  if not exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and channel='WHATSAPP' and provider='META_CLOUD_API' and provider_template_verified=false and template_key='cita_confirmada' and blocking_reason like '%PROVIDER_TEMPLATE_APPROVAL_UNVERIFIED%') then
+    raise exception 'L3_WA_CONFIRMATION_FAIL_CLOSED_MISSING';
+  end if;
+
+  -- Replaying projection/reconciliation never duplicates the event delivery intents.
+  perform public.aos_agenda_delivery_enqueue_event_v3(v_e1);
+  perform public.aos_agenda_delivery_reconcile_v3(100);
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and delivery_kind='CONFIRMATION';
+  if v_n<>2 then raise exception 'L3_CONFIRMATION_IDEMPOTENCY_FAILED:%',v_n; end if;
+
+  -- Day-before reminder materializes exactly once per channel for the current revision.
+  v_r:=public.aos_agenda_delivery_materialize_reminders_v3(((v_date-1)::timestamp + time '12:00') at time zone 'America/Lima',100);
+  v_r:=public.aos_agenda_delivery_materialize_reminders_v3(((v_date-1)::timestamp + time '12:05') at time zone 'America/Lima',100);
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and delivery_kind='REMINDER_TOMORROW';
+  if v_n<>2 then raise exception 'L3_TOMORROW_REMINDER_IDEMPOTENCY_FAILED:%',v_n; end if;
+  if not exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e1 and delivery_kind='REMINDER_TOMORROW' and channel='WHATSAPP' and template_key='recordatorio_manana_si') then
+    raise exception 'L3_TOMORROW_SITE_TEMPLATE_FAILED';
+  end if;
+
+  -- REBOOK creates a new revision and supersedes every still-unsent old-revision intent.
+  update public.aos_agenda_citas
+     set fecha_cita=v_new_date,hora_cita='11:00',ts_actualizado=now()
+   where id=v_appt;
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,appointment_id,treatment_id,
+    professional_ref,site,appointment_date,appointment_time,identity_state,status,response
+  ) values (
+    v_op2,'agv2-l3-canary-rebook-0001',repeat('b',64),'REBOOK','AGENDA',v_actor,v_appt,v_treatment,
+    'wa4c-doctor-1','SAN ISIDRO',v_new_date,'11:00','UNRESOLVED','REBOOKED','{}'::jsonb
+  );
+  insert into public.aos_agenda_events_v2(
+    operation_id,appointment_id,event_type,actor_id,channel,reason,before_snapshot,after_snapshot
+  ) values (
+    v_op2,v_appt,'RESCHEDULED',v_actor,'AGENDA','L3 canary rebook',
+    jsonb_build_object('date',v_date,'time','10:00'),jsonb_build_object('date',v_new_date,'time','11:00')
+  ) returning id into v_e2;
+
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where appointment_id=v_appt and schedule_revision=v_e1::text and state='SUPERSEDED';
+  if v_n<>4 then raise exception 'L3_REBOOK_SUPERSESSION_EXPECTED_4:%',v_n; end if;
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e2 and delivery_kind='REPROGRAMMATION' and state='DORMANT';
+  if v_n<>2 then raise exception 'L3_REPROGRAM_INTENTS_EXPECTED_2:%',v_n; end if;
+
+  -- New schedule gets its own day-before and same-day reminder revisions.
+  perform public.aos_agenda_delivery_materialize_reminders_v3(((v_new_date-1)::timestamp + time '12:00') at time zone 'America/Lima',100);
+  perform public.aos_agenda_delivery_materialize_reminders_v3((v_new_date::timestamp + time '08:00') at time zone 'America/Lima',100);
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e2 and delivery_kind in ('REMINDER_TOMORROW','REMINDER_TODAY');
+  if v_n<>4 then raise exception 'L3_NEW_REVISION_REMINDERS_EXPECTED_4:%',v_n; end if;
+  if not exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e2 and delivery_kind='REMINDER_TODAY' and channel='WHATSAPP' and template_key='recordatorio_hoy_si') then
+    raise exception 'L3_TODAY_SITE_TEMPLATE_FAILED';
+  end if;
+
+  -- Malformed legacy email data never rolls back the event; only the valid phone intent is projected.
+  insert into public.aos_agenda_citas(
+    id,fecha_cita,tratamiento,tipo_cita,sede,numero,nombre,apellido,correo,asesor,id_asesor,
+    estado_cita,hora_cita,doctora,tipo_atencion,origen_cita,numero_limpio,origen
+  ) values (
+    v_appt_bad,v_date,'L3 TEST SERVICE','CONSULTA NUEVA','PUEBLO LIBRE','51933333333','Paciente','BadMail',
+    'correo-invalido','TEST','TEST','PENDIENTE','14:00','DRA. TEST','DOCTORA','AGENDA_V2','51933333333','AGENDA_INTERNAL'
+  );
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,appointment_id,treatment_id,
+    professional_ref,site,appointment_date,appointment_time,identity_state,status,response
+  ) values (
+    v_op3,'agv2-l3-canary-book-0002',repeat('c',64),'BOOK','AGENDA',v_actor,v_appt_bad,v_treatment,
+    'wa4c-doctor-1','PUEBLO LIBRE',v_date,'14:00','UNRESOLVED','BOOKED','{}'::jsonb
+  );
+  insert into public.aos_agenda_events_v2(
+    operation_id,appointment_id,event_type,actor_id,channel,before_snapshot,after_snapshot
+  ) values (
+    v_op3,v_appt_bad,'BOOKED',v_actor,'AGENDA',null,jsonb_build_object('appointment_id',v_appt_bad)
+  ) returning id into v_e3;
+  if not exists(select 1 from public.aos_agenda_events_v2 where id=v_e3) then raise exception 'L3_FAIL_SOFT_EVENT_ROLLED_BACK'; end if;
+  select count(*) into v_n from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e3;
+  if v_n<>1 then raise exception 'L3_MALFORMED_EMAIL_EXPECTED_WA_ONLY:%',v_n; end if;
+  if not exists(select 1 from public.aos_agenda_delivery_outbox_v3 where agenda_event_id=v_e3 and channel='WHATSAPP') then
+    raise exception 'L3_MALFORMED_EMAIL_WA_INTENT_MISSING';
+  end if;
+
+  if exists(select 1 from public.aos_agenda_delivery_outbox_v3 where state in ('READY','CLAIMED','ACCEPTED')) then
+    raise exception 'L3_AUTONOMOUS_DISPATCH_MUST_REMAIN_OFF';
+  end if;
+  if exists(select idempotency_key from public.aos_agenda_delivery_outbox_v3 group by idempotency_key having count(*)>1) then
+    raise exception 'L3_DUPLICATE_IDEMPOTENCY_KEYS';
+  end if;
+end
+$$;
+
+select 'AGV2_L3_DELIVERY_OUTBOX_CANARY_PASS' as result;
+
+rollback;

--- a/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
+++ b/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const test=require('node:test')
+const assert=require('node:assert/strict')
+const fs=require('node:fs')
+
+const migration=fs.readFileSync('supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql','utf8')
+const rollback=fs.readFileSync('supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql','utf8')
+
+function has(s){assert.ok(migration.includes(s),`missing contract: ${s}`)}
+
+test('L3 is durable/idempotent and remains dormant until L4',()=>{
+  has('aos_agenda_delivery_outbox_v3')
+  has('idempotency_key text not null unique')
+  has("state text not null default 'DORMANT'")
+  has("'dispatch_boundary','L4_AUTHORITY_REQUIRED'")
+  assert.equal(/sendResend|graph\.facebook\.com|https:\/\//i.test(migration),false,'DDL must not perform provider network dispatch')
+})
+
+test('booking event projection is fail-soft and repairable',()=>{
+  has('trg_aos_agenda_delivery_event_v3')
+  has('after insert on public.aos_agenda_events_v2')
+  has('Delivery projection is repairable from the append-only event ledger. Never roll back a booking.')
+  has('aos_agenda_delivery_reconcile_v3')
+  has('exception when others then')
+})
+
+test('BOOK and REBOOK confirmations are revision-aware',()=>{
+  has("v_kind:=case when v_e.event_type='BOOKED' then 'CONFIRMATION' else 'REPROGRAMMATION' end")
+  has("blocking_reason='SUPERSEDED_BY_RESCHEDULE'")
+  has("schedule_revision<>v_e.id::text")
+  has("provider_message_id is null")
+})
+
+test('TODAY/TOMORROW reminders are local-time, V2-only, and idempotent',()=>{
+  has("at time zone 'America/Lima'")
+  has("c.fecha_cita in (v_local_date,v_local_date+1)")
+  has("exists(select 1 from public.aos_agenda_events_v2 e where e.appointment_id=c.id)")
+  has("'REMINDER_TODAY' else 'REMINDER_TOMORROW'")
+  has("v_key:='agv2-l3:'||p_schedule_revision||':'||v_kind||':'||v_channel")
+})
+
+test('email can be provider-ready but WhatsApp remains fail-closed pending Meta approval',()=>{
+  has("('CONFIRMATION','EMAIL','*','confirmacion_cita','RESEND','confirmacion_cita',true")
+  has("('REPROGRAMMATION','EMAIL','*','reprogramacion','RESEND','reprogramacion',true")
+  has("('CONFIRMATION','WHATSAPP','*','cita_confirmada','META_CLOUD_API',null,false")
+  has('PROVIDER_TEMPLATE_APPROVAL_UNVERIFIED')
+  has('recordatorio_manana_si')
+  has('recordatorio_manana_pl')
+  has('recordatorio_hoy_si')
+  has('recordatorio_hoy_pl')
+})
+
+test('rollback is narrow and never mutates Agenda data',()=>{
+  assert.ok(rollback.includes('drop trigger if exists trg_aos_agenda_delivery_event_v3'))
+  assert.ok(rollback.includes('drop table if exists public.aos_agenda_delivery_outbox_v3'))
+  assert.equal(/delete\s+from\s+public\.aos_agenda_citas|update\s+public\.aos_agenda_citas/i.test(rollback),false)
+})

--- a/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
+++ b/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
@@ -5,17 +5,19 @@ const assert=require('node:assert/strict')
 const fs=require('node:fs')
 
 const migration=fs.readFileSync('supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql','utf8')
+const revisionFix=fs.readFileSync('supabase/migrations/20260901193500_agv2_l3_active_revision_fix_v3.sql','utf8')
 const rollback=fs.readFileSync('supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql','utf8')
 const server=fs.readFileSync('app/server.js','utf8')
 
 function has(s){assert.ok(migration.includes(s),`missing contract: ${s}`)}
+function hasFix(s){assert.ok(revisionFix.includes(s),`missing active-revision fix: ${s}`)}
 
 test('L3 is durable/idempotent and remains dormant until L4',()=>{
   has('aos_agenda_delivery_outbox_v3')
   has('idempotency_key text not null unique')
   has("state text not null default 'DORMANT'")
   has("'dispatch_boundary','L4_AUTHORITY_REQUIRED'")
-  assert.equal(/sendResend|graph\.facebook\.com|https:\/\//i.test(migration),false,'DDL must not perform provider network dispatch')
+  assert.equal(/sendResend|graph\.facebook\.com|https:\/\//i.test(migration+revisionFix),false,'DDL must not perform provider network dispatch')
 })
 
 test('booking event projection is fail-soft and repairable',()=>{
@@ -39,6 +41,14 @@ test('TODAY/TOMORROW reminders are local-time, V2-only, and idempotent',()=>{
   has("exists(select 1 from public.aos_agenda_events_v2 e where e.appointment_id=c.id)")
   has("'REMINDER_TODAY' else 'REMINDER_TOMORROW'")
   has("v_key:='agv2-l3:'||p_schedule_revision||':'||v_kind||':'||v_channel")
+})
+
+test('reminders resolve the active non-superseded schedule revision deterministically',()=>{
+  hasFix("o.delivery_kind in ('CONFIRMATION','REPROGRAMMATION')")
+  hasFix("o.state<>'SUPERSEDED'")
+  hasFix("case when e.event_type='RESCHEDULED' then 0 else 1 end")
+  hasFix('perform public.aos_agenda_delivery_reconcile_v3(2000)')
+  assert.equal(/order by\s+e\.created_at desc\s*,\s*e\.id desc\s*limit 1/i.test(revisionFix),false,'must not rely on timestamp+UUID alone for active revision')
 })
 
 test('current email runtime already supports the L3 transactional contracts',()=>{

--- a/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
+++ b/ci/agv2-l3-delivery/delivery-outbox-contract.test.js
@@ -6,6 +6,7 @@ const fs=require('node:fs')
 
 const migration=fs.readFileSync('supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql','utf8')
 const rollback=fs.readFileSync('supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql','utf8')
+const server=fs.readFileSync('app/server.js','utf8')
 
 function has(s){assert.ok(migration.includes(s),`missing contract: ${s}`)}
 
@@ -38,6 +39,15 @@ test('TODAY/TOMORROW reminders are local-time, V2-only, and idempotent',()=>{
   has("exists(select 1 from public.aos_agenda_events_v2 e where e.appointment_id=c.id)")
   has("'REMINDER_TODAY' else 'REMINDER_TOMORROW'")
   has("v_key:='agv2-l3:'||p_schedule_revision||':'||v_kind||':'||v_channel")
+})
+
+test('current email runtime already supports the L3 transactional contracts',()=>{
+  assert.ok(server.includes("tipo === 'confirmacion_cita'"),'confirmation renderer missing')
+  assert.ok(server.includes("tipo === 'reprogramacion'"),'reprogram renderer missing')
+  assert.ok(server.includes("template === 'recordatorio_manana'"),'tomorrow reminder runtime missing')
+  assert.ok(server.includes('buildEmailRecordatorio'),'reminder renderer missing')
+  assert.ok(server.includes("'recordatorio_hoy'"),'today reminder contract missing')
+  assert.ok(server.includes("'recordatorio_manana'"),'tomorrow reminder transactional type missing')
 })
 
 test('email can be provider-ready but WhatsApp remains fail-closed pending Meta approval',()=>{

--- a/supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+++ b/supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
@@ -1,0 +1,410 @@
+-- ASCENDA OS · WA-AUTO L3 — Post-commit confirmation + reminder outbox V3
+-- Durable/idempotent delivery intents only. No provider dispatch is enabled in this phase.
+-- L4 owns autonomous dispatch authority / kill switch. Provider failure must never roll back booking.
+
+begin;
+
+create table if not exists public.aos_agenda_delivery_template_registry_v3 (
+  delivery_kind text not null check (delivery_kind in ('CONFIRMATION','REPROGRAMMATION','REMINDER_TOMORROW','REMINDER_TODAY')),
+  channel text not null check (channel in ('EMAIL','WHATSAPP')),
+  site_scope text not null default '*' check (site_scope in ('*','SAN ISIDRO','PUEBLO LIBRE')),
+  template_key text not null,
+  provider text not null check (provider in ('RESEND','META_CLOUD_API')),
+  provider_template_name text null,
+  provider_verified boolean not null default false,
+  active boolean not null default true,
+  evidence_ref text not null,
+  updated_at timestamptz not null default now(),
+  primary key(delivery_kind,channel,site_scope)
+);
+
+insert into public.aos_agenda_delivery_template_registry_v3(
+  delivery_kind,channel,site_scope,template_key,provider,provider_template_name,provider_verified,evidence_ref
+)
+values
+  ('CONFIRMATION','EMAIL','*','confirmacion_cita','RESEND','confirmacion_cita',true,'APP_SERVER_TRANSACTIONAL_TYPE_CURRENT'),
+  ('REPROGRAMMATION','EMAIL','*','reprogramacion','RESEND','reprogramacion',true,'APP_SERVER_TRANSACTIONAL_TYPE_CURRENT'),
+  ('REMINDER_TOMORROW','EMAIL','*','recordatorio_manana','RESEND','recordatorio_manana',true,'APP_SERVER_TRANSACTIONAL_TYPE_CURRENT'),
+  ('REMINDER_TODAY','EMAIL','*','recordatorio_hoy','RESEND','recordatorio_hoy',true,'APP_SERVER_TRANSACTIONAL_TYPE_CURRENT'),
+  ('CONFIRMATION','WHATSAPP','*','cita_confirmada','META_CLOUD_API',null,false,'AOS_PLANTILLAS_WHATSAPP:cita_confirmada;META_APPROVAL_UNVERIFIED'),
+  ('REPROGRAMMATION','WHATSAPP','*','reprogramacion','META_CLOUD_API',null,false,'LOGICAL_REPROGRAM_TEMPLATE;META_APPROVAL_UNVERIFIED'),
+  ('REMINDER_TOMORROW','WHATSAPP','SAN ISIDRO','recordatorio_manana_si','META_CLOUD_API',null,false,'AOS_PLANTILLAS_WHATSAPP:recordatorio_manana_si;META_APPROVAL_UNVERIFIED'),
+  ('REMINDER_TOMORROW','WHATSAPP','PUEBLO LIBRE','recordatorio_manana_pl','META_CLOUD_API',null,false,'AOS_PLANTILLAS_WHATSAPP:recordatorio_manana_pl;META_APPROVAL_UNVERIFIED'),
+  ('REMINDER_TODAY','WHATSAPP','SAN ISIDRO','recordatorio_hoy_si','META_CLOUD_API',null,false,'AOS_PLANTILLAS_WHATSAPP:recordatorio_hoy_si;META_APPROVAL_UNVERIFIED'),
+  ('REMINDER_TODAY','WHATSAPP','PUEBLO LIBRE','recordatorio_hoy_pl','META_CLOUD_API',null,false,'AOS_PLANTILLAS_WHATSAPP:recordatorio_hoy_pl;META_APPROVAL_UNVERIFIED')
+on conflict(delivery_kind,channel,site_scope) do update
+set template_key=excluded.template_key,
+    provider=excluded.provider,
+    provider_template_name=excluded.provider_template_name,
+    provider_verified=excluded.provider_verified,
+    active=true,
+    evidence_ref=excluded.evidence_ref,
+    updated_at=now();
+
+create table if not exists public.aos_agenda_delivery_outbox_v3 (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  agenda_event_id uuid not null references public.aos_agenda_events_v2(id),
+  operation_id uuid not null references public.aos_booking_operations_v2(id),
+  appointment_id text not null,
+  schedule_revision text not null,
+  delivery_kind text not null check (delivery_kind in ('CONFIRMATION','REPROGRAMMATION','REMINDER_TOMORROW','REMINDER_TODAY')),
+  channel text not null check (channel in ('EMAIL','WHATSAPP')),
+  provider text not null check (provider in ('RESEND','META_CLOUD_API')),
+  template_key text not null,
+  provider_template_name text null,
+  provider_template_verified boolean not null default false,
+  recipient_email text null,
+  recipient_phone text null,
+  payload jsonb not null default '{}'::jsonb,
+  state text not null default 'DORMANT' check (state in ('DORMANT','READY','CLAIMED','ACCEPTED','FAILED','SUPERSEDED','SKIPPED')),
+  blocking_reason text null,
+  available_at timestamptz not null default now(),
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  provider_message_id text null,
+  last_error text null,
+  last_attempt_at timestamptz null,
+  accepted_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check ((channel='EMAIL' and recipient_email is not null) or (channel='WHATSAPP' and recipient_phone is not null))
+);
+
+create index if not exists idx_aos_agenda_delivery_outbox_v3_appointment
+  on public.aos_agenda_delivery_outbox_v3(appointment_id,created_at desc);
+create index if not exists idx_aos_agenda_delivery_outbox_v3_state
+  on public.aos_agenda_delivery_outbox_v3(state,available_at,created_at)
+  where state in ('DORMANT','READY','FAILED');
+create index if not exists idx_aos_agenda_delivery_outbox_v3_revision
+  on public.aos_agenda_delivery_outbox_v3(appointment_id,schedule_revision,delivery_kind,channel);
+
+create table if not exists public.aos_agenda_delivery_errors_v3 (
+  id uuid primary key default gen_random_uuid(),
+  agenda_event_id uuid null,
+  appointment_id text null,
+  error_code text not null,
+  error_detail text null,
+  created_at timestamptz not null default now()
+);
+
+revoke all on table public.aos_agenda_delivery_template_registry_v3 from public,anon,authenticated;
+revoke all on table public.aos_agenda_delivery_outbox_v3 from public,anon,authenticated;
+revoke all on table public.aos_agenda_delivery_errors_v3 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_agenda_delivery_template_registry_v3 to service_role;
+grant select,insert,update,delete on table public.aos_agenda_delivery_outbox_v3 to service_role;
+grant select,insert on table public.aos_agenda_delivery_errors_v3 to service_role;
+
+create or replace function public.aos_agenda_delivery_insert_intent_v3(
+  p_agenda_event_id uuid,
+  p_operation_id uuid,
+  p_appointment_id text,
+  p_schedule_revision text,
+  p_delivery_kind text,
+  p_channel text,
+  p_site text,
+  p_recipient_email text,
+  p_recipient_phone text,
+  p_payload jsonb
+)
+returns boolean
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_kind text:=upper(btrim(coalesce(p_delivery_kind,'')));
+  v_channel text:=upper(btrim(coalesce(p_channel,'')));
+  v_site text:=upper(replace(btrim(coalesce(p_site,'')),'_',' '));
+  v_tpl public.aos_agenda_delivery_template_registry_v3%rowtype;
+  v_email text:=nullif(lower(btrim(coalesce(p_recipient_email,''))),'');
+  v_phone text:=regexp_replace(coalesce(p_recipient_phone,''),'[^0-9]','','g');
+  v_key text;
+  v_inserted uuid;
+  v_block text;
+begin
+  if p_agenda_event_id is null or p_operation_id is null or coalesce(btrim(p_appointment_id),'')='' or coalesce(btrim(p_schedule_revision),'')='' then
+    return false;
+  end if;
+
+  select * into v_tpl
+  from public.aos_agenda_delivery_template_registry_v3 t
+  where t.active=true
+    and t.delivery_kind=v_kind
+    and t.channel=v_channel
+    and t.site_scope in (v_site,'*')
+  order by case when t.site_scope=v_site then 0 else 1 end
+  limit 1;
+  if not found then return false; end if;
+
+  if v_channel='EMAIL' then
+    if v_email is null or v_email !~* '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$' then return false; end if;
+  elsif v_channel='WHATSAPP' then
+    if length(v_phone)<7 then return false; end if;
+  else
+    return false;
+  end if;
+
+  v_key:='agv2-l3:'||p_schedule_revision||':'||v_kind||':'||v_channel;
+  v_block:='L4_DISPATCH_AUTHORITY_REQUIRED';
+  if v_tpl.provider_verified is not true then
+    v_block:=v_block||'|PROVIDER_TEMPLATE_APPROVAL_UNVERIFIED';
+  end if;
+
+  insert into public.aos_agenda_delivery_outbox_v3(
+    idempotency_key,agenda_event_id,operation_id,appointment_id,schedule_revision,
+    delivery_kind,channel,provider,template_key,provider_template_name,provider_template_verified,
+    recipient_email,recipient_phone,payload,state,blocking_reason
+  ) values (
+    v_key,p_agenda_event_id,p_operation_id,p_appointment_id,p_schedule_revision,
+    v_kind,v_channel,v_tpl.provider,v_tpl.template_key,v_tpl.provider_template_name,v_tpl.provider_verified,
+    case when v_channel='EMAIL' then v_email else null end,
+    case when v_channel='WHATSAPP' then v_phone else null end,
+    coalesce(p_payload,'{}'::jsonb),'DORMANT',v_block
+  )
+  on conflict(idempotency_key) do nothing
+  returning id into v_inserted;
+
+  return v_inserted is not null;
+end
+$$;
+
+create or replace function public.aos_agenda_delivery_enqueue_event_v3(p_event_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_e public.aos_agenda_events_v2%rowtype;
+  v_c public.aos_agenda_citas%rowtype;
+  v_kind text;
+  v_email text;
+  v_phone text;
+  v_payload jsonb;
+  v_email_added boolean:=false;
+  v_wa_added boolean:=false;
+begin
+  select * into v_e from public.aos_agenda_events_v2 where id=p_event_id;
+  if not found then return jsonb_build_object('ok',false,'error','L3_EVENT_NOT_FOUND'); end if;
+  if v_e.event_type not in ('BOOKED','RESCHEDULED') then return jsonb_build_object('ok',false,'error','L3_EVENT_NOT_DELIVERABLE'); end if;
+
+  select * into v_c from public.aos_agenda_citas where id=v_e.appointment_id;
+  if not found then return jsonb_build_object('ok',false,'error','L3_APPOINTMENT_NOT_FOUND'); end if;
+
+  v_kind:=case when v_e.event_type='BOOKED' then 'CONFIRMATION' else 'REPROGRAMMATION' end;
+  v_email:=nullif(lower(btrim(coalesce(v_c.correo,''))),'');
+  v_phone:=regexp_replace(coalesce(v_c.numero_limpio,v_c.numero,''),'[^0-9]','','g');
+
+  -- A rebook invalidates any unsent intent generated from an older schedule revision.
+  if v_e.event_type='RESCHEDULED' then
+    update public.aos_agenda_delivery_outbox_v3
+       set state='SUPERSEDED',blocking_reason='SUPERSEDED_BY_RESCHEDULE',updated_at=now()
+     where appointment_id=v_e.appointment_id
+       and schedule_revision<>v_e.id::text
+       and state in ('DORMANT','READY','FAILED')
+       and provider_message_id is null;
+  end if;
+
+  v_payload:=jsonb_build_object(
+    'appointment_id',v_c.id,
+    'event_id',v_e.id,
+    'event_type',v_e.event_type,
+    'name',btrim(concat_ws(' ',v_c.nombre,v_c.apellido)),
+    'treatment',v_c.tratamiento,
+    'site',v_c.sede,
+    'date',v_c.fecha_cita,
+    'time',substring(coalesce(v_c.hora_cita,'') from 1 for 5),
+    'status',v_c.estado_cita,
+    'professional_name',v_c.doctora,
+    'professional_role',v_c.tipo_atencion,
+    'reason',v_e.reason,
+    'source_channel',v_e.channel
+  );
+
+  v_email_added:=public.aos_agenda_delivery_insert_intent_v3(
+    v_e.id,v_e.operation_id,v_e.appointment_id,v_e.id::text,v_kind,'EMAIL',v_c.sede,v_email,v_phone,v_payload
+  );
+  v_wa_added:=public.aos_agenda_delivery_insert_intent_v3(
+    v_e.id,v_e.operation_id,v_e.appointment_id,v_e.id::text,v_kind,'WHATSAPP',v_c.sede,v_email,v_phone,v_payload
+  );
+
+  return jsonb_build_object(
+    'ok',true,'event_id',v_e.id,'appointment_id',v_e.appointment_id,'delivery_kind',v_kind,
+    'email_added',v_email_added,'whatsapp_added',v_wa_added,'dispatch_state','DORMANT_L4_REQUIRED'
+  );
+end
+$$;
+
+create or replace function public.aos_agenda_delivery_event_trigger_v3()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+begin
+  begin
+    perform public.aos_agenda_delivery_enqueue_event_v3(new.id);
+  exception when others then
+    -- Delivery projection is repairable from the append-only event ledger. Never roll back a booking.
+    begin
+      insert into public.aos_agenda_delivery_errors_v3(agenda_event_id,appointment_id,error_code,error_detail)
+      values(new.id,new.appointment_id,'L3_ENQUEUE_FAILED',left(sqlerrm,1000));
+    exception when others then
+      null;
+    end;
+  end;
+  return new;
+end
+$$;
+
+drop trigger if exists trg_aos_agenda_delivery_event_v3 on public.aos_agenda_events_v2;
+create trigger trg_aos_agenda_delivery_event_v3
+after insert on public.aos_agenda_events_v2
+for each row execute function public.aos_agenda_delivery_event_trigger_v3();
+
+create or replace function public.aos_agenda_delivery_reconcile_v3(p_limit integer default 500)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_e record;
+  v_limit integer:=greatest(1,least(coalesce(p_limit,500),2000));
+  v_scanned integer:=0;
+  v_ok integer:=0;
+  v_r jsonb;
+begin
+  for v_e in
+    select e.id
+    from public.aos_agenda_events_v2 e
+    where e.event_type in ('BOOKED','RESCHEDULED')
+    order by e.created_at,e.id
+    limit v_limit
+  loop
+    v_scanned:=v_scanned+1;
+    begin
+      v_r:=public.aos_agenda_delivery_enqueue_event_v3(v_e.id);
+      if coalesce((v_r->>'ok')::boolean,false) then v_ok:=v_ok+1; end if;
+    exception when others then
+      begin
+        insert into public.aos_agenda_delivery_errors_v3(agenda_event_id,error_code,error_detail)
+        values(v_e.id,'L3_RECONCILE_FAILED',left(sqlerrm,1000));
+      exception when others then null; end;
+    end;
+  end loop;
+  return jsonb_build_object('ok',true,'scanned',v_scanned,'reconciled',v_ok);
+end
+$$;
+
+create or replace function public.aos_agenda_delivery_materialize_reminders_v3(
+  p_now timestamptz default now(),
+  p_limit integer default 500
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_local_date date:=(coalesce(p_now,now()) at time zone 'America/Lima')::date;
+  v_limit integer:=greatest(1,least(coalesce(p_limit,500),2000));
+  v_c public.aos_agenda_citas%rowtype;
+  v_e public.aos_agenda_events_v2%rowtype;
+  v_kind text;
+  v_email text;
+  v_phone text;
+  v_payload jsonb;
+  v_email_added boolean;
+  v_wa_added boolean;
+  v_scanned integer:=0;
+  v_inserted integer:=0;
+begin
+  for v_c in
+    select c.*
+    from public.aos_agenda_citas c
+    where c.fecha_cita in (v_local_date,v_local_date+1)
+      and upper(coalesce(c.estado_cita,'PENDIENTE')) in ('PENDIENTE','CITA CONFIRMADA')
+      and exists(select 1 from public.aos_agenda_events_v2 e where e.appointment_id=c.id)
+    order by c.fecha_cita,substring(coalesce(c.hora_cita,'') from 1 for 5),c.id
+    limit v_limit
+  loop
+    v_scanned:=v_scanned+1;
+    select * into v_e
+    from public.aos_agenda_events_v2 e
+    where e.appointment_id=v_c.id
+    order by e.created_at desc,e.id desc
+    limit 1;
+    if not found then continue; end if;
+
+    v_kind:=case when v_c.fecha_cita=v_local_date then 'REMINDER_TODAY' else 'REMINDER_TOMORROW' end;
+    v_email:=nullif(lower(btrim(coalesce(v_c.correo,''))),'');
+    v_phone:=regexp_replace(coalesce(v_c.numero_limpio,v_c.numero,''),'[^0-9]','','g');
+    v_payload:=jsonb_build_object(
+      'appointment_id',v_c.id,
+      'event_id',v_e.id,
+      'event_type',v_e.event_type,
+      'name',btrim(concat_ws(' ',v_c.nombre,v_c.apellido)),
+      'treatment',v_c.tratamiento,
+      'site',v_c.sede,
+      'date',v_c.fecha_cita,
+      'time',substring(coalesce(v_c.hora_cita,'') from 1 for 5),
+      'status',v_c.estado_cita,
+      'professional_name',v_c.doctora,
+      'professional_role',v_c.tipo_atencion,
+      'reminder_local_date',v_local_date
+    );
+
+    v_email_added:=public.aos_agenda_delivery_insert_intent_v3(
+      v_e.id,v_e.operation_id,v_c.id,v_e.id::text,v_kind,'EMAIL',v_c.sede,v_email,v_phone,v_payload
+    );
+    v_wa_added:=public.aos_agenda_delivery_insert_intent_v3(
+      v_e.id,v_e.operation_id,v_c.id,v_e.id::text,v_kind,'WHATSAPP',v_c.sede,v_email,v_phone,v_payload
+    );
+    v_inserted:=v_inserted + case when v_email_added then 1 else 0 end + case when v_wa_added then 1 else 0 end;
+  end loop;
+
+  return jsonb_build_object(
+    'ok',true,'local_date',v_local_date,'appointments_scanned',v_scanned,
+    'intents_inserted',v_inserted,'dispatch_state','DORMANT_L4_REQUIRED'
+  );
+end
+$$;
+
+create or replace function public.aos_agenda_delivery_audit_v3()
+returns jsonb
+language sql
+stable
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+  select jsonb_build_object(
+    'template_registry_total',(select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true),
+    'template_provider_verified',(select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true and provider_verified=true),
+    'template_provider_unverified',(select count(*) from public.aos_agenda_delivery_template_registry_v3 where active=true and provider_verified=false),
+    'outbox_total',(select count(*) from public.aos_agenda_delivery_outbox_v3),
+    'dormant',(select count(*) from public.aos_agenda_delivery_outbox_v3 where state='DORMANT'),
+    'accepted',(select count(*) from public.aos_agenda_delivery_outbox_v3 where state='ACCEPTED'),
+    'superseded',(select count(*) from public.aos_agenda_delivery_outbox_v3 where state='SUPERSEDED'),
+    'projection_errors',(select count(*) from public.aos_agenda_delivery_errors_v3),
+    'dispatch_boundary','L4_AUTHORITY_REQUIRED'
+  );
+$$;
+
+revoke all on function public.aos_agenda_delivery_insert_intent_v3(uuid,uuid,text,text,text,text,text,text,text,jsonb) from public,anon,authenticated;
+revoke all on function public.aos_agenda_delivery_enqueue_event_v3(uuid) from public,anon,authenticated;
+revoke all on function public.aos_agenda_delivery_event_trigger_v3() from public,anon,authenticated;
+revoke all on function public.aos_agenda_delivery_reconcile_v3(integer) from public,anon,authenticated;
+revoke all on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) from public,anon,authenticated;
+revoke all on function public.aos_agenda_delivery_audit_v3() from public,anon,authenticated;
+grant execute on function public.aos_agenda_delivery_insert_intent_v3(uuid,uuid,text,text,text,text,text,text,text,jsonb) to service_role;
+grant execute on function public.aos_agenda_delivery_enqueue_event_v3(uuid) to service_role;
+grant execute on function public.aos_agenda_delivery_reconcile_v3(integer) to service_role;
+grant execute on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) to service_role;
+grant execute on function public.aos_agenda_delivery_audit_v3() to service_role;
+
+comment on table public.aos_agenda_delivery_outbox_v3 is 'WA-AUTO L3 durable/idempotent post-booking delivery intents. Provider dispatch remains dormant until L4 authority.';
+comment on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) is 'Materializes TODAY/TOMORROW reminder intents for V2-booked appointments; does not send them.';
+comment on function public.aos_agenda_delivery_event_trigger_v3() is 'Fail-soft projection from append-only Agenda V2 events. Delivery projection failure must never roll back booking.';
+
+commit;

--- a/supabase/migrations/20260901193500_agv2_l3_active_revision_fix_v3.sql
+++ b/supabase/migrations/20260901193500_agv2_l3_active_revision_fix_v3.sql
@@ -1,0 +1,128 @@
+-- ASCENDA OS · WA-AUTO L3 — deterministic active schedule revision
+-- PostgreSQL now() is transaction-stable, so BOOKED and RESCHEDULED events created
+-- in one transaction may share created_at. Reminder materialization must therefore
+-- resolve the active non-superseded delivery revision, not guess from timestamps.
+
+begin;
+
+create or replace function public.aos_agenda_delivery_materialize_reminders_v3(
+  p_now timestamptz default now(),
+  p_limit integer default 500
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path='pg_catalog','public','pg_temp'
+as $$
+declare
+  v_local_date date:=(coalesce(p_now,now()) at time zone 'America/Lima')::date;
+  v_limit integer:=greatest(1,least(coalesce(p_limit,500),2000));
+  v_c public.aos_agenda_citas%rowtype;
+  v_e public.aos_agenda_events_v2%rowtype;
+  v_kind text;
+  v_email text;
+  v_phone text;
+  v_payload jsonb;
+  v_email_added boolean;
+  v_wa_added boolean;
+  v_scanned integer:=0;
+  v_inserted integer:=0;
+begin
+  for v_c in
+    select c.*
+    from public.aos_agenda_citas c
+    where c.fecha_cita in (v_local_date,v_local_date+1)
+      and upper(coalesce(c.estado_cita,'PENDIENTE')) in ('PENDIENTE','CITA CONFIRMADA')
+      and exists(select 1 from public.aos_agenda_events_v2 e where e.appointment_id=c.id)
+    order by c.fecha_cita,substring(coalesce(c.hora_cita,'') from 1 for 5),c.id
+    limit v_limit
+  loop
+    v_scanned:=v_scanned+1;
+
+    -- The active schedule revision is the BOOK/REBOOK revision whose post-commit
+    -- confirmation/reprogramming intent has not been superseded. This is deterministic
+    -- even when multiple event rows share the same transaction-stable created_at.
+    select e.* into v_e
+    from public.aos_agenda_events_v2 e
+    where e.appointment_id=v_c.id
+      and e.event_type in ('BOOKED','RESCHEDULED')
+      and exists (
+        select 1
+        from public.aos_agenda_delivery_outbox_v3 o
+        where o.agenda_event_id=e.id
+          and o.schedule_revision=e.id::text
+          and o.delivery_kind in ('CONFIRMATION','REPROGRAMMATION')
+          and o.state<>'SUPERSEDED'
+      )
+    order by
+      case when e.event_type='RESCHEDULED' then 0 else 1 end,
+      e.created_at desc,
+      e.id desc
+    limit 1;
+
+    if not found then
+      -- Projection may have failed transiently. Reconcile once from the append-only
+      -- event ledger and retry active-revision resolution without touching the booking.
+      perform public.aos_agenda_delivery_reconcile_v3(2000);
+      select e.* into v_e
+      from public.aos_agenda_events_v2 e
+      where e.appointment_id=v_c.id
+        and e.event_type in ('BOOKED','RESCHEDULED')
+        and exists (
+          select 1
+          from public.aos_agenda_delivery_outbox_v3 o
+          where o.agenda_event_id=e.id
+            and o.schedule_revision=e.id::text
+            and o.delivery_kind in ('CONFIRMATION','REPROGRAMMATION')
+            and o.state<>'SUPERSEDED'
+        )
+      order by
+        case when e.event_type='RESCHEDULED' then 0 else 1 end,
+        e.created_at desc,
+        e.id desc
+      limit 1;
+    end if;
+    if not found then continue; end if;
+
+    v_kind:=case when v_c.fecha_cita=v_local_date then 'REMINDER_TODAY' else 'REMINDER_TOMORROW' end;
+    v_email:=nullif(lower(btrim(coalesce(v_c.correo,''))),'');
+    v_phone:=regexp_replace(coalesce(v_c.numero_limpio,v_c.numero,''),'[^0-9]','','g');
+    v_payload:=jsonb_build_object(
+      'appointment_id',v_c.id,
+      'event_id',v_e.id,
+      'event_type',v_e.event_type,
+      'name',btrim(concat_ws(' ',v_c.nombre,v_c.apellido)),
+      'treatment',v_c.tratamiento,
+      'site',v_c.sede,
+      'date',v_c.fecha_cita,
+      'time',substring(coalesce(v_c.hora_cita,'') from 1 for 5),
+      'status',v_c.estado_cita,
+      'professional_name',v_c.doctora,
+      'professional_role',v_c.tipo_atencion,
+      'reminder_local_date',v_local_date,
+      'schedule_revision',v_e.id
+    );
+
+    v_email_added:=public.aos_agenda_delivery_insert_intent_v3(
+      v_e.id,v_e.operation_id,v_c.id,v_e.id::text,v_kind,'EMAIL',v_c.sede,v_email,v_phone,v_payload
+    );
+    v_wa_added:=public.aos_agenda_delivery_insert_intent_v3(
+      v_e.id,v_e.operation_id,v_c.id,v_e.id::text,v_kind,'WHATSAPP',v_c.sede,v_email,v_phone,v_payload
+    );
+    v_inserted:=v_inserted + case when v_email_added then 1 else 0 end + case when v_wa_added then 1 else 0 end;
+  end loop;
+
+  return jsonb_build_object(
+    'ok',true,'local_date',v_local_date,'appointments_scanned',v_scanned,
+    'intents_inserted',v_inserted,'dispatch_state','DORMANT_L4_REQUIRED'
+  );
+end
+$$;
+
+revoke all on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) from public,anon,authenticated;
+grant execute on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) to service_role;
+
+comment on function public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer) is
+'Materializes TODAY/TOMORROW reminder intents for the active non-superseded V2 schedule revision; never dispatches providers.';
+
+commit;

--- a/supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql
+++ b/supabase/rollbacks/20260901193000_agv2_l3_delivery_outbox_v3_rollback.sql
@@ -1,0 +1,19 @@
+-- ASCENDA OS · WA-AUTO L3 rollback
+-- Removes only L3 projection/outbox objects. Does not mutate Agenda appointments or V2 booking/event ledgers.
+
+begin;
+
+drop trigger if exists trg_aos_agenda_delivery_event_v3 on public.aos_agenda_events_v2;
+
+drop function if exists public.aos_agenda_delivery_audit_v3();
+drop function if exists public.aos_agenda_delivery_materialize_reminders_v3(timestamptz,integer);
+drop function if exists public.aos_agenda_delivery_reconcile_v3(integer);
+drop function if exists public.aos_agenda_delivery_event_trigger_v3();
+drop function if exists public.aos_agenda_delivery_enqueue_event_v3(uuid);
+drop function if exists public.aos_agenda_delivery_insert_intent_v3(uuid,uuid,text,text,text,text,text,text,text,jsonb);
+
+drop table if exists public.aos_agenda_delivery_errors_v3;
+drop table if exists public.aos_agenda_delivery_outbox_v3;
+drop table if exists public.aos_agenda_delivery_template_registry_v3;
+
+commit;


### PR DESCRIPTION
Implements WA-AUTO L3 as a dormant, durable post-booking delivery layer on top of merged L1/L2.

Contract:
- BOOKED/RESCHEDULED Agenda V2 events project idempotent EMAIL + WHATSAPP delivery intents.
- Projection is fail-soft: delivery projection errors never roll back booking; the append-only event ledger remains repair authority.
- REBOOK supersedes unsent stale-revision intents.
- TODAY/TOMORROW reminders materialize in America/Lima and only for appointments represented in the V2 event ledger.
- Email logical contracts reuse current transactional types (`confirmacion_cita`, `reprogramacion`, `recordatorio_manana`, `recordatorio_hoy`).
- WhatsApp reuses existing internal template keys where available, but Meta approval remains explicitly unverified/fail-closed.
- All intents remain `DORMANT`; no provider dispatch, scheduler, autonomous send, or routing activation is introduced. L4 owns dispatch authority / kill switch.
- Includes rollback, deterministic FULL LOCAL canaries, idempotency/rebook/reminder tests and local lint.

Baseline before L3: main `3c8114f80ed3bbd3d8777c3c3469405c45aed8c0`; Agenda 3192 total / 29 today-future; V2 ops/events 0/0; Copilot ON, auto-reply OFF, AI-send OFF, auto-routing OFF.