### PR TITLE
REV-PERF P0: reduce Sales and Commissions read pressure

### DIFF
--- a/.github/workflows/rev-perf-sales-commissions-p0.yml
+++ b/.github/workflows/rev-perf-sales-commissions-p0.yml
@@ -1,0 +1,44 @@
+name: ASCENDA REV-PERF Sales Commissions P0
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/20260902181000_rev_perf_sales_commissions_p0_v1.sql'
+      - 'supabase/rollbacks/20260902181000_rev_perf_sales_commissions_p0_v1_rollback.sql'
+      - 'ci/performance/rev-perf-sales-commissions-p0.test.js'
+      - 'app/public/commissions.js'
+      - '.github/workflows/rev-perf-sales-commissions-p0.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rev-perf-sales-commissions:
+    name: Self-hosted Sales + Commissions performance contract
+    runs-on: [self-hosted, linux, x64, ascenda-zero-cost-v2]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: JavaScript syntax
+        run: |
+          set -euo pipefail
+          node --check ci/performance/rev-perf-sales-commissions-p0.test.js
+          node --check app/public/commissions.js
+      - name: REV-PERF contracts
+        run: node --test ci/performance/rev-perf-sales-commissions-p0.test.js
+      - name: Static pressure assertions
+        run: |
+          set -euo pipefail
+          MIG='supabase/migrations/20260902181000_rev_perf_sales_commissions_p0_v1.sql'
+          RB='supabase/rollbacks/20260902181000_rev_perf_sales_commissions_p0_v1_rollback.sql'
+          grep -q 'period_all as materialized' "$MIG"
+          grep -q 'year_sales as materialized' "$MIG"
+          grep -q "'rankingTop'" "$MIG"
+          grep -q 'aos_comisiones_asesor' "$RB"
+          ! sed 's/--.*$//' "$MIG" | grep -Eq 'statement_timeout|SET[[:space:]]+LOCAL.*timeout'
+          echo 'ASCENDA_REV_PERF_SALES_COMMISSIONS_P0_PASS'

--- a/app/public/commissions.js
+++ b/app/public/commissions.js
@@ -1,6 +1,6 @@
 // commissions.js — Panel Comisiones Asesor | AscendaOS v1 | 100% Supabase
 var _SB='https://ituyqwstonmhnfshnaqz.supabase.co';
-var _SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+var _SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXN1cGFza2V5IiwicmVmIjoiaXR1eXF3c3Rvbm1obmZzaG5hcXoiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc3NDc0NDIxOCwiZXhwIjoyMDkwMzIwMjE4fQ.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
 
 function _rpc(fn,p,ok,fail){
   fetch(_SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':_SK,'Authorization':'Bearer '+_SK,'Content-Type':'application/json'},body:JSON.stringify(p||{})})
@@ -14,151 +14,70 @@ var VCom={mes:new Date().getMonth()+1, anio:new Date().getFullYear()};
 function h(s){var o=String(s||'');o=o.split('&').join('&amp;');o=o.split(String.fromCharCode(60)).join('&lt;');o=o.split('>').join('&gt;');o=o.split('"').join('&quot;');return o;}
 function el(id){return document.getElementById(id);}
 
-// Init
 (function(){
-  var mSel=el('mes-sel');
-  if(mSel)mSel.value=String(VCom.mes);
-  var aSel=el('anio-sel');
-  if(aSel)aSel.value=String(VCom.anio);
+  var mSel=el('mes-sel');if(mSel)mSel.value=String(VCom.mes);
+  var aSel=el('anio-sel');if(aSel)aSel.value=String(VCom.anio);
   reload();
 })();
 
 function reload(){
-  VCom.mes=Number(el('mes-sel').value);
-  VCom.anio=Number(el('anio-sel').value);
+  VCom.mes=Number(el('mes-sel').value);VCom.anio=Number(el('anio-sel').value);
   var ctx=(window.AOS_getCtx&&window.AOS_getCtx())||{};
-  var nom=(ctx.asesor||'').toUpperCase();
-  var idAs=ctx.idAsesor||'';
-  if(!nom){
-    el('h-com-total').textContent='Sin sesion';
-    return;
-  }
+  var nom=(ctx.asesor||'').toUpperCase();var idAs=ctx.idAsesor||'';
+  if(!nom){el('h-com-total').textContent='Sin sesion';return;}
   _rpc('aos_comisiones_asesor',{p_asesor:nom,p_id_asesor:idAs,p_mes:VCom.mes,p_anio:VCom.anio},function(d){
-    if(!d){el('h-com-total').textContent='Sin datos';return;}
-    renderData(d);
+    if(!d){el('h-com-total').textContent='Sin datos';return;}renderData(d);
   });
 }
 
 function renderData(d){
-  var comT=parseFloat(d.comTotal||0);
-  var comS=parseFloat(d.comServ||0);
-  var comP=parseFloat(d.comProd||0);
-  var factT=parseFloat(d.factTotal||0);
-  var meta=parseFloat(d.meta||100);
-  var pct=parseFloat(d.pct||0);
-  var rank=parseInt(d.ranking||1);
-  var nv=parseInt(d.nVentas||0);
-  var ns=parseInt(d.nServ||0);
-  var np=parseInt(d.nProd||0);
-
-  // Hero KPIs
+  var comT=parseFloat(d.comTotal||0),comS=parseFloat(d.comServ||0),comP=parseFloat(d.comProd||0),factT=parseFloat(d.factTotal||0);
+  var meta=parseFloat(d.meta||100),pct=parseFloat(d.pct||0),rank=parseInt(d.ranking||1),nv=parseInt(d.nVentas||0),ns=parseInt(d.nServ||0),np=parseInt(d.nProd||0);
   el('h-com-total').textContent='S/. '+comT.toFixed(2);
   el('h-com-meta').textContent='Meta: S/. '+meta.toFixed(2)+' | Fact. S/. '+factT.toFixed(2);
-  el('h-com-prog').style.width=Math.min(pct,100)+'%';
-  el('h-com-pct').textContent=pct.toFixed(1)+'% completado';
-  el('h-com-rank').textContent='Rank #'+rank;
-
-  el('h-com-serv').textContent='S/. '+comS.toFixed(2);
-  el('h-com-serv-sub').textContent=ns+' vta'+((ns!==1)?'s':'')+' | fact S/'+factT.toFixed(0)+' x 0.5%';
-  el('h-com-prod').textContent='S/. '+comP.toFixed(2);
-  el('h-com-prod-sub').textContent=np+' vta'+((np!==1)?'s':'')+' | tabla de rangos';
-
-  // Ranking
+  el('h-com-prog').style.width=Math.min(pct,100)+'%';el('h-com-pct').textContent=pct.toFixed(1)+'% completado';el('h-com-rank').textContent='Rank #'+rank;
+  el('h-com-serv').textContent='S/. '+comS.toFixed(2);el('h-com-serv-sub').textContent=ns+' vta'+((ns!==1)?'s':'')+' | fact S/'+factT.toFixed(0)+' x 0.5%';
+  el('h-com-prod').textContent='S/. '+comP.toFixed(2);el('h-com-prod-sub').textContent=np+' vta'+((np!==1)?'s':'')+' | tabla de rangos';
   var medalEmoji=rank===1?'\uD83E\uDD47':rank===2?'\uD83E\uDD48':rank===3?'\uD83E\uDD49':'\uD83C\uDFC5';
-  el('h-rank-emoji').textContent=medalEmoji;
-  el('h-rank-pos').textContent='#'+rank;
+  el('h-rank-emoji').textContent=medalEmoji;el('h-rank-pos').textContent='#'+rank;
 
-  // Delta vs mes anterior
-  var anual=d.anual||[];
-  var prevMes=anual.find(function(a){return parseInt(a.mes_num)===(VCom.mes-1);});
-  var dEl=el('h-delta');
-  if(prevMes&&parseFloat(prevMes.comision)>0){
-    var prevCom=parseFloat(prevMes.comision);
-    var delta=((comT-prevCom)/prevCom*100);
-    var up=delta>=0;
-    dEl.textContent='vs mes anterior: '+(up?'+':'')+delta.toFixed(1)+'%';
-    dEl.className='delta-chip '+(up?'delta-up':'delta-dn');
-  } else {
-    dEl.textContent='vs mes anterior: --';
-    dEl.className='delta-chip delta-n';
-  }
+  var anual=d.anual||[];var prevMes=anual.find(function(a){return parseInt(a.mes_num)===(VCom.mes-1);});var dEl=el('h-delta');
+  if(prevMes&&parseFloat(prevMes.comision)>0){var prevCom=parseFloat(prevMes.comision);var delta=((comT-prevCom)/prevCom*100);var up=delta>=0;dEl.textContent='vs mes anterior: '+(up?'+':'')+delta.toFixed(1)+'%';dEl.className='delta-chip '+(up?'delta-up':'delta-dn');}
+  else{dEl.textContent='vs mes anterior: --';dEl.className='delta-chip delta-n';}
 
-  // Historial anual
   var hb=el('hist-body');
-  if(anual.length){
-    hb.innerHTML=anual.map(function(row){
-      var mn=parseInt(row.mes_num);
-      var cur=mn===VCom.mes;
-      var fact=parseFloat(row.facturado||0);
-      var cs=parseFloat(row.com_serv||0);
-      var cp=parseFloat(row.com_prod||0);
-      var ct=parseFloat(row.comision||0);
-      return '<tr'+(cur?' class="cur"':'')+'>'+'<td style="font-weight:'+(cur?'700':'500')+';">'+h(MF[mn]||'')+'</td>'+'<td>S/'+fact.toFixed(2)+'</td>'+'<td>S/'+cs.toFixed(2)+'</td>'+'<td>S/'+cp.toFixed(2)+'</td>'+'<td style="font-weight:700;color:#0A4FBF;">S/'+ct.toFixed(2)+'</td>'+'</tr>';
-    }).join('');
-  } else {
-    hb.innerHTML='<tr><td colspan="5" class="ld">Sin historial</td></tr>';
-  }
+  if(anual.length){hb.innerHTML=anual.map(function(row){var mn=parseInt(row.mes_num),cur=mn===VCom.mes,fact=parseFloat(row.facturado||0),cs=parseFloat(row.com_serv||0),cp=parseFloat(row.com_prod||0),ct=parseFloat(row.comision||0);return '<tr'+(cur?' class="cur"':'')+'>'+'<td style="font-weight:'+(cur?'700':'500')+';">'+h(MF[mn]||'')+'</td>'+'<td>S/'+fact.toFixed(2)+'</td>'+'<td>S/'+cs.toFixed(2)+'</td>'+'<td>S/'+cp.toFixed(2)+'</td>'+'<td style="font-weight:700;color:#0A4FBF;">S/'+ct.toFixed(2)+'</td>'+'</tr>';}).join('');}
+  else{hb.innerHTML='<tr><td colspan="5" class="ld">Sin historial</td></tr>';}
 
-  // Top clientes
-  var tops=d.topClientes||[];
-  var tcEl=el('top-clientes');
-  if(tops.length){
-    tcEl.innerHTML=tops.map(function(cl,i){
-      var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':String(i+1);
-      var wa='https://api.whatsapp.com/send?phone=51'+(cl.num||'').replace(/[^0-9]/g,'');
-      var nom=h(((cl.cliente||cl.num||'--')).substring(0,25));
-      var f=parseFloat(cl.total||0);
-      return '<div class="top-row">'+'<div class="top-rank">'+medal+'</div>'+'<div class="top-info"><div class="top-nom">'+nom+'</div>'+'<div class="top-met">'+h(cl.num||'')+' - '+(cl.compras||0)+' compras - ult: '+(cl.ult_fecha||'')+'</div></div>'+'<div class="top-fact">S/'+f.toFixed(2)+'</div>'+'<div class="wa-sm" onclick="window.open(\''+wa+'\',\'_blank\')">WA</div>'+'</div>';
-    }).join('');
-  } else {
-    tcEl.innerHTML='<div class="ld">Sin clientes</div>';
-  }
+  var tops=d.topClientes||[];var tcEl=el('top-clientes');
+  if(tops.length){tcEl.innerHTML=tops.map(function(cl,i){var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':String(i+1);var wa='https://api.whatsapp.com/send?phone=51'+(cl.num||'').replace(/[^0-9]/g,'');var nom=h(((cl.cliente||cl.num||'--')).substring(0,25));var f=parseFloat(cl.total||0);return '<div class="top-row">'+'<div class="top-rank">'+medal+'</div>'+'<div class="top-info"><div class="top-nom">'+nom+'</div>'+'<div class="top-met">'+h(cl.num||'')+' - '+(cl.compras||0)+' compras - ult: '+(cl.ult_fecha||'')+'</div></div>'+'<div class="top-fact">S/'+f.toFixed(2)+'</div>'+'<div class="wa-sm" onclick="window.open(\''+wa+'\',\'_blank\')">WA</div>'+'</div>';}).join('');}
+  else{tcEl.innerHTML='<div class="ld">Sin clientes</div>';}
 
-  // Detalle ventas
-  var det=d.detalle||[];
-  el('det-count').textContent=det.length+' venta'+(det.length!==1?'s':'');
-  var db=el('det-body');
-  if(det.length){
-    db.innerHTML=det.map(function(v){
-      var com=parseFloat(v.comision_calculada||0);
-      var monto=parseFloat(v.monto||0);
-      var cls=(v.tipo||'')==='PRODUCTO'?'tb-prod':'tb-serv';
-      var cliente=((v.nombres||'')+' '+(v.apellidos||'')).trim();
-      return '<tr>'+'<td style="color:#6B7BA8;">'+h(v.fecha||'')+'</td>'+'<td><div style="font-weight:700;font-size:11px;">'+h((cliente||v.numero_limpio||'--').substring(0,22))+'</div>'+'<div style="font-size:10px;color:#9AAAC8;">'+h(v.numero_limpio||'')+'</div></td>'+'<td style="font-size:10px;color:#6B7BA8;">'+h((v.tratamiento||'').substring(0,18))+'</td>'+'<td style="font-weight:700;font-size:12px;color:#0D1B3E;">S/'+monto.toFixed(2)+'</td>'+'<td><span class="com-v">S/'+com.toFixed(2)+'</span></td>'+'<td><span class="tipo-b '+cls+'">'+((v.tipo||'')==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+'</tr>';
-    }).join('');
-  } else {
-    db.innerHTML='<tr><td colspan="6" class="ld">Sin ventas</td></tr>';
-  }
+  var det=d.detalle||[];el('det-count').textContent=det.length+' venta'+(det.length!==1?'s':'');var db=el('det-body');
+  if(det.length){db.innerHTML=det.map(function(v){var com=parseFloat(v.comision_calculada||0),monto=parseFloat(v.monto||0),cls=(v.tipo||'')==='PRODUCTO'?'tb-prod':'tb-serv',cliente=((v.nombres||'')+' '+(v.apellidos||'')).trim();return '<tr>'+'<td style="color:#6B7BA8;">'+h(v.fecha||'')+'</td>'+'<td><div style="font-weight:700;font-size:11px;">'+h((cliente||v.numero_limpio||'--').substring(0,22))+'</div>'+'<div style="font-size:10px;color:#9AAAC8;">'+h(v.numero_limpio||'')+'</div></td>'+'<td style="font-size:10px;color:#6B7BA8;">'+h((v.tratamiento||'').substring(0,18))+'</td>'+'<td style="font-weight:700;font-size:12px;color:#0D1B3E;">S/'+monto.toFixed(2)+'</td>'+'<td><span class="com-v">S/'+com.toFixed(2)+'</span></td>'+'<td><span class="tipo-b '+cls+'">'+((v.tipo||'')==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+'</tr>';}).join('');}
+  else{db.innerHTML='<tr><td colspan="6" class="ld">Sin ventas</td></tr>';}
 
-  // Ranking mini (otros asesores)
-  loadRankingMini();
+  // REV-PERF: consume the ranking embedded by the canonical commission RPC.
+  // Fallback preserves deploy-order compatibility if an older DB function is temporarily active.
+  loadRankingMini(d.rankingTop);
 }
 
-function loadRankingMini(){
+function renderRankingMini(arr){
+  if(!arr||!arr.length){el('h-rank-mini').innerHTML='Sin datos';return;}
+  el('h-rank-mini').innerHTML=arr.slice(0,5).map(function(r,i){
+    var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':'#'+(i+1);
+    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:3px 0;">'+'<span style="font-size:11px;">'+medal+' '+h((r.asesor||'').split(' ')[0])+'</span>'+'<span style="font-weight:800;font-size:12px;color:#0A4FBF;">S/'+parseFloat(r.com||0).toFixed(2)+'</span>'+'</div>';
+  }).join('');
+}
+
+function loadRankingMini(rankingTop){
+  if(Array.isArray(rankingTop)){renderRankingMini(rankingTop);return;}
   var mesI=VCom.anio+'-'+String(VCom.mes).padStart(2,'0')+'-01';
   var mesFin=VCom.anio+'-'+String(VCom.mes).padStart(2,'0')+'-31';
-  fetch(_SB+'/rest/v1/aos_ventas?select=asesor,monto,tipo&fecha=gte.'+mesI+'&fecha=lte.'+mesFin+'&asesor=not.in.(NO+APLICA,DRA+CAROLINA,DRA+YESSICA,VINO+SOLA(O))',{
-    headers:{'apikey':_SK,'Authorization':'Bearer '+_SK}
-  }).then(function(r){return r.json();}).then(function(rows){
-    if(!rows||!rows.length){el('h-rank-mini').innerHTML='Sin datos';return;}
-    var by={};
-    rows.forEach(function(v){
-      var a=v.asesor||'';if(!a)return;
-      if(!by[a])by[a]={fact:0,com:0};
-      var m=parseFloat(v.monto||0);
-      by[a].fact+=m;
-      if(v.tipo==='SERVICIO')by[a].com+=Math.round(m*0.005*100)/100;
-      else if(v.tipo==='PRODUCTO'){
-        var c=0;if(m>=201)c=6;else if(m>=149)c=5;else if(m>=101)c=4;else if(m>=51)c=3;else if(m>=18)c=1;else c=0.3;
-        by[a].com+=c;
-      }
-    });
-    var arr=Object.keys(by).map(function(a){return{asesor:a,com:by[a].com,fact:by[a].fact};});
-    arr.sort(function(a,b){return b.com-a.com;});
-    var html=arr.slice(0,5).map(function(r,i){
-      var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':'#'+(i+1);
-      return '<div style="display:flex;align-items:center;justify-content:space-between;padding:3px 0;">'+'<span style="font-size:11px;">'+medal+' '+h(r.asesor.split(' ')[0])+'</span>'+'<span style="font-weight:800;font-size:12px;color:#0A4FBF;">S/'+r.com.toFixed(2)+'</span>'+'</div>';
-    }).join('');
-    el('h-rank-mini').innerHTML=html;
+  fetch(_SB+'/rest/v1/aos_ventas?select=asesor,monto,tipo&fecha=gte.'+mesI+'&fecha=lte.'+mesFin+'&asesor=not.in.(NO+APLICA,DRA+CAROLINA,DRA+YESSICA,VINO+SOLA(O))',{headers:{'apikey':_SK,'Authorization':'Bearer '+_SK}})
+  .then(function(r){return r.json();}).then(function(rows){
+    if(!rows||!rows.length){renderRankingMini([]);return;}
+    var by={};rows.forEach(function(v){var a=v.asesor||'';if(!a)return;if(!by[a])by[a]={fact:0,com:0};var m=parseFloat(v.monto||0);by[a].fact+=m;if(v.tipo==='SERVICIO')by[a].com+=Math.round(m*0.005*100)/100;else if(v.tipo==='PRODUCTO'){var c=0;if(m>=201)c=6;else if(m>=149)c=5;else if(m>=101)c=4;else if(m>=51)c=3;else if(m>=18)c=1;else c=0.3;by[a].com+=c;}});
+    var arr=Object.keys(by).map(function(a){return{asesor:a,com:by[a].com,fact:by[a].fact};});arr.sort(function(a,b){return b.com-a.com;});renderRankingMini(arr);
   }).catch(function(){el('h-rank-mini').innerHTML='Error';});
 }

--- a/app/public/commissions.js
+++ b/app/public/commissions.js
@@ -14,70 +14,158 @@ var VCom={mes:new Date().getMonth()+1, anio:new Date().getFullYear()};
 function h(s){var o=String(s||'');o=o.split('&').join('&amp;');o=o.split(String.fromCharCode(60)).join('&lt;');o=o.split('>').join('&gt;');o=o.split('"').join('&quot;');return o;}
 function el(id){return document.getElementById(id);}
 
+// Init
 (function(){
-  var mSel=el('mes-sel');if(mSel)mSel.value=String(VCom.mes);
-  var aSel=el('anio-sel');if(aSel)aSel.value=String(VCom.anio);
+  var mSel=el('mes-sel');
+  if(mSel)mSel.value=String(VCom.mes);
+  var aSel=el('anio-sel');
+  if(aSel)aSel.value=String(VCom.anio);
   reload();
 })();
 
 function reload(){
-  VCom.mes=Number(el('mes-sel').value);VCom.anio=Number(el('anio-sel').value);
+  VCom.mes=Number(el('mes-sel').value);
+  VCom.anio=Number(el('anio-sel').value);
   var ctx=(window.AOS_getCtx&&window.AOS_getCtx())||{};
-  var nom=(ctx.asesor||'').toUpperCase();var idAs=ctx.idAsesor||'';
-  if(!nom){el('h-com-total').textContent='Sin sesion';return;}
+  var nom=(ctx.asesor||'').toUpperCase();
+  var idAs=ctx.idAsesor||'';
+  if(!nom){
+    el('h-com-total').textContent='Sin sesion';
+    return;
+  }
   _rpc('aos_comisiones_asesor',{p_asesor:nom,p_id_asesor:idAs,p_mes:VCom.mes,p_anio:VCom.anio},function(d){
-    if(!d){el('h-com-total').textContent='Sin datos';return;}renderData(d);
+    if(!d){el('h-com-total').textContent='Sin datos';return;}
+    renderData(d);
   });
 }
 
 function renderData(d){
-  var comT=parseFloat(d.comTotal||0),comS=parseFloat(d.comServ||0),comP=parseFloat(d.comProd||0),factT=parseFloat(d.factTotal||0);
-  var meta=parseFloat(d.meta||100),pct=parseFloat(d.pct||0),rank=parseInt(d.ranking||1),nv=parseInt(d.nVentas||0),ns=parseInt(d.nServ||0),np=parseInt(d.nProd||0);
+  var comT=parseFloat(d.comTotal||0);
+  var comS=parseFloat(d.comServ||0);
+  var comP=parseFloat(d.comProd||0);
+  var factT=parseFloat(d.factTotal||0);
+  var meta=parseFloat(d.meta||100);
+  var pct=parseFloat(d.pct||0);
+  var rank=parseInt(d.ranking||1);
+  var nv=parseInt(d.nVentas||0);
+  var ns=parseInt(d.nServ||0);
+  var np=parseInt(d.nProd||0);
+
+  // Hero KPIs
   el('h-com-total').textContent='S/. '+comT.toFixed(2);
   el('h-com-meta').textContent='Meta: S/. '+meta.toFixed(2)+' | Fact. S/. '+factT.toFixed(2);
-  el('h-com-prog').style.width=Math.min(pct,100)+'%';el('h-com-pct').textContent=pct.toFixed(1)+'% completado';el('h-com-rank').textContent='Rank #'+rank;
-  el('h-com-serv').textContent='S/. '+comS.toFixed(2);el('h-com-serv-sub').textContent=ns+' vta'+((ns!==1)?'s':'')+' | fact S/'+factT.toFixed(0)+' x 0.5%';
-  el('h-com-prod').textContent='S/. '+comP.toFixed(2);el('h-com-prod-sub').textContent=np+' vta'+((np!==1)?'s':'')+' | tabla de rangos';
+  el('h-com-prog').style.width=Math.min(pct,100)+'%';
+  el('h-com-pct').textContent=pct.toFixed(1)+'% completado';
+  el('h-com-rank').textContent='Rank #'+rank;
+
+  el('h-com-serv').textContent='S/. '+comS.toFixed(2);
+  el('h-com-serv-sub').textContent=ns+' vta'+((ns!==1)?'s':'')+' | fact S/'+factT.toFixed(0)+' x 0.5%';
+  el('h-com-prod').textContent='S/. '+comP.toFixed(2);
+  el('h-com-prod-sub').textContent=np+' vta'+((np!==1)?'s':'')+' | tabla de rangos';
+
+  // Ranking
   var medalEmoji=rank===1?'\uD83E\uDD47':rank===2?'\uD83E\uDD48':rank===3?'\uD83E\uDD49':'\uD83C\uDFC5';
-  el('h-rank-emoji').textContent=medalEmoji;el('h-rank-pos').textContent='#'+rank;
+  el('h-rank-emoji').textContent=medalEmoji;
+  el('h-rank-pos').textContent='#'+rank;
 
-  var anual=d.anual||[];var prevMes=anual.find(function(a){return parseInt(a.mes_num)===(VCom.mes-1);});var dEl=el('h-delta');
-  if(prevMes&&parseFloat(prevMes.comision)>0){var prevCom=parseFloat(prevMes.comision);var delta=((comT-prevCom)/prevCom*100);var up=delta>=0;dEl.textContent='vs mes anterior: '+(up?'+':'')+delta.toFixed(1)+'%';dEl.className='delta-chip '+(up?'delta-up':'delta-dn');}
-  else{dEl.textContent='vs mes anterior: --';dEl.className='delta-chip delta-n';}
+  // Delta vs mes anterior
+  var anual=d.anual||[];
+  var prevMes=anual.find(function(a){return parseInt(a.mes_num)===(VCom.mes-1);});
+  var dEl=el('h-delta');
+  if(prevMes&&parseFloat(prevMes.comision)>0){
+    var prevCom=parseFloat(prevMes.comision);
+    var delta=((comT-prevCom)/prevCom*100);
+    var up=delta>=0;
+    dEl.textContent='vs mes anterior: '+(up?'+':'')+delta.toFixed(1)+'%';
+    dEl.className='delta-chip '+(up?'delta-up':'delta-dn');
+  } else {
+    dEl.textContent='vs mes anterior: --';
+    dEl.className='delta-chip delta-n';
+  }
 
+  // Historial anual
   var hb=el('hist-body');
-  if(anual.length){hb.innerHTML=anual.map(function(row){var mn=parseInt(row.mes_num),cur=mn===VCom.mes,fact=parseFloat(row.facturado||0),cs=parseFloat(row.com_serv||0),cp=parseFloat(row.com_prod||0),ct=parseFloat(row.comision||0);return '<tr'+(cur?' class="cur"':'')+'>'+'<td style="font-weight:'+(cur?'700':'500')+';">'+h(MF[mn]||'')+'</td>'+'<td>S/'+fact.toFixed(2)+'</td>'+'<td>S/'+cs.toFixed(2)+'</td>'+'<td>S/'+cp.toFixed(2)+'</td>'+'<td style="font-weight:700;color:#0A4FBF;">S/'+ct.toFixed(2)+'</td>'+'</tr>';}).join('');}
-  else{hb.innerHTML='<tr><td colspan="5" class="ld">Sin historial</td></tr>';}
+  if(anual.length){
+    hb.innerHTML=anual.map(function(row){
+      var mn=parseInt(row.mes_num);
+      var cur=mn===VCom.mes;
+      var fact=parseFloat(row.facturado||0);
+      var cs=parseFloat(row.com_serv||0);
+      var cp=parseFloat(row.com_prod||0);
+      var ct=parseFloat(row.comision||0);
+      return '<tr'+(cur?' class="cur"':'')+'>'+'<td style="font-weight:'+(cur?'700':'500')+';">'+h(MF[mn]||'')+'</td>'+'<td>S/'+fact.toFixed(2)+'</td>'+'<td>S/'+cs.toFixed(2)+'</td>'+'<td>S/'+cp.toFixed(2)+'</td>'+'<td style="font-weight:700;color:#0A4FBF;">S/'+ct.toFixed(2)+'</td>'+'</tr>';
+    }).join('');
+  } else {
+    hb.innerHTML='<tr><td colspan="5" class="ld">Sin historial</td></tr>';
+  }
 
-  var tops=d.topClientes||[];var tcEl=el('top-clientes');
-  if(tops.length){tcEl.innerHTML=tops.map(function(cl,i){var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':String(i+1);var wa='https://api.whatsapp.com/send?phone=51'+(cl.num||'').replace(/[^0-9]/g,'');var nom=h(((cl.cliente||cl.num||'--')).substring(0,25));var f=parseFloat(cl.total||0);return '<div class="top-row">'+'<div class="top-rank">'+medal+'</div>'+'<div class="top-info"><div class="top-nom">'+nom+'</div>'+'<div class="top-met">'+h(cl.num||'')+' - '+(cl.compras||0)+' compras - ult: '+(cl.ult_fecha||'')+'</div></div>'+'<div class="top-fact">S/'+f.toFixed(2)+'</div>'+'<div class="wa-sm" onclick="window.open(\''+wa+'\',\'_blank\')">WA</div>'+'</div>';}).join('');}
-  else{tcEl.innerHTML='<div class="ld">Sin clientes</div>';}
+  // Top clientes
+  var tops=d.topClientes||[];
+  var tcEl=el('top-clientes');
+  if(tops.length){
+    tcEl.innerHTML=tops.map(function(cl,i){
+      var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':String(i+1);
+      var wa='https://api.whatsapp.com/send?phone=51'+(cl.num||'').replace(/[^0-9]/g,'');
+      var nom=h(((cl.cliente||cl.num||'--')).substring(0,25));
+      var f=parseFloat(cl.total||0);
+      return '<div class="top-row">'+'<div class="top-rank">'+medal+'</div>'+'<div class="top-info"><div class="top-nom">'+nom+'</div>'+'<div class="top-met">'+h(cl.num||'')+' - '+(cl.compras||0)+' compras - ult: '+(cl.ult_fecha||'')+'</div></div>'+'<div class="top-fact">S/'+f.toFixed(2)+'</div>'+'<div class="wa-sm" onclick="window.open(\''+wa+'\',\'_blank\')">WA</div>'+'</div>';
+    }).join('');
+  } else {
+    tcEl.innerHTML='<div class="ld">Sin clientes</div>';
+  }
 
-  var det=d.detalle||[];el('det-count').textContent=det.length+' venta'+(det.length!==1?'s':'');var db=el('det-body');
-  if(det.length){db.innerHTML=det.map(function(v){var com=parseFloat(v.comision_calculada||0),monto=parseFloat(v.monto||0),cls=(v.tipo||'')==='PRODUCTO'?'tb-prod':'tb-serv',cliente=((v.nombres||'')+' '+(v.apellidos||'')).trim();return '<tr>'+'<td style="color:#6B7BA8;">'+h(v.fecha||'')+'</td>'+'<td><div style="font-weight:700;font-size:11px;">'+h((cliente||v.numero_limpio||'--').substring(0,22))+'</div>'+'<div style="font-size:10px;color:#9AAAC8;">'+h(v.numero_limpio||'')+'</div></td>'+'<td style="font-size:10px;color:#6B7BA8;">'+h((v.tratamiento||'').substring(0,18))+'</td>'+'<td style="font-weight:700;font-size:12px;color:#0D1B3E;">S/'+monto.toFixed(2)+'</td>'+'<td><span class="com-v">S/'+com.toFixed(2)+'</span></td>'+'<td><span class="tipo-b '+cls+'">'+((v.tipo||'')==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+'</tr>';}).join('');}
-  else{db.innerHTML='<tr><td colspan="6" class="ld">Sin ventas</td></tr>';}
+  // Detalle ventas
+  var det=d.detalle||[];
+  el('det-count').textContent=det.length+' venta'+(det.length!==1?'s':'');
+  var db=el('det-body');
+  if(det.length){
+    db.innerHTML=det.map(function(v){
+      var com=parseFloat(v.comision_calculada||0);
+      var monto=parseFloat(v.monto||0);
+      var cls=(v.tipo||'')==='PRODUCTO'?'tb-prod':'tb-serv';
+      var cliente=((v.nombres||'')+' '+(v.apellidos||'')).trim();
+      return '<tr>'+'<td style="color:#6B7BA8;">'+h(v.fecha||'')+'</td>'+'<td><div style="font-weight:700;font-size:11px;">'+h((cliente||v.numero_limpio||'--').substring(0,22))+'</div>'+'<div style="font-size:10px;color:#9AAAC8;">'+h(v.numero_limpio||'')+'</div></td>'+'<td style="font-size:10px;color:#6B7BA8;">'+h((v.tratamiento||'').substring(0,18))+'</td>'+'<td style="font-weight:700;font-size:12px;color:#0D1B3E;">S/'+monto.toFixed(2)+'</td>'+'<td><span class="com-v">S/'+com.toFixed(2)+'</span></td>'+'<td><span class="tipo-b '+cls+'">'+((v.tipo||'')==='PRODUCTO'?'PROD':'SERV')+'</span></td>'+'</tr>';
+    }).join('');
+  } else {
+    db.innerHTML='<tr><td colspan="6" class="ld">Sin ventas</td></tr>';
+  }
 
-  // REV-PERF: consume the ranking embedded by the canonical commission RPC.
-  // Fallback preserves deploy-order compatibility if an older DB function is temporarily active.
+  // Ranking mini (otros asesores). REV-PERF prefers the ranking embedded in the main RPC.
   loadRankingMini(d.rankingTop);
 }
 
 function renderRankingMini(arr){
   if(!arr||!arr.length){el('h-rank-mini').innerHTML='Sin datos';return;}
-  el('h-rank-mini').innerHTML=arr.slice(0,5).map(function(r,i){
+  var html=arr.slice(0,5).map(function(r,i){
     var medal=i===0?'\uD83E\uDD47':i===1?'\uD83E\uDD48':i===2?'\uD83E\uDD49':'#'+(i+1);
     return '<div style="display:flex;align-items:center;justify-content:space-between;padding:3px 0;">'+'<span style="font-size:11px;">'+medal+' '+h((r.asesor||'').split(' ')[0])+'</span>'+'<span style="font-weight:800;font-size:12px;color:#0A4FBF;">S/'+parseFloat(r.com||0).toFixed(2)+'</span>'+'</div>';
   }).join('');
+  el('h-rank-mini').innerHTML=html;
 }
 
 function loadRankingMini(rankingTop){
+  // Deploy-order compatibility: use the legacy read only if the DB has not yet exposed rankingTop.
   if(Array.isArray(rankingTop)){renderRankingMini(rankingTop);return;}
   var mesI=VCom.anio+'-'+String(VCom.mes).padStart(2,'0')+'-01';
   var mesFin=VCom.anio+'-'+String(VCom.mes).padStart(2,'0')+'-31';
-  fetch(_SB+'/rest/v1/aos_ventas?select=asesor,monto,tipo&fecha=gte.'+mesI+'&fecha=lte.'+mesFin+'&asesor=not.in.(NO+APLICA,DRA+CAROLINA,DRA+YESSICA,VINO+SOLA(O))',{headers:{'apikey':_SK,'Authorization':'Bearer '+_SK}})
-  .then(function(r){return r.json();}).then(function(rows){
-    if(!rows||!rows.length){renderRankingMini([]);return;}
-    var by={};rows.forEach(function(v){var a=v.asesor||'';if(!a)return;if(!by[a])by[a]={fact:0,com:0};var m=parseFloat(v.monto||0);by[a].fact+=m;if(v.tipo==='SERVICIO')by[a].com+=Math.round(m*0.005*100)/100;else if(v.tipo==='PRODUCTO'){var c=0;if(m>=201)c=6;else if(m>=149)c=5;else if(m>=101)c=4;else if(m>=51)c=3;else if(m>=18)c=1;else c=0.3;by[a].com+=c;}});
-    var arr=Object.keys(by).map(function(a){return{asesor:a,com:by[a].com,fact:by[a].fact};});arr.sort(function(a,b){return b.com-a.com;});renderRankingMini(arr);
+  fetch(_SB+'/rest/v1/aos_ventas?select=asesor,monto,tipo&fecha=gte.'+mesI+'&fecha=lte.'+mesFin+'&asesor=not.in.(NO+APLICA,DRA+CAROLINA,DRA+YESSICA,VINO+SOLA(O))',{
+    headers:{'apikey':_SK,'Authorization':'Bearer '+_SK}
+  }).then(function(r){return r.json();}).then(function(rows){
+    if(!rows||!rows.length){el('h-rank-mini').innerHTML='Sin datos';return;}
+    var by={};
+    rows.forEach(function(v){
+      var a=v.asesor||'';if(!a)return;
+      if(!by[a])by[a]={fact:0,com:0};
+      var m=parseFloat(v.monto||0);
+      by[a].fact+=m;
+      if(v.tipo==='SERVICIO')by[a].com+=Math.round(m*0.005*100)/100;
+      else if(v.tipo==='PRODUCTO'){
+        var c=0;if(m>=201)c=6;else if(m>=149)c=5;else if(m>=101)c=4;else if(m>=51)c=3;else if(m>=18)c=1;else c=0.3;
+        by[a].com+=c;
+      }
+    });
+    var arr=Object.keys(by).map(function(a){return{asesor:a,com:by[a].com,fact:by[a].fact};});
+    arr.sort(function(a,b){return b.com-a.com;});
+    renderRankingMini(arr);
   }).catch(function(){el('h-rank-mini').innerHTML='Error';});
 }

--- a/app/public/commissions.js
+++ b/app/public/commissions.js
@@ -1,6 +1,6 @@
 // commissions.js — Panel Comisiones Asesor | AscendaOS v1 | 100% Supabase
 var _SB='https://ituyqwstonmhnfshnaqz.supabase.co';
-var _SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYXN1cGFza2V5IiwicmVmIjoiaXR1eXF3c3Rvbm1obmZzaG5hcXoiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc3NDc0NDIxOCwiZXhwIjoyMDkwMzIwMjE4fQ.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
+var _SK='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0dXlxd3N0b25taG5mc2huYXF6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3NDQyMTgsImV4cCI6MjA5MDMyMDIxOH0.w_pU4ecrrgekB7WzWrQrQd_7Deu_Cxm5ybUCZry5Mh0';
 
 function _rpc(fn,p,ok,fail){
   fetch(_SB+'/rest/v1/rpc/'+fn,{method:'POST',headers:{'apikey':_SK,'Authorization':'Bearer '+_SK,'Content-Type':'application/json'},body:JSON.stringify(p||{})})

--- a/ci/performance/rev-perf-sales-commissions-p0.test.js
+++ b/ci/performance/rev-perf-sales-commissions-p0.test.js
@@ -1,0 +1,66 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+const migration=fs.readFileSync('supabase/migrations/20260902181000_rev_perf_sales_commissions_p0_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260902181000_rev_perf_sales_commissions_p0_v1_rollback.sql','utf8');
+
+function fnBody(sql,name){
+  const marker=`function public.${name}`;
+  const i=sql.toLowerCase().indexOf(marker.toLowerCase());
+  assert.notEqual(i,-1,`${name} must exist`);
+  const next=sql.toLowerCase().indexOf('create or replace function public.',i+marker.length);
+  return sql.slice(i,next===-1?sql.length:next);
+}
+
+test('REV-PERF P0 replaces only intended read contracts',()=>{
+  assert.match(migration,/aos_comisiones_asesor/i);
+  assert.match(migration,/aos_ventas_admin\(/i);
+  assert.match(migration,/aos_ventas_admin_anio/i);
+  assert.doesNotMatch(migration,/create\s+or\s+replace\s+function\s+public\.aos_comisiones_admin\b/i);
+  assert.doesNotMatch(migration,/insert\s+into\s+public\.aos_ventas/i);
+  assert.doesNotMatch(migration,/update\s+public\.aos_ventas/i);
+  assert.doesNotMatch(migration,/delete\s+from\s+public\.aos_ventas/i);
+});
+
+test('Sales monthly hot path uses scoped materialized bases',()=>{
+  const body=fnBody(migration,'aos_ventas_admin');
+  for(const token of ['period_all as materialized','base as materialized','advisor_base as materialized','year_base as materialized','agg as']){
+    assert.ok(body.toLowerCase().includes(token),`missing ${token}`);
+  }
+  assert.match(body,/fecha\s+between\s+v_desde\s+and\s+v_hasta/i);
+  assert.match(body,/Legacy filter semantics intentionally preserved/i);
+});
+
+test('Sales annual hot path reuses one annual base',()=>{
+  const body=fnBody(migration,'aos_ventas_admin_anio');
+  assert.match(body,/period_all as materialized/i);
+  assert.match(body,/base as materialized/i);
+  assert.match(body,/advisor_base as materialized/i);
+});
+
+test('Commission hot path derives month from one advisor-year base and preserves empty-month nulls',()=>{
+  const body=fnBody(migration,'aos_comisiones_asesor');
+  assert.match(body,/year_sales as materialized/i);
+  assert.match(body,/month_sales as materialized/i);
+  assert.match(body,/ranking_sales as materialized/i);
+  assert.match(body,/'comServ',\(select sum\(calc_com\)/i);
+  assert.match(body,/'comProd',\(select sum\(calc_com\)/i);
+  assert.match(body,/'rankingTop'/i);
+});
+
+test('Commission rules remain canonical and no timeout is raised',()=>{
+  assert.match(migration,/aos_tabla_comisiones/i);
+  assert.match(migration,/monto_min<=/i);
+  assert.match(migration,/0\.005/);
+  const executable=migration.replace(/--.*$/gm,'');
+  assert.doesNotMatch(executable,/statement_timeout/i);
+  assert.doesNotMatch(executable,/set\s+local\s+.*timeout/i);
+});
+
+test('Rollback restores all three replaced functions',()=>{
+  for(const name of ['aos_comisiones_asesor','aos_ventas_admin','aos_ventas_admin_anio']){
+    assert.ok(rollback.toLowerCase().includes(`function public.${name}`),`rollback missing ${name}`);
+  }
+  assert.doesNotMatch(rollback,/rankingTop/i);
+});

--- a/supabase/migrations/20260902181000_rev_perf_sales_commissions_p0_v1.sql
+++ b/supabase/migrations/20260902181000_rev_perf_sales_commissions_p0_v1.sql
@@ -1,0 +1,330 @@
+-- ASCENDA OS · REV-PERF P0 · Sales + Commissions
+-- Read-path only. Preserve business formulas and result contracts.
+-- Doctrine: critical path first; scoped/materialized reads; no timeout changes.
+
+create or replace function public.aos_comisiones_asesor(
+  p_asesor text,
+  p_id_asesor text,
+  p_mes integer,
+  p_anio integer
+) returns jsonb
+language plpgsql
+security definer
+as $function$
+declare
+  v_mes_inicio date := make_date(p_anio,p_mes,1);
+  v_mes_fin date := (make_date(p_anio,p_mes,1)+interval '1 month'-interval '1 day')::date;
+  v_anio_inicio date := make_date(p_anio,1,1);
+  v_anio_fin date := make_date(p_anio,12,31);
+begin
+  return (
+    with product_rules as materialized (
+      select monto_min::numeric monto_min,comision::numeric comision
+      from public.aos_tabla_comisiones
+      where tipo='PRODUCTO' and activo=true
+    ),
+    year_sales as materialized (
+      select v.*,
+        case
+          when v.tipo='SERVICIO' then round(v.monto::numeric*0.005,2)
+          when v.tipo='PRODUCTO' then (
+            select coalesce(max(r.comision),0)
+            from product_rules r
+            where r.monto_min<=v.monto::numeric
+          )
+          else 0
+        end as calc_com
+      from public.aos_ventas v
+      where v.asesor=p_asesor
+        and v.fecha between v_anio_inicio and v_anio_fin
+    ),
+    month_sales as materialized (
+      select * from year_sales
+      where fecha between v_mes_inicio and v_mes_fin
+    ),
+    ranking_sales as materialized (
+      select v.asesor,
+        sum(v.monto::numeric) as fact,
+        sum(
+          case
+            when v.tipo='SERVICIO' then round(v.monto::numeric*0.005,2)
+            when v.tipo='PRODUCTO' then (
+              select coalesce(max(r.comision),0)
+              from product_rules r
+              where r.monto_min<=v.monto::numeric
+            )
+            else 0
+          end
+        ) as com
+      from public.aos_ventas v
+      where v.fecha between v_mes_inicio and v_mes_fin
+        and v.asesor not in ('NO APLICA','DRA CAROLINA','DRA YESSICA','VINO SOLA(O)')
+      group by v.asesor
+    ),
+    rankpos as (
+      select asesor,row_number() over(order by com desc) pos
+      from ranking_sales
+    )
+    select jsonb_build_object(
+      'comTotal',coalesce((select sum(calc_com) from month_sales),0),
+      -- Preserve legacy null semantics when the advisor has no sales in the month.
+      'comServ',(select sum(calc_com) from month_sales where tipo='SERVICIO'),
+      'comProd',(select sum(calc_com) from month_sales where tipo='PRODUCTO'),
+      'factTotal',coalesce((select sum(monto::numeric) from month_sales),0),
+      'nVentas',(select count(*) from month_sales),
+      'nServ',(select count(*) from month_sales where tipo='SERVICIO'),
+      'nProd',(select count(*) from month_sales where tipo='PRODUCTO'),
+      'ranking',(select pos from rankpos where asesor=p_asesor),
+      'meta',100,
+      'pct',round(coalesce((select sum(calc_com) from month_sales),0)/100.0*100,1),
+      'detalle',coalesce((
+        select jsonb_agg(to_jsonb(d) order by d.fecha desc)
+        from (
+          select fecha::text,nombres,apellidos,numero_limpio,tratamiento,descripcion,
+            monto::numeric,tipo,sede,pago,estado_pago,calc_com as comision_calculada
+          from month_sales
+        ) d
+      ),'[]'::jsonb),
+      'anual',coalesce((
+        select jsonb_agg(to_jsonb(h) order by h.mes_num)
+        from (
+          select extract(month from fecha)::integer mes_num,
+            to_char(fecha,'TMMonth') mes_nombre,
+            sum(monto::numeric) facturado,
+            sum(calc_com) comision,
+            sum(calc_com) filter(where tipo='SERVICIO') com_serv,
+            sum(calc_com) filter(where tipo='PRODUCTO') com_prod,
+            count(*) n_ventas
+          from year_sales
+          group by extract(month from fecha),to_char(fecha,'TMMonth')
+        ) h
+      ),'[]'::jsonb),
+      'topClientes',coalesce((
+        select jsonb_agg(to_jsonb(t) order by t.total desc)
+        from (
+          select (coalesce(nombres,'')||' '||coalesce(apellidos,'')) cliente,
+            numero_limpio num,sum(monto::numeric) total,count(*) compras,max(fecha::text) ult_fecha
+          from year_sales
+          where numero_limpio is not null and numero_limpio<>''
+          group by nombres,apellidos,numero_limpio
+          order by sum(monto::numeric) desc
+          limit 5
+        ) t
+      ),'[]'::jsonb),
+      -- Additive field: lets the advisor UI render ranking without a second sales-table download.
+      'rankingTop',coalesce((
+        select jsonb_agg(to_jsonb(r) order by r.com desc)
+        from (
+          select asesor,com,fact
+          from ranking_sales
+          order by com desc
+          limit 5
+        ) r
+      ),'[]'::jsonb)
+    )
+  );
+end;
+$function$;
+
+comment on function public.aos_comisiones_asesor(text,text,integer,integer) is
+  'REV-PERF P0: one scoped advisor/year base + monthly derivation and embedded ranking. Commission semantics preserved.';
+
+create or replace function public.aos_ventas_admin(
+  p_mes integer,
+  p_anio integer,
+  p_sede text default '',
+  p_asesor text default ''
+) returns jsonb
+language plpgsql
+security definer
+as $function$
+declare
+  v_desde date := make_date(p_anio,p_mes,1);
+  v_hasta date := (make_date(p_anio,p_mes,1)+interval '1 month'-interval '1 day')::date;
+  v_periodo text := p_anio||'-'||lpad(p_mes::text,2,'0');
+  v_anio_desde date := make_date(p_anio,1,1);
+  v_anio_hasta date := make_date(p_anio,12,31);
+begin
+  return (
+    with product_rules as materialized (
+      select monto_min::numeric monto_min,comision::numeric comision
+      from public.aos_tabla_comisiones
+      where tipo='PRODUCTO' and activo=true
+    ),
+    period_all as materialized (
+      select v.*
+      from public.aos_ventas v
+      where v.fecha between v_desde and v_hasta
+    ),
+    base as materialized (
+      select v.*
+      from period_all v
+      where (p_sede='' or v.sede=p_sede)
+        and (p_asesor='' or v.asesor=p_asesor)
+    ),
+    advisor_base as materialized (
+      select v.*
+      from period_all v
+      where p_asesor='' or v.asesor=p_asesor
+    ),
+    year_base as materialized (
+      select v.fecha,v.monto
+      from public.aos_ventas v
+      where v.fecha between v_anio_desde and v_anio_hasta
+        and (p_sede='' or v.sede=p_sede)
+        and (p_asesor='' or v.asesor=p_asesor)
+    ),
+    agg as (
+      select count(*) nventas,
+        coalesce(sum(monto),0) fact,
+        case when count(*)>0 then round(sum(monto)/count(*)) else 0 end ticket,
+        count(*) filter(where tipo='SERVICIO') nserv,
+        coalesce(sum(monto) filter(where tipo='SERVICIO'),0) fserv,
+        count(*) filter(where tipo='PRODUCTO') nprod,
+        coalesce(sum(monto) filter(where tipo='PRODUCTO'),0) fprod,
+        count(*) filter(where estado_pago='PAGO COMPLETO') npago,
+        count(*) filter(where estado_pago='ADELANTO') nadel,
+        coalesce(sum(monto) filter(where estado_pago='ADELANTO'),0) fadel,
+        count(*) filter(where estado_pago is null or estado_pago not in ('PAGO COMPLETO','ADELANTO')) nsin
+      from base
+    )
+    select jsonb_build_object(
+      'factTotal',a.fact,'nVentas',a.nventas,'ticketProm',a.ticket,
+      'nServ',a.nserv,'factServ',a.fserv,'nProd',a.nprod,'factProd',a.fprod,
+      'nPagoCompleto',a.npago,'nAdelanto',a.nadel,'factAdelanto',a.fadel,'nSinDefinir',a.nsin,
+      'meta',(select coalesce(meta,0) from public.aos_metas_ventas where periodo=v_periodo),
+      'detalle',coalesce((
+        select jsonb_agg(to_jsonb(d) order by d.fecha desc,d.id desc)
+        from (
+          select v.id,v.fecha::text fecha,v.monto,v.tipo,v.tratamiento,v.descripcion,v.pago,v.sede,
+            v.estado_pago,v.atendio,v.numero_limpio,v.asesor,v.nombres,v.apellidos,
+            case when v.asesor='NO APLICA' then 0
+                 when v.tipo='SERVICIO' then round(v.monto*0.005,2)
+                 when v.tipo='PRODUCTO' then coalesce((select max(r.comision) from product_rules r where r.monto_min<=v.monto),0)
+                 else 0 end as comision
+          from base v
+        ) d
+      ),'[]'::jsonb),
+      -- Legacy filter semantics intentionally preserved: advisor ranking ignores p_asesor.
+      'porAsesor',coalesce((
+        select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (
+          select v.asesor,count(*) n,sum(v.monto) total,
+            sum(case when v.tipo='SERVICIO' then round(v.monto*0.005,2)
+                     when v.tipo='PRODUCTO' then coalesce((select max(r.comision) from product_rules r where r.monto_min<=v.monto),0)
+                     else 0 end) comision
+          from period_all v
+          where (p_sede='' or v.sede=p_sede) and v.asesor!='NO APLICA'
+          group by v.asesor
+        ) x
+      ),'[]'::jsonb),
+      'noAplica',(select jsonb_build_object('n',count(*),'total',coalesce(sum(v.monto),0))
+        from period_all v where v.asesor='NO APLICA' and (p_sede='' or v.sede=p_sede)),
+      -- Legacy filter semantics intentionally preserved: sede summaries ignore p_sede.
+      'porSede',coalesce((
+        select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select sede,count(*) n,sum(monto) total,
+          count(*) filter(where tipo='SERVICIO') n_serv,count(*) filter(where tipo='PRODUCTO') n_prod
+          from advisor_base group by sede) x
+      ),'[]'::jsonb),
+      'porMetodoPago',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select pago metodo,count(*) n,sum(monto) total from base group by pago) x),'[]'::jsonb),
+      'porMetodoPagoSede',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select pago metodo,sede,count(*) n,sum(monto) total from advisor_base group by pago,sede) x),'[]'::jsonb),
+      'porTratamiento',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select tratamiento,count(*) n,sum(monto) total from base group by tratamiento order by sum(monto) desc limit 10) x),'[]'::jsonb),
+      'anual',coalesce((select jsonb_agg(to_jsonb(x) order by x.mes_num)
+        from (select extract(month from fecha)::int mes_num,sum(monto) facturado,count(*) n_ventas
+          from year_base group by extract(month from fecha)) x),'[]'::jsonb),
+      'metodos',(select coalesce(jsonb_agg(to_jsonb(x) order by x.orden),'[]'::jsonb)
+        from (select id,nombre,moneda,activo,orden,sede from public.aos_metodos_pago order by orden) x),
+      'metas',(select coalesce(jsonb_agg(to_jsonb(x) order by x.periodo desc),'[]'::jsonb)
+        from (select id,periodo,meta,moneda,descripcion from public.aos_metas_ventas order by periodo desc) x)
+    ) from agg a
+  );
+end;
+$function$;
+
+comment on function public.aos_ventas_admin(integer,integer,text,text) is
+  'REV-PERF P0: one materialized monthly base reused by KPIs/detail/rankings; legacy JSON/filter semantics preserved.';
+
+create or replace function public.aos_ventas_admin_anio(
+  p_anio integer,
+  p_sede text default '',
+  p_asesor text default ''
+) returns jsonb
+language plpgsql
+security definer
+as $function$
+declare
+  v_desde date := make_date(p_anio,1,1);
+  v_hasta date := make_date(p_anio,12,31);
+begin
+  return (
+    with product_rules as materialized (
+      select monto_min::numeric monto_min,comision::numeric comision
+      from public.aos_tabla_comisiones
+      where tipo='PRODUCTO' and activo=true
+    ),
+    period_all as materialized (
+      select v.* from public.aos_ventas v where v.fecha between v_desde and v_hasta
+    ),
+    base as materialized (
+      select v.* from period_all v
+      where (p_sede='' or v.sede=p_sede) and (p_asesor='' or v.asesor=p_asesor)
+    ),
+    advisor_base as materialized (
+      select v.* from period_all v where p_asesor='' or v.asesor=p_asesor
+    ),
+    agg as (
+      select count(*) nventas,coalesce(sum(monto),0) fact,
+        case when count(*)>0 then round(sum(monto)/count(*)) else 0 end ticket,
+        count(*) filter(where tipo='SERVICIO') nserv,
+        coalesce(sum(monto) filter(where tipo='SERVICIO'),0) fserv,
+        count(*) filter(where tipo='PRODUCTO') nprod,
+        coalesce(sum(monto) filter(where tipo='PRODUCTO'),0) fprod,
+        count(*) filter(where estado_pago='PAGO COMPLETO') npago,
+        count(*) filter(where estado_pago='ADELANTO') nadel,
+        coalesce(sum(monto) filter(where estado_pago='ADELANTO'),0) fadel,
+        count(*) filter(where estado_pago is null or estado_pago not in ('PAGO COMPLETO','ADELANTO')) nsin
+      from base
+    )
+    select jsonb_build_object(
+      'factTotal',a.fact,'nVentas',a.nventas,'ticketProm',a.ticket,
+      'nServ',a.nserv,'factServ',a.fserv,'nProd',a.nprod,'factProd',a.fprod,
+      'nPagoCompleto',a.npago,'nAdelanto',a.nadel,'factAdelanto',a.fadel,'nSinDefinir',a.nsin,
+      'detalle',coalesce((select jsonb_agg(to_jsonb(d) order by d.fecha desc,d.id desc)
+        from (select v.id,v.fecha::text fecha,v.monto,v.tipo,v.tratamiento,v.descripcion,v.pago,v.sede,
+          v.estado_pago,v.atendio,v.numero_limpio,v.asesor,v.nombres,v.apellidos,
+          case when v.asesor='NO APLICA' then 0
+               when v.tipo='SERVICIO' then round(v.monto*0.005,2)
+               when v.tipo='PRODUCTO' then coalesce((select max(r.comision) from product_rules r where r.monto_min<=v.monto),0)
+               else 0 end as comision
+          from base v) d),'[]'::jsonb),
+      'porAsesor',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select v.asesor,count(*) n,sum(v.monto) total,
+          sum(case when v.tipo='SERVICIO' then round(v.monto*0.005,2)
+                   when v.tipo='PRODUCTO' then coalesce((select max(r.comision) from product_rules r where r.monto_min<=v.monto),0)
+                   else 0 end) comision
+          from period_all v where (p_sede='' or v.sede=p_sede) and v.asesor!='NO APLICA' group by v.asesor) x),'[]'::jsonb),
+      'noAplica',(select jsonb_build_object('n',count(*),'total',coalesce(sum(v.monto),0))
+        from period_all v where v.asesor='NO APLICA' and (p_sede='' or v.sede=p_sede)),
+      'porSede',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select sede,count(*) n,sum(monto) total,count(*) filter(where tipo='SERVICIO') n_serv,
+          count(*) filter(where tipo='PRODUCTO') n_prod from advisor_base group by sede) x),'[]'::jsonb),
+      'porMetodoPago',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select pago metodo,count(*) n,sum(monto) total from base group by pago) x),'[]'::jsonb),
+      'porMetodoPagoSede',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select pago metodo,sede,count(*) n,sum(monto) total from advisor_base group by pago,sede) x),'[]'::jsonb),
+      'porTratamiento',coalesce((select jsonb_agg(to_jsonb(x) order by x.total desc)
+        from (select tratamiento,count(*) n,sum(monto) total from base group by tratamiento order by sum(monto) desc limit 10) x),'[]'::jsonb),
+      'anual',coalesce((select jsonb_agg(to_jsonb(x) order by x.mes_num)
+        from (select extract(month from fecha)::int mes_num,sum(monto) facturado,count(*) n_ventas
+          from base group by extract(month from fecha)) x),'[]'::jsonb)
+    ) from agg a
+  );
+end;
+$function$;
+
+comment on function public.aos_ventas_admin_anio(integer,text,text) is
+  'REV-PERF P0: one materialized annual base reused by all dashboard aggregates; legacy JSON/filter semantics preserved.';

--- a/supabase/rollbacks/20260902181000_rev_perf_sales_commissions_p0_v1_rollback.sql
+++ b/supabase/rollbacks/20260902181000_rev_perf_sales_commissions_p0_v1_rollback.sql
@@ -1,0 +1,170 @@
+-- ASCENDA OS · REV-PERF P0 rollback
+-- Restores the three pre-P0 read functions exactly in behavior.
+
+CREATE OR REPLACE FUNCTION public.aos_comisiones_asesor(p_asesor text, p_id_asesor text, p_mes integer, p_anio integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_mes_inicio date;
+  v_mes_fin date;
+  v_detalle jsonb;
+  v_anual jsonb;
+  v_top jsonb;
+  v_ranking jsonb;
+  v_com_total numeric := 0;
+  v_com_serv numeric := 0;
+  v_com_prod numeric := 0;
+  v_fact_total numeric := 0;
+  v_n_ventas integer := 0;
+  v_n_serv integer := 0;
+  v_n_prod integer := 0;
+  v_puesto integer := 1;
+BEGIN
+  v_mes_inicio := make_date(p_anio, p_mes, 1);
+  v_mes_fin := (v_mes_inicio + interval '1 month' - interval '1 day')::date;
+  SELECT COALESCE(jsonb_agg(row_to_json(d)::jsonb ORDER BY d.fecha DESC), '[]'::jsonb)
+  INTO v_detalle
+  FROM (
+    SELECT v.fecha::text, v.nombres, v.apellidos, v.numero_limpio,
+      v.tratamiento, v.descripcion, v.monto::numeric, v.tipo, v.sede, v.pago, v.estado_pago,
+      CASE WHEN v.tipo = 'SERVICIO' THEN ROUND(v.monto::numeric * 0.005, 2)
+        WHEN v.tipo = 'PRODUCTO' THEN (
+          SELECT COALESCE(MAX(tc.comision::numeric), 0) FROM aos_tabla_comisiones tc
+          WHERE tc.tipo = 'PRODUCTO' AND tc.monto_min::numeric <= v.monto::numeric AND tc.activo = true
+        ) ELSE 0 END as comision_calculada
+    FROM aos_ventas v
+    WHERE v.asesor = p_asesor AND v.fecha >= v_mes_inicio AND v.fecha <= v_mes_fin
+  ) d;
+  SELECT COUNT(*), SUM(monto::numeric),
+    SUM(CASE WHEN tipo='SERVICIO' THEN ROUND(monto::numeric * 0.005, 2) ELSE 0 END),
+    SUM(CASE WHEN tipo='PRODUCTO' THEN (
+      SELECT COALESCE(MAX(tc.comision::numeric), 0) FROM aos_tabla_comisiones tc
+      WHERE tc.tipo = 'PRODUCTO' AND tc.monto_min::numeric <= v.monto::numeric AND tc.activo = true
+    ) ELSE 0 END),
+    COUNT(*) FILTER (WHERE tipo='SERVICIO'), COUNT(*) FILTER (WHERE tipo='PRODUCTO')
+  INTO v_n_ventas, v_fact_total, v_com_serv, v_com_prod, v_n_serv, v_n_prod
+  FROM aos_ventas v
+  WHERE v.asesor = p_asesor AND v.fecha >= v_mes_inicio AND v.fecha <= v_mes_fin;
+  v_com_total := COALESCE(v_com_serv, 0) + COALESCE(v_com_prod, 0);
+  SELECT COALESCE(jsonb_agg(row_to_json(h)::jsonb ORDER BY h.mes_num), '[]'::jsonb)
+  INTO v_anual
+  FROM (
+    SELECT EXTRACT(MONTH FROM v.fecha)::integer as mes_num, TO_CHAR(v.fecha, 'TMMonth') as mes_nombre,
+      SUM(v.monto::numeric) as facturado,
+      SUM(CASE WHEN v.tipo = 'SERVICIO' THEN ROUND(v.monto::numeric * 0.005, 2)
+        WHEN v.tipo = 'PRODUCTO' THEN (
+          SELECT COALESCE(MAX(tc.comision::numeric), 0) FROM aos_tabla_comisiones tc
+          WHERE tc.tipo = 'PRODUCTO' AND tc.monto_min::numeric <= v.monto::numeric AND tc.activo = true
+        ) ELSE 0 END) as comision,
+      SUM(CASE WHEN v.tipo = 'SERVICIO' THEN ROUND(v.monto::numeric * 0.005, 2) ELSE 0 END) as com_serv,
+      SUM(CASE WHEN v.tipo = 'PRODUCTO' THEN (
+        SELECT COALESCE(MAX(tc.comision::numeric), 0) FROM aos_tabla_comisiones tc
+        WHERE tc.tipo = 'PRODUCTO' AND tc.monto_min::numeric <= v.monto::numeric AND tc.activo = true
+      ) ELSE 0 END) as com_prod, COUNT(*) as n_ventas
+    FROM aos_ventas v WHERE v.asesor = p_asesor AND EXTRACT(YEAR FROM v.fecha) = p_anio
+    GROUP BY EXTRACT(MONTH FROM v.fecha), TO_CHAR(v.fecha, 'TMMonth')
+  ) h;
+  SELECT COALESCE(jsonb_agg(row_to_json(t)::jsonb ORDER BY t.total DESC), '[]'::jsonb)
+  INTO v_top
+  FROM (
+    SELECT (COALESCE(v.nombres,'') || ' ' || COALESCE(v.apellidos,'')) as cliente,
+      v.numero_limpio as num, SUM(v.monto::numeric) as total, COUNT(*) as compras, MAX(v.fecha::text) as ult_fecha
+    FROM aos_ventas v
+    WHERE v.asesor = p_asesor AND EXTRACT(YEAR FROM v.fecha) = p_anio
+      AND v.numero_limpio IS NOT NULL AND v.numero_limpio != ''
+    GROUP BY v.nombres, v.apellidos, v.numero_limpio ORDER BY SUM(v.monto::numeric) DESC LIMIT 5
+  ) t;
+  SELECT COALESCE(rk.pos, 1) INTO v_puesto
+  FROM (
+    SELECT asesor, ROW_NUMBER() OVER (ORDER BY SUM(
+      CASE WHEN tipo='SERVICIO' THEN ROUND(monto::numeric*0.005,2)
+        WHEN tipo='PRODUCTO' THEN (SELECT COALESCE(MAX(tc.comision::numeric),0) FROM aos_tabla_comisiones tc WHERE tc.tipo='PRODUCTO' AND tc.monto_min::numeric<=v.monto::numeric AND tc.activo=true)
+        ELSE 0 END
+    ) DESC) as pos
+    FROM aos_ventas v
+    WHERE fecha >= v_mes_inicio AND fecha <= v_mes_fin
+      AND asesor NOT IN ('NO APLICA','DRA CAROLINA','DRA YESSICA','VINO SOLA(O)')
+    GROUP BY asesor
+  ) rk WHERE rk.asesor = p_asesor;
+  RETURN jsonb_build_object(
+    'comTotal', v_com_total,'comServ', v_com_serv,'comProd', v_com_prod,
+    'factTotal', COALESCE(v_fact_total, 0),'nVentas', COALESCE(v_n_ventas, 0),
+    'nServ', COALESCE(v_n_serv, 0),'nProd', COALESCE(v_n_prod, 0),'ranking', v_puesto,
+    'meta', 100,'pct', ROUND(COALESCE(v_com_total,0) / 100.0 * 100, 1),
+    'detalle', v_detalle,'anual', v_anual,'topClientes', v_top
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.aos_ventas_admin(p_mes integer, p_anio integer, p_sede text DEFAULT ''::text, p_asesor text DEFAULT ''::text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_desde date; v_hasta date; v_periodo text;
+BEGIN
+  v_desde := make_date(p_anio, p_mes, 1);
+  v_hasta := (v_desde + interval '1 month' - interval '1 day')::date;
+  v_periodo := p_anio || '-' || LPAD(p_mes::text, 2, '0');
+  RETURN jsonb_build_object(
+    'factTotal', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nVentas', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'ticketProm', (SELECT CASE WHEN COUNT(*)>0 THEN ROUND(SUM(monto)/COUNT(*)) ELSE 0 END FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nServ', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='SERVICIO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factServ', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='SERVICIO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nProd', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='PRODUCTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factProd', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='PRODUCTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nPagoCompleto', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='PAGO COMPLETO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nAdelanto', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='ADELANTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factAdelanto', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='ADELANTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nSinDefinir', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (estado_pago IS NULL OR estado_pago NOT IN ('PAGO COMPLETO','ADELANTO')) AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'meta', (SELECT COALESCE(meta,0) FROM aos_metas_ventas WHERE periodo=v_periodo),
+    'detalle', COALESCE((SELECT jsonb_agg(row_to_json(d) ORDER BY d.fecha DESC, d.id DESC) FROM (
+      SELECT v.id, v.fecha::text, v.monto, v.tipo, v.tratamiento, v.descripcion, v.pago, v.sede, v.estado_pago, v.atendio, v.numero_limpio, v.asesor, v.nombres, v.apellidos,
+        CASE WHEN v.asesor='NO APLICA' THEN 0 WHEN v.tipo='SERVICIO' THEN ROUND(v.monto*0.005,2) WHEN v.tipo='PRODUCTO' THEN COALESCE((SELECT MAX(tc.comision::numeric) FROM aos_tabla_comisiones tc WHERE tc.tipo='PRODUCTO' AND tc.monto_min::numeric<=v.monto AND tc.activo=true),0) ELSE 0 END as comision
+      FROM aos_ventas v WHERE v.fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR v.sede=p_sede) AND (p_asesor='' OR v.asesor=p_asesor)) d), '[]'::jsonb),
+    'porAsesor', COALESCE((SELECT jsonb_agg(row_to_json(a) ORDER BY a.total DESC) FROM (
+      SELECT asesor, COUNT(*) as n, SUM(monto) as total,
+        SUM(CASE WHEN tipo='SERVICIO' THEN ROUND(monto*0.005,2) WHEN tipo='PRODUCTO' THEN COALESCE((SELECT MAX(tc.comision::numeric) FROM aos_tabla_comisiones tc WHERE tc.tipo='PRODUCTO' AND tc.monto_min::numeric<=v.monto AND tc.activo=true),0) ELSE 0 END) as comision
+      FROM aos_ventas v WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND asesor!='NO APLICA' GROUP BY asesor) a), '[]'::jsonb),
+    'noAplica', (SELECT jsonb_build_object('n',COUNT(*),'total',COALESCE(SUM(monto),0)) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND asesor='NO APLICA' AND (p_sede='' OR sede=p_sede)),
+    'porSede', COALESCE((SELECT jsonb_agg(row_to_json(s) ORDER BY s.total DESC) FROM (SELECT sede, COUNT(*) as n, SUM(monto) as total, COUNT(*) FILTER(WHERE tipo='SERVICIO') as n_serv, COUNT(*) FILTER(WHERE tipo='PRODUCTO') as n_prod FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_asesor='' OR asesor=p_asesor) GROUP BY sede) s), '[]'::jsonb),
+    'porMetodoPago', COALESCE((SELECT jsonb_agg(row_to_json(mp) ORDER BY mp.total DESC) FROM (SELECT pago as metodo, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY pago) mp), '[]'::jsonb),
+    'porMetodoPagoSede', COALESCE((SELECT jsonb_agg(row_to_json(mp) ORDER BY mp.total DESC) FROM (SELECT pago as metodo, sede, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_asesor='' OR asesor=p_asesor) GROUP BY pago, sede) mp), '[]'::jsonb),
+    'porTratamiento', COALESCE((SELECT jsonb_agg(row_to_json(t) ORDER BY t.total DESC) FROM (SELECT tratamiento, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY tratamiento ORDER BY SUM(monto) DESC LIMIT 10) t), '[]'::jsonb),
+    'anual', COALESCE((SELECT jsonb_agg(row_to_json(m) ORDER BY m.mes_num) FROM (SELECT EXTRACT(MONTH FROM fecha)::int as mes_num, SUM(monto) as facturado, COUNT(*) as n_ventas FROM aos_ventas WHERE EXTRACT(YEAR FROM fecha)=p_anio AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY EXTRACT(MONTH FROM fecha)) m), '[]'::jsonb),
+    'metodos', (SELECT COALESCE(jsonb_agg(row_to_json(mp) ORDER BY mp.orden), '[]'::jsonb) FROM (SELECT id, nombre, moneda, activo, orden, sede FROM aos_metodos_pago ORDER BY orden) mp),
+    'metas', (SELECT COALESCE(jsonb_agg(row_to_json(mt) ORDER BY mt.periodo DESC), '[]'::jsonb) FROM (SELECT id, periodo, meta, moneda, descripcion FROM aos_metas_ventas ORDER BY periodo DESC) mt)
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.aos_ventas_admin_anio(p_anio integer, p_sede text DEFAULT ''::text, p_asesor text DEFAULT ''::text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_desde date; v_hasta date;
+BEGIN
+  v_desde := make_date(p_anio, 1, 1); v_hasta := make_date(p_anio, 12, 31);
+  RETURN jsonb_build_object(
+    'factTotal', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nVentas', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'ticketProm', (SELECT CASE WHEN COUNT(*)>0 THEN ROUND(SUM(monto)/COUNT(*)) ELSE 0 END FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nServ', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='SERVICIO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factServ', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='SERVICIO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nProd', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='PRODUCTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factProd', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND tipo='PRODUCTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nPagoCompleto', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='PAGO COMPLETO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nAdelanto', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='ADELANTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'factAdelanto', (SELECT COALESCE(SUM(monto),0) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND estado_pago='ADELANTO' AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'nSinDefinir', (SELECT COUNT(*) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (estado_pago IS NULL OR estado_pago NOT IN ('PAGO COMPLETO','ADELANTO')) AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor)),
+    'detalle', COALESCE((SELECT jsonb_agg(row_to_json(d) ORDER BY d.fecha DESC, d.id DESC) FROM (SELECT v.id, v.fecha::text, v.monto, v.tipo, v.tratamiento, v.descripcion, v.pago, v.sede, v.estado_pago, v.atendio, v.numero_limpio, v.asesor, v.nombres, v.apellidos, CASE WHEN v.asesor='NO APLICA' THEN 0 WHEN v.tipo='SERVICIO' THEN ROUND(v.monto*0.005,2) WHEN v.tipo='PRODUCTO' THEN COALESCE((SELECT MAX(tc.comision::numeric) FROM aos_tabla_comisiones tc WHERE tc.tipo='PRODUCTO' AND tc.monto_min::numeric<=v.monto AND tc.activo=true),0) ELSE 0 END as comision FROM aos_ventas v WHERE v.fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR v.sede=p_sede) AND (p_asesor='' OR v.asesor=p_asesor)) d), '[]'::jsonb),
+    'porAsesor', COALESCE((SELECT jsonb_agg(row_to_json(a) ORDER BY a.total DESC) FROM (SELECT asesor, COUNT(*) as n, SUM(monto) as total, SUM(CASE WHEN tipo='SERVICIO' THEN ROUND(monto*0.005,2) WHEN tipo='PRODUCTO' THEN COALESCE((SELECT MAX(tc.comision::numeric) FROM aos_tabla_comisiones tc WHERE tc.tipo='PRODUCTO' AND tc.monto_min::numeric<=v.monto AND tc.activo=true),0) ELSE 0 END) as comision FROM aos_ventas v WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND asesor!='NO APLICA' GROUP BY asesor) a), '[]'::jsonb),
+    'noAplica', (SELECT jsonb_build_object('n',COUNT(*),'total',COALESCE(SUM(monto),0)) FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND asesor='NO APLICA' AND (p_sede='' OR sede=p_sede)),
+    'porSede', COALESCE((SELECT jsonb_agg(row_to_json(s) ORDER BY s.total DESC) FROM (SELECT sede, COUNT(*) as n, SUM(monto) as total, COUNT(*) FILTER(WHERE tipo='SERVICIO') as n_serv, COUNT(*) FILTER(WHERE tipo='PRODUCTO') as n_prod FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_asesor='' OR asesor=p_asesor) GROUP BY sede) s), '[]'::jsonb),
+    'porMetodoPago', COALESCE((SELECT jsonb_agg(row_to_json(mp) ORDER BY mp.total DESC) FROM (SELECT pago as metodo, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY pago) mp), '[]'::jsonb),
+    'porMetodoPagoSede', COALESCE((SELECT jsonb_agg(row_to_json(mp) ORDER BY mp.total DESC) FROM (SELECT pago as metodo, sede, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_asesor='' OR asesor=p_asesor) GROUP BY pago, sede) mp), '[]'::jsonb),
+    'porTratamiento', COALESCE((SELECT jsonb_agg(row_to_json(t) ORDER BY t.total DESC) FROM (SELECT tratamiento, COUNT(*) as n, SUM(monto) as total FROM aos_ventas WHERE fecha BETWEEN v_desde AND v_hasta AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY tratamiento ORDER BY SUM(monto) DESC LIMIT 10) t), '[]'::jsonb),
+    'anual', COALESCE((SELECT jsonb_agg(row_to_json(m) ORDER BY m.mes_num) FROM (SELECT EXTRACT(MONTH FROM fecha)::int as mes_num, SUM(monto) as facturado, COUNT(*) as n_ventas FROM aos_ventas WHERE EXTRACT(YEAR FROM fecha)=p_anio AND (p_sede='' OR sede=p_sede) AND (p_asesor='' OR asesor=p_asesor) GROUP BY EXTRACT(MONTH FROM fecha)) m), '[]'::jsonb)
+  );
+END;
+$function$;


### PR DESCRIPTION
REV-PERF P0 under the mandatory Reliability & Performance Doctrine.

Scope:
- optimize `aos_comisiones_asesor` using one advisor/year base + monthly derivation;
- embed `rankingTop` so the advisor commissions UI avoids a second `aos_ventas` download after DB promotion;
- optimize `aos_ventas_admin` and `aos_ventas_admin_anio` by reusing scoped/materialized period bases instead of rescanning the same sales rows for every KPI;
- preserve legacy filter exceptions and empty-month null semantics;
- add exact rollback and a zero-cost dedicated gate.

Pre-PROD evidence:
- Sales month all: exact JSON parity; 195/195 detail rows, 0 diff.
- Sales month SAN ISIDRO + MIREYA: exact JSON parity.
- Sales year 2026: exact JSON parity; 1,388/1,388 detail rows.
- Commissions MIREYA Aug, WILMER Jul, RUVILA Jun: all old fields + detail parity, 0 diff.
- Empty MIREYA Sep edge preserved (`comServ=null`, `comProd=null`, `ranking=null`, totals 0).
- Sales month benchmark: ~2,251 -> ~93 shared buffer hits (~95.9% reduction); ~123 ms -> ~12 ms warm benchmark.
- Advisor commissions benchmark: ~1,838 -> ~247 shared buffer hits (~86.6% reduction); ~27 ms -> ~18 ms warm benchmark.

No commission formula, sale amount, business data, authority flag, statement timeout or autonomous WhatsApp boundary changes. PROD remains untouched until exact-head gates pass.