### PR TITLE
P0 #436: mostrar teléfono y correo en filiación de Pacientes 360

### DIFF
--- a/app/public/patients-f6-v2.js
+++ b/app/public/patients-f6-v2.js
@@ -3,6 +3,7 @@
 if(window.__AOS_PATIENTS_360_V3__==='installed'||window.__AOS_PATIENTS_360_V3__==='waiting')return;
 window.__AOS_PATIENTS_360_V3__='waiting';
 window.__AOS_PATIENT_BRIDGE_GUARD__='p0436-v2-hotpath';
+window.__AOS_PATIENT_FILIATION_CONTACTS__='v1';
 var installed=false,timer=null,cards={},bridgeReadyPromise=null,activeCid='',enrichmentSeq=0;
 function esc(v){return typeof window.h==='function'?window.h(v):String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
 function token(){try{return sessionStorage.getItem('aos_app_token')||'';}catch(_){return '';}}
@@ -59,7 +60,15 @@ function install(){
     if(box)box.innerHTML=contextHtml(d);
     if(!root.querySelector('[data-p360v3="trust"]')){var fkr=root.querySelector('.fkr');if(fkr)fkr.insertAdjacentHTML('afterend','<div data-p360v3="trust" style="margin:0 0 10px;padding:9px 12px;background:#0F172A;color:#E2E8F0;border-radius:10px;font-size:9px;line-height:1.5;"><b style="color:white;">Revenue enrichment</b> · el expediente operativo carga primero; identidad/lifecycle se enriquecen en serie. 2024/2025 transaccional sigue siendo NO_CERTIFIED_SOURCE.</div>');}
   }
-  function renderCurrent(d){window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';baseRender360(d);augment(d);var rt=document.getElementById('pt-right');if(rt&&rt.classList)rt.classList.toggle('hidden',!d.clinical_access);if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);}
+  function ensureFiliationContacts(d){
+    var root=document.getElementById('pt-ficha'),grid=root&&root.querySelector('.fd');if(!grid)return;
+    var p=d&&d.paciente||{},labels=grid.querySelectorAll('.fdl'),seen={};
+    for(var i=0;i<labels.length;i++)seen[String(labels[i].textContent||'').trim().toUpperCase()]=true;
+    function card(label,value,key){if(seen[label.toUpperCase()])return;var node=document.createElement('div');node.className='fdc';node.setAttribute('data-p360v3',key);node.innerHTML='<div class="fdl">'+esc(label)+'</div><div class="fdv">'+esc(value||'—')+'</div>';grid.insertBefore(node,grid.firstChild);seen[label.toUpperCase()]=true;}
+    card('Teléfono',p.telefono,'filiation-phone');
+    card('Correo',p.correo,'filiation-email');
+  }
+  function renderCurrent(d){window.PT.data=d;window.PT.sel=d.paciente;window.PT.tab='cotizaciones';baseRender360(d);augment(d);ensureFiliationContacts(d);var rt=document.getElementById('pt-right');if(rt&&rt.classList)rt.classList.toggle('hidden',!d.clinical_access);if(typeof window.renderNotas==='function')window.renderNotas(d.notas||[]);}
   function applyDeferred(cid,seq,section,res){
     if(activeCid!==cid||seq!==enrichmentSeq||!window.PT.data)return;
     var payload=res&&res.payload||null;
@@ -90,7 +99,7 @@ function install(){
   };
 
   window.ptSel=function(value){value=String(value||'').trim();if(/^P-/i.test(value)){window.ptSelCurrent(value);return;}window._rpc('aos_patient_search_v2',{p_token:token(),p_query:value,p_limit:10},function(d){var rows=d&&d.results||[];if(rows.length===1&&rows[0].canonical_patient_id){window.ptSelCurrent(rows[0].canonical_patient_id);return;}showError(rows.length>1?'El teléfono corresponde a más de un paciente actual. Selecciona la ficha por nombre.':'No se encontró un paciente actual para ese identificador.');},function(){showError('No se pudo resolver el botón legado hacia un paciente actual.');});};
-  window.render360=function(d){baseRender360(d);augment(d);};
+  window.render360=function(d){baseRender360(d);augment(d);ensureFiliationContacts(d);};
 }
 install();
 })();

--- a/ci/rev-f6-1/ui_contract.js
+++ b/ci/rev-f6-1/ui_contract.js
@@ -10,6 +10,7 @@ ok(app.includes('ASCENDA_CRITICAL_RUNTIME_BRIDGES_20260820'),'App shell must con
 ok(app.includes('/patients-f6-v2.js?v=20260820-rev-f6-runtime-hotfix-v1'),'Patient runtime must load directly from app shell');
 ok(ui.includes('window.__AOS_PATIENTS_360_V3__'),'Patient runtime must publish V3 idempotency state');
 ok(ui.includes("window.__AOS_PATIENT_BRIDGE_GUARD__='p0436-v2-hotpath'"),'Runtime must publish P0 #436 hot-path generation');
+ok(ui.includes("window.__AOS_PATIENT_FILIATION_CONTACTS__='v1'"),'Runtime must publish filiación contact-field generation');
 ok(ui.includes("'aos_patient_search_v2'"),'Search must keep canonical patient discovery');
 ok(ui.includes("'aos_patient_360_current_v3'"),'Selection must call canonical-current operational RPC');
 ok(ui.includes('p_canonical_patient_id:cid'),'Selection must pass canonical_patient_id directly');
@@ -39,8 +40,13 @@ ok(!ui.includes('loadCurrent(cid,true)'),'Deterministic operational RPC failures
 ok(ui.includes('activeCid!==cid||seq!==enrichmentSeq'),'Late enrichment responses must not overwrite a newly selected patient');
 ok(ui.includes('el contexto analítico nunca bloquea la ficha'),'UI must state the operational/enrichment boundary');
 
+// Owner-smoke UX correction: filiación must surface contact data already present in the canonical patient payload.
+ok(ui.includes("card('Teléfono',p.telefono,'filiation-phone')"),'Filiación must explicitly render canonical phone');
+ok(ui.includes("card('Correo',p.correo,'filiation-email')"),'Filiación must preserve explicit email rendering when base UI omits it');
+ok(!ui.includes('ep-telefono'),'P0 contact display correction must not introduce direct phone mutation authority');
+
 ok(ui.includes('ACTUAL RESOLVED'),'UI must distinguish resolved current patient identity');
 ok(ui.includes('HISTÓRICO REVIEW'),'UI must preserve historical review visibility');
 ok(ui.includes('NO_CERTIFIED_SOURCE'),'Historical revenue limitation must remain explicit');
 ok(ui.includes('Selecciona la ficha por nombre'),'Shared phone compatibility must remain fail-closed');
-console.log('REV-F6.1 UI contract PASS — Patient operational hot path + serial deferred enrichment');
+console.log('REV-F6.1 UI contract PASS — Patient operational hot path + serial deferred enrichment + filiación contacts');


### PR DESCRIPTION
## Scope
Owner smoke confirmó que Patient 360 ya renderiza, pero Filiación omitía el teléfono aunque el payload canónico sí lo trae. Correo ya existe en la base UI; este parche mantiene/asegura ambos campos visibles.

## Change
- `patients-f6-v2.js`: inserta de forma idempotente `Teléfono` y `Correo` en la grilla de filiación usando exclusivamente `d.paciente.telefono/correo`.
- No agrega edición directa de teléfono ni nueva autoridad de identidad.
- `ui_contract.js`: fija contrato de presencia de ambos campos y ausencia de mutación directa de teléfono.

## Production evidence
- `P-5549` LIVE: teléfono `986293339` existe; email canónico es NULL.
- Root P0 #436 ya está resuelto y desplegado en `main@78568ba85a01d4cc98718af7febeb8dee6ed982d`.

## Safety
UI-only follow-up. Sin DDL, sin mutación de paciente, sin timeout change, sin WhatsApp authority change.