### PR TITLE
P0 #432: decouple call-ledger MV refresh from insert hot path

### DIFF
--- a/.github/workflows/p0432-call-ledger-refresh.yml
+++ b/.github/workflows/p0432-call-ledger-refresh.yml
@@ -1,0 +1,46 @@
+name: P0 #432 Call Ledger Refresh
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql'
+      - 'supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql'
+      - 'ci/performance/p0432-call-ledger-refresh.test.js'
+      - '.github/workflows/p0432-call-ledger-refresh.yml'
+  push:
+    branches: [main, 'perf/p0432-call-ledger-refresh-decouple-20260902']
+    paths:
+      - 'supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql'
+      - 'supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql'
+      - 'ci/performance/p0432-call-ledger-refresh.test.js'
+      - '.github/workflows/p0432-call-ledger-refresh.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: [self-hosted, linux, x64, ascenda-zero-cost-v2]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Static regression gate
+        run: node --test ci/performance/p0432-call-ledger-refresh.test.js
+      - name: Existing Call Center performance contract
+        run: node --test ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+      - name: Migration boundary assertions
+        shell: bash
+        run: |
+          set -euo pipefail
+          m='supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql'
+          r='supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql'
+          grep -Eq 'DROP TRIGGER trg_refresh_llammap ON public\.aos_llamadas' "$m"
+          ! grep -Eqi 'DROP (MATERIALIZED VIEW|FUNCTION|TABLE)' "$m"
+          grep -Eq 'CREATE TRIGGER trg_refresh_llammap' "$r"
+          grep -Eq 'FOR EACH STATEMENT' "$r"
+          grep -Eq 'fn_refresh_llammap' "$r"
+          echo P0432_CALL_LEDGER_REFRESH_GATE_PASS

--- a/ci/performance/p0432-call-ledger-refresh.test.js
+++ b/ci/performance/p0432-call-ledger-refresh.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('fs');
+
+const migration='supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql';
+const rollback='supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql';
+const m=fs.readFileSync(migration,'utf8');
+const r=fs.readFileSync(rollback,'utf8');
+
+function stripComments(sql){return sql.replace(/--.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');}
+
+test('P0 #432 removes only legacy per-insert refresh trigger',()=>{
+  const sql=stripComments(m);
+  assert.match(sql,/DROP\s+TRIGGER\s+trg_refresh_llammap\s+ON\s+public\.aos_llamadas\s*;/i);
+  assert.doesNotMatch(sql,/DROP\s+(?:MATERIALIZED\s+VIEW|FUNCTION|TABLE)\b/i);
+  assert.doesNotMatch(sql,/DROP\s+TRIGGER\s+trg_000_aos_loop6_governed_call_v22/i);
+  assert.doesNotMatch(sql,/DROP\s+TRIGGER\s+trg_aos_hotfix_call_guard_v1/i);
+  assert.match(sql,/P0432_GOVERNED_WRITE_GUARD_MISSING/);
+  assert.match(sql,/P0432_COMMERCIAL_POLICY_GUARD_MISSING/);
+});
+
+test('explicit legacy refresh compatibility remains intact',()=>{
+  assert.match(m,/public\.fn_refresh_llammap\(\)/);
+  assert.match(m,/public\.aos_refresh_llammap\(\)/);
+  assert.doesNotMatch(stripComments(m),/REVOKE\b|GRANT\b/i);
+});
+
+test('rollback recreates exact statement-level trigger only',()=>{
+  const sql=stripComments(r);
+  assert.match(sql,/CREATE\s+TRIGGER\s+trg_refresh_llammap\s+AFTER\s+INSERT\s+ON\s+public\.aos_llamadas\s+FOR\s+EACH\s+STATEMENT\s+EXECUTE\s+FUNCTION\s+public\.fn_refresh_llammap\(\)\s*;/is);
+  assert.doesNotMatch(sql,/CREATE\s+(?:MATERIALIZED\s+VIEW|TABLE)\b/i);
+  assert.doesNotMatch(sql,/DROP\s+TRIGGER\s+trg_000_aos_loop6_governed_call_v22/i);
+  assert.doesNotMatch(sql,/DROP\s+TRIGGER\s+trg_aos_hotfix_call_guard_v1/i);
+});
+
+test('no timeout or WA authority manipulation',()=>{
+  const sql=stripComments(m+'\n'+r);
+  assert.doesNotMatch(sql,/statement_timeout\s*=/i);
+  assert.doesNotMatch(sql,/auto_reply|ai_send|auto_routing|human_send/i);
+});

--- a/supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql
+++ b/supabase/migrations/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql
@@ -1,0 +1,63 @@
+-- ASCENDA OS · P0 #432 · Call-ledger materialized-view refresh decoupling V1
+-- Scope: remove only the legacy AFTER INSERT statement trigger that refreshes
+-- aos_llamadas_ultimo synchronously inside every aos_llamadas INSERT.
+--
+-- Preserved intentionally:
+--   * public.aos_llamadas_ultimo materialized view + unique index
+--   * public.fn_refresh_llammap()
+--   * public.aos_refresh_llammap() explicit refresh RPC for legacy sync jobs
+--   * every Loop6 governed-write / commercial-policy / audit / cleanup trigger
+--
+-- Reliability doctrine: do not hide pressure by increasing statement_timeout.
+
+DO $p0432_guard$
+DECLARE
+  v_trigger_def text;
+BEGIN
+  SELECT pg_catalog.pg_get_triggerdef(t.oid)
+    INTO v_trigger_def
+  FROM pg_catalog.pg_trigger t
+  JOIN pg_catalog.pg_class c ON c.oid=t.tgrelid
+  JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public'
+    AND c.relname='aos_llamadas'
+    AND t.tgname='trg_refresh_llammap'
+    AND NOT t.tgisinternal;
+
+  IF v_trigger_def IS NULL THEN
+    RAISE EXCEPTION 'P0432_EXPECTED_REFRESH_TRIGGER_MISSING';
+  END IF;
+
+  IF v_trigger_def NOT ILIKE '%AFTER INSERT ON public.aos_llamadas FOR EACH STATEMENT%fn_refresh_llammap%' THEN
+    RAISE EXCEPTION 'P0432_REFRESH_TRIGGER_DRIFT:%',v_trigger_def;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_trigger t
+    JOIN pg_catalog.pg_class c ON c.oid=t.tgrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname='aos_llamadas'
+      AND t.tgname='trg_000_aos_loop6_governed_call_v22' AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'P0432_GOVERNED_WRITE_GUARD_MISSING';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_trigger t
+    JOIN pg_catalog.pg_class c ON c.oid=t.tgrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname='aos_llamadas'
+      AND t.tgname='trg_aos_hotfix_call_guard_v1' AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'P0432_COMMERCIAL_POLICY_GUARD_MISSING';
+  END IF;
+END
+$p0432_guard$;
+
+DROP TRIGGER trg_refresh_llammap ON public.aos_llamadas;
+
+COMMENT ON FUNCTION public.fn_refresh_llammap() IS
+  'Legacy explicit materialized-view refresh implementation. P0 #432 removed its per-INSERT trigger; retained for explicit refresh compatibility.';
+
+COMMENT ON FUNCTION public.aos_refresh_llammap() IS
+  'Explicit compatibility refresh for aos_llamadas_ultimo. P0 #432 decoupled this work from the aos_llamadas INSERT hot path.';

--- a/supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql
+++ b/supabase/rollbacks/20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1_recovery.sql
@@ -1,0 +1,31 @@
+-- ASCENDA OS · rollback · P0 #432 call-ledger refresh decoupling V1
+-- Restores only the legacy statement-level refresh trigger.
+
+DO $p0432_recovery_guard$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_catalog.pg_trigger t
+    JOIN pg_catalog.pg_class c ON c.oid=t.tgrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname='aos_llamadas'
+      AND t.tgname='trg_refresh_llammap' AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'P0432_REFRESH_TRIGGER_ALREADY_PRESENT';
+  END IF;
+
+  IF pg_catalog.to_regprocedure('public.fn_refresh_llammap()') IS NULL THEN
+    RAISE EXCEPTION 'P0432_REFRESH_FUNCTION_MISSING';
+  END IF;
+END
+$p0432_recovery_guard$;
+
+CREATE TRIGGER trg_refresh_llammap
+AFTER INSERT ON public.aos_llamadas
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.fn_refresh_llammap();
+
+COMMENT ON FUNCTION public.fn_refresh_llammap() IS
+  'Legacy trigger implementation: refreshes public.aos_llamadas_ultimo concurrently after aos_llamadas INSERT statements.';
+
+COMMENT ON FUNCTION public.aos_refresh_llammap() IS
+  'Explicit compatibility refresh for public.aos_llamadas_ultimo.';


### PR DESCRIPTION
## P0 #432 · SQL-side pressure amplifier

Base exacta: `224715d10096f9d944101205b353b523342df5cc`.

### Evidence
PROD `public.aos_llamadas` has a legacy statement-level trigger:
`trg_refresh_llammap AFTER INSERT ... FOR EACH STATEMENT -> fn_refresh_llammap()`.

`fn_refresh_llammap()` executes:
`REFRESH MATERIALIZED VIEW CONCURRENTLY public.aos_llamadas_ultimo`.

Therefore every call INSERT statement rebuilds/reconciles the call-ledger materialized view inside the foreground transaction. During the #432 burst PostgreSQL recorded a ShareLock wait ~1.6s plus widespread statement timeouts.

Read-only benchmark of the materialized-view source query in PROD:
- 36,975 call rows scanned
- 6,498 latest-phone rows produced
- ~35,779 shared buffer hits
- ~291 ms execution warm, before the concurrent-refresh reconciliation/locking work

### Dependency boundary
Current DB routine references to `aos_llamadas_ultimo` are only:
- `fn_refresh_llammap()`
- `aos_refresh_llammap()`

Repository consumers are legacy `src/backend/GS_*` sync jobs, and those already invoke `aos_refresh_llammap()` explicitly. No current browser/runtime code reference was found.

### Change
Migration `20260902201500_mkt_loop6_p0432_decouple_llammap_refresh_v1.sql`:
- asserts expected trigger shape and safety guards
- drops only `trg_refresh_llammap`
- preserves the MV, its unique index, `fn_refresh_llammap()` and `aos_refresh_llammap()`

Rollback recreates exactly the prior `AFTER INSERT ... FOR EACH STATEMENT` trigger.

### Explicitly unchanged
- governed-write guard `trg_000_aos_loop6_governed_call_v22`
- commercial-policy guard `trg_aos_hotfix_call_guard_v1`
- manual-agenda cleanup trigger
- audit/sync-key triggers
- statement_timeout (remains 3s for anon/browser)
- WA authority / autonomous-send flags
- schema/data business semantics outside MV refresh freshness

### Gates
Dedicated P0 #432 workflow + existing Call Center performance contract; migration name contains `loop6` so governed-runtime guard also runs. No PROD migration will be applied until exact-head gates pass.

After merge: apply migration to PROD, verify trigger checksum, safety triggers, explicit refresh compatibility, then execute rollback-safe Call Center canary under the unchanged 3s boundary and observe real traffic before closing #432.