### PR TITLE
P0.3: stabilize Marketing attribution and intent reads

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -1,20 +1,22 @@
-/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.1
+/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.2
  * Keeps the certified V4.2 controller byte-for-byte in admin-marketing-v2-core.js.
  * This bootstrap only shapes read pressure: single-flight, short-lived read cache,
- * viewport-gating for the two expensive annual analytics (History + LTV), and
- * suppression of the redundant legacy aos_ltv_cohortes read once V4.2 is mounted.
+ * viewport-gating for the two expensive annual analytics (History + LTV),
+ * suppression of the redundant legacy aos_ltv_cohortes read once V4.2 is mounted,
+ * and one-at-a-time execution for heavy monthly attribution/intent reads.
  */
 (function(){
 'use strict';
 
-var RELEASE='2026-09-01-p0-marketing-read-pressure-v1.1';
+var RELEASE='2026-09-02-p0-marketing-read-pressure-v1.2';
 var G=window.__AOS_MKT_PERF_V1;
 
 if(!G){
   var baseFetch=window.fetch.bind(window);
   var cache=new Map();
   var inflight=new Map();
-  var stats={network:0,cacheHit:0,coalesced:0,deferred:0,suppressedLegacyLtv:0};
+  var insightTail=Promise.resolve();
+  var stats={network:0,cacheHit:0,coalesced:0,deferred:0,suppressedLegacyLtv:0,serializedInsights:0};
   var targets={
     aos_marketing_dashboard:2500,
     aos_marketing_dashboard_anio:2500,
@@ -29,6 +31,11 @@ if(!G){
   var lazy={
     aos_marketing_historico_public_v2:'#mk-hist',
     aos_marketing_ltv_public_v2:'#mk-ltv'
+  };
+  var serialInsights={
+    aos_marketing_attribution_public_v3:true,
+    aos_marketing_intent_public_v2:true,
+    aos_marketing_intent_detail_public_v3:true
   };
 
   function fnFrom(url){
@@ -84,6 +91,24 @@ if(!G){
   function emptyJsonResponse(){
     return new Response('{}',{status:200,headers:{'Content-Type':'application/json'}});
   }
+  function withoutSignal(init){
+    var x={};
+    Object.keys(init||{}).forEach(function(k){if(k!=='signal')x[k]=init[k];});
+    return x;
+  }
+  function runSerializedInsight(input,init,signal){
+    var queued=insightTail.catch(function(){}).then(function(){
+      if(aborted(signal))throw abortError();
+      stats.serializedInsights++;
+      stats.network++;
+      // Once a read-only insight reaches PostgREST, do not abort the HTTP request.
+      // Aborting fetch does not reliably cancel the PostgreSQL statement and can let
+      // the next month overlap it. The V4.2 cycle guard still discards stale results.
+      return baseFetch(input,withoutSignal(init)).then(snap);
+    });
+    insightTail=queued.then(function(){},function(){});
+    return queued;
+  }
 
   window.fetch=function(input,init){
     var url=typeof input==='string'?input:(input&&input.url)||'';
@@ -119,9 +144,10 @@ if(!G){
     if(lazy[fn])p=p.then(function(){return waitVisible(lazy[fn],signal);});
     p=p.then(function(){
       if(aborted(signal))throw abortError();
+      if(serialInsights[fn])return runSerializedInsight(input,init,signal);
       stats.network++;
-      return baseFetch(input,init);
-    }).then(snap).then(function(x){
+      return baseFetch(input,init).then(snap);
+    }).then(function(x){
       cache.set(key,{ts:Date.now(),snap:x});
       return x;
     }).finally(function(){inflight.delete(key);});

--- a/ci/performance/marketing-read-pressure.test.js
+++ b/ci/performance/marketing-read-pressure.test.js
@@ -4,6 +4,7 @@ const test=require('node:test');
 const assert=require('node:assert/strict');
 const boot=fs.readFileSync('app/public/admin-marketing-v2.js','utf8');
 const core=fs.readFileSync('app/public/admin-marketing-v2-core.js','utf8');
+const migration=fs.readFileSync('supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql','utf8');
 
 test('preserves certified Marketing V4.2 core',()=>{
   assert.match(boot,/admin-marketing-v2-core\.js/);
@@ -36,6 +37,30 @@ test('legacy LTV cohort read is suppressed only after V4.2 owns rendering',()=>{
   assert.match(boot,/suppressedLegacyLtv/);
   assert.match(boot,/emptyJsonResponse/);
   assert.doesNotMatch(core,/suppressedLegacyLtv/);
+});
+
+test('monthly attribution and intent insights share one serialized lane',()=>{
+  assert.match(boot,/var insightTail=Promise\.resolve\(\)/);
+  assert.match(boot,/var serialInsights=\{/);
+  assert.match(boot,/aos_marketing_attribution_public_v3:true/);
+  assert.match(boot,/aos_marketing_intent_public_v2:true/);
+  assert.match(boot,/aos_marketing_intent_detail_public_v3:true/);
+  assert.match(boot,/function runSerializedInsight\(/);
+  assert.match(boot,/function withoutSignal\(/);
+  assert.match(boot,/baseFetch\(input,withoutSignal\(init\)\)/);
+  assert.match(boot,/insightTail=queued\.then/);
+  assert.match(boot,/serializedInsights/);
+});
+
+test('confirmed-call lookup index is partial and formula-neutral',()=>{
+  assert.match(migration,/idx_aos_llamadas_mkt_confirmed_phone_advisor_v1/);
+  assert.match(migration,/numero_limpio/);
+  assert.match(migration,/upper\(coalesce\(asesor,''\)\)/);
+  assert.match(migration,/where upper\(coalesce\(estado,''\)\)='CITA CONFIRMADA'/);
+  assert.match(migration,/include \(id, lead_id_origen, fecha, hora_llamada, created_at, ult_ts, ts_log\)/);
+  assert.doesNotMatch(migration,/statement_timeout/i);
+  assert.doesNotMatch(migration,/create or replace function/i);
+  assert.doesNotMatch(migration,/update\s+public\./i);
 });
 
 test('bootstrap adds no recurrent polling and core keeps canonical RPCs',()=>{

--- a/supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql
+++ b/supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql
@@ -1,0 +1,14 @@
+-- ASCENDA OS · Marketing P0.3
+-- Read-path only: accelerate Call Center appointment -> confirmed call lookup used by
+-- aos_marketing_call_cita_match_v2 / attribution / intent analytics.
+-- No business-rule, attribution-formula, timeout, or data mutation change.
+
+create index if not exists idx_aos_llamadas_mkt_confirmed_phone_advisor_v1
+  on public.aos_llamadas (
+    numero_limpio,
+    (upper(coalesce(asesor,'')))
+  )
+  include (id, lead_id_origen, fecha, hora_llamada, created_at, ult_ts, ts_log)
+  where upper(coalesce(estado,''))='CITA CONFIRMADA';
+
+analyze public.aos_llamadas;


### PR DESCRIPTION
Follow-up to P0.2 after real production smoke.

Observed LIVE after PR #425:
- legacy `aos_ltv_cohortes`: zero repeated network calls ✅
- `aos_marketing_historico_public_v2`: one 200 ✅
- `aos_marketing_ltv_public_v2`: one 200 ✅
- one AUG→JUL transition produced HTTP 500 on attribution + intent + intent detail.
- PostgreSQL logs confirmed all three as `canceling statement due to statement timeout`.
- next JUL→JUN transition recovered to HTTP 200, matching the user's perceived latency difference.

Diagnosis:
- `aos_marketing_attribution_public_v3` averages ~1.10s and has reached ~2.21s; intent reads add more concurrent pressure.
- EXPLAIN ANALYZE for July showed the dominant cost inside `aos_marketing_call_lead_match_v2` / `aos_marketing_call_cita_match_v2`, especially confirmed-call lookup by phone+advisor+time.
- PROD has 36,942 calls, only 1,887 `CITA CONFIRMADA`, across 1,252 phone+advisor pairs.
- browser AbortController can abandon an HTTP request while PostgreSQL may continue executing it; a rapid month change can therefore overlap old/new heavy insight statements.

P0.3 changes only read pressure/access paths:
1. partial covering index on confirmed calls by `(numero_limpio, upper(asesor))` for the existing call↔appointment matching predicate;
2. one serialized client lane for monthly attribution + intent + intent-detail reads; once an insight reaches PostgREST, the HTTP request is allowed to finish while the V4.2 stale-cycle guard discards obsolete UI results.

No KPI/attribution/ORGANICO formula changes. No timeout increase. No business data DML. No recurrent polling.