### PR TITLE
P0: stabilize Agenda/Call Center runtime after L3

### DIFF
--- a/app/public/calls-performance-v1.js
+++ b/app/public/calls-performance-v1.js
@@ -43,8 +43,11 @@ function install(){
     var actual=fn==='aos_siguiente_lead_v2'?'aos_siguiente_lead':fn;
     var isWrite=/^aos_callcenter_(commit|confirm)_/.test(actual);
     var ms=ttl[actual]||0;
+    // Lead selection must never be TTL-cached because the next lead is mutable,
+    // but concurrent selectors are still coalesced to one server call.
+    var coalesceOnly=actual==='aos_siguiente_lead';
 
-    if(!ms){
+    if(!ms&&!coalesceOnly){
       return base(actual,p,function(d){
         if(isWrite&&d&&d.ok===true)clearOperationalCache();
         if(ok)ok(d);
@@ -52,7 +55,7 @@ function install(){
     }
 
     var key=actual+'|'+stable(p||{}),now=Date.now(),hit=cache.get(key);
-    if(hit&&now-hit.at<=ms){
+    if(ms&&hit&&now-hit.at<=ms){
       Promise.resolve().then(function(){if(ok)ok(hit.data);});
       return;
     }
@@ -64,7 +67,7 @@ function install(){
     pending.set(key,waiters);
     return base(actual,p,function(d){
       pending.delete(key);
-      cache.set(key,{at:Date.now(),data:d});
+      if(ms)cache.set(key,{at:Date.now(),data:d});
       deliver(waiters,'ok',d);
     },function(e){
       pending.delete(key);
@@ -75,8 +78,29 @@ function install(){
   perfRpc.__ccPerfV1=true;
   perfRpc.__base=base;
   window._rpc=perfRpc;
-  window.__AOS_CC_PERF_V1__={version:'v1',installedAt:new Date().toISOString(),clear:clearOperationalCache};
-  console.log('[ASCENDA][CC-PERF] P0 read coalescing + governed lead selector active');
+
+  // calls-loop6.js is replayed after the inline Call Center runtime and schedules
+  // one defensive loadLead() ~80 ms later. ccInit() has already started the real
+  // selector, so that replay can race the same expensive RPC and overwrite the UI.
+  // Suppress only this immediate post-load duplicate; retries and subsequent user
+  // actions remain untouched. The RPC layer above also single-flights later races.
+  if(typeof window.loadLead==='function'&&!window.loadLead.__ccPerfLeadGuardV1){
+    var baseLoadLead=window.loadLead;
+    var installedAt=Date.now();
+    function guardedLoadLead(_retried){
+      if(!_retried&&Date.now()-installedAt<350){
+        console.log('[ASCENDA][CC-PERF] suppressed duplicate postload lead request');
+        return;
+      }
+      return baseLoadLead.apply(this,arguments);
+    }
+    guardedLoadLead.__ccPerfLeadGuardV1=true;
+    guardedLoadLead.__base=baseLoadLead;
+    window.loadLead=guardedLoadLead;
+  }
+
+  window.__AOS_CC_PERF_V1__={version:'v1.1',installedAt:new Date().toISOString(),clear:clearOperationalCache};
+  console.log('[ASCENDA][CC-PERF] P0 read coalescing + single-flight lead selector active');
   return true;
 }
 

--- a/ci/performance/performance-guard.mjs
+++ b/ci/performance/performance-guard.mjs
@@ -39,6 +39,11 @@ expect('WA_HIDDEN_GUARD',waMulti.includes('X.busy||document.hidden'),'multiagent
 const calls=read('app/public/calls.html');
 expect('CALLS_SINGLE_PANEL_OWNER',count(calls,/_rpc\('aos_panel_asesor'/g)===1,'Calls has more than one direct aos_panel_asesor owner');
 expect('CALLS_SHARED_HELPER',calls.includes('function _panelAsesorShared('),'Calls shared snapshot helper missing');
+const callsPerf=read('app/public/calls-performance-v1.js');
+try{new Function(callsPerf);}catch(e){fail('CALLS_PERF_SYNTAX',e.message);}
+expect('CALLS_LEAD_SINGLE_FLIGHT',callsPerf.includes("var coalesceOnly=actual==='aos_siguiente_lead'"),'Call Center lead selector is not single-flight');
+expect('CALLS_LEAD_NO_TTL_CACHE',callsPerf.includes('if(ms)cache.set(key,{at:Date.now(),data:d});'),'mutable lead selector can be TTL-cached');
+expect('CALLS_POSTLOAD_DUP_GUARD',callsPerf.includes('__ccPerfLeadGuardV1')&&callsPerf.includes('suppressed duplicate postload lead request'),'postload duplicate lead guard missing');
 
 const admin=read('app/public/admin-home.html');
 expect('ADMIN_SINGLE_PANEL_OWNER',count(admin,/_r\('aos_panel_admin'/g)===1,'Admin has more than one direct aos_panel_admin owner');


### PR DESCRIPTION
## Incident
Production screenshots on 2026-09-01 showed:
- Agenda governed status save returning `HTTP_404`.
- Call Center lead/KPI loading intermittently slow or ending in `Error cargando lead`.

## Root-cause containment
- PROD PostgREST schema cache was explicitly reloaded (`NOTIFY pgrst, 'reload schema'`) after confirming the governed Agenda/Call Center RPCs exist with exact signatures and anon EXECUTE grants.
- Call Center runtime currently starts `loadLead()` in `ccInit()`, then Loop6 postload schedules another `loadLead()` ~80ms later. `aos_siguiente_lead` is the heaviest current Call Center read (~560ms mean, ~2.9s max in pg_stat_statements), so the duplicate selectors race and can overwrite UI state.

## Code hotfix
- Keep lead selection mutable (no TTL cache).
- Single-flight concurrent `aos_siguiente_lead` requests.
- Suppress only the immediate Loop6 postload duplicate within the 350ms installation boundary.
- Preserve retries and every later/user-triggered lead load.
- Preserve Loop6 governed write/credit/ownership authority unchanged.
- Add performance guard assertions + syntax validation.

## Safety boundaries
No DB mutation in this PR. No attribution changes. No sales logic changes. No Agenda/WhatsApp autonomous activation. `auto_reply=false`, `ai_send=false`, `auto_routing=false` remain untouched.

## PROD observations before PR
- No blocking DB locks.
- `aos_callcenter_prepare_action_v1`: ~44ms mean.
- `aos_agenda_set_status_v1`: ~44ms mean.
- `aos_siguiente_lead`: ~560ms mean, ~2911ms max.
- `aos_panel_asesor`: ~469ms mean, max outlier ~12.7s.
- `aos_get_historial_paciente`: ~454ms mean.
- `aos_agenda_dia`: ~211ms mean.
