### PR TITLE
P0-D: make background shield race-safe

### DIFF
--- a/.github/workflows/business-priority-p0.yml
+++ b/.github/workflows/business-priority-p0.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ascenda-zero-cost-v2]
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/business-priority-p0.yml
+++ b/.github/workflows/business-priority-p0.yml
@@ -8,6 +8,7 @@ on:
       - 'app/public/browser-business-priority-v1.js'
       - 'app/public/f4-production-canary-hotfix.js'
       - 'ci/performance/business-priority-p0.test.js'
+      - 'ci/performance/business-priority-race.test.js'
       - '.github/workflows/business-priority-p0.yml'
   push:
     branches: ['main','perf/p0-business-priority-lazy-calendar-20260901']
@@ -17,6 +18,7 @@ on:
       - 'app/public/browser-business-priority-v1.js'
       - 'app/public/f4-production-canary-hotfix.js'
       - 'ci/performance/business-priority-p0.test.js'
+      - 'ci/performance/business-priority-race.test.js'
       - '.github/workflows/business-priority-p0.yml'
 
 permissions:
@@ -37,7 +39,8 @@ jobs:
           node --check app/supabase-quota-circuit-preload.cjs
           node --check app/public/browser-business-priority-v1.js
           node --check app/public/f4-production-canary-hotfix.js
+          node --check ci/performance/business-priority-race.test.js
       - name: Regression gates
-        run: node --test ci/performance/business-priority-p0.test.js
+        run: node --test ci/performance/business-priority-p0.test.js ci/performance/business-priority-race.test.js
       - name: Existing Call Center performance gates
         run: node --test ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js

--- a/app/business-priority-preload.js
+++ b/app/business-priority-preload.js
@@ -52,9 +52,15 @@ if (!https.__AOS_BUSINESS_PRIORITY_PRELOAD_V1__) {
     return ''
   }
 
-  function stateFor() {
-    if (!states.has(SHIELD_KEY)) states.set(SHIELD_KEY, { failures: 0, openUntil: 0, lastLogUntil: 0, lastKey: '' })
+  function shieldState() {
+    if (!states.has(SHIELD_KEY)) states.set(SHIELD_KEY, { openUntil: 0, lastLogUntil: 0, lastKey: '' })
     return states.get(SHIELD_KEY)
+  }
+
+  function keyState(key) {
+    const stateKey = 'source:' + key
+    if (!states.has(stateKey)) states.set(stateKey, { failures: 0, lastFailureAt: 0, lastSuccessAt: 0 })
+    return states.get(stateKey)
   }
 
   function isFailureStatus(status) {
@@ -64,28 +70,31 @@ if (!https.__AOS_BUSINESS_PRIORITY_PRELOAD_V1__) {
 
   function markSuccess(key) {
     if (!key) return
-    const s = stateFor()
-    s.failures = 0
-    s.openUntil = 0
-    s.lastLogUntil = 0
-    s.lastKey = key
+    const k = keyState(key)
+    k.failures = 0
+    k.lastSuccessAt = Date.now()
+    // A successful sibling request must never close a shield opened by another
+    // background source. The shared cooldown expires only by time.
   }
 
   function markFailure(key, reason) {
     if (!key) return
-    const s = stateFor()
-    s.failures += 1
+    const now = Date.now()
+    const s = shieldState()
+    const k = keyState(key)
+    k.failures += 1
+    k.lastFailureAt = now
+    const wait = k.failures >= 3 ? 600000 : (k.failures === 2 ? 120000 : 30000)
     s.lastKey = key
-    const wait = s.failures >= 3 ? 600000 : (s.failures === 2 ? 120000 : 30000)
-    s.openUntil = Math.max(s.openUntil, Date.now() + wait)
-    if (Date.now() >= s.lastLogUntil) {
+    s.openUntil = Math.max(s.openUntil, now + wait)
+    if (now >= s.lastLogUntil) {
       s.lastLogUntil = s.openUntil
-      console.warn('[BUSINESS-PRIORITY] background shield open', { source: key, wait_ms: wait, failures: s.failures, reason: String(reason || 'upstream') })
+      console.warn('[BUSINESS-PRIORITY] background shield open', { source: key, wait_ms: wait, failures: k.failures, reason: String(reason || 'upstream') })
     }
   }
 
   function circuitOpen(key) {
-    return !!key && Date.now() < stateFor().openUntil
+    return !!key && Date.now() < shieldState().openUntil
   }
 
   function syntheticResponse() {
@@ -162,11 +171,11 @@ if (!https.__AOS_BUSINESS_PRIORITY_PRELOAD_V1__) {
   }
 
   global.__AOS_BUSINESS_PRIORITY_V1__ = {
-    version: 'p0-a-v1.2',
+    version: 'p0-a-v1.3',
     states: states,
     shieldKey: SHIELD_KEY,
     classify: classify
   }
 
-  console.log('[BUSINESS-PRIORITY] shared background shield active')
+  console.log('[BUSINESS-PRIORITY] race-safe shared background shield active')
 }

--- a/ci/performance/business-priority-race.test.js
+++ b/ci/performance/business-priority-race.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('fs');
+const vm=require('vm');
+const {EventEmitter}=require('events');
+
+const preload=fs.readFileSync('app/business-priority-preload.js','utf8');
+
+function harness(){
+  const fakeHttps={};
+  let baseCalls=0;
+  fakeHttps.request=function(){
+    baseCalls++;
+    const req=new EventEmitter();
+    req.write=function(){return true;};
+    req.end=function(){return req;};
+    req.setTimeout=function(){return req;};
+    req.abort=function(){return req;};
+    req.destroy=function(){return req;};
+    return req;
+  };
+  fakeHttps.get=function(){const req=fakeHttps.request.apply(fakeHttps,arguments);req.end();return req;};
+  const localGlobal={};
+  const customRequire=function(id){return id==='https'?fakeHttps:require(id);};
+  const module={exports:{}};
+  vm.runInNewContext(preload,{require:customRequire,process,console,global:localGlobal,module,exports:module.exports,URL,setTimeout,clearTimeout,Buffer},{filename:'business-priority-preload.js'});
+  return {fakeHttps,localGlobal,getBaseCalls:()=>baseCalls};
+}
+
+test('sibling success cannot close a shield opened by another background failure',()=>{
+  const h=harness();
+  const runtime=h.localGlobal.__AOS_BUSINESS_PRIORITY_V1__;
+  const host='ituyqwstonmhnfshnaqz.supabase.co';
+  const agent={hostname:host,path:'/rest/v1/aos_agentes?select=id&activo=eq.true&tipo_ejecucion=eq.cron'};
+  const push={hostname:host,path:'/rest/v1/rpc/aos_notification_push_claim_v1'};
+
+  // Reproduce the PROD race: a sibling request is already in flight when the
+  // cron scan fails and opens the shared shield.
+  const sibling=h.fakeHttps.request(push,function(){});
+  const failing=h.fakeHttps.request(agent,function(){});
+  assert.equal(h.getBaseCalls(),2);
+  failing.emit('response',{statusCode:524});
+
+  const shield=runtime.states.get(runtime.shieldKey);
+  const openedUntil=shield.openUntil;
+  assert.ok(openedUntil>Date.now());
+  assert.equal(shield.lastKey,'agent-cron-scan');
+  assert.equal(runtime.states.get('source:agent-cron-scan').failures,1);
+
+  // The sibling succeeds after the failure. This used to clear openUntil and
+  // allowed the next minute cron tick to hit Supabase again.
+  sibling.emit('response',{statusCode:200});
+  assert.equal(shield.openUntil,openedUntil,'unrelated success closed the shared cooldown');
+  assert.equal(runtime.states.get('source:notification-push-claim').failures,0);
+
+  const suppressed=h.fakeHttps.request(agent,function(){});
+  suppressed.end();
+  assert.equal(h.getBaseCalls(),2,'cron retry escaped an active shared cooldown');
+
+  h.fakeHttps.request({hostname:host,path:'/rest/v1/rpc/aos_siguiente_lead'},function(){});
+  h.fakeHttps.request({hostname:host,path:'/rest/v1/rpc/aos_callcenter_commit_action_v1'},function(){});
+  h.fakeHttps.request({hostname:host,path:'/rest/v1/rpc/aos_wa3_actor_v1'},function(){});
+  assert.equal(h.getBaseCalls(),5,'critical business traffic must remain outside the shield');
+});


### PR DESCRIPTION
P0-D live observation found a race in P0-A.2: an in-flight success from a different background source could reset the shared shield after `aos_agentes` opened it on 522/504, allowing the next cron tick to hit Supabase again.

This patch:
- keeps one shared `openUntil` cooldown;
- tracks failures per background source;
- prevents sibling successes from closing another source's cooldown;
- preserves Call Center, Agenda, Sales, WhatsApp actor/routing, and AI-key bootstrap outside the shield;
- adds a regression that reproduces the exact in-flight sibling-success race observed in PROD.

No schema/data changes. No governed-write changes.