### PR TITLE
P0 #432: remove legacy llammap refresh from Call Center hot path

### DIFF
--- a/.github/workflows/business-priority-p0.yml
+++ b/.github/workflows/business-priority-p0.yml
@@ -10,9 +10,11 @@ on:
       - 'ci/performance/business-priority-p0.test.js'
       - 'ci/performance/business-priority-race.test.js'
       - 'ci/performance/cross-panel-pressure-p0432.test.js'
+      - 'supabase/migrations/20260902202000_p0432_db_hotpath_refresh_removal_v1.sql'
+      - 'supabase/rollbacks/20260902202000_p0432_db_hotpath_refresh_removal_v1_recovery.sql'
       - '.github/workflows/business-priority-p0.yml'
   push:
-    branches: ['main','perf/p0-business-priority-lazy-calendar-20260901','perf/p0432-cross-panel-pressure-20260902']
+    branches: ['main','perf/p0-business-priority-lazy-calendar-20260901','perf/p0432-cross-panel-pressure-20260902','perf/p0432-db-hotpath-refresh-removal-20260902']
     paths:
       - 'app/business-priority-preload.js'
       - 'app/supabase-quota-circuit-preload.cjs'
@@ -21,6 +23,8 @@ on:
       - 'ci/performance/business-priority-p0.test.js'
       - 'ci/performance/business-priority-race.test.js'
       - 'ci/performance/cross-panel-pressure-p0432.test.js'
+      - 'supabase/migrations/20260902202000_p0432_db_hotpath_refresh_removal_v1.sql'
+      - 'supabase/rollbacks/20260902202000_p0432_db_hotpath_refresh_removal_v1_recovery.sql'
       - '.github/workflows/business-priority-p0.yml'
 
 permissions:

--- a/ci/performance/cross-panel-pressure-p0432.test.js
+++ b/ci/performance/cross-panel-pressure-p0432.test.js
@@ -6,6 +6,8 @@ const fs=require('fs');
 const vm=require('vm');
 
 const browser=fs.readFileSync('app/public/browser-business-priority-v1.js','utf8');
+const migration=fs.readFileSync('supabase/migrations/20260902202000_p0432_db_hotpath_refresh_removal_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260902202000_p0432_db_hotpath_refresh_removal_v1_recovery.sql','utf8');
 
 function rpcName(input){const m=String(input||'').match(/\/rpc\/([^?]+)/);return m&&m[1]||'';}
 function FakeResponse(name,status){this.name=name;this.status=status==null?200:status;this.ok=this.status>=200&&this.status<300;}
@@ -31,6 +33,23 @@ test('P0 #432 static contract keeps governed and mutable paths outside throttle'
   assert.match(browser,/\^aos_callcenter_\/\.test\(name\)/);
   assert.doesNotMatch(browser,/aos_get_historial_paciente:1/);
   assert.doesNotMatch(browser,/aos_search_pacientes:1/);
+});
+
+test('P0 #432 DB hot-path migration removes only the per-insert refresh trigger',()=>{
+  assert.match(migration,/drop trigger if exists trg_refresh_llammap on public\.aos_llamadas/i);
+  assert.match(migration,/to_regclass\('public\.aos_llamadas_ultimo'\)/i);
+  assert.match(migration,/to_regprocedure\('public\.fn_refresh_llammap\(\)'\)/i);
+  assert.match(migration,/to_regprocedure\('public\.aos_refresh_llammap\(\)'\)/i);
+  assert.doesNotMatch(migration,/drop\s+materialized\s+view/i);
+  assert.doesNotMatch(migration,/drop\s+function/i);
+  assert.doesNotMatch(migration,/statement_timeout/i);
+  assert.doesNotMatch(migration,/alter\s+table/i);
+});
+
+test('P0 #432 DB hot-path rollback restores exact legacy trigger shape',()=>{
+  assert.match(rollback,/create trigger trg_refresh_llammap\s+after insert on public\.aos_llamadas\s+for each statement\s+execute function public\.fn_refresh_llammap\(\)/is);
+  assert.doesNotMatch(rollback,/statement_timeout/i);
+  assert.doesNotMatch(rollback,/drop\s+materialized\s+view/i);
 });
 
 test('heavy cross-panel analytics are serialized even without Call Center mounted',async()=>{

--- a/supabase/migrations/20260902202000_p0432_db_hotpath_refresh_removal_v1.sql
+++ b/supabase/migrations/20260902202000_p0432_db_hotpath_refresh_removal_v1.sql
@@ -1,0 +1,24 @@
+-- ASCENDA OS · P0 #432 · DB hot-path refresh removal V1
+-- Scope: remove ONLY the legacy per-INSERT materialized-view refresh trigger.
+-- Preserve aos_llamadas_ultimo plus explicit refresh functions/RPCs.
+-- No business-rule, write-authority, timeout, or data mutation changes.
+
+do $$
+begin
+  if to_regclass('public.aos_llamadas_ultimo') is null then
+    raise exception 'P0432_EXPECTED_MATVIEW_MISSING';
+  end if;
+  if to_regprocedure('public.fn_refresh_llammap()') is null then
+    raise exception 'P0432_EXPECTED_TRIGGER_FUNCTION_MISSING';
+  end if;
+  if to_regprocedure('public.aos_refresh_llammap()') is null then
+    raise exception 'P0432_EXPECTED_EXPLICIT_REFRESH_RPC_MISSING';
+  end if;
+end
+$$;
+
+-- This trigger used to execute REFRESH MATERIALIZED VIEW CONCURRENTLY
+-- public.aos_llamadas_ultimo after every INSERT statement on aos_llamadas.
+-- That full-view rebuild is intentionally removed from the synchronous
+-- Call Center write path; explicit legacy refresh mechanisms remain available.
+drop trigger if exists trg_refresh_llammap on public.aos_llamadas;

--- a/supabase/rollbacks/20260902202000_p0432_db_hotpath_refresh_removal_v1_recovery.sql
+++ b/supabase/rollbacks/20260902202000_p0432_db_hotpath_refresh_removal_v1_recovery.sql
@@ -1,0 +1,20 @@
+-- ASCENDA OS · P0 #432 · DB hot-path refresh removal V1 · RECOVERY
+-- Exact rollback: restore the legacy AFTER INSERT / FOR EACH STATEMENT trigger.
+-- The trigger function and materialized view are expected to remain present.
+
+do $$
+begin
+  if to_regclass('public.aos_llamadas_ultimo') is null then
+    raise exception 'P0432_EXPECTED_MATVIEW_MISSING';
+  end if;
+  if to_regprocedure('public.fn_refresh_llammap()') is null then
+    raise exception 'P0432_EXPECTED_TRIGGER_FUNCTION_MISSING';
+  end if;
+end
+$$;
+
+drop trigger if exists trg_refresh_llammap on public.aos_llamadas;
+create trigger trg_refresh_llammap
+after insert on public.aos_llamadas
+for each statement
+execute function public.fn_refresh_llammap();


### PR DESCRIPTION
Closes the remaining DB-hot-path layer of #432.

Scope is intentionally narrow:
- DROP only `trg_refresh_llammap` from `public.aos_llamadas`.
- Preserve `aos_llamadas_ultimo`, `fn_refresh_llammap()`, and explicit `aos_refresh_llammap()`.
- Add exact rollback restoring `AFTER INSERT / FOR EACH STATEMENT` trigger.
- No timeout changes, business-rule changes, write-authority changes, or data mutation.
- Extend P0 #432 regression gate to freeze this boundary.

Measured baseline before change: materialized-view source rebuild scans ~36,975 calls, ~35,779 shared buffer hits, ~291 ms warm before REFRESH CONCURRENTLY reconciliation overhead; historical burst showed ShareLock wait ~1.6 s and cross-panel statement timeouts.