### PR TITLE
P0.5: harden Marketing month-switch summary

### DIFF
--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -1,14 +1,12 @@
-/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.3
+/* ASCENDA OS — Marketing P0 read-pressure bootstrap V1.4
  * Keeps the certified V4.2 controller byte-for-byte in admin-marketing-v2-core.js.
- * This bootstrap only shapes read pressure: single-flight, short-lived read cache,
- * viewport-gating for the two expensive annual analytics (History + LTV),
- * suppression of the redundant legacy aos_ltv_cohortes read from bootstrap start,
- * and one-at-a-time execution for heavy monthly attribution/intent reads.
+ * Shapes read pressure only: single-flight, successful-response cache, monthly lane,
+ * annual quiescence, startup suppression of obsolete LTV, and one timeout retry.
  */
 (function(){
 'use strict';
 
-var RELEASE='2026-09-02-p0-marketing-read-pressure-v1.3';
+var RELEASE='2026-09-02-p0-marketing-read-pressure-v1.4';
 var G=window.__AOS_MKT_PERF_V1;
 
 // SPA remounts can keep an older fetch wrapper alive. Upgrade deterministically by
@@ -23,8 +21,16 @@ if(!G){
   var baseFetch=window.fetch.bind(window);
   var cache=new Map();
   var inflight=new Map();
-  var insightTail=Promise.resolve();
-  var stats={network:0,cacheHit:0,coalesced:0,deferred:0,suppressedLegacyLtv:0,serializedInsights:0};
+  var monthlyTail=Promise.resolve();
+  var annualTail=Promise.resolve();
+  var lastCriticalSettledAt=Date.now();
+  var QUIET_MS=3500;
+  var RETRY_MS=300;
+  var stats={
+    network:0,cacheHit:0,coalesced:0,deferred:0,suppressedLegacyLtv:0,
+    serializedInsights:0,serializedMonthly:0,annualDeferred:0,timeoutRetries:0,
+    failedNotCached:0
+  };
   var targets={
     aos_marketing_dashboard:2500,
     aos_marketing_dashboard_anio:2500,
@@ -40,7 +46,19 @@ if(!G){
     aos_marketing_historico_public_v2:'#mk-hist',
     aos_marketing_ltv_public_v2:'#mk-ltv'
   };
-  var serialInsights={
+  var monthlySerial={
+    aos_marketing_period_summary_v2:true,
+    aos_marketing_attribution_public_v3:true,
+    aos_marketing_intent_public_v2:true,
+    aos_marketing_intent_detail_public_v3:true
+  };
+  var annualReads={
+    aos_marketing_historico_public_v2:true,
+    aos_marketing_ltv_public_v2:true
+  };
+  var criticalReads={
+    aos_marketing_dashboard:true,
+    aos_marketing_period_summary_v2:true,
     aos_marketing_attribution_public_v3:true,
     aos_marketing_intent_public_v2:true,
     aos_marketing_intent_detail_public_v3:true
@@ -54,6 +72,16 @@ if(!G){
   function abortError(){
     try{return new DOMException('The operation was aborted.','AbortError');}
     catch(e){var x=new Error('The operation was aborted.');x.name='AbortError';return x;}
+  }
+  function sleep(ms,signal){
+    if(aborted(signal))return Promise.reject(abortError());
+    return new Promise(function(resolve,reject){
+      var done=false;
+      var timer=setTimeout(function(){if(done)return;done=true;clean();resolve();},ms);
+      function clean(){if(signal&&signal.removeEventListener)signal.removeEventListener('abort',onAbort);}
+      function onAbort(){if(done)return;done=true;clearTimeout(timer);clean();reject(abortError());}
+      if(signal&&signal.addEventListener)signal.addEventListener('abort',onAbort,{once:true});
+    });
   }
   function visible(el){
     if(!el||!el.getBoundingClientRect)return true;
@@ -79,10 +107,16 @@ if(!G){
         if(entries.some(function(x){return x.isIntersecting;}))finish();
       },{rootMargin:'500px 0px'});
       io.observe(el);
-      // Safety fallback: analytics eventually arrive even if browser/layout visibility is unusual.
       timer=setTimeout(finish,12000);
       if(signal&&signal.addEventListener)signal.addEventListener('abort',onAbort,{once:true});
     });
+  }
+  function waitQuiescent(signal){
+    if(aborted(signal))return Promise.reject(abortError());
+    var remaining=QUIET_MS-(Date.now()-lastCriticalSettledAt);
+    if(remaining<=0)return Promise.resolve();
+    stats.annualDeferred++;
+    return sleep(remaining,signal).then(function(){return waitQuiescent(signal);});
   }
   function snap(resp){
     return resp.clone().text().then(function(body){
@@ -104,18 +138,66 @@ if(!G){
     Object.keys(init||{}).forEach(function(k){if(k!=='signal')x[k]=init[k];});
     return x;
   }
-  function runSerializedInsight(input,init,signal){
-    var queued=insightTail.catch(function(){}).then(function(){
-      if(aborted(signal))throw abortError();
-      stats.serializedInsights++;
-      stats.network++;
-      // Once a read-only insight reaches PostgREST, do not abort the HTTP request.
-      // Aborting fetch does not reliably cancel the PostgreSQL statement and can let
-      // the next month overlap it. The V4.2 cycle guard still discards stale results.
-      return baseFetch(input,withoutSignal(init)).then(snap);
+  function timeoutSnap(x){
+    return !!(x&&x.status>=500&&(/\"code\"\s*:\s*\"57014\"/i.test(x.body||'')||/statement timeout/i.test(x.body||'')));
+  }
+  function successful(x){return !!(x&&x.status>=200&&x.status<300);}
+  function networkSnap(input,init,signal,allowRetry){
+    if(aborted(signal))return Promise.reject(abortError());
+    stats.network++;
+    // Once a read reaches PostgREST, let it finish. Browser abort does not reliably
+    // cancel the server statement and can otherwise create hidden overlap.
+    return baseFetch(input,withoutSignal(init)).then(snap).then(function(x){
+      if(!allowRetry||!timeoutSnap(x))return x;
+      stats.timeoutRetries++;
+      return sleep(RETRY_MS,signal).then(function(){
+        if(aborted(signal))throw abortError();
+        stats.network++;
+        return baseFetch(input,withoutSignal(init)).then(snap);
+      });
     });
-    insightTail=queued.then(function(){},function(){});
+  }
+  function waitAnnualDrain(signal){
+    return annualTail.catch(function(){}).then(function(){if(aborted(signal))throw abortError();});
+  }
+  function runMonthly(input,init,signal){
+    var queued=monthlyTail.catch(function(){}).then(function(){
+      if(aborted(signal))throw abortError();
+      return waitAnnualDrain(signal);
+    }).then(function(){
+      if(aborted(signal))throw abortError();
+      stats.serializedMonthly++;
+      stats.serializedInsights++;
+      return networkSnap(input,init,signal,true);
+    }).finally(function(){lastCriticalSettledAt=Date.now();});
+    monthlyTail=queued.then(function(){},function(){});
     return queued;
+  }
+  function runCritical(input,init,signal){
+    return waitAnnualDrain(signal).then(function(){
+      if(aborted(signal))throw abortError();
+      return networkSnap(input,init,signal,true);
+    }).finally(function(){lastCriticalSettledAt=Date.now();});
+  }
+  function runAnnual(input,init,signal){
+    return monthlyTail.catch(function(){}).then(function(){
+      if(aborted(signal))throw abortError();
+      return waitQuiescent(signal);
+    }).then(function(){
+      if(aborted(signal))throw abortError();
+      var queued=annualTail.catch(function(){}).then(function(){
+        if(aborted(signal))throw abortError();
+        return monthlyTail.catch(function(){});
+      }).then(function(){
+        if(aborted(signal))throw abortError();
+        return waitQuiescent(signal);
+      }).then(function(){
+        if(aborted(signal))throw abortError();
+        return networkSnap(input,init,signal,true);
+      });
+      annualTail=queued.then(function(){},function(){});
+      return queued;
+    });
   }
 
   window.fetch=function(input,init){
@@ -123,9 +205,7 @@ if(!G){
     var fn=fnFrom(url);
     var method=String((init&&init.method)||'GET').toUpperCase();
 
-    // V4.2 is always loaded by this bootstrap and owns History/LTV rendering.
-    // Suppress the obsolete cohort request immediately, including the startup race
-    // before window.__AOS_MKT4 has finished mounting.
+    // V4.2 owns History/LTV rendering; this legacy cohort response is discarded.
     if(method==='POST'&&fn==='aos_ltv_cohortes'){
       stats.suppressedLegacyLtv++;
       return Promise.resolve(emptyJsonResponse());
@@ -151,11 +231,15 @@ if(!G){
     if(lazy[fn])p=p.then(function(){return waitVisible(lazy[fn],signal);});
     p=p.then(function(){
       if(aborted(signal))throw abortError();
-      if(serialInsights[fn])return runSerializedInsight(input,init,signal);
+      if(annualReads[fn])return runAnnual(input,init,signal);
+      if(monthlySerial[fn])return runMonthly(input,init,signal);
+      if(criticalReads[fn])return runCritical(input,init,signal);
       stats.network++;
       return baseFetch(input,init).then(snap);
     }).then(function(x){
-      cache.set(key,{ts:Date.now(),snap:x});
+      // A transient API/database error must never poison the short-lived cache.
+      if(successful(x))cache.set(key,{ts:Date.now(),snap:x});
+      else stats.failedNotCached++;
       return x;
     }).finally(function(){inflight.delete(key);});
 

--- a/ci/performance/marketing-read-pressure.test.js
+++ b/ci/performance/marketing-read-pressure.test.js
@@ -6,6 +6,7 @@ const boot=fs.readFileSync('app/public/admin-marketing-v2.js','utf8');
 const core=fs.readFileSync('app/public/admin-marketing-v2-core.js','utf8');
 const indexMigration=fs.readFileSync('supabase/migrations/20260902022000_p0_marketing_confirmed_call_lookup_index.sql','utf8');
 const callLeadMigration=fs.readFileSync('supabase/migrations/20260902024000_p0_marketing_call_lead_single_pass_v4.sql','utf8');
+const summaryMigration=fs.readFileSync('supabase/migrations/20260902164000_p0_marketing_period_summary_fast_v5.sql','utf8');
 
 test('preserves certified Marketing V4.2 core',()=>{
   assert.match(boot,/admin-marketing-v2-core\.js/);
@@ -24,12 +25,28 @@ test('single-flight and cache are scoped to Marketing reads',()=>{
   assert.match(boot,/cache\.get\(key\)/);
 });
 
-test('expensive annual analytics are viewport gated',()=>{
+test('failed reads never poison the short-lived cache and one timeout retry is bounded',()=>{
+  assert.match(boot,/function timeoutSnap\(/);
+  assert.match(boot,/57014/);
+  assert.match(boot,/var RETRY_MS=300/);
+  assert.match(boot,/stats\.timeoutRetries\+\+/);
+  assert.match(boot,/if\(successful\(x\)\)cache\.set/);
+  assert.match(boot,/else stats\.failedNotCached\+\+/);
+  assert.doesNotMatch(boot,/while\s*\([^)]*timeout/i);
+});
+
+test('expensive annual analytics are viewport gated and wait for monthly quiescence',()=>{
   assert.match(boot,/aos_marketing_historico_public_v2:'#mk-hist'/);
   assert.match(boot,/aos_marketing_ltv_public_v2:'#mk-ltv'/);
   assert.match(boot,/IntersectionObserver/);
   assert.match(boot,/rootMargin:'500px 0px'/);
   assert.match(boot,/setTimeout\(finish,12000\)/);
+  assert.match(boot,/var annualTail=Promise\.resolve\(\)/);
+  assert.match(boot,/var QUIET_MS=3500/);
+  assert.match(boot,/function waitQuiescent\(/);
+  assert.match(boot,/function runAnnual\(/);
+  assert.match(boot,/return monthlyTail\.catch/);
+  assert.match(boot,/annualTail=queued\.then/);
 });
 
 test('legacy LTV cohort read is suppressed from bootstrap start',()=>{
@@ -42,23 +59,24 @@ test('legacy LTV cohort read is suppressed from bootstrap start',()=>{
 });
 
 test('new bootstrap release replaces older SPA fetch wrapper',()=>{
-  assert.match(boot,/p0-marketing-read-pressure-v1\.3/);
+  assert.match(boot,/p0-marketing-read-pressure-v1\.4/);
   assert.match(boot,/G&&G\.release!==RELEASE&&typeof G\.baseFetch==='function'/);
   assert.match(boot,/window\.fetch=G\.baseFetch/);
   assert.match(boot,/delete window\.__AOS_MKT_PERF_V1/);
 });
 
-test('monthly attribution and intent insights share one serialized lane',()=>{
-  assert.match(boot,/var insightTail=Promise\.resolve\(\)/);
-  assert.match(boot,/var serialInsights=\{/);
+test('period summary attribution and intent share one serialized monthly lane',()=>{
+  assert.match(boot,/var monthlyTail=Promise\.resolve\(\)/);
+  assert.match(boot,/var monthlySerial=\{/);
+  assert.match(boot,/aos_marketing_period_summary_v2:true/);
   assert.match(boot,/aos_marketing_attribution_public_v3:true/);
   assert.match(boot,/aos_marketing_intent_public_v2:true/);
   assert.match(boot,/aos_marketing_intent_detail_public_v3:true/);
-  assert.match(boot,/function runSerializedInsight\(/);
+  assert.match(boot,/function runMonthly\(/);
   assert.match(boot,/function withoutSignal\(/);
-  assert.match(boot,/baseFetch\(input,withoutSignal\(init\)\)/);
-  assert.match(boot,/insightTail=queued\.then/);
-  assert.match(boot,/serializedInsights/);
+  assert.match(boot,/monthlyTail=queued\.then/);
+  assert.match(boot,/serializedMonthly/);
+  assert.match(boot,/waitAnnualDrain/);
 });
 
 test('confirmed-call lookup index is partial and formula-neutral',()=>{
@@ -87,6 +105,20 @@ test('call-lead P0.4 preserves canonical match states and removes global touchpo
   assert.doesNotMatch(callLeadMigration,/aos_marketing_touchpoints_v2\(null,null\)/i);
   assert.doesNotMatch(callLeadMigration,/statement_timeout/i);
   assert.doesNotMatch(callLeadMigration,/update\s+public\./i);
+});
+
+test('period summary P0.5 keeps canonical fields while removing full lead-detail materialization',()=>{
+  assert.match(summaryMigration,/create or replace function public\.aos_marketing_period_summary_v2/);
+  assert.match(summaryMigration,/period_seed as materialized/);
+  assert.match(summaryMigration,/phones as materialized/);
+  assert.match(summaryMigration,/join phones p using\(numero_limpio\)/);
+  assert.match(summaryMigration,/person_flags as materialized/);
+  assert.match(summaryMigration,/touch_flags as materialized/);
+  assert.match(summaryMigration,/aos_marketing_attribution_v2_preview\(p_fecha_desde,p_fecha_hasta\)/);
+  ['ingresos','personasUnicas','reingresos','personasGestionadas','personasSinGestion','personasCitaTel','personasConCita','personasAsistieron','touchpointsGestionados','touchpointsConCita','clientesM0','ventasM0','factM0'].forEach(k=>assert.match(summaryMigration,new RegExp("'"+k+"'")));
+  assert.doesNotMatch(summaryMigration,/aos_marketing_leads_detalle_v2/i);
+  assert.doesNotMatch(summaryMigration,/statement_timeout/i);
+  assert.doesNotMatch(summaryMigration,/update\s+public\./i);
 });
 
 test('bootstrap adds no recurrent polling and core keeps canonical RPCs',()=>{

--- a/supabase/migrations/20260902164000_p0_marketing_period_summary_fast_v5.sql
+++ b/supabase/migrations/20260902164000_p0_marketing_period_summary_fast_v5.sql
@@ -1,0 +1,156 @@
+-- ASCENDA OS · Marketing P0.5
+-- Preserve the canonical monthly summary JSON while avoiding the full lead-detail
+-- materialization used only to answer two boolean counters.
+
+create or replace function public.aos_marketing_period_summary_v2(
+  p_fecha_desde date,
+  p_fecha_hasta date
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path to 'public'
+as $function$
+with params as (
+  select p_fecha_desde::date d,p_fecha_hasta::date h
+),
+period_seed as materialized (
+  select l.id,l.fecha,l.numero_limpio,l.tratamiento,l.hora_ingreso,l.created_at
+  from public.aos_leads l,params p
+  where l.fecha between p.d and p.h
+    and l.numero_limpio is not null
+    and l.numero_limpio<>''
+),
+phones as materialized (
+  select distinct numero_limpio
+  from period_seed
+),
+timeline as materialized (
+  select
+    l.id,
+    l.fecha,
+    l.numero_limpio,
+    l.tratamiento,
+    public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at) lead_ts,
+    lead(public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at)) over(
+      partition by l.numero_limpio
+      order by public.aos_lead_event_ts(l.fecha,l.hora_ingreso,l.created_at),l.id
+    ) next_lead_ts
+  from public.aos_leads l
+  join phones p using(numero_limpio)
+),
+period_leads as materialized (
+  select t.*
+  from timeline t,params p
+  where t.fecha between p.d and p.h
+),
+cohort as materialized (
+  select numero_limpio,min(fecha) first_lead_date
+  from period_seed
+  group by numero_limpio
+),
+person_flags as materialized (
+  select
+    c.numero_limpio,
+    exists(
+      select 1
+      from public.aos_llamadas l,params p
+      where l.numero_limpio=c.numero_limpio
+        and l.fecha between c.first_lead_date and p.h
+    ) managed,
+    exists(
+      select 1
+      from public.aos_llamadas l,params p
+      where l.numero_limpio=c.numero_limpio
+        and l.fecha between c.first_lead_date and p.h
+        and upper(l.estado)='CITA CONFIRMADA'
+    ) cita_tel,
+    exists(
+      select 1
+      from public.aos_agenda_citas a,params p
+      where a.numero_limpio=c.numero_limpio
+        and a.fecha_cita between c.first_lead_date and p.h
+    ) con_cita,
+    exists(
+      select 1
+      from public.aos_agenda_citas a,params p
+      where a.numero_limpio=c.numero_limpio
+        and a.fecha_cita between c.first_lead_date and p.h
+        and upper(a.estado_cita) in ('ASISTIO','EFECTIVA')
+    ) asistio
+  from cohort c
+),
+touch_flags as materialized (
+  select
+    lp.id,
+    exists(
+      select 1
+      from public.aos_llamadas ll
+      where ll.numero_limpio=lp.numero_limpio
+        and (
+          ll.lead_id_origen=lp.id
+          or (
+            ll.lead_id_origen is null
+            and public.aos_llamada_event_ts(ll.fecha,ll.hora_llamada,ll.created_at,ll.ult_ts,ll.ts_log)>=lp.lead_ts
+            and (
+              lp.next_lead_ts is null
+              or public.aos_llamada_event_ts(ll.fecha,ll.hora_llamada,ll.created_at,ll.ult_ts,ll.ts_log)<lp.next_lead_ts
+            )
+          )
+        )
+    ) has_call,
+    exists(
+      select 1
+      from public.aos_agenda_citas c
+      where c.numero_limpio=lp.numero_limpio
+        and (
+          c.lead_id_origen=lp.id
+          or exists(
+            select 1
+            from public.aos_llamadas llx
+            where llx.numero_limpio=lp.numero_limpio
+              and llx.lead_id_origen=lp.id
+              and upper(coalesce(llx.estado,''))='CITA CONFIRMADA'
+              and abs(extract(epoch from(
+                public.aos_llamada_event_ts(llx.fecha,llx.hora_llamada,llx.created_at,llx.ult_ts,llx.ts_log)
+                -coalesce(c.ts_creado,c.fecha_cita::timestamptz)
+              )))<=600
+          )
+          or (
+            c.lead_id_origen is null
+            and coalesce(c.ts_creado,c.fecha_cita::timestamptz)>=lp.lead_ts
+            and (
+              lp.next_lead_ts is null
+              or coalesce(c.ts_creado,c.fecha_cita::timestamptz)<lp.next_lead_ts
+            )
+          )
+        )
+    ) has_cita
+  from period_leads lp
+),
+attrs_m0 as materialized (
+  select a.*
+  from public.aos_marketing_attribution_v2_preview(p_fecha_desde,p_fecha_hasta) a
+  where a.lead_fecha between p_fecha_desde and p_fecha_hasta
+    and a.venta_fecha between p_fecha_desde and p_fecha_hasta
+)
+select jsonb_build_object(
+  'ingresos',(select count(*) from period_seed),
+  'personasUnicas',(select count(*) from cohort),
+  'reingresos',greatest(0,(select count(*) from period_seed)-(select count(*) from cohort)),
+  'personasGestionadas',(select count(*) from person_flags where managed),
+  'personasSinGestion',greatest(0,(select count(*) from cohort)-(select count(*) from person_flags where managed)),
+  'personasCitaTel',(select count(*) from person_flags where cita_tel),
+  'personasConCita',(select count(*) from person_flags where con_cita),
+  'personasAsistieron',(select count(*) from person_flags where asistio),
+  'touchpointsGestionados',(select count(*) from touch_flags where has_call),
+  'touchpointsConCita',(select count(*) from touch_flags where has_cita),
+  'clientesM0',(select count(distinct numero_limpio) from attrs_m0),
+  'ventasM0',(select count(*) from attrs_m0),
+  'factM0',(select coalesce(sum(monto),0) from attrs_m0)
+);
+$function$;
+
+comment on function public.aos_marketing_period_summary_v2(date,date) is
+  'Marketing V4.2 canonical period summary. P0.5 preserves output semantics while limiting lead timeline/detail work to phones participating in the requested period.';


### PR DESCRIPTION
Follow-up to real P0.4 smoke where June partially loaded and required a page reload.

LIVE evidence:
- P0.4 fixed Attribution/Intent/Intent Detail: all three returned 200 in the failing June cycle.
- the only Marketing 500 was `aos_marketing_period_summary_v2` and PostgreSQL logged `canceling statement due to statement timeout`.
- after reload the same Summary returned 200 and subsequent months were fast.
- P0.4 bootstrap also cached non-2xx snapshots, so a transient 500 could poison the 10s short-lived cache and make reload appear necessary.

P0.5:
1. Replace only `aos_marketing_period_summary_v2` internals with phone-scoped timeline + boolean aggregations; canonical JSON fields/formulas unchanged.
2. Parity proven before PR for JUN/JUL/AGO: old JSON == new JSON exactly for all 13 fields.
3. June benchmark candidate: ~1.52s / 26.8k shared hits -> ~0.18s / 11.2k shared hits.
4. Never cache failed Marketing reads.
5. Retry a read once, and only when PostgREST reports PostgreSQL 57014/statement timeout.
6. Summary + Attribution + Intent + Intent Detail share one non-overlapping monthly lane.
7. History/LTV wait for a quiet monthly window; a new critical month request waits for an already-running annual read instead of competing with it.
8. Legacy `aos_ltv_cohortes` remains suppressed from bootstrap start.

No KPI/attribution/ORGANICO formula changes. No timeout increase. No business-data DML. Certified V4.2 core remains untouched.