### PR TITLE
P0: fix Call Center canonical session token

### DIFF
--- a/app/public/calls-performance-v1.js
+++ b/app/public/calls-performance-v1.js
@@ -12,6 +12,17 @@ function stable(v){
   return '{'+Object.keys(v).sort().map(function(k){return JSON.stringify(k)+':'+stable(v[k]);}).join(',')+'}';
 }
 
+function callCenterTokenCandidates(){
+  var out=[];
+  function add(v){v=String(v||'').trim();if(v&&out.indexOf(v)<0)out.push(v);}
+  // The F4 strong-session bridge keeps the canonical app token in sessionStorage.
+  // Prefer it over the legacy shell getter, which can remain stale after token sync.
+  try{add(sessionStorage.getItem('aos_app_token'));}catch(_e){}
+  try{if(window.AOS_getToken)add(window.AOS_getToken());}catch(_e2){}
+  try{add(window.CC&&CC.token);}catch(_e3){}
+  return out;
+}
+
 function install(){
   if(window.__AOS_CC_LOOP6_POSTLOAD_READY__!=='v2.3-postload')return false;
   if(typeof window._rpc!=='function')return false;
@@ -37,6 +48,29 @@ function install(){
     });
   }
 
+  function callBase(actual,p,ok,fail){
+    var governed=/^aos_callcenter_(prepare_action_v1|commit_action_v1|confirm_queue_appointment_v1)$/.test(actual);
+    if(!governed)return base(actual,p,ok,fail);
+
+    var candidates=callCenterTokenCandidates();
+    var i=0;
+    function attempt(){
+      var body=Object.assign({},p||{});
+      if(candidates.length)body.p_token=candidates[i++];
+      return base(actual,body,function(d){
+        // UNAUTHORIZED is a fail-closed response before any governed mutation.
+        // Retry only with the next already-present session candidate; never bypass auth.
+        if(d&&d.ok===false&&d.error==='UNAUTHORIZED'&&i<candidates.length){attempt();return;}
+        if(d&&d.ok===true&&body.p_token){
+          try{sessionStorage.setItem('aos_app_token',body.p_token);}catch(_e){}
+          if(window.CC)CC.token=body.p_token;
+        }
+        if(ok)ok(d);
+      },fail);
+    }
+    return attempt();
+  }
+
   function perfRpc(fn,p,ok,fail){
     // calls.js still invokes _v2. The certified selector is aos_siguiente_lead;
     // because `base` is Loop6, CONTACT_DEBT/lead lineage metadata is preserved.
@@ -48,7 +82,7 @@ function install(){
     var coalesceOnly=actual==='aos_siguiente_lead';
 
     if(!ms&&!coalesceOnly){
-      return base(actual,p,function(d){
+      return callBase(actual,p,function(d){
         if(isWrite&&d&&d.ok===true)clearOperationalCache();
         if(ok)ok(d);
       },fail);
@@ -65,7 +99,7 @@ function install(){
 
     var waiters=[{ok:ok,fail:fail}];
     pending.set(key,waiters);
-    return base(actual,p,function(d){
+    return callBase(actual,p,function(d){
       pending.delete(key);
       if(ms)cache.set(key,{at:Date.now(),data:d});
       deliver(waiters,'ok',d);
@@ -99,8 +133,8 @@ function install(){
     window.loadLead=guardedLoadLead;
   }
 
-  window.__AOS_CC_PERF_V1__={version:'v1.1',installedAt:new Date().toISOString(),clear:clearOperationalCache};
-  console.log('[ASCENDA][CC-PERF] P0 read coalescing + single-flight lead selector active');
+  window.__AOS_CC_PERF_V1__={version:'v1.2',installedAt:new Date().toISOString(),clear:clearOperationalCache};
+  console.log('[ASCENDA][CC-PERF] P0 read coalescing + canonical strong-session auth active');
   return true;
 }
 

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -17,6 +17,16 @@ test('Call Center waits for Loop6 and coalesces duplicated panel reads',()=>{
   assert.match(cc,/aos_horarios_semana:30000/);
 });
 
+test('Call Center governed writes prefer canonical strong-session token and fail closed',()=>{
+  const storage=cc.indexOf("sessionStorage.getItem('aos_app_token')");
+  const legacy=cc.indexOf('window.AOS_getToken');
+  assert.ok(storage>=0,'canonical app token read missing');
+  assert.ok(legacy>storage,'legacy shell token must remain fallback after canonical session token');
+  assert.match(cc,/^\s*var governed=\/\^aos_callcenter_/m);
+  assert.match(cc,/d\.error==='UNAUTHORIZED'&&i<candidates\.length/);
+  assert.doesNotMatch(cc,/UNAUTHORIZED.*ok\)ok\(\{ok:true/s);
+});
+
 test('Call Center attribution fast-path is transaction-scoped, not a global reporting filter',()=>{
   assert.match(io,/current_setting\('aos\.callcenter_phone',true\)/);
   assert.match(io,/set_config\('aos\.callcenter_phone',v_num,true\)/);


### PR DESCRIPTION
## Incident
Agenda writes are recovered, but Call Center manual booking and confirmed-appointment tipification still return `UNAUTHORIZED` for advisors.

## PROD evidence
- Affected advisor has `advisor-calls` access.
- Advisor has one active, non-revoked `PASSWORD_2FA` app session valid through 2026-09-02.
- `aos_callcenter_prepare_action_v1` is reached over HTTP 200, then returns application-level `UNAUTHORIZED`; no governed commit follows.
- Therefore DB permissions/session state are valid and the browser is selecting a stale credential before the canonical strong-session token.

## Root cause
Loop6's closure prefers `AOS_getToken()` before `sessionStorage.aos_app_token`. The F4 strong-session bridge synchronizes the canonical token into `sessionStorage`, so a stale legacy shell token can win and block all governed Call Center writes.

## Fix
- Keep Loop6 unchanged.
- In the already-certified outer Call Center runtime, build auth candidates in this order: canonical `sessionStorage.aos_app_token` -> legacy `AOS_getToken()` -> `CC.token`.
- Apply this only to governed Call Center RPCs (`prepare`, `commit`, `confirm`).
- Retry only when the server returns fail-closed `UNAUTHORIZED`, using the next already-present credential candidate.
- Persist the successful candidate back to sessionStorage/CC for self-healing.
- No auth bypass, no direct table write restoration, no attribution/ownership change.

## Safety
`auto_reply=false`, `ai_send=false`, `auto_routing=false` unchanged. No DB mutation in this PR.