### PR TITLE
P0.4: optimize Marketing call-lead hot path

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -1,15 +1,23 @@
-/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.2
+/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.3
  * Keeps the certified V4.2 controller byte-for-byte in admin-marketing-v2-core.js.
  * This bootstrap only shapes read pressure: single-flight, short-lived read cache,
  * viewport-gating for the two expensive annual analytics (History + LTV),
- * suppression of the redundant legacy aos_ltv_cohortes read once V4.2 is mounted,
+ * suppression of the redundant legacy aos_ltv_cohortes read from bootstrap start,
  * and one-at-a-time execution for heavy monthly attribution/intent reads.
  */
 (function(){
 'use strict';
 
-var RELEASE='2026-09-02-p0-marketing-read-pressure-v1.2';
+var RELEASE='2026-09-02-p0-marketing-read-pressure-v1.3';
 var G=window.__AOS_MKT_PERF_V1;
+
+// SPA remounts can keep an older fetch wrapper alive. Upgrade deterministically by
+// restoring its original fetch and installing the current release once.
+if(G&&G.release!==RELEASE&&typeof G.baseFetch==='function'){
+  try{window.fetch=G.baseFetch;}catch(e){}
+  try{delete window.__AOS_MKT_PERF_V1;}catch(e){window.__AOS_MKT_PERF_V1=null;}
+  G=null;
+}
 
 if(!G){
   var baseFetch=window.fetch.bind(window);
@@ -115,11 +123,10 @@ if(!G){
     var fn=fnFrom(url);
     var method=String((init&&init.method)||'GET').toUpperCase();
 
-    // V4.2 owns History/LTV rendering. The legacy mkL() still asks aos_ltv_cohortes
-    // only to feed rHist/rLTV callbacks that V4.2 already intercepts and ignores.
-    // Once V4.2 is mounted, return an empty successful payload locally instead of
-    // spending ~0.7-1.1s of Supabase work on every month switch.
-    if(method==='POST'&&fn==='aos_ltv_cohortes'&&window.__AOS_MKT4){
+    // V4.2 is always loaded by this bootstrap and owns History/LTV rendering.
+    // Suppress the obsolete cohort request immediately, including the startup race
+    // before window.__AOS_MKT4 has finished mounting.
+    if(method==='POST'&&fn==='aos_ltv_cohortes'){
       stats.suppressedLegacyLtv++;
       return Promise.resolve(emptyJsonResponse());
     }

--- a/ci/performance/marketing-read-pressure.test.js
+++ b/ci/performance/marketing-read-pressure.test.js
@@ -4,7 +4,8 @@ const test=require('node:test');
 const assert=require('node:assert/strict');
 const boot=fs.readFileSync('app/public/admin-marketing-v2.js','utf8');
 const core=fs.readFileSync('app/public/admin-marketing-v2-core.js','utf8');
-const migration=fs.readFileSync('supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql','utf8');
+const indexMigration=fs.readFileSync('supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql','utf8');
+const callLeadMigration=fs.readFileSync('supabase/migrations/20260902024000_p0_marketing_call_lead_single_pass_v4.sql','utf8');
 
 test('preserves certified Marketing V4.2 core',()=>{
   assert.match(boot,/admin-marketing-v2-core\.js/);
@@ -31,12 +32,20 @@ test('expensive annual analytics are viewport gated',()=>{
   assert.match(boot,/setTimeout\(finish,12000\)/);
 });
 
-test('legacy LTV cohort read is suppressed only after V4.2 owns rendering',()=>{
+test('legacy LTV cohort read is suppressed from bootstrap start',()=>{
   assert.match(boot,/aos_ltv_cohortes/);
-  assert.match(boot,/fn==='aos_ltv_cohortes'&&window\.__AOS_MKT4/);
+  assert.match(boot,/fn==='aos_ltv_cohortes'/);
+  assert.doesNotMatch(boot,/fn==='aos_ltv_cohortes'&&window\.__AOS_MKT4/);
   assert.match(boot,/suppressedLegacyLtv/);
   assert.match(boot,/emptyJsonResponse/);
   assert.doesNotMatch(core,/suppressedLegacyLtv/);
+});
+
+test('new bootstrap release replaces older SPA fetch wrapper',()=>{
+  assert.match(boot,/p0-marketing-read-pressure-v1\.3/);
+  assert.match(boot,/G&&G\.release!==RELEASE&&typeof G\.baseFetch==='function'/);
+  assert.match(boot,/window\.fetch=G\.baseFetch/);
+  assert.match(boot,/delete window\.__AOS_MKT_PERF_V1/);
 });
 
 test('monthly attribution and intent insights share one serialized lane',()=>{
@@ -53,14 +62,31 @@ test('monthly attribution and intent insights share one serialized lane',()=>{
 });
 
 test('confirmed-call lookup index is partial and formula-neutral',()=>{
-  assert.match(migration,/idx_aos_llamadas_mkt_confirmed_phone_advisor_v1/);
-  assert.match(migration,/numero_limpio/);
-  assert.match(migration,/upper\(coalesce\(asesor,''\)\)/);
-  assert.match(migration,/where upper\(coalesce\(estado,''\)\)='CITA CONFIRMADA'/);
-  assert.match(migration,/include \(id, lead_id_origen, fecha, hora_llamada, created_at, ult_ts, ts_log\)/);
-  assert.doesNotMatch(migration,/statement_timeout/i);
-  assert.doesNotMatch(migration,/create or replace function/i);
-  assert.doesNotMatch(migration,/update\s+public\./i);
+  assert.match(indexMigration,/idx_aos_llamadas_mkt_confirmed_phone_advisor_v1/);
+  assert.match(indexMigration,/numero_limpio/);
+  assert.match(indexMigration,/upper\(coalesce\(asesor,''\)\)/);
+  assert.match(indexMigration,/where upper\(coalesce\(estado,''\)\)='CITA CONFIRMADA'/);
+  assert.match(indexMigration,/include \(id, lead_id_origen, fecha, hora_llamada, created_at, ult_ts, ts_log\)/);
+  assert.doesNotMatch(indexMigration,/statement_timeout/i);
+  assert.doesNotMatch(indexMigration,/create or replace function/i);
+  assert.doesNotMatch(indexMigration,/update\s+public\./i);
+});
+
+test('call-lead P0.4 preserves canonical match states and removes global touchpoint function scan',()=>{
+  assert.match(callLeadMigration,/create or replace function public\.aos_marketing_call_lead_match_v2/);
+  assert.match(callLeadMigration,/DIRECT_LEAD_ID/);
+  assert.match(callLeadMigration,/UNIQUE_PRIOR_LEAD/);
+  assert.match(callLeadMigration,/UNIQUE_PRIOR_BY_TREATMENT/);
+  assert.match(callLeadMigration,/NO_PRIOR_MARKETING_LEAD/);
+  assert.match(callLeadMigration,/AMBIGUOUS_PRIOR_LEAD/);
+  assert.match(callLeadMigration,/when r\.lead_id_origen is not null then 100/);
+  assert.match(callLeadMigration,/when r\.n_prior=1 then 90/);
+  assert.match(callLeadMigration,/when r\.n_prior>1 and r\.n_trat=1 then 85/);
+  assert.match(callLeadMigration,/row_number\(\) over/);
+  assert.match(callLeadMigration,/join phones p on p\.numero_limpio=l\.numero_limpio/);
+  assert.doesNotMatch(callLeadMigration,/aos_marketing_touchpoints_v2\(null,null\)/i);
+  assert.doesNotMatch(callLeadMigration,/statement_timeout/i);
+  assert.doesNotMatch(callLeadMigration,/update\s+public\./i);
 });
 
 test('bootstrap adds no recurrent polling and core keeps canonical RPCs',()=>{

--- a/supabase/migrations/20260902024000_p0_marketing_call_lead_single_pass_v4.sql
+++ b/supabase/migrations/20260902024000_p0_marketing_call_lead_single_pass_v4.sql
@@ -1,0 +1,135 @@
+-- ASCENDA OS · Marketing P0.4
+-- Replace repeated scans of the global touchpoint CTE in aos_marketing_call_lead_match_v2
+-- with one phone-scoped dedupe + aggregation pass.
+-- Business semantics are intentionally unchanged.
+
+create or replace function public.aos_marketing_call_lead_match_v2(
+  p_desde date default null::date,
+  p_hasta date default null::date
+)
+returns table(
+  cita_id text,
+  llamada_id bigint,
+  llamada_ts timestamptz,
+  numero_limpio text,
+  lead_id bigint,
+  lead_ts timestamptz,
+  candidatos_previos bigint,
+  candidatos_tratamiento bigint,
+  metodo_match text,
+  confidence integer
+)
+language sql
+stable
+as $function$
+with chain as materialized (
+  select
+    m.cita_id,
+    m.llamada_id,
+    m.llamada_ts,
+    m.numero_limpio,
+    ll.lead_id_origen,
+    ll.tratamiento
+  from public.aos_marketing_call_cita_match_v2(p_desde,p_hasta) m
+  join public.aos_llamadas ll on ll.id=m.llamada_id
+  where m.metodo_match in ('CALL_CITA_UNICO_10M','DIRECT_LLAMADA_ID')
+),
+phones as materialized (
+  select distinct numero_limpio
+  from chain
+  where numero_limpio is not null and numero_limpio<>''
+),
+tp_base as materialized (
+  select
+    l.id::bigint lead_id,
+    l.numero_limpio,
+    public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at) lead_ts,
+    l.tratamiento,
+    row_number() over(
+      partition by
+        l.numero_limpio,
+        l.fecha,
+        l.hora_ingreso,
+        coalesce(l.tratamiento,''),
+        coalesce(l.anuncio,''),
+        l.created_at
+      order by l.id
+    ) dup_rank
+  from public.aos_leads l
+  join phones p on p.numero_limpio=l.numero_limpio
+  where l.numero_limpio is not null and l.numero_limpio<>''
+),
+tp as materialized (
+  select lead_id,numero_limpio,lead_ts,tratamiento
+  from tp_base
+  where dup_rank=1
+),
+agg as materialized (
+  select
+    c.cita_id,
+    c.llamada_id,
+    c.llamada_ts,
+    c.numero_limpio,
+    c.lead_id_origen,
+    c.tratamiento,
+    count(t.lead_id)::bigint n_prior,
+    count(t.lead_id) filter (
+      where nullif(trim(c.tratamiento),'') is not null
+        and upper(coalesce(t.tratamiento,''))=upper(c.tratamiento)
+    )::bigint n_trat,
+    (array_agg(t.lead_id order by t.lead_ts desc,t.lead_id desc)
+      filter (where t.lead_id is not null))[1] latest_prior_lead_id,
+    (array_agg(t.lead_id order by t.lead_ts desc,t.lead_id desc)
+      filter (
+        where t.lead_id is not null
+          and nullif(trim(c.tratamiento),'') is not null
+          and upper(coalesce(t.tratamiento,''))=upper(c.tratamiento)
+      ))[1] latest_trat_lead_id
+  from chain c
+  left join tp t
+    on t.numero_limpio=c.numero_limpio
+   and t.lead_ts<=c.llamada_ts
+  group by
+    c.cita_id,c.llamada_id,c.llamada_ts,c.numero_limpio,c.lead_id_origen,c.tratamiento
+),
+resolved as (
+  select
+    a.*,
+    case
+      when a.lead_id_origen is not null then a.lead_id_origen
+      when a.n_prior=1 then a.latest_prior_lead_id
+      when a.n_prior>1 and a.n_trat=1 then a.latest_trat_lead_id
+      else null
+    end resolved_lead_id
+  from agg a
+)
+select
+  r.cita_id,
+  r.llamada_id,
+  r.llamada_ts,
+  r.numero_limpio,
+  r.resolved_lead_id::bigint lead_id,
+  public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at) lead_ts,
+  r.n_prior::bigint candidatos_previos,
+  r.n_trat::bigint candidatos_tratamiento,
+  case
+    when r.lead_id_origen is not null then 'DIRECT_LEAD_ID'
+    when r.n_prior=1 then 'UNIQUE_PRIOR_LEAD'
+    when r.n_prior>1 and r.n_trat=1 then 'UNIQUE_PRIOR_BY_TREATMENT'
+    when r.n_prior=0 then 'NO_PRIOR_MARKETING_LEAD'
+    else 'AMBIGUOUS_PRIOR_LEAD'
+  end::text metodo_match,
+  case
+    when r.lead_id_origen is not null then 100
+    when r.n_prior=1 then 90
+    when r.n_prior>1 and r.n_trat=1 then 85
+    when r.n_prior=0 then 0
+    else 40
+  end::integer confidence
+from resolved r
+left join public.aos_leads l on l.id=r.resolved_lead_id
+order by r.llamada_ts,r.llamada_id;
+$function$;
+
+comment on function public.aos_marketing_call_lead_match_v2(date,date) is
+  'Marketing attribution call-to-lead resolver. P0.4 preserves V2 match/confidence semantics while using phone-scoped single-pass touchpoint aggregation.';


### PR DESCRIPTION
Follow-up to P0.3 after real June smoke still required reload.

LIVE evidence:
- P0.3 serialization worked: attribution/intent/detail failures were sequential, not overlapping.
- PostgreSQL still produced statement timeouts under real load.
- June smoke had 500 on attribution and intent, then recovered after reload; a later intent-detail also returned 500.
- one startup `aos_ltv_cohortes` request still escaped before V4.2 mounted.

Root cause:
- `aos_marketing_call_lead_match_v2` materialized all touchpoints then repeatedly rescanned that material per call.
- June→current-date equivalence test: old 540 rows, optimized 540 rows, old-minus-new 0, new-minus-old 0.
- optimized June call→lead benchmark: ~300 ms while preserving DIRECT_LEAD_ID / UNIQUE_PRIOR_LEAD / UNIQUE_PRIOR_BY_TREATMENT / confidence semantics.

P0.4 changes:
1. replace internal implementation of `aos_marketing_call_lead_match_v2` with phone-scoped dedupe + one-pass aggregation;
2. suppress obsolete `aos_ltv_cohortes` from bootstrap start, including initial mount race;
3. upgrade stale SPA fetch wrappers deterministically to bootstrap V1.3.

No KPI formula changes. No ORGANICO boundary changes. No timeout increase. No business-data DML.