### PR TITLE
P0.2: suppress redundant legacy Marketing LTV read

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -1,19 +1,20 @@
-/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1
+/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.1
  * Keeps the certified V4.2 controller byte-for-byte in admin-marketing-v2-core.js.
  * This bootstrap only shapes read pressure: single-flight, short-lived read cache,
- * and viewport-gating for the two expensive annual analytics (History + LTV).
+ * viewport-gating for the two expensive annual analytics (History + LTV), and
+ * suppression of the redundant legacy aos_ltv_cohortes read once V4.2 is mounted.
  */
 (function(){
 'use strict';
 
-var RELEASE='2026-09-01-p0-marketing-read-pressure-v1';
+var RELEASE='2026-09-01-p0-marketing-read-pressure-v1.1';
 var G=window.__AOS_MKT_PERF_V1;
 
 if(!G){
   var baseFetch=window.fetch.bind(window);
   var cache=new Map();
   var inflight=new Map();
-  var stats={network:0,cacheHit:0,coalesced:0,deferred:0};
+  var stats={network:0,cacheHit:0,coalesced:0,deferred:0,suppressedLegacyLtv:0};
   var targets={
     aos_marketing_dashboard:2500,
     aos_marketing_dashboard_anio:2500,
@@ -31,7 +32,7 @@ if(!G){
   };
 
   function fnFrom(url){
-    var m=String(url||'').match(/\/rest\/v1\/rpc\/(aos_marketing_[A-Za-z0-9_]+)/);
+    var m=String(url||'').match(/\/rest\/v1\/rpc\/(aos_marketing_[A-Za-z0-9_]+|aos_ltv_cohortes)/);
     return m?m[1]:'';
   }
   function aborted(signal){return !!(signal&&signal.aborted);}
@@ -80,11 +81,24 @@ if(!G){
     if(typeof b==='string')return b;
     return b==null?'':String(b);
   }
+  function emptyJsonResponse(){
+    return new Response('{}',{status:200,headers:{'Content-Type':'application/json'}});
+  }
 
   window.fetch=function(input,init){
     var url=typeof input==='string'?input:(input&&input.url)||'';
     var fn=fnFrom(url);
     var method=String((init&&init.method)||'GET').toUpperCase();
+
+    // V4.2 owns History/LTV rendering. The legacy mkL() still asks aos_ltv_cohortes
+    // only to feed rHist/rLTV callbacks that V4.2 already intercepts and ignores.
+    // Once V4.2 is mounted, return an empty successful payload locally instead of
+    // spending ~0.7-1.1s of Supabase work on every month switch.
+    if(method==='POST'&&fn==='aos_ltv_cohortes'&&window.__AOS_MKT4){
+      stats.suppressedLegacyLtv++;
+      return Promise.resolve(emptyJsonResponse());
+    }
+
     if(method!=='POST'||!Object.prototype.hasOwnProperty.call(targets,fn))return baseFetch(input,init);
 
     var signal=init&&init.signal;

--- a/ci/performance/marketing-read-pressure.test.js
+++ b/ci/performance/marketing-read-pressure.test.js
@@ -30,6 +30,14 @@ test('expensive annual analytics are viewport gated',()=>{
   assert.match(boot,/setTimeout\(finish,12000\)/);
 });
 
+test('legacy LTV cohort read is suppressed only after V4.2 owns rendering',()=>{
+  assert.match(boot,/aos_ltv_cohortes/);
+  assert.match(boot,/fn==='aos_ltv_cohortes'&&window\.__AOS_MKT4/);
+  assert.match(boot,/suppressedLegacyLtv/);
+  assert.match(boot,/emptyJsonResponse/);
+  assert.doesNotMatch(core,/suppressedLegacyLtv/);
+});
+
 test('bootstrap adds no recurrent polling and core keeps canonical RPCs',()=>{
   assert.doesNotMatch(boot,/setInterval\s*\(/);
   assert.match(core,/aos_marketing_period_summary_v2/);


### PR DESCRIPTION
Follow-up to PR #424 after real production smoke.

Observed during month switching after P0:
- V4.2 `aos_marketing_historico_public_v2`: only once ✅
- V4.2 `aos_marketing_ltv_public_v2`: only once ✅
- legacy `aos_ltv_cohortes`: still once per month switch, ~690.7 ms mean / 1091.8 ms max.

The legacy result is redundant after V4.2 mounts: the core hooks `rHist`/`rLTV` and renders from canonical V4.2 state. This PR makes the bootstrap recognize `aos_ltv_cohortes` and returns an empty successful JSON payload locally only when `window.__AOS_MKT4` is already mounted. If V4.2 is not mounted, legacy behavior is untouched.

No SQL changes, no KPI/formula changes, no polling, no timeout changes.