### PR TITLE
REV-F5.11 — Historical Patient Identity Completion 2024–2026

### DIFF
--- a/.github/workflows/rev-f5-11-historical-identity-completion.yml
+++ b/.github/workflows/rev-f5-11-historical-identity-completion.yml
@@ -1,0 +1,114 @@
+name: ASCENDA REV-F5.11 Historical Identity Completion
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*rev_f5_11*'
+      - 'supabase/rollbacks/*rev_f5_11*'
+      - 'ci/rev-f5-11/**'
+      - 'docs/control/REV_F5_11*'
+      - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
+      - '.github/workflows/rev-f5-11-historical-identity-completion.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rev-f5-11-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-safety:
+    name: F5.11 static mutation boundary
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce identity-only scope
+        shell: powershell
+        run: |
+          $m='supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql'
+          $r='supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql'
+          if (-not (Test-Path $m)) { throw 'migration missing' }
+          if (-not (Test-Path $r)) { throw 'recovery missing' }
+          $sql=Get-Content $m -Raw
+          if ($sql -match '(?i)update\s+public\.aos_pacientes') { throw 'existing patient UPDATE forbidden' }
+          if ($sql -match '(?i)delete\s+from\s+public\.aos_pacientes') { throw 'patient DELETE forbidden in forward migration' }
+          if ($sql -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.aos_ventas') { throw '2024/2025 sales mutation forbidden' }
+          if ($sql -match '(?i)grant\s+.*\s+to\s+(anon|authenticated)') { throw 'browser privilege escalation forbidden' }
+          if ($sql -notmatch 'PHONE.*never auto-links' -and $sql -notmatch 'phone alone never auto-links') { throw 'phone-only safety contract missing' }
+          if ($sql -notmatch 'P-HIST-F511-') { throw 'deterministic historical patient namespace missing' }
+
+  db-contract:
+    name: F5.11 DB apply / replay / recovery
+    needs: static-safety
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59642/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce Zero-Cost DB runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Configure isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-rev-f5-11"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59641/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59642/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59640/' supabase/config.toml
+      - name: Start isolated Postgres
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-rev-f5-11' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59642 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+      - name: Build synthetic certified identity state
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f5-11/schema_contract.sql
+      - name: Apply exact F5.11 migration
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+      - name: Security and schema contract
+        run: |
+          set -euo pipefail
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_f5_historical_identity_resolution_v2') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_f5_historical_identity_completion_preview_v1') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_f5_11_apply_identity_completion_v1(text,integer)') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('anon','public.aos_f5_historical_identity_resolution_v2','SELECT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('authenticated','public.aos_f5_historical_identity_resolution_v2','SELECT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('anon','public.aos_f5_11_apply_identity_completion_v1(text,integer)','EXECUTE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('service_role','public.aos_f5_11_apply_identity_completion_v1(text,integer)','EXECUTE')")" = "t"
+      - name: Behavioral resolution / apply / replay contract
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f5-11/tests/001_identity_completion.sql
+      - name: Recovery contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_f5_historical_identity_resolution_v2') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_f5_11_apply_identity_completion_v1(text,integer)') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_pacientes where \"ID_PACIENTE\" like 'P-HIST-F511-%'")" = "0"
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from public.aos_pacientes where \"ID_PACIENTE\" in ('P-A','P-B','P-C','P-D','P-E','P-OLD')")" = "6"
+      - name: Full apply after recovery remains reproducible
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f5-11/tests/001_identity_completion.sql
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/.github/workflows/rev-f5-11-historical-identity-completion.yml
+++ b/.github/workflows/rev-f5-11-historical-identity-completion.yml
@@ -29,16 +29,15 @@ jobs:
       - name: Enforce identity-only scope
         shell: powershell
         run: |
-          $m='supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql'
-          $r='supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql'
-          if (-not (Test-Path $m)) { throw 'migration missing' }
-          if (-not (Test-Path $r)) { throw 'recovery missing' }
-          $sql=Get-Content $m -Raw
+          $files=Get-ChildItem 'supabase/migrations/*rev_f5_11*.sql'
+          if (-not $files) { throw 'migrations missing' }
+          if (-not (Test-Path 'supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql')) { throw 'recovery missing' }
+          $sql=($files | ForEach-Object { Get-Content $_.FullName -Raw }) -join "`n"
           if ($sql -match '(?i)update\s+public\.aos_pacientes') { throw 'existing patient UPDATE forbidden' }
           if ($sql -match '(?i)delete\s+from\s+public\.aos_pacientes') { throw 'patient DELETE forbidden in forward migration' }
           if ($sql -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.aos_ventas') { throw '2024/2025 sales mutation forbidden' }
           if ($sql -match '(?i)grant\s+.*\s+to\s+(anon|authenticated)') { throw 'browser privilege escalation forbidden' }
-          if ($sql -notmatch 'PHONE.*never auto-links' -and $sql -notmatch 'phone alone never auto-links') { throw 'phone-only safety contract missing' }
+          if ($sql -notmatch '(?i)phone alone never auto-links') { throw 'phone-only safety contract missing' }
           if ($sql -notmatch 'P-HIST-F511-') { throw 'deterministic historical patient namespace missing' }
 
   db-contract:
@@ -81,8 +80,11 @@ jobs:
           exit 1
       - name: Build synthetic certified identity state
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f5-11/schema_contract.sql
-      - name: Apply exact F5.11 migration
-        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+      - name: Apply exact F5.11 migrations
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224100_rev_f5_11_alias_continuity_fix.sql
       - name: Security and schema contract
         run: |
           set -euo pipefail
@@ -107,6 +109,7 @@ jobs:
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902224100_rev_f5_11_alias_continuity_fix.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/rev-f5-11/tests/001_identity_completion.sql
       - name: Stop isolated Supabase
         if: always()

--- a/ci/rev-f5-11/schema_contract.sql
+++ b/ci/rev-f5-11/schema_contract.sql
@@ -1,0 +1,81 @@
+\set ON_ERROR_STOP on
+create extension if not exists pgcrypto;
+
+create table public.aos_pacientes(
+  "ID_PACIENTE" text primary key,
+  "Nombres" text,"Apellidos" text,"Teléfono" text,"Email" text,"N° documento" text,"Sexo" text,"Fecha de nacimiento" text,
+  "ESTADO_PACIENTE" text default 'NUEVO',numero_limpio text,fuente_datos text,"FUENTE" text,"FECHA_REGISTRO" text,
+  created_at timestamptz default now(),updated_at timestamptz default now(),pais text default 'Perú',etiqueta_vip text default 'NORMAL'
+);
+create table public.aos_f5_identity_clusters_v1(
+  id uuid primary key,status text not null,confidence text not null,source_row_count integer not null,
+  canonical_preview jsonb not null default '{}'::jsonb,evidence jsonb not null default '{}'::jsonb,conflicts jsonb not null default '{}'::jsonb
+);
+create table public.aos_f5_canonical_classification_v1(
+  cluster_id uuid primary key references public.aos_f5_identity_clusters_v1(id),target_patient_id text,source_match_status text,classification text not null,reason text not null,
+  match_method text,match_score numeric,canonical_dni_conflict boolean not null default false,canonical_email_conflict boolean not null default false,
+  canonical_dob_conflict boolean not null default false,canonical_sex_conflict boolean not null default false,target_missing boolean not null default false,
+  target_collision boolean not null default false,source_strong_conflict boolean not null default false
+);
+create table public.aos_f5_patient_source_rows_v1(
+  id bigint primary key,phone_key text,phone_type text,names_raw text,surnames_raw text,name_key text,email_key text,document_key text,document_type text,
+  sex_raw text,birth_date date,source_created_date date,last_appointment date
+);
+create table public.aos_f5_identity_cluster_members_v1(cluster_id uuid not null references public.aos_f5_identity_clusters_v1(id),source_row_id bigint not null references public.aos_f5_patient_source_rows_v1(id),primary key(cluster_id,source_row_id));
+create table public.aos_ventas(id bigserial primary key,fecha date);
+create table public.aos_f5_audit_v1(id bigserial primary key,action text,entity_type text,entity_key text,actor_user_id uuid,details jsonb,created_at timestamptz default now());
+
+create or replace function public.aos_f5_norm_name_v1(v text) returns text language sql immutable as $$
+ select nullif(regexp_replace(upper(btrim(coalesce(v,''))),'[^A-Z0-9]+','','g'),'')
+$$;
+create or replace function public.aos_rev_normalize_patient_identifier_v2(p_type text,p_value text) returns text language plpgsql immutable as $$
+declare v text:=nullif(btrim(coalesce(p_value,'')),''); d text;
+begin
+ if v is null then return null; end if;
+ if upper(p_type)='EMAIL' then return lower(v); end if;
+ if upper(p_type)='PHONE' then d:=regexp_replace(v,'[^0-9]','','g'); if length(d)>9 and right(d,9)<>'' then d:=right(d,9); end if; if length(d)<>9 then return null; end if; return d; end if;
+ if upper(p_type)='DOCUMENT' then d:=regexp_replace(upper(v),'[^A-Z0-9]','','g'); return nullif(d,''); end if;
+ return v;
+end $$;
+
+-- Current canonical patients. P-A/P-B must remain byte-for-byte unchanged.
+insert into public.aos_pacientes("ID_PACIENTE","Nombres","Apellidos","Teléfono",numero_limpio,"Email","N° documento","Sexo","ESTADO_PACIENTE",fuente_datos) values
+('P-A','Ana','Actual','999111222','999111222','ana@clinic.test','11111111','F','ACTIVO','historico'),
+('P-B','Bruno','Base','988777666','988777666','bruno@clinic.test','22222222','M','ACTIVO','historico'),
+('P-C','Shared','One','977555444','977555444',null,'33333333','F','ACTIVO','historico'),
+('P-D','Shared','Two','977555444','977555444',null,'44444444','M','ACTIVO','historico'),
+('P-OLD','Old','Merged','966000111','966000111','old@clinic.test','55555555','F','FUSIONADO','historico');
+
+-- Eight clusters covering positive and fail-closed branches.
+insert into public.aos_f5_identity_clusters_v1(id,status,confidence,source_row_count,canonical_preview,evidence,conflicts) values
+('00000000-0000-0000-0000-000000000001','READY_TO_LINK','HIGH',1,'{"nombres":"Ana","apellidos":"Actual","sex":"F"}','{}','{}'),
+('00000000-0000-0000-0000-000000000002','REVIEW_REQUIRED','HIGH',1,'{"nombres":"Ana","apellidos":"Actual","sex":"F"}','{}','{}'),
+('00000000-0000-0000-0000-000000000003','REVIEW_REQUIRED','MEDIUM',1,'{"nombres":"Ana","apellidos":"Actual","sex":"F"}','{}','{}'),
+('00000000-0000-0000-0000-000000000004','REVIEW_REQUIRED','HIGH',1,'{"nombres":"Bruno","apellidos":"Base","sex":"F"}','{}','{}'),
+('00000000-0000-0000-0000-000000000005','NEW_CANDIDATE','HIGH',1,'{"nombres":"Bruno","apellidos":"Base","sex":"M"}','{}','{}'),
+('00000000-0000-0000-0000-000000000006','NEW_CANDIDATE','HIGH',2,'{"nombres":"Carla","apellidos":"Historica","sex":"F","birth_date":"1990-01-02","document_key":"87654321"}','{}','{}'),
+('00000000-0000-0000-0000-000000000007','NEW_CANDIDATE','SINGLETON',1,'{"nombres":"Dario","apellidos":"Dudoso","sex":"M"}','{}','{}'),
+('00000000-0000-0000-0000-000000000008','READY_TO_LINK','HIGH',1,'{"nombres":"Old","apellidos":"Merged","sex":"F"}','{}','{}');
+
+insert into public.aos_f5_canonical_classification_v1(cluster_id,target_patient_id,source_match_status,classification,reason,match_method,match_score,canonical_sex_conflict) values
+('00000000-0000-0000-0000-000000000001','P-A','AUTO_CANDIDATE','MATCH','EXACT_OR_STRONG_MATCH','DNI_NAME+PHONE_NAME',120,false),
+('00000000-0000-0000-0000-000000000002','P-A','REVIEW_REQUIRED','REVIEW','CANONICAL_TARGET_COLLISION','EMAIL',60,false),
+('00000000-0000-0000-0000-000000000003','P-A','REVIEW_REQUIRED','REVIEW','AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE','PHONE_NAME',50,false),
+('00000000-0000-0000-0000-000000000004','P-B','REVIEW_REQUIRED','REVIEW','CANONICAL_STRONG_FIELD_CONFLICT','DNI_NAME',70,true),
+('00000000-0000-0000-0000-000000000005',null,'UNMATCHED','NEW','NO_CANONICAL_MATCH',null,null,false),
+('00000000-0000-0000-0000-000000000006',null,'UNMATCHED','NEW','NO_CANONICAL_MATCH',null,null,false),
+('00000000-0000-0000-0000-000000000007',null,'UNMATCHED','NEW','NO_CANONICAL_MATCH',null,null,false),
+('00000000-0000-0000-0000-000000000008','P-OLD','AUTO_CANDIDATE','MATCH','EXACT_OR_STRONG_MATCH','DNI_NAME+PHONE_NAME',120,false);
+
+insert into public.aos_f5_patient_source_rows_v1(id,phone_key,phone_type,names_raw,surnames_raw,name_key,email_key,document_key,document_type,sex_raw,birth_date,source_created_date,last_appointment) values
+(1,'999111222','PERU_9','Ana','Actual','ANAACTUAL','ana@clinic.test','11111111','DNI8','F','1980-01-01','2024-01-01','2024-12-01'),
+(2,null,'MISSING','Ana','Actual','ANAACTUAL','ana@clinic.test',null,null,'F',null,'2024-02-01',null),
+(3,'999111222','PERU_9','Ana','Actual','ANAACTUAL',null,null,null,'F',null,'2024-03-01',null),
+(4,'988777666','PERU_9','Bruno','Base','BRUNOBASE',null,'22222222','DNI8','F',null,'2024-04-01',null),
+(5,'988777666','PERU_9','Bruno','Base','BRUNOBASE',null,'22222222','DNI8','M',null,'2025-01-01',null),
+(6,'955444333','PERU_9','Carla','Historica','CARLAHISTORICA','carla.hist@test.pe','87654321','DNI8','F','1990-01-02','2024-01-05','2025-01-05'),
+(7,'955444333','PERU_9','Carla','Historica','CARLAHISTORICA','carla.hist@test.pe','87654321','DNI8','F','1990-01-02','2025-01-05','2025-02-05'),
+(8,'944333222','PERU_9','Dario','Dudoso','DARIODUDOSO',null,null,null,'M',null,'2026-01-01',null),
+(9,'966000111','PERU_9','Old','Merged','OLDMERGED','old@clinic.test','55555555','DNI8','F','1975-05-05','2024-06-01',null);
+insert into public.aos_f5_identity_cluster_members_v1 values
+('00000000-0000-0000-0000-000000000001',1),('00000000-0000-0000-0000-000000000002',2),('00000000-0000-0000-0000-000000000003',3),('00000000-0000-0000-0000-000000000004',4),('00000000-0000-0000-0000-000000000005',5),('00000000-0000-0000-0000-000000000006',6),('00000000-0000-0000-0000-000000000006',7),('00000000-0000-0000-0000-000000000007',8),('00000000-0000-0000-0000-000000000008',9);

--- a/ci/rev-f5-11/tests/001_identity_completion.sql
+++ b/ci/rev-f5-11/tests/001_identity_completion.sql
@@ -2,14 +2,15 @@
 
 -- A REVIEW with identity strong enough to retain the target while current identity anchors are absent;
 -- sex conflict must remain explicit rather than overwrite the patient.
-insert into public.aos_pacientes("ID_PACIENTE","Nombres","Apellidos","Sexo","ESTADO_PACIENTE",fuente_datos) values ('P-E','Elena','Evidencia','F','ACTIVO','historico');
+insert into public.aos_pacientes("ID_PACIENTE","Nombres","Apellidos","Sexo","ESTADO_PACIENTE",fuente_datos)
+values ('P-E','Elena','Evidencia','F','ACTIVO','historico') on conflict ("ID_PACIENTE") do nothing;
 insert into public.aos_f5_identity_clusters_v1(id,status,confidence,source_row_count,canonical_preview,evidence,conflicts) values
-('00000000-0000-0000-0000-000000000009','REVIEW_REQUIRED','HIGH',1,'{"nombres":"Elena","apellidos":"Evidencia","sex":"M"}','{}','{}');
+('00000000-0000-0000-0000-000000000009','REVIEW_REQUIRED','HIGH',1,'{"nombres":"Elena","apellidos":"Evidencia","sex":"M"}','{}','{}') on conflict (id) do nothing;
 insert into public.aos_f5_canonical_classification_v1(cluster_id,target_patient_id,source_match_status,classification,reason,match_method,match_score,canonical_sex_conflict) values
-('00000000-0000-0000-0000-000000000009','P-E','REVIEW_REQUIRED','REVIEW','CANONICAL_STRONG_FIELD_CONFLICT','EMAIL',60,true);
+('00000000-0000-0000-0000-000000000009','P-E','REVIEW_REQUIRED','REVIEW','CANONICAL_STRONG_FIELD_CONFLICT','EMAIL',60,true) on conflict (cluster_id) do nothing;
 insert into public.aos_f5_patient_source_rows_v1(id,phone_key,phone_type,names_raw,surnames_raw,name_key,email_key,document_key,document_type,sex_raw,source_created_date) values
-(10,null,'MISSING','Elena','Evidencia','ELENAEVIDENCIA','elena.old@test.pe',null,null,'M','2024-07-01');
-insert into public.aos_f5_identity_cluster_members_v1 values ('00000000-0000-0000-0000-000000000009',10);
+(10,null,'MISSING','Elena','Evidencia','ELENAEVIDENCIA','elena.old@test.pe',null,null,'M','2024-07-01') on conflict (id) do nothing;
+insert into public.aos_f5_identity_cluster_members_v1 values ('00000000-0000-0000-0000-000000000009',10) on conflict (cluster_id,source_row_id) do nothing;
 
 do $$
 declare s jsonb;

--- a/ci/rev-f5-11/tests/001_identity_completion.sql
+++ b/ci/rev-f5-11/tests/001_identity_completion.sql
@@ -1,0 +1,80 @@
+\set ON_ERROR_STOP on
+
+-- A REVIEW with identity strong enough to retain the target while current identity anchors are absent;
+-- sex conflict must remain explicit rather than overwrite the patient.
+insert into public.aos_pacientes("ID_PACIENTE","Nombres","Apellidos","Sexo","ESTADO_PACIENTE",fuente_datos) values ('P-E','Elena','Evidencia','F','ACTIVO','historico');
+insert into public.aos_f5_identity_clusters_v1(id,status,confidence,source_row_count,canonical_preview,evidence,conflicts) values
+('00000000-0000-0000-0000-000000000009','REVIEW_REQUIRED','HIGH',1,'{"nombres":"Elena","apellidos":"Evidencia","sex":"M"}','{}','{}');
+insert into public.aos_f5_canonical_classification_v1(cluster_id,target_patient_id,source_match_status,classification,reason,match_method,match_score,canonical_sex_conflict) values
+('00000000-0000-0000-0000-000000000009','P-E','REVIEW_REQUIRED','REVIEW','CANONICAL_STRONG_FIELD_CONFLICT','EMAIL',60,true);
+insert into public.aos_f5_patient_source_rows_v1(id,phone_key,phone_type,names_raw,surnames_raw,name_key,email_key,document_key,document_type,sex_raw,source_created_date) values
+(10,null,'MISSING','Elena','Evidencia','ELENAEVIDENCIA','elena.old@test.pe',null,null,'M','2024-07-01');
+insert into public.aos_f5_identity_cluster_members_v1 values ('00000000-0000-0000-0000-000000000009',10);
+
+do $$
+declare s jsonb;
+begin
+ s:=public.aos_f5_11_identity_completion_snapshot_v1();
+ if (s->>'clusters')::int<>9 then raise exception 'F5_11_TEST_CLUSTER_COUNT %',s; end if;
+ if (s->>'source_rows')::int<>10 then raise exception 'F5_11_TEST_SOURCE_COUNT %',s; end if;
+ if (s->>'resolved_existing')::int<>4 then raise exception 'F5_11_TEST_RESOLVED_EXISTING %',s; end if;
+ if (s->>'resolved_attribute_review')::int<>1 then raise exception 'F5_11_TEST_ATTRIBUTE_REVIEW %',s; end if;
+ if (s->>'safe_new')::int<>1 then raise exception 'F5_11_TEST_SAFE_NEW %',s; end if;
+ if (s->>'stale_target')::int<>1 then raise exception 'F5_11_TEST_STALE %',s; end if;
+ if (s->>'review_required')::int<>2 then raise exception 'F5_11_TEST_REVIEW %',s; end if;
+end $$;
+
+-- Phone-only evidence must never auto-link.
+do $$ begin
+ if (select resolution_status from public.aos_f5_historical_identity_completion_preview_v1 where cluster_id='00000000-0000-0000-0000-000000000003')<>'REVIEW_REQUIRED' then
+  raise exception 'F5_11_PHONE_ONLY_MUST_REVIEW';
+ end if;
+ if (select resolution_status from public.aos_f5_historical_identity_completion_preview_v1 where cluster_id='00000000-0000-0000-0000-000000000008')<>'STALE_TARGET' then
+  raise exception 'F5_11_STALE_MATCH_MUST_NOT_PHONE_REMAP';
+ end if;
+ if (select resolution_status from public.aos_f5_historical_identity_completion_preview_v1 where cluster_id='00000000-0000-0000-0000-000000000009')<>'RESOLVED_EXISTING_ATTRIBUTE_REVIEW' then
+  raise exception 'F5_11_SEX_CONFLICT_IDENTITY_EXPECTED';
+ end if;
+end $$;
+
+-- Apply with optimistic fingerprint/count lock.
+do $$
+declare s jsonb; r jsonb;
+begin
+ s:=public.aos_f5_11_identity_completion_snapshot_v1();
+ r:=public.aos_f5_11_apply_identity_completion_v1(s->>'preview_fingerprint',(s->>'safe_new')::int);
+ if not coalesce((r->>'ok')::boolean,false) or coalesce((r->>'replay')::boolean,true) then raise exception 'F5_11_APPLY_FAILED %',r; end if;
+ if (r->>'new_created')::int<>1 then raise exception 'F5_11_NEW_CREATED_BAD %',r; end if;
+end $$;
+
+-- Existing canonical identity fields remain untouched.
+do $$ begin
+ if not exists(select 1 from public.aos_pacientes where "ID_PACIENTE"='P-A' and "Teléfono"='999111222' and numero_limpio='999111222' and "Email"='ana@clinic.test' and "N° documento"='11111111' and "Nombres"='Ana' and "Apellidos"='Actual') then raise exception 'F5_11_EXISTING_P_A_MUTATED'; end if;
+ if not exists(select 1 from public.aos_pacientes where "ID_PACIENTE"='P-B' and "Teléfono"='988777666' and numero_limpio='988777666' and "Email"='bruno@clinic.test' and "N° documento"='22222222' and "Sexo"='M') then raise exception 'F5_11_EXISTING_P_B_MUTATED'; end if;
+ if not exists(select 1 from public.aos_pacientes where "ID_PACIENTE"='P-E' and "Sexo"='F') then raise exception 'F5_11_ATTRIBUTE_REVIEW_OVERWROTE_SEX'; end if;
+end $$;
+
+-- Exactly one deterministic safe-new patient is created with provenance.
+do $$ begin
+ if (select count(*) from public.aos_pacientes where "ID_PACIENTE" like 'P-HIST-F511-%')<>1 then raise exception 'F5_11_SAFE_NEW_COUNT'; end if;
+ if not exists(select 1 from public.aos_pacientes where "ID_PACIENTE"='P-HIST-F511-00000000000000000000000000000006' and "Nombres"='Carla' and "Apellidos"='Historica' and "Teléfono"='955444333' and numero_limpio='955444333' and "Email"='carla.hist@test.pe' and "N° documento"='87654321' and "ESTADO_PACIENTE"='PROSPECTO' and fuente_datos='historico_f5_completion_v2') then raise exception 'F5_11_SAFE_NEW_PAYLOAD'; end if;
+end $$;
+
+-- Alias bridge exposes completed history, and stale fused targets disappear.
+do $$ begin
+ if not exists(select 1 from public.aos_rev_patient_identity_alias_v2 where identifier_type='PHONE' and identifier_key='955444333' and canonical_patient_id='P-HIST-F511-00000000000000000000000000000006' and status='RESOLVED' and confidence_band='HIGH' and evidence_scopes ? 'F5_COMPLETION_V2') then raise exception 'F5_11_NEW_PHONE_ALIAS_MISSING'; end if;
+ if not exists(select 1 from public.aos_rev_patient_identity_alias_v2 where identifier_type='EMAIL' and identifier_key='ana@clinic.test' and canonical_patient_id='P-A' and evidence_scopes ? 'F5_COMPLETION_V2') then raise exception 'F5_11_REVIEW_ALIAS_NOT_PROMOTED'; end if;
+ if exists(select 1 from public.aos_rev_patient_identity_alias_v2 where canonical_patient_id='P-OLD') then raise exception 'F5_11_STALE_FUSED_ALIAS_LEAK'; end if;
+end $$;
+
+-- Full accounting and idempotent replay.
+do $$
+declare r jsonb;
+begin
+ if (select count(*) from public.aos_f5_historical_identity_resolution_v2)<>9 then raise exception 'F5_11_LEDGER_INCOMPLETE'; end if;
+ if (select sum(source_row_count) from public.aos_f5_historical_identity_resolution_v2)<>10 then raise exception 'F5_11_LEDGER_SOURCE_INCOMPLETE'; end if;
+ r:=public.aos_f5_11_apply_identity_completion_v1('ignored-on-replay',999);
+ if not coalesce((r->>'replay')::boolean,false) then raise exception 'F5_11_REPLAY_NOT_IDEMPOTENT %',r; end if;
+ if (select count(*) from public.aos_pacientes where "ID_PACIENTE" like 'P-HIST-F511-%')<>1 then raise exception 'F5_11_REPLAY_DUPLICATED_PATIENT'; end if;
+ if exists(select 1 from public.aos_ventas where fecha between date '2024-01-01' and date '2025-12-31') then raise exception 'F5_11_HISTORICAL_SALES_MUTATED'; end if;
+end $$;

--- a/ci/rev-f6-2/static_contract.js
+++ b/ci/rev-f6-2/static_contract.js
@@ -17,6 +17,13 @@ must(fix.includes("America/Lima"),'Lima business-date boundary missing');
 must(fix.includes("aos_rev_business_date_lima_v1"),'business-date helper missing');
 must(fix.includes("coalesce(p.\"ESTADO_PACIENTE\",'')<>'FUSIONADO'"),'active canonical subject filter missing');
 must(fix.includes("grant execute on function public.aos_patient_commercial_360_v2(text,text,text) to anon,authenticated,service_role"),'governed browser gateway missing after hotfix');
-must(ui.includes('cs.lifecycle_state'),'Patient 360 has no lifecycle display path');
+// P0 #436 split Patient 360 into operational core + serial deferred enrichment.
+// Lifecycle is now rendered from `life.lifecycle_state`, populated only by the governed
+// LIFECYCLE section of aos_patient_360_enrichment_v1. Accept the legacy direct path only
+// for backward compatibility, but require the governed deferred path in the current V3 UI.
+const legacyLifecyclePath=ui.includes('cs.lifecycle_state');
+const deferredLifecyclePath=ui.includes('life.lifecycle_state')&&ui.includes("section==='LIFECYCLE'")&&ui.includes("aos_patient_360_enrichment_v1");
+must(legacyLifecyclePath||deferredLifecyclePath,'Patient 360 has no lifecycle display path');
+must(deferredLifecyclePath,'Patient 360 current V3 must use governed deferred lifecycle enrichment');
 must(!fix.includes("lifecycle_state','PENDING_REV_F6_2"),'F6.2 hotfix still emits pending lifecycle');
 console.log('REV-F6.2 FAST static contract PASS');

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,124 +1,65 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Status:** CURRENT / WHATSAPP REVENUE HUB V2  
-**Captured:** 2026-08-28 America/Lima  
-**WA-4B exact head:** `d5d63515c9ee94bb2458a70f825fabdfd0804697`  
-**WA-4B functional merge:** `e8180b99ba3a77716969f9ea4a7bbf604cb20d6d`  
-**WA-4B:** `TEST CERTIFIED / RUNTIME DEPLOYED SAFE-OFF / LIVE COPILOT CANARY PENDING`  
-**ACTIVE LOCK:** `WA-4C — AI SALES COPILOT CANARY`
+**Captured:** 2026-09-02 America/Lima  
+**Canonical entry baseline:** `main@943e93333d31a25cdbd102ce5332b0412a6e7489`  
+**ACTIVE HIGH/CRITICAL LOCK:** `REV-F5.11 — Historical Patient Identity Completion 2024–2026`  
+**GitHub authority:** Issue `#441`  
+**WhatsApp authority:** `HOLD / SAFE-OFF`; WA-L4 implementation does not own the mutable lock while REV-F5.11 is active.
 
-## Execution rule
-Only one HIGH/CRITICAL mutable workstream at a time. `WA-4C` is the only mutable lane. All other HIGH/CRITICAL workstreams remain read-only/regression-only unless WA-4C has a narrowly documented dependency.
+## Why this lock exists
 
-Preserved: REV-F5/F6 production-certified; REV-F7 paused; CIA/Sentinel/KronIA/unrelated work read-only/regression-only unless strict dependency.
+The six certified historical patient exports for San Isidro and Pueblo Libre, years 2024/2025/2026, are fully preserved in F5 staging but the original F5 classification intentionally left most ambiguous identities uncommitted. The owner has authorized completing only the deterministic identity subset now so historical phone/email/document evidence can support future patient/customer resolution.
 
-## Preserved WA authority
-- WA-7A.0: channel continuity.
-- WA-7A.1: REV/F5/F6 canonical identity reuse.
-- WA-7A.2: channel verification/identifier lineage.
-- WA-7A.3: acquisition provenance.
-- WA-7A.4: TEST-certified marketing eligibility; PROD promotion pending.
-- WA-4A: governed Knowledge Fabric.
-- WA-4A.1: role-aware Zi Vital clinic knowledge; PROD promotion pending.
-- WA-4A.1B: certified commercial semantics across 167 services + 50 products; feature graph PROD promotion pending.
-- WA-4A.1C: certified treatment/process/current-price architecture; feature DDL PROD promotion pending.
-- WA-4B: certified advisor-only sales playbook orchestration; runtime deployed SAFE-OFF.
+Transactional sales 2024/2025 are explicitly out of scope. `aos_ventas` remains governed by its independently certified source boundary.
 
-No parallel patient/product/revenue/pricing/customer/clinical/commercial master may be created.
+## Certified entry truth
 
-Mandatory separations:
-`IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`
-`ATTRIBUTION EVIDENCE != CONSENT`
-`LIVE PRICE AUTHORITY != DOCUMENT EXAMPLE PRICE`
-`COMMERCIAL PHASE != CLINICAL LIFECYCLE`
-`PROCESS TEMPLATE != PATIENT-SPECIFIC PRESCRIPTION`
-`ADVISOR RECOMMENDATION != AUTONOMOUS SEND`
-`PLAYBOOK LOGIC != BUSINESS FACT AUTHORITY`
-`TEST CERTIFICATION != LIVE CANARY CERTIFICATION`
+- P0 `#436` Patient 360 runtime incident = **CLOSED** after owner smoke.
+- Patient 360 hot path/enrichment split = production deployed.
+- Filiación Teléfono/Correo = production deployed and owner-verified.
+- Historical source batches = **6/6 MATCHED**.
+- Historical source rows = **15,498 / 15,498**.
+- Identity memberships = **15,498 / 15,498**.
+- Historical identity clusters = **8,716**.
+- Original F5 classification = **296 MATCH / 6,984 REVIEW / 1,436 NEW**.
+- Current `aos_pacientes` at entry readback = **7,737 total / 7,311 non-FUSIONADO / 426 FUSIONADO**.
+- Historical phone/email/document remain provenance; no mass contact overwrite was certified.
+- Transactional sales 2024 = `NO_CERTIFIED_SOURCE`.
+- Transactional sales 2025 = `NO_CERTIFIED_SOURCE`.
 
-## WA-4B certified boundary
-PR #387 exact head `d5d63515c9ee94bb2458a70f825fabdfd0804697` passed all required exact-head gates before merge.
-
-Exact-head SUCCESS:
-- WA-4B dedicated `33188177283`;
-- WA-4 AI Sales Router `33188177180`;
-- Ascenda CI `33188177163`;
-- WA-3 V2 Multiagent FAST `33188177241`;
-- WA-3 Boxes Routing Handoff `33188177177`;
-- ASC-PERF Audit 360 `33188177183`;
-- Performance Guard CI `33188177665`;
-- Phase S WA3 Stabilization `33188177230`.
-
-Anti-drift before merge:
-- `main = 95b77e2630cc67fb407276ead48caa42865befd7`;
-- PR #387 head remained `d5d63515c9ee94bb2458a70f825fabdfd0804697`;
-- no base/head drift.
-
-PR #387 merged with `expected_head_sha` to `e8180b99ba3a77716969f9ea4a7bbf604cb20d6d`.
-
-## Certified WA-4B behavior
-- deterministic commercial-stage/playbook orchestration;
-- Copilot no longer reads `aos_catalogo_servicios` / `aos_promociones` directly as business authority;
-- Knowledge Fabric retrieval separates `PUBLIC_CLIENT` from `ADVISOR_INTERNAL`;
-- governed commercial rules are required by stage and missing rule evidence fails closed;
-- catalog money is stripped from model context unless the stage is PRICE/PAYMENT and WA-4A.1C marks the entity `ready_for_quote` with READY/FRESH price context;
-- stale/anomalous/missing price fails closed;
-- promotions require READY governed promotion evidence;
-- continuity products are candidates only and never auto-added;
-- personalized clinical risk deterministically escalates `HUMAN_CLINICAL`;
-- playbook output remains advisor-facing with evidence refs;
-- `send_authority=HUMAN_ONLY`; `auto_send=false`.
-
-## Post-merge runtime and PROD safety
-Railway status for exact merge `e8180b99...` = SUCCESS on `ascenda-os-production.up.railway.app`. `app/railway.json` configures `/health` as deployment healthcheck, so the successful Railway deployment passed the configured runtime deployment gate.
-
-Merge-commit checks:
-- Runtime baseline = SUCCESS;
-- Performance architecture guard = SUCCESS.
-
-PROD readback after merge:
-- active services = 167;
-- active products = 50;
-- active toppings = 20;
-- offer-above-base review rows = 7;
-- price fingerprint = `4f2bdff1a36dc1c621c237a8da655155`;
-- WA-4A.1 / WA-4A.1B / WA-4A.1C feature objects remain absent in PROD;
-- `copilot_enabled=false`;
-- `auto_reply_enabled=false`;
-- `ai_send_enabled=false`;
-- `auto_routing_enabled=false`;
-- `human_send_enabled=true`;
-- WA messages = 21; conversations = 2; events = 39.
-
-Therefore the production runtime is SAFE-OFF and no autonomous behavior was activated by WA-4B.
-
-## Certification
-`WA-4B — Sales Playbook Engine = TEST CERTIFIED / RUNTIME DEPLOYED SAFE-OFF / LIVE COPILOT CANARY NOT YET CERTIFIED`.
-
-The remaining LIVE boundary is not a code-quality failure: the upstream Knowledge Fabric / commercial graph / process-pricing contracts are still intentionally absent in PROD, and Copilot remains disabled. No bypass is allowed.
-
-## WA-4C — AI Sales Copilot Canary — active lock
-Purpose: prove the certified WA-4B playbook through the real authenticated advisor Copilot path under controlled canary conditions.
-
-WA-4C starts discover/recovery-first. The LIVE canary is BLOCKED until its upstream dependencies are deliberately promoted/revalidated in the certified order.
+## REV-F5.11 mutation boundary
 
 Allowed:
-- inventory exact queued WA-4A/4A.1/4A.1B/4A.1C PROD dependencies and promotion order;
-- revalidate PROD Auth/REST and provider/model readiness;
-- promote only already-certified dependencies through their own migration/readback gates;
-- verify least-privilege retrieval and advisor-only audience separation;
-- enable a narrowly scoped Copilot canary only after dependencies and controls are proven;
-- execute authenticated advisor canaries for INFO, PRICE, PAYMENT, OBJECTION, CONTINUITY and CLINICAL_ESCALATION;
-- prove evidence refs, fail-closed behavior, cost/audit logging and HUMAN_ONLY send authority;
-- immediately roll SAFE-OFF on any evidence, identity, pricing, clinical or authorization failure.
+1. create a governed resolution overlay over immutable F5 clusters;
+2. resolve an historical cluster to an existing **current non-FUSIONADO** patient only with deterministic strong evidence;
+3. preserve historical phone/email/document as aliases/provenance;
+4. create deterministic `P-HIST-F511-*` patients only for high-confidence NEW identities with DNI8 + second signal, repeated coherent evidence, and no current collision;
+5. keep identity-vs-attribute conflicts explicit;
+6. produce exact coverage and an idempotent audit ledger.
 
-Must not:
-- enable autonomous WhatsApp sending;
-- enable auto-reply or auto-routing;
-- bypass marketing eligibility/consent;
-- fabricate missing knowledge/prices/promotions;
-- promote unreviewed migrations out of certified order;
-- mutate patient/REV/canonical identity to satisfy canaries;
-- call WA-4C LIVE-certified until authenticated real runtime evidence passes.
+Forbidden:
+- merge by name alone;
+- merge/link by phone alone;
+- fuzzy/numeric-neighbor phone matching;
+- overwrite any existing canonical phone/email/document/name;
+- silently discard conflicts;
+- mutate/import 2024/2025 transactional sales;
+- create a second patient master;
+- enable WhatsApp autonomous sending/routing while this lock is active.
 
-Next phase after WA-4C remains `WA-5` per roadmap; it stays BLOCKED until WA-4C closeout.
+## Exit gates
+
+REV-F5.11 may close only after:
+1. deterministic preview covers every certified F5 cluster/source row;
+2. exact-head CI proves safe branches and fail-closed branches;
+3. migration + replay + recovery pass in isolated PostgreSQL;
+4. LIVE preview fingerprint/count is captured before apply;
+5. LIVE canary/recovery evidence passes;
+6. governed batch apply preserves the fingerprint of all pre-existing canonical patient identity fields;
+7. new patient count equals the certified `NEW_SAFE` preview exactly;
+8. every resolved alias points only to a current non-FUSIONADO patient and conflicts remain explicit;
+9. no 2024/2025 sale row is introduced;
+10. post-apply source coverage remains 15,498/15,498 and residual REVIEW is quantified;
+11. GitHub + Notion + CURRENT control are reconciled.
+
+Only after those gates may the HIGH/CRITICAL lock return to WhatsApp (`WA-L4`, still AUTO_OFF until its own authorization gates).

--- a/supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+++ b/supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
@@ -1,7 +1,6 @@
 -- ASCENDA OS · REV-F5.11 Historical Patient Identity Completion V1
 -- Scope: patient identity/provenance 2024-2026 only. No 2024/2025 sales ingestion.
--- Safety: never overwrites an existing canonical patient. New rows are limited to
--- deterministic HIGH-confidence historical identities with DNI8 + second signal.
+-- Existing canonical rows are immutable; ambiguous identity remains REVIEW_REQUIRED.
 
 begin;
 
@@ -11,9 +10,7 @@ create table if not exists public.aos_f5_historical_identity_resolution_v2 (
   original_reason text not null,
   original_match_method text null,
   original_match_score numeric null,
-  resolution_status text not null check (resolution_status in (
-    'RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_SAFE','NEW_CREATED','STALE_TARGET','REVIEW_REQUIRED'
-  )),
+  resolution_status text not null check (resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_SAFE','NEW_CREATED','STALE_TARGET','REVIEW_REQUIRED')),
   resolution_rule text not null,
   canonical_patient_id text null,
   proposed_patient_id text null,
@@ -26,70 +23,36 @@ create table if not exists public.aos_f5_historical_identity_resolution_v2 (
   generated_at timestamptz not null default now(),
   applied_at timestamptz null
 );
-
-comment on table public.aos_f5_historical_identity_resolution_v2 is
-'REV-F5.11 immutable completion snapshot over certified F5 source identity. Existing canonical patient rows are never overwritten; ambiguous identity remains REVIEW_REQUIRED.';
-
+comment on table public.aos_f5_historical_identity_resolution_v2 is 'REV-F5.11 immutable completion snapshot over certified F5 identity. Existing canonical rows are never overwritten.';
 revoke all on table public.aos_f5_historical_identity_resolution_v2 from public,anon,authenticated;
 grant select,insert,update,delete on table public.aos_f5_historical_identity_resolution_v2 to service_role;
-
-create index if not exists idx_f5_hist_identity_resolution_v2_patient
-  on public.aos_f5_historical_identity_resolution_v2(canonical_patient_id)
-  where canonical_patient_id is not null;
-create index if not exists idx_f5_hist_identity_resolution_v2_status
-  on public.aos_f5_historical_identity_resolution_v2(resolution_status);
+create index if not exists idx_f5_hist_identity_resolution_v2_patient on public.aos_f5_historical_identity_resolution_v2(canonical_patient_id) where canonical_patient_id is not null;
+create index if not exists idx_f5_hist_identity_resolution_v2_status on public.aos_f5_historical_identity_resolution_v2(resolution_status);
 
 create or replace view public.aos_f5_historical_identity_completion_preview_v1 as
 with current_alias_raw as (
-  select 'PHONE'::text identifier_type,
-         public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) identifier_key,
-         p."ID_PACIENTE"::text canonical_patient_id
-  from public.aos_pacientes p
-  where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  union all
-  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text
+  select 'PHONE'::text identifier_type,public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) identifier_key,p."ID_PACIENTE"::text canonical_patient_id
   from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  union all
-  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text
-  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
 ), current_alias as (
-  select identifier_type,identifier_key,min(canonical_patient_id) canonical_patient_id,
-         count(distinct canonical_patient_id)::integer candidate_count
-  from current_alias_raw
-  where identifier_key is not null and identifier_key<>''
-  group by identifier_type,identifier_key
+  select identifier_type,identifier_key,min(canonical_patient_id) canonical_patient_id,count(distinct canonical_patient_id)::integer candidate_count
+  from current_alias_raw where identifier_key is not null and identifier_key<>'' group by identifier_type,identifier_key
 ), core as (
   select c.id cluster_id,c.status cluster_status,c.confidence,c.source_row_count,c.canonical_preview,c.evidence cluster_evidence,c.conflicts,
          cc.classification original_classification,cc.reason original_reason,cc.match_method original_match_method,cc.match_score original_match_score,
-         cc.target_patient_id original_target_patient_id,
-         cc.canonical_dni_conflict,cc.canonical_email_conflict,cc.canonical_dob_conflict,cc.canonical_sex_conflict,
-         cc.source_strong_conflict,
+         cc.target_patient_id original_target_patient_id,cc.canonical_dni_conflict,cc.canonical_email_conflict,cc.canonical_dob_conflict,cc.canonical_sex_conflict,cc.source_strong_conflict,
          public.aos_f5_norm_name_v1(concat_ws(' ',c.canonical_preview->>'nombres',c.canonical_preview->>'apellidos')) source_name_key
-  from public.aos_f5_identity_clusters_v1 c
-  join public.aos_f5_canonical_classification_v1 cc on cc.cluster_id=c.id
+  from public.aos_f5_identity_clusters_v1 c join public.aos_f5_canonical_classification_v1 cc on cc.cluster_id=c.id
 ), identifier_hits as (
-  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
-  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
-  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join current_alias a on a.identifier_type='DOCUMENT' and a.identifier_key=s.document_key and nullif(s.document_key,'') is not null
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join current_alias a on a.identifier_type='DOCUMENT' and a.identifier_key=s.document_key and nullif(s.document_key,'') is not null
   union all
-  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
-  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
-  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join current_alias a on a.identifier_type='EMAIL' and a.identifier_key=s.email_key and nullif(s.email_key,'') is not null
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join current_alias a on a.identifier_type='EMAIL' and a.identifier_key=s.email_key and nullif(s.email_key,'') is not null
   union all
-  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
-  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
-  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join current_alias a on a.identifier_type='PHONE' and a.identifier_key=s.phone_key and nullif(s.phone_key,'') is not null
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join current_alias a on a.identifier_type='PHONE' and a.identifier_key=s.phone_key and nullif(s.phone_key,'') is not null
 ), current_hit_agg as (
-  select cluster_id,
-         count(distinct canonical_patient_id) filter(where candidate_count=1)::integer current_target_count,
-         min(canonical_patient_id) filter(where candidate_count=1) current_target,
-         bool_or(identifier_type='DOCUMENT' and candidate_count=1) has_document,
-         bool_or(identifier_type='EMAIL' and candidate_count=1) has_email,
-         bool_or(identifier_type='PHONE' and candidate_count=1) has_phone,
-         bool_or(candidate_count>1) has_current_key_conflict
+  select cluster_id,count(distinct canonical_patient_id) filter(where candidate_count=1)::integer current_target_count,min(canonical_patient_id) filter(where candidate_count=1) current_target,
+         bool_or(identifier_type='DOCUMENT' and candidate_count=1) has_document,bool_or(identifier_type='EMAIL' and candidate_count=1) has_email,bool_or(identifier_type='PHONE' and candidate_count=1) has_phone,bool_or(candidate_count>1) has_current_key_conflict
   from identifier_hits group by cluster_id
 ), source_stats as (
   select c.cluster_id,
@@ -105,110 +68,61 @@ with current_alias_raw as (
          max(s.document_key) filter(where nullif(s.document_key,'') is not null and s.document_type='DNI8') proposed_document,
          min(s.source_created_date) filter(where s.source_created_date is not null) first_source_date,
          max(s.last_appointment) filter(where s.last_appointment is not null) last_source_appointment
-  from core c
-  join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
-  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  group by c.cluster_id
+  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id group by c.cluster_id
 ), evaluated as (
-  select c.*,coalesce(h.current_target_count,0) current_target_count,h.current_target,
-         coalesce(h.has_document,false) has_document,coalesce(h.has_email,false) has_email,coalesce(h.has_phone,false) has_phone,
-         coalesce(h.has_current_key_conflict,false) has_current_key_conflict,
-         ss.*,
-         po."ID_PACIENTE" old_current_patient_id,
-         pc."ID_PACIENTE" current_candidate_patient_id,
+  select c.*,
+         coalesce(h.current_target_count,0) current_target_count,h.current_target,
+         coalesce(h.has_document,false) has_document,coalesce(h.has_email,false) has_email,coalesce(h.has_phone,false) has_phone,coalesce(h.has_current_key_conflict,false) has_current_key_conflict,
+         ss.distinct_names,ss.distinct_documents,ss.distinct_dni8,ss.distinct_emails,ss.distinct_peru_phones,ss.distinct_birth_dates,ss.distinct_sexes,
+         ss.proposed_phone,ss.proposed_email,ss.proposed_document,ss.first_source_date,ss.last_source_appointment,
+         po."ID_PACIENTE" old_current_patient_id,pc."ID_PACIENTE" current_candidate_patient_id,
          public.aos_f5_norm_name_v1(concat_ws(' ',pc."Nombres",pc."Apellidos")) current_candidate_name_key
-  from core c
-  join source_stats ss on ss.cluster_id=c.cluster_id
-  left join current_hit_agg h on h.cluster_id=c.cluster_id
+  from core c join source_stats ss on ss.cluster_id=c.cluster_id left join current_hit_agg h on h.cluster_id=c.cluster_id
   left join public.aos_pacientes po on po."ID_PACIENTE"=c.original_target_patient_id and coalesce(po."ESTADO_PACIENTE",'')<>'FUSIONADO'
   left join public.aos_pacientes pc on pc."ID_PACIENTE"=h.current_target and coalesce(pc."ESTADO_PACIENTE",'')<>'FUSIONADO'
 ), decided as (
   select e.*,
     case
       when original_classification='MATCH' and old_current_patient_id is not null then 'RESOLVED_EXISTING'
-      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict
-       and current_candidate_patient_id is not null and (
-          (has_document and (has_email or has_phone)) or (has_email and has_phone)
-          or (has_document and source_name_key=current_candidate_name_key)
-          or (has_email and source_name_key=current_candidate_name_key)
-       ) then 'RESOLVED_EXISTING'
-      when original_classification='REVIEW' and old_current_patient_id is not null
-       and original_reason='CANONICAL_TARGET_COLLISION'
-       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING'
-      when original_classification='REVIEW' and old_current_patient_id is not null
-       and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
-       and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'RESOLVED_EXISTING'
-      when original_classification='REVIEW' and old_current_patient_id is not null
-       and original_reason='CANONICAL_STRONG_FIELD_CONFLICT'
-       and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict
-       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING_ATTRIBUTE_REVIEW'
-      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict
-       and confidence='HIGH' and source_row_count>=2 and distinct_names=1
-       and distinct_documents=1 and distinct_dni8=1 and distinct_emails<=1 and distinct_peru_phones<=1
-       and distinct_birth_dates<=1 and distinct_sexes<=1 and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_SAFE'
+      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict and current_candidate_patient_id is not null and ((has_document and (has_email or has_phone)) or (has_email and has_phone) or (has_document and source_name_key=current_candidate_name_key) or (has_email and source_name_key=current_candidate_name_key)) then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_TARGET_COLLISION' and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE' and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_STRONG_FIELD_CONFLICT' and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING_ATTRIBUTE_REVIEW'
+      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict and confidence='HIGH' and source_row_count>=2 and distinct_names=1 and distinct_documents=1 and distinct_dni8=1 and distinct_emails<=1 and distinct_peru_phones<=1 and distinct_birth_dates<=1 and distinct_sexes<=1 and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_SAFE'
       when original_classification='MATCH' and old_current_patient_id is null then 'STALE_TARGET'
       else 'REVIEW_REQUIRED'
     end::text resolution_status,
     case
       when original_classification='MATCH' and old_current_patient_id is not null then 'CERTIFIED_F5_MATCH_CURRENT_TARGET'
-      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict
-       and current_candidate_patient_id is not null and (
-          (has_document and (has_email or has_phone)) or (has_email and has_phone)
-          or (has_document and source_name_key=current_candidate_name_key)
-          or (has_email and source_name_key=current_candidate_name_key)
-       ) then 'CANONICAL_CURRENT_EXACT_MULTI_SIGNAL'
-      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_TARGET_COLLISION'
-       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'F5_STRONG_TARGET_COLLISION_NON_IDENTITY'
-      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
-       and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'F5_STRONG_LEGACY_EVIDENCE'
-      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_STRONG_FIELD_CONFLICT'
-       and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict
-       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'IDENTITY_RESOLVED_SEX_REVIEW_RETAINED'
-      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict
-       and confidence='HIGH' and source_row_count>=2 and distinct_names=1 and distinct_documents=1 and distinct_dni8=1
-       and distinct_emails<=1 and distinct_peru_phones<=1 and distinct_birth_dates<=1 and distinct_sexes<=1
-       and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_HIGH_DNI8_PLUS_SECOND_SIGNAL'
+      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict and current_candidate_patient_id is not null and ((has_document and (has_email or has_phone)) or (has_email and has_phone) or (has_document and source_name_key=current_candidate_name_key) or (has_email and source_name_key=current_candidate_name_key)) then 'CANONICAL_CURRENT_EXACT_MULTI_SIGNAL'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_TARGET_COLLISION' and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'F5_STRONG_TARGET_COLLISION_NON_IDENTITY'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE' and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'F5_STRONG_LEGACY_EVIDENCE'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_STRONG_FIELD_CONFLICT' and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'IDENTITY_RESOLVED_SEX_REVIEW_RETAINED'
+      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict and confidence='HIGH' and source_row_count>=2 and distinct_names=1 and distinct_documents=1 and distinct_dni8=1 and distinct_emails<=1 and distinct_peru_phones<=1 and distinct_birth_dates<=1 and distinct_sexes<=1 and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_HIGH_DNI8_PLUS_SECOND_SIGNAL'
       when original_classification='MATCH' and old_current_patient_id is null then 'CERTIFIED_TARGET_NO_LONGER_CURRENT'
       else 'INSUFFICIENT_OR_CONFLICTING_IDENTITY_EVIDENCE'
     end::text resolution_rule
   from evaluated e
 )
-select
-  cluster_id,original_classification,original_reason,original_match_method,original_match_score,
-  resolution_status,resolution_rule,
-  case
-    when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id
-    when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id
-    else null
-  end::text canonical_patient_id,
+select cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,
+  case when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id else null end::text canonical_patient_id,
   case when resolution_status='NEW_SAFE' then 'P-HIST-F511-'||upper(replace(cluster_id::text,'-','')) else null end::text proposed_patient_id,
   source_row_count,confidence,
   case when resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW' then jsonb_build_object('Sexo','REVIEW_REQUIRED') else '{}'::jsonb end attribute_review,
-  jsonb_build_object(
-    'cluster_status',cluster_status,'cluster_evidence',cluster_evidence,'source_conflicts',conflicts,
-    'current_target_count',current_target_count,'has_current_key_conflict',has_current_key_conflict,
+  jsonb_build_object('cluster_status',cluster_status,'cluster_evidence',cluster_evidence,'source_conflicts',conflicts,'current_target_count',current_target_count,'has_current_key_conflict',has_current_key_conflict,
     'source_identity_counts',jsonb_build_object('names',distinct_names,'documents',distinct_documents,'dni8',distinct_dni8,'emails',distinct_emails,'phones',distinct_peru_phones,'birth_dates',distinct_birth_dates,'sexes',distinct_sexes),
-    'proposed_identity',jsonb_build_object('nombres',canonical_preview->>'nombres','apellidos',canonical_preview->>'apellidos','phone',proposed_phone,'email',proposed_email,'document',proposed_document),
-    'first_source_date',first_source_date,'last_source_appointment',last_source_appointment
-  ) evidence,
+    'proposed_identity',jsonb_build_object('nombres',canonical_preview->>'nombres','apellidos',canonical_preview->>'apellidos','sex',canonical_preview->>'sex','birth_date',canonical_preview->>'birth_date','phone',proposed_phone,'email',proposed_email,'document',proposed_document),
+    'first_source_date',first_source_date,'last_source_appointment',last_source_appointment) evidence,
   md5(concat_ws('|',cluster_id::text,original_classification,original_reason,coalesce(original_match_method,''),coalesce(original_match_score::text,''),resolution_status,resolution_rule,
-      coalesce(case when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id end,''),
-      coalesce(case when resolution_status='NEW_SAFE' then 'P-HIST-F511-'||upper(replace(cluster_id::text,'-','')) end,''),source_row_count::text,confidence)) preview_hash
+    coalesce(case when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id end,''),
+    coalesce(case when resolution_status='NEW_SAFE' then 'P-HIST-F511-'||upper(replace(cluster_id::text,'-','')) end,''),source_row_count::text,confidence)) preview_hash
 from decided;
-
-comment on view public.aos_f5_historical_identity_completion_preview_v1 is
-'REV-F5.11 deterministic preview. Current exact identifiers are authoritative only when non-fused and unique; phone alone never auto-links. Ambiguous clusters remain REVIEW_REQUIRED.';
+comment on view public.aos_f5_historical_identity_completion_preview_v1 is 'REV-F5.11 deterministic preview. Current exact identifiers must be non-fused and unique; phone alone never auto-links.';
 revoke all on public.aos_f5_historical_identity_completion_preview_v1 from public,anon,authenticated;
 grant select on public.aos_f5_historical_identity_completion_preview_v1 to service_role;
 
-create or replace function public.aos_f5_11_identity_completion_snapshot_v1()
-returns jsonb
-language sql
-security definer
-set search_path=''
-as $$
-  with p as (select * from public.aos_f5_historical_identity_completion_preview_v1),
-  x as (
+create or replace function public.aos_f5_11_identity_completion_snapshot_v1() returns jsonb language sql security definer set search_path='' as $$
+  with x as (
     select count(*) clusters,coalesce(sum(source_row_count),0) source_rows,
       count(*) filter(where resolution_status='RESOLVED_EXISTING') resolved_existing,
       count(*) filter(where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW') resolved_attribute_review,
@@ -216,179 +130,58 @@ as $$
       count(*) filter(where resolution_status='STALE_TARGET') stale_target,
       count(*) filter(where resolution_status='REVIEW_REQUIRED') review_required,
       md5(string_agg(preview_hash,',' order by cluster_id)) preview_fingerprint
-    from p
-  )
-  select jsonb_build_object('ok',true,'resolution_version','REV-F5.11-V1','clusters',clusters,'source_rows',source_rows,
-    'resolved_existing',resolved_existing,'resolved_attribute_review',resolved_attribute_review,'safe_new',safe_new,
-    'stale_target',stale_target,'review_required',review_required,'preview_fingerprint',preview_fingerprint)
-  from x
+    from public.aos_f5_historical_identity_completion_preview_v1
+  ) select jsonb_build_object('ok',true,'resolution_version','REV-F5.11-V1','clusters',clusters,'source_rows',source_rows,'resolved_existing',resolved_existing,'resolved_attribute_review',resolved_attribute_review,'safe_new',safe_new,'stale_target',stale_target,'review_required',review_required,'preview_fingerprint',preview_fingerprint) from x
 $$;
 revoke all on function public.aos_f5_11_identity_completion_snapshot_v1() from public,anon,authenticated;
 grant execute on function public.aos_f5_11_identity_completion_snapshot_v1() to service_role;
 
-create or replace function public.aos_f5_11_apply_identity_completion_v1(p_expected_preview_fingerprint text,p_expected_safe_new integer)
-returns jsonb
-language plpgsql
-security definer
-set search_path=''
-as $$
-declare
-  v_preview jsonb;
-  v_fp text;
-  v_safe integer;
-  v_clusters integer;
-  v_source bigint;
-  v_members bigint;
-  v_existing_before bigint;
-  v_existing_after bigint;
-  v_existing_fp_before text;
-  v_existing_fp_after text;
-  v_inserted integer:=0;
-  v_now timestamptz:=clock_timestamp();
+create or replace function public.aos_f5_11_apply_identity_completion_v1(p_expected_preview_fingerprint text,p_expected_safe_new integer) returns jsonb language plpgsql security definer set search_path='' as $$
+declare v_preview jsonb; v_fp text; v_safe integer; v_clusters integer; v_source bigint; v_members bigint; v_existing_before bigint; v_existing_after bigint; v_existing_fp_before text; v_existing_fp_after text; v_inserted integer:=0; v_now timestamptz:=clock_timestamp();
 begin
   if exists(select 1 from public.aos_f5_historical_identity_resolution_v2) then
-    if (select count(*) from public.aos_f5_historical_identity_resolution_v2)<>(select count(*) from public.aos_f5_identity_clusters_v1) then
-      raise exception 'F5_11_PARTIAL_RESOLUTION_LEDGER';
-    end if;
-    if exists(select 1 from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_SAFE') then
-      raise exception 'F5_11_PARTIAL_NEW_APPLY';
-    end if;
-    return jsonb_build_object('ok',true,'replay',true,'resolution_version','REV-F5.11-V1',
-      'resolution_rows',(select count(*) from public.aos_f5_historical_identity_resolution_v2),
-      'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'));
+    if (select count(*) from public.aos_f5_historical_identity_resolution_v2)<>(select count(*) from public.aos_f5_identity_clusters_v1) then raise exception 'F5_11_PARTIAL_RESOLUTION_LEDGER'; end if;
+    if exists(select 1 from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_SAFE') then raise exception 'F5_11_PARTIAL_NEW_APPLY'; end if;
+    return jsonb_build_object('ok',true,'replay',true,'resolution_version','REV-F5.11-V1','resolution_rows',(select count(*) from public.aos_f5_historical_identity_resolution_v2),'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'));
   end if;
-
-  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1;
-  select count(*) into v_source from public.aos_f5_patient_source_rows_v1;
-  select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
+  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1; select count(*) into v_source from public.aos_f5_patient_source_rows_v1; select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
   if v_clusters=0 or v_source=0 or v_members<>v_source then raise exception 'F5_11_SOURCE_COVERAGE_INVALID'; end if;
   if (select count(*) from public.aos_f5_historical_identity_completion_preview_v1)<>v_clusters then raise exception 'F5_11_PREVIEW_COVERAGE_INVALID'; end if;
   if exists(select 1 from public.aos_ventas where fecha between date '2024-01-01' and date '2025-12-31') then raise exception 'F5_11_2024_2025_SALES_OUT_OF_SCOPE'; end if;
-
-  v_preview:=public.aos_f5_11_identity_completion_snapshot_v1();
-  v_fp:=v_preview->>'preview_fingerprint';
-  v_safe:=(v_preview->>'safe_new')::integer;
+  v_preview:=public.aos_f5_11_identity_completion_snapshot_v1(); v_fp:=v_preview->>'preview_fingerprint'; v_safe:=(v_preview->>'safe_new')::integer;
   if p_expected_preview_fingerprint is null or p_expected_preview_fingerprint<>v_fp then raise exception 'F5_11_PREVIEW_FINGERPRINT_MISMATCH'; end if;
   if p_expected_safe_new is null or p_expected_safe_new<>v_safe then raise exception 'F5_11_SAFE_NEW_COUNT_MISMATCH'; end if;
-
-  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE"))
-  into v_existing_before,v_existing_fp_before
-  from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
-
-  insert into public.aos_f5_historical_identity_resolution_v2(
-    cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,
-    canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,resolution_version,generated_at,applied_at)
-  select cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,
-    canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,'REV-F5.11-V1',v_now,
-    case when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then v_now else null end
-  from public.aos_f5_historical_identity_completion_preview_v1;
-
-  insert into public.aos_pacientes(
-    "ID_PACIENTE","Nombres","Apellidos","Teléfono",numero_limpio,"Email","N° documento","Sexo","Fecha de nacimiento",
-    "ESTADO_PACIENTE",fuente_datos,"FUENTE","FECHA_REGISTRO",created_at,updated_at,pais,etiqueta_vip)
-  select r.proposed_patient_id,
-         nullif(r.evidence->'proposed_identity'->>'nombres',''),
-         nullif(r.evidence->'proposed_identity'->>'apellidos',''),
-         nullif(r.evidence->'proposed_identity'->>'phone',''),
-         nullif(r.evidence->'proposed_identity'->>'phone',''),
-         nullif(r.evidence->'proposed_identity'->>'email',''),
-         nullif(r.evidence->'proposed_identity'->>'document',''),
-         nullif(c.canonical_preview->>'sex',''),
-         nullif(c.canonical_preview->>'birth_date',''),
-         'PROSPECTO','historico_f5_completion_v2','F5_2024_2026',
-         nullif(r.evidence->>'first_source_date',''),v_now,v_now,'Perú','NORMAL'
-  from public.aos_f5_historical_identity_resolution_v2 r
-  join public.aos_f5_identity_clusters_v1 c on c.id=r.cluster_id
-  where r.resolution_status='NEW_SAFE'
-  on conflict ("ID_PACIENTE") do nothing;
-  get diagnostics v_inserted=row_count;
-
-  if v_inserted<>v_safe then raise exception 'F5_11_NEW_PATIENT_INSERT_COUNT_MISMATCH expected %, inserted %',v_safe,v_inserted; end if;
-
-  update public.aos_f5_historical_identity_resolution_v2
-  set resolution_status='NEW_CREATED',canonical_patient_id=proposed_patient_id,applied_at=v_now
-  where resolution_status='NEW_SAFE';
-
-  if exists(
-    select 1 from public.aos_f5_historical_identity_resolution_v2 r
-    left join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id
-    where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED')
-      and (p."ID_PACIENTE" is null or coalesce(p."ESTADO_PACIENTE",'')='FUSIONADO')
-  ) then raise exception 'F5_11_RESOLUTION_POINTS_TO_NONCURRENT_PATIENT'; end if;
-
-  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE"))
-  into v_existing_after,v_existing_fp_after
-  from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
+  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE")) into v_existing_before,v_existing_fp_before from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
+  insert into public.aos_f5_historical_identity_resolution_v2(cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,resolution_version,generated_at,applied_at)
+  select cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,'REV-F5.11-V1',v_now,case when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then v_now else null end from public.aos_f5_historical_identity_completion_preview_v1;
+  insert into public.aos_pacientes("ID_PACIENTE","Nombres","Apellidos","Teléfono",numero_limpio,"Email","N° documento","Sexo","Fecha de nacimiento","ESTADO_PACIENTE",fuente_datos,"FUENTE","FECHA_REGISTRO",created_at,updated_at,pais,etiqueta_vip)
+  select r.proposed_patient_id,nullif(r.evidence->'proposed_identity'->>'nombres',''),nullif(r.evidence->'proposed_identity'->>'apellidos',''),nullif(r.evidence->'proposed_identity'->>'phone',''),nullif(r.evidence->'proposed_identity'->>'phone',''),nullif(r.evidence->'proposed_identity'->>'email',''),nullif(r.evidence->'proposed_identity'->>'document',''),nullif(r.evidence->'proposed_identity'->>'sex',''),nullif(r.evidence->'proposed_identity'->>'birth_date',''),'PROSPECTO','historico_f5_completion_v2','F5_2024_2026',nullif(r.evidence->>'first_source_date',''),v_now,v_now,'Perú','NORMAL'
+  from public.aos_f5_historical_identity_resolution_v2 r where r.resolution_status='NEW_SAFE' on conflict ("ID_PACIENTE") do nothing;
+  get diagnostics v_inserted=row_count; if v_inserted<>v_safe then raise exception 'F5_11_NEW_PATIENT_INSERT_COUNT_MISMATCH expected %, inserted %',v_safe,v_inserted; end if;
+  update public.aos_f5_historical_identity_resolution_v2 set resolution_status='NEW_CREATED',canonical_patient_id=proposed_patient_id,applied_at=v_now where resolution_status='NEW_SAFE';
+  if exists(select 1 from public.aos_f5_historical_identity_resolution_v2 r left join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and (p."ID_PACIENTE" is null or coalesce(p."ESTADO_PACIENTE",'')='FUSIONADO')) then raise exception 'F5_11_RESOLUTION_POINTS_TO_NONCURRENT_PATIENT'; end if;
+  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE")) into v_existing_after,v_existing_fp_after from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
   if v_existing_after<>v_existing_before or v_existing_fp_after is distinct from v_existing_fp_before then raise exception 'F5_11_EXISTING_CANONICAL_MUTATION_DETECTED'; end if;
-
-  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
-  values('HISTORICAL_IDENTITY_COMPLETION_APPLIED','REV_F5','REV-F5.11',jsonb_build_object(
-    'version','REV-F5.11-V1','preview_fingerprint',v_fp,'source_rows',v_source,'clusters',v_clusters,
-    'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),
-    'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),
-    'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'),
-    'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),
-    'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'),
-    'existing_patient_mutation',false,'sales_2024_2025_mutation',false));
-
-  return jsonb_build_object('ok',true,'replay',false,'resolution_version','REV-F5.11-V1','preview_fingerprint',v_fp,
-    'source_rows',v_source,'clusters',v_clusters,'new_created',v_inserted,
-    'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),
-    'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),
-    'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),
-    'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'));
-end
-$$;
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details) values('HISTORICAL_IDENTITY_COMPLETION_APPLIED','REV_F5','REV-F5.11',jsonb_build_object('version','REV-F5.11-V1','preview_fingerprint',v_fp,'source_rows',v_source,'clusters',v_clusters,'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'),'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'),'existing_patient_mutation',false,'sales_2024_2025_mutation',false));
+  return jsonb_build_object('ok',true,'replay',false,'resolution_version','REV-F5.11-V1','preview_fingerprint',v_fp,'source_rows',v_source,'clusters',v_clusters,'new_created',v_inserted,'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'));
+end $$;
 revoke all on function public.aos_f5_11_apply_identity_completion_v1(text,integer) from public,anon,authenticated;
 grant execute on function public.aos_f5_11_apply_identity_completion_v1(text,integer) to service_role;
 
--- Replace the alias bridge with the completion ledger. This intentionally removes stale
--- aliases pointing at FUSIONADO historical MATCH targets.
 create or replace view public.aos_rev_patient_identity_alias_v2 as
 with raw_alias as (
-  select 'CANONICAL_ID'::text identifier_type,p."ID_PACIENTE"::text identifier_key,p."ID_PACIENTE"::text canonical_patient_id,'CANONICAL_CURRENT'::text source_scope
-  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  union all
-  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
-  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) is not null
-  union all
-  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
-  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento") is not null
-  union all
-  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
-  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email") is not null
-  union all
-  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),r.canonical_patient_id,'F5_COMPLETION_V2'
-  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
-  union all
-  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),r.canonical_patient_id,'F5_COMPLETION_V2'
-  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
-  union all
-  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),r.canonical_patient_id,'F5_COMPLETION_V2'
-  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
-  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
-  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
+  select 'CANONICAL_ID'::text identifier_type,p."ID_PACIENTE"::text identifier_key,p."ID_PACIENTE"::text canonical_patient_id,'CANONICAL_CURRENT'::text source_scope from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")),p."ID_PACIENTE"::text,'CANONICAL_CURRENT' from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) is not null
+  union all select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT' from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento") is not null
+  union all select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT' from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email") is not null
+  union all select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),r.canonical_patient_id,'F5_COMPLETION_V2' from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
+  union all select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),r.canonical_patient_id,'F5_COMPLETION_V2' from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
+  union all select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),r.canonical_patient_id,'F5_COMPLETION_V2' from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
 ), per_candidate as (
-  select identifier_type,identifier_key,canonical_patient_id,count(*)::integer evidence_rows,
-         bool_or(source_scope='F5_COMPLETION_V2') has_reviewed_match,
-         jsonb_agg(distinct source_scope order by source_scope) evidence_scopes
-  from raw_alias where identifier_key is not null and identifier_key<>'' and canonical_patient_id is not null
-  group by identifier_type,identifier_key,canonical_patient_id
-), scored as (
-  select pc.*,count(*) over(partition by identifier_type,identifier_key)::integer candidate_count from per_candidate pc
-)
-select identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,
-       case when candidate_count=1 then 'RESOLVED' else 'CONFLICT' end::text status,
-       case when identifier_type='CANONICAL_ID' then 'EXACT' when has_reviewed_match then 'HIGH' else 'MEDIUM' end::text confidence_band,
-       has_reviewed_match
-from scored;
-
-comment on view public.aos_rev_patient_identity_alias_v2 is
-'REV-F5.11/F6.1 identity lookup bridge. Current canonical aliases plus governed historical completion aliases; stale FUSIONADO targets are excluded and conflicting identifiers remain explicit.';
+  select identifier_type,identifier_key,canonical_patient_id,count(*)::integer evidence_rows,bool_or(source_scope='F5_COMPLETION_V2') has_reviewed_match,jsonb_agg(distinct source_scope order by source_scope) evidence_scopes from raw_alias where identifier_key is not null and identifier_key<>'' and canonical_patient_id is not null group by identifier_type,identifier_key,canonical_patient_id
+), scored as (select pc.*,count(*) over(partition by identifier_type,identifier_key)::integer candidate_count from per_candidate pc)
+select identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,case when candidate_count=1 then 'RESOLVED' else 'CONFLICT' end::text status,case when identifier_type='CANONICAL_ID' then 'EXACT' when has_reviewed_match then 'HIGH' else 'MEDIUM' end::text confidence_band,has_reviewed_match from scored;
+comment on view public.aos_rev_patient_identity_alias_v2 is 'REV-F5.11/F6.1 identity bridge: canonical current + governed historical completion; stale fused targets excluded; conflicts explicit.';
 revoke all on public.aos_rev_patient_identity_alias_v2 from public,anon,authenticated;
 grant select on public.aos_rev_patient_identity_alias_v2 to service_role;
 

--- a/supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
+++ b/supabase/migrations/20260902224000_rev_f5_11_historical_identity_completion_v1.sql
@@ -1,0 +1,396 @@
+-- ASCENDA OS · REV-F5.11 Historical Patient Identity Completion V1
+-- Scope: patient identity/provenance 2024-2026 only. No 2024/2025 sales ingestion.
+-- Safety: never overwrites an existing canonical patient. New rows are limited to
+-- deterministic HIGH-confidence historical identities with DNI8 + second signal.
+
+begin;
+
+create table if not exists public.aos_f5_historical_identity_resolution_v2 (
+  cluster_id uuid primary key references public.aos_f5_identity_clusters_v1(id) on delete restrict,
+  original_classification text not null,
+  original_reason text not null,
+  original_match_method text null,
+  original_match_score numeric null,
+  resolution_status text not null check (resolution_status in (
+    'RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_SAFE','NEW_CREATED','STALE_TARGET','REVIEW_REQUIRED'
+  )),
+  resolution_rule text not null,
+  canonical_patient_id text null,
+  proposed_patient_id text null,
+  source_row_count integer not null,
+  confidence text not null,
+  attribute_review jsonb not null default '{}'::jsonb,
+  evidence jsonb not null default '{}'::jsonb,
+  preview_hash text not null,
+  resolution_version text not null default 'REV-F5.11-V1',
+  generated_at timestamptz not null default now(),
+  applied_at timestamptz null
+);
+
+comment on table public.aos_f5_historical_identity_resolution_v2 is
+'REV-F5.11 immutable completion snapshot over certified F5 source identity. Existing canonical patient rows are never overwritten; ambiguous identity remains REVIEW_REQUIRED.';
+
+revoke all on table public.aos_f5_historical_identity_resolution_v2 from public,anon,authenticated;
+grant select,insert,update,delete on table public.aos_f5_historical_identity_resolution_v2 to service_role;
+
+create index if not exists idx_f5_hist_identity_resolution_v2_patient
+  on public.aos_f5_historical_identity_resolution_v2(canonical_patient_id)
+  where canonical_patient_id is not null;
+create index if not exists idx_f5_hist_identity_resolution_v2_status
+  on public.aos_f5_historical_identity_resolution_v2(resolution_status);
+
+create or replace view public.aos_f5_historical_identity_completion_preview_v1 as
+with current_alias_raw as (
+  select 'PHONE'::text identifier_type,
+         public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) identifier_key,
+         p."ID_PACIENTE"::text canonical_patient_id
+  from public.aos_pacientes p
+  where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+), current_alias as (
+  select identifier_type,identifier_key,min(canonical_patient_id) canonical_patient_id,
+         count(distinct canonical_patient_id)::integer candidate_count
+  from current_alias_raw
+  where identifier_key is not null and identifier_key<>''
+  group by identifier_type,identifier_key
+), core as (
+  select c.id cluster_id,c.status cluster_status,c.confidence,c.source_row_count,c.canonical_preview,c.evidence cluster_evidence,c.conflicts,
+         cc.classification original_classification,cc.reason original_reason,cc.match_method original_match_method,cc.match_score original_match_score,
+         cc.target_patient_id original_target_patient_id,
+         cc.canonical_dni_conflict,cc.canonical_email_conflict,cc.canonical_dob_conflict,cc.canonical_sex_conflict,
+         cc.source_strong_conflict,
+         public.aos_f5_norm_name_v1(concat_ws(' ',c.canonical_preview->>'nombres',c.canonical_preview->>'apellidos')) source_name_key
+  from public.aos_f5_identity_clusters_v1 c
+  join public.aos_f5_canonical_classification_v1 cc on cc.cluster_id=c.id
+), identifier_hits as (
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
+  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join current_alias a on a.identifier_type='DOCUMENT' and a.identifier_key=s.document_key and nullif(s.document_key,'') is not null
+  union all
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
+  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join current_alias a on a.identifier_type='EMAIL' and a.identifier_key=s.email_key and nullif(s.email_key,'') is not null
+  union all
+  select c.cluster_id,a.identifier_type,a.canonical_patient_id,a.candidate_count
+  from core c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join current_alias a on a.identifier_type='PHONE' and a.identifier_key=s.phone_key and nullif(s.phone_key,'') is not null
+), current_hit_agg as (
+  select cluster_id,
+         count(distinct canonical_patient_id) filter(where candidate_count=1)::integer current_target_count,
+         min(canonical_patient_id) filter(where candidate_count=1) current_target,
+         bool_or(identifier_type='DOCUMENT' and candidate_count=1) has_document,
+         bool_or(identifier_type='EMAIL' and candidate_count=1) has_email,
+         bool_or(identifier_type='PHONE' and candidate_count=1) has_phone,
+         bool_or(candidate_count>1) has_current_key_conflict
+  from identifier_hits group by cluster_id
+), source_stats as (
+  select c.cluster_id,
+         count(distinct s.name_key) filter(where nullif(s.name_key,'') is not null)::integer distinct_names,
+         count(distinct s.document_key) filter(where nullif(s.document_key,'') is not null)::integer distinct_documents,
+         count(distinct s.document_key) filter(where nullif(s.document_key,'') is not null and s.document_type='DNI8')::integer distinct_dni8,
+         count(distinct s.email_key) filter(where nullif(s.email_key,'') is not null)::integer distinct_emails,
+         count(distinct s.phone_key) filter(where nullif(s.phone_key,'') is not null and s.phone_type='PERU_9')::integer distinct_peru_phones,
+         count(distinct s.birth_date) filter(where s.birth_date is not null)::integer distinct_birth_dates,
+         count(distinct upper(nullif(btrim(s.sex_raw),'')))::integer distinct_sexes,
+         max(s.phone_key) filter(where nullif(s.phone_key,'') is not null and s.phone_type='PERU_9') proposed_phone,
+         max(s.email_key) filter(where nullif(s.email_key,'') is not null) proposed_email,
+         max(s.document_key) filter(where nullif(s.document_key,'') is not null and s.document_type='DNI8') proposed_document,
+         min(s.source_created_date) filter(where s.source_created_date is not null) first_source_date,
+         max(s.last_appointment) filter(where s.last_appointment is not null) last_source_appointment
+  from core c
+  join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  group by c.cluster_id
+), evaluated as (
+  select c.*,coalesce(h.current_target_count,0) current_target_count,h.current_target,
+         coalesce(h.has_document,false) has_document,coalesce(h.has_email,false) has_email,coalesce(h.has_phone,false) has_phone,
+         coalesce(h.has_current_key_conflict,false) has_current_key_conflict,
+         ss.*,
+         po."ID_PACIENTE" old_current_patient_id,
+         pc."ID_PACIENTE" current_candidate_patient_id,
+         public.aos_f5_norm_name_v1(concat_ws(' ',pc."Nombres",pc."Apellidos")) current_candidate_name_key
+  from core c
+  join source_stats ss on ss.cluster_id=c.cluster_id
+  left join current_hit_agg h on h.cluster_id=c.cluster_id
+  left join public.aos_pacientes po on po."ID_PACIENTE"=c.original_target_patient_id and coalesce(po."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  left join public.aos_pacientes pc on pc."ID_PACIENTE"=h.current_target and coalesce(pc."ESTADO_PACIENTE",'')<>'FUSIONADO'
+), decided as (
+  select e.*,
+    case
+      when original_classification='MATCH' and old_current_patient_id is not null then 'RESOLVED_EXISTING'
+      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict
+       and current_candidate_patient_id is not null and (
+          (has_document and (has_email or has_phone)) or (has_email and has_phone)
+          or (has_document and source_name_key=current_candidate_name_key)
+          or (has_email and source_name_key=current_candidate_name_key)
+       ) then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null
+       and original_reason='CANONICAL_TARGET_COLLISION'
+       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null
+       and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
+       and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'RESOLVED_EXISTING'
+      when original_classification='REVIEW' and old_current_patient_id is not null
+       and original_reason='CANONICAL_STRONG_FIELD_CONFLICT'
+       and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict
+       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'RESOLVED_EXISTING_ATTRIBUTE_REVIEW'
+      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict
+       and confidence='HIGH' and source_row_count>=2 and distinct_names=1
+       and distinct_documents=1 and distinct_dni8=1 and distinct_emails<=1 and distinct_peru_phones<=1
+       and distinct_birth_dates<=1 and distinct_sexes<=1 and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_SAFE'
+      when original_classification='MATCH' and old_current_patient_id is null then 'STALE_TARGET'
+      else 'REVIEW_REQUIRED'
+    end::text resolution_status,
+    case
+      when original_classification='MATCH' and old_current_patient_id is not null then 'CERTIFIED_F5_MATCH_CURRENT_TARGET'
+      when original_classification in ('REVIEW','NEW') and current_target_count=1 and not has_current_key_conflict
+       and current_candidate_patient_id is not null and (
+          (has_document and (has_email or has_phone)) or (has_email and has_phone)
+          or (has_document and source_name_key=current_candidate_name_key)
+          or (has_email and source_name_key=current_candidate_name_key)
+       ) then 'CANONICAL_CURRENT_EXACT_MULTI_SIGNAL'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_TARGET_COLLISION'
+       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'F5_STRONG_TARGET_COLLISION_NON_IDENTITY'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='AMBIGUOUS_OR_INSUFFICIENT_EVIDENCE'
+       and original_match_method in ('EMAIL','NAME_DOB+PHONE_NAME') then 'F5_STRONG_LEGACY_EVIDENCE'
+      when original_classification='REVIEW' and old_current_patient_id is not null and original_reason='CANONICAL_STRONG_FIELD_CONFLICT'
+       and not canonical_dni_conflict and not canonical_email_conflict and not canonical_dob_conflict and canonical_sex_conflict
+       and (coalesce(original_match_method,'') like '%DNI%' or original_match_method='EMAIL') then 'IDENTITY_RESOLVED_SEX_REVIEW_RETAINED'
+      when original_classification='NEW' and current_target_count=0 and not has_current_key_conflict
+       and confidence='HIGH' and source_row_count>=2 and distinct_names=1 and distinct_documents=1 and distinct_dni8=1
+       and distinct_emails<=1 and distinct_peru_phones<=1 and distinct_birth_dates<=1 and distinct_sexes<=1
+       and (distinct_peru_phones=1 or distinct_emails=1) then 'NEW_HIGH_DNI8_PLUS_SECOND_SIGNAL'
+      when original_classification='MATCH' and old_current_patient_id is null then 'CERTIFIED_TARGET_NO_LONGER_CURRENT'
+      else 'INSUFFICIENT_OR_CONFLICTING_IDENTITY_EVIDENCE'
+    end::text resolution_rule
+  from evaluated e
+)
+select
+  cluster_id,original_classification,original_reason,original_match_method,original_match_score,
+  resolution_status,resolution_rule,
+  case
+    when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id
+    when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id
+    else null
+  end::text canonical_patient_id,
+  case when resolution_status='NEW_SAFE' then 'P-HIST-F511-'||upper(replace(cluster_id::text,'-','')) else null end::text proposed_patient_id,
+  source_row_count,confidence,
+  case when resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW' then jsonb_build_object('Sexo','REVIEW_REQUIRED') else '{}'::jsonb end attribute_review,
+  jsonb_build_object(
+    'cluster_status',cluster_status,'cluster_evidence',cluster_evidence,'source_conflicts',conflicts,
+    'current_target_count',current_target_count,'has_current_key_conflict',has_current_key_conflict,
+    'source_identity_counts',jsonb_build_object('names',distinct_names,'documents',distinct_documents,'dni8',distinct_dni8,'emails',distinct_emails,'phones',distinct_peru_phones,'birth_dates',distinct_birth_dates,'sexes',distinct_sexes),
+    'proposed_identity',jsonb_build_object('nombres',canonical_preview->>'nombres','apellidos',canonical_preview->>'apellidos','phone',proposed_phone,'email',proposed_email,'document',proposed_document),
+    'first_source_date',first_source_date,'last_source_appointment',last_source_appointment
+  ) evidence,
+  md5(concat_ws('|',cluster_id::text,original_classification,original_reason,coalesce(original_match_method,''),coalesce(original_match_score::text,''),resolution_status,resolution_rule,
+      coalesce(case when resolution_status='RESOLVED_EXISTING' and resolution_rule='CANONICAL_CURRENT_EXACT_MULTI_SIGNAL' then current_candidate_patient_id when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then original_target_patient_id end,''),
+      coalesce(case when resolution_status='NEW_SAFE' then 'P-HIST-F511-'||upper(replace(cluster_id::text,'-','')) end,''),source_row_count::text,confidence)) preview_hash
+from decided;
+
+comment on view public.aos_f5_historical_identity_completion_preview_v1 is
+'REV-F5.11 deterministic preview. Current exact identifiers are authoritative only when non-fused and unique; phone alone never auto-links. Ambiguous clusters remain REVIEW_REQUIRED.';
+revoke all on public.aos_f5_historical_identity_completion_preview_v1 from public,anon,authenticated;
+grant select on public.aos_f5_historical_identity_completion_preview_v1 to service_role;
+
+create or replace function public.aos_f5_11_identity_completion_snapshot_v1()
+returns jsonb
+language sql
+security definer
+set search_path=''
+as $$
+  with p as (select * from public.aos_f5_historical_identity_completion_preview_v1),
+  x as (
+    select count(*) clusters,coalesce(sum(source_row_count),0) source_rows,
+      count(*) filter(where resolution_status='RESOLVED_EXISTING') resolved_existing,
+      count(*) filter(where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW') resolved_attribute_review,
+      count(*) filter(where resolution_status='NEW_SAFE') safe_new,
+      count(*) filter(where resolution_status='STALE_TARGET') stale_target,
+      count(*) filter(where resolution_status='REVIEW_REQUIRED') review_required,
+      md5(string_agg(preview_hash,',' order by cluster_id)) preview_fingerprint
+    from p
+  )
+  select jsonb_build_object('ok',true,'resolution_version','REV-F5.11-V1','clusters',clusters,'source_rows',source_rows,
+    'resolved_existing',resolved_existing,'resolved_attribute_review',resolved_attribute_review,'safe_new',safe_new,
+    'stale_target',stale_target,'review_required',review_required,'preview_fingerprint',preview_fingerprint)
+  from x
+$$;
+revoke all on function public.aos_f5_11_identity_completion_snapshot_v1() from public,anon,authenticated;
+grant execute on function public.aos_f5_11_identity_completion_snapshot_v1() to service_role;
+
+create or replace function public.aos_f5_11_apply_identity_completion_v1(p_expected_preview_fingerprint text,p_expected_safe_new integer)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_preview jsonb;
+  v_fp text;
+  v_safe integer;
+  v_clusters integer;
+  v_source bigint;
+  v_members bigint;
+  v_existing_before bigint;
+  v_existing_after bigint;
+  v_existing_fp_before text;
+  v_existing_fp_after text;
+  v_inserted integer:=0;
+  v_now timestamptz:=clock_timestamp();
+begin
+  if exists(select 1 from public.aos_f5_historical_identity_resolution_v2) then
+    if (select count(*) from public.aos_f5_historical_identity_resolution_v2)<>(select count(*) from public.aos_f5_identity_clusters_v1) then
+      raise exception 'F5_11_PARTIAL_RESOLUTION_LEDGER';
+    end if;
+    if exists(select 1 from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_SAFE') then
+      raise exception 'F5_11_PARTIAL_NEW_APPLY';
+    end if;
+    return jsonb_build_object('ok',true,'replay',true,'resolution_version','REV-F5.11-V1',
+      'resolution_rows',(select count(*) from public.aos_f5_historical_identity_resolution_v2),
+      'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'));
+  end if;
+
+  select count(*) into v_clusters from public.aos_f5_identity_clusters_v1;
+  select count(*) into v_source from public.aos_f5_patient_source_rows_v1;
+  select count(*) into v_members from public.aos_f5_identity_cluster_members_v1;
+  if v_clusters=0 or v_source=0 or v_members<>v_source then raise exception 'F5_11_SOURCE_COVERAGE_INVALID'; end if;
+  if (select count(*) from public.aos_f5_historical_identity_completion_preview_v1)<>v_clusters then raise exception 'F5_11_PREVIEW_COVERAGE_INVALID'; end if;
+  if exists(select 1 from public.aos_ventas where fecha between date '2024-01-01' and date '2025-12-31') then raise exception 'F5_11_2024_2025_SALES_OUT_OF_SCOPE'; end if;
+
+  v_preview:=public.aos_f5_11_identity_completion_snapshot_v1();
+  v_fp:=v_preview->>'preview_fingerprint';
+  v_safe:=(v_preview->>'safe_new')::integer;
+  if p_expected_preview_fingerprint is null or p_expected_preview_fingerprint<>v_fp then raise exception 'F5_11_PREVIEW_FINGERPRINT_MISMATCH'; end if;
+  if p_expected_safe_new is null or p_expected_safe_new<>v_safe then raise exception 'F5_11_SAFE_NEW_COUNT_MISMATCH'; end if;
+
+  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE"))
+  into v_existing_before,v_existing_fp_before
+  from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
+
+  insert into public.aos_f5_historical_identity_resolution_v2(
+    cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,
+    canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,resolution_version,generated_at,applied_at)
+  select cluster_id,original_classification,original_reason,original_match_method,original_match_score,resolution_status,resolution_rule,
+    canonical_patient_id,proposed_patient_id,source_row_count,confidence,attribute_review,evidence,preview_hash,'REV-F5.11-V1',v_now,
+    case when resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW') then v_now else null end
+  from public.aos_f5_historical_identity_completion_preview_v1;
+
+  insert into public.aos_pacientes(
+    "ID_PACIENTE","Nombres","Apellidos","Teléfono",numero_limpio,"Email","N° documento","Sexo","Fecha de nacimiento",
+    "ESTADO_PACIENTE",fuente_datos,"FUENTE","FECHA_REGISTRO",created_at,updated_at,pais,etiqueta_vip)
+  select r.proposed_patient_id,
+         nullif(r.evidence->'proposed_identity'->>'nombres',''),
+         nullif(r.evidence->'proposed_identity'->>'apellidos',''),
+         nullif(r.evidence->'proposed_identity'->>'phone',''),
+         nullif(r.evidence->'proposed_identity'->>'phone',''),
+         nullif(r.evidence->'proposed_identity'->>'email',''),
+         nullif(r.evidence->'proposed_identity'->>'document',''),
+         nullif(c.canonical_preview->>'sex',''),
+         nullif(c.canonical_preview->>'birth_date',''),
+         'PROSPECTO','historico_f5_completion_v2','F5_2024_2026',
+         nullif(r.evidence->>'first_source_date',''),v_now,v_now,'Perú','NORMAL'
+  from public.aos_f5_historical_identity_resolution_v2 r
+  join public.aos_f5_identity_clusters_v1 c on c.id=r.cluster_id
+  where r.resolution_status='NEW_SAFE'
+  on conflict ("ID_PACIENTE") do nothing;
+  get diagnostics v_inserted=row_count;
+
+  if v_inserted<>v_safe then raise exception 'F5_11_NEW_PATIENT_INSERT_COUNT_MISMATCH expected %, inserted %',v_safe,v_inserted; end if;
+
+  update public.aos_f5_historical_identity_resolution_v2
+  set resolution_status='NEW_CREATED',canonical_patient_id=proposed_patient_id,applied_at=v_now
+  where resolution_status='NEW_SAFE';
+
+  if exists(
+    select 1 from public.aos_f5_historical_identity_resolution_v2 r
+    left join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id
+    where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED')
+      and (p."ID_PACIENTE" is null or coalesce(p."ESTADO_PACIENTE",'')='FUSIONADO')
+  ) then raise exception 'F5_11_RESOLUTION_POINTS_TO_NONCURRENT_PATIENT'; end if;
+
+  select count(*),md5(string_agg(md5(concat_ws('|',p."ID_PACIENTE",coalesce(p."Teléfono",''),coalesce(p.numero_limpio,''),coalesce(p."Email",''),coalesce(p."N° documento",''),coalesce(p."ESTADO_PACIENTE",''),coalesce(p."Nombres",''),coalesce(p."Apellidos",''))),',' order by p."ID_PACIENTE"))
+  into v_existing_after,v_existing_fp_after
+  from public.aos_pacientes p where p."ID_PACIENTE" not like 'P-HIST-F511-%';
+  if v_existing_after<>v_existing_before or v_existing_fp_after is distinct from v_existing_fp_before then raise exception 'F5_11_EXISTING_CANONICAL_MUTATION_DETECTED'; end if;
+
+  insert into public.aos_f5_audit_v1(action,entity_type,entity_key,details)
+  values('HISTORICAL_IDENTITY_COMPLETION_APPLIED','REV_F5','REV-F5.11',jsonb_build_object(
+    'version','REV-F5.11-V1','preview_fingerprint',v_fp,'source_rows',v_source,'clusters',v_clusters,
+    'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),
+    'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),
+    'new_created',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='NEW_CREATED'),
+    'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),
+    'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'),
+    'existing_patient_mutation',false,'sales_2024_2025_mutation',false));
+
+  return jsonb_build_object('ok',true,'replay',false,'resolution_version','REV-F5.11-V1','preview_fingerprint',v_fp,
+    'source_rows',v_source,'clusters',v_clusters,'new_created',v_inserted,
+    'resolved_existing',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING'),
+    'resolved_attribute_review',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='RESOLVED_EXISTING_ATTRIBUTE_REVIEW'),
+    'stale_target',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='STALE_TARGET'),
+    'review_required',(select count(*) from public.aos_f5_historical_identity_resolution_v2 where resolution_status='REVIEW_REQUIRED'));
+end
+$$;
+revoke all on function public.aos_f5_11_apply_identity_completion_v1(text,integer) from public,anon,authenticated;
+grant execute on function public.aos_f5_11_apply_identity_completion_v1(text,integer) to service_role;
+
+-- Replace the alias bridge with the completion ledger. This intentionally removes stale
+-- aliases pointing at FUSIONADO historical MATCH targets.
+create or replace view public.aos_rev_patient_identity_alias_v2 as
+with raw_alias as (
+  select 'CANONICAL_ID'::text identifier_type,p."ID_PACIENTE"::text identifier_key,p."ID_PACIENTE"::text canonical_patient_id,'CANONICAL_CURRENT'::text source_scope
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento") is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email") is not null
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
+), per_candidate as (
+  select identifier_type,identifier_key,canonical_patient_id,count(*)::integer evidence_rows,
+         bool_or(source_scope='F5_COMPLETION_V2') has_reviewed_match,
+         jsonb_agg(distinct source_scope order by source_scope) evidence_scopes
+  from raw_alias where identifier_key is not null and identifier_key<>'' and canonical_patient_id is not null
+  group by identifier_type,identifier_key,canonical_patient_id
+), scored as (
+  select pc.*,count(*) over(partition by identifier_type,identifier_key)::integer candidate_count from per_candidate pc
+)
+select identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,
+       case when candidate_count=1 then 'RESOLVED' else 'CONFLICT' end::text status,
+       case when identifier_type='CANONICAL_ID' then 'EXACT' when has_reviewed_match then 'HIGH' else 'MEDIUM' end::text confidence_band,
+       has_reviewed_match
+from scored;
+
+comment on view public.aos_rev_patient_identity_alias_v2 is
+'REV-F5.11/F6.1 identity lookup bridge. Current canonical aliases plus governed historical completion aliases; stale FUSIONADO targets are excluded and conflicting identifiers remain explicit.';
+revoke all on public.aos_rev_patient_identity_alias_v2 from public,anon,authenticated;
+grant select on public.aos_rev_patient_identity_alias_v2 to service_role;
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260902224100_rev_f5_11_alias_continuity_fix.sql
+++ b/supabase/migrations/20260902224100_rev_f5_11_alias_continuity_fix.sql
@@ -1,0 +1,81 @@
+-- REV-F5.11 alias continuity fix.
+-- Keep certified current-target F5 MATCH aliases available before the completion
+-- ledger is applied, while excluding aliases whose target is now FUSIONADO.
+
+begin;
+
+create or replace view public.aos_rev_patient_identity_alias_v2 as
+with raw_alias as (
+  select 'CANONICAL_ID'::text identifier_type,p."ID_PACIENTE"::text identifier_key,p."ID_PACIENTE"::text canonical_patient_id,'CANONICAL_CURRENT'::text source_scope
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento") is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email") is not null
+
+  -- Certified F5 MATCH continuity. Target must still be a current canonical patient.
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c
+  join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=c.target_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c
+  join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=c.target_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c
+  join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id
+  join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=c.target_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
+
+  -- REV-F5.11 governed completion aliases after apply.
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),r.canonical_patient_id,'F5_COMPLETION_V2'
+  from public.aos_f5_historical_identity_resolution_v2 r join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=r.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  join public.aos_pacientes p on p."ID_PACIENTE"=r.canonical_patient_id and coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  where r.resolution_status in ('RESOLVED_EXISTING','RESOLVED_EXISTING_ATTRIBUTE_REVIEW','NEW_CREATED') and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
+), per_candidate as (
+  select identifier_type,identifier_key,canonical_patient_id,count(*)::integer evidence_rows,
+         bool_or(source_scope in ('F5_REVIEWED_MATCH','F5_COMPLETION_V2')) has_reviewed_match,
+         jsonb_agg(distinct source_scope order by source_scope) evidence_scopes
+  from raw_alias where identifier_key is not null and identifier_key<>'' and canonical_patient_id is not null
+  group by identifier_type,identifier_key,canonical_patient_id
+), scored as (
+  select pc.*,count(*) over(partition by identifier_type,identifier_key)::integer candidate_count from per_candidate pc
+)
+select identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,
+       case when candidate_count=1 then 'RESOLVED' else 'CONFLICT' end::text status,
+       case when identifier_type='CANONICAL_ID' then 'EXACT' when has_reviewed_match then 'HIGH' else 'MEDIUM' end::text confidence_band,
+       has_reviewed_match
+from scored;
+
+comment on view public.aos_rev_patient_identity_alias_v2 is
+'REV-F5.11/F6.1 identity bridge with zero-gap cutover: canonical current + certified current-target F5 MATCH + governed completion aliases. FUSIONADO targets excluded; conflicts explicit.';
+revoke all on public.aos_rev_patient_identity_alias_v2 from public,anon,authenticated;
+grant select on public.aos_rev_patient_identity_alias_v2 to service_role;
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql
+++ b/supabase/rollbacks/20260902224000_rev_f5_11_historical_identity_completion_v1_recovery.sql
@@ -1,0 +1,94 @@
+-- REV-F5.11 recovery. Fail-closed if any deterministic historical patient has
+-- acquired downstream operational references after apply.
+
+begin;
+
+do $$
+declare
+  r record;
+  n bigint;
+begin
+  if to_regclass('public.aos_f5_historical_identity_resolution_v2') is not null then
+    for r in
+      select c.table_schema,c.table_name,c.column_name
+      from information_schema.columns c
+      join information_schema.tables t on t.table_schema=c.table_schema and t.table_name=c.table_name
+      where c.table_schema='public' and t.table_type='BASE TABLE'
+        and lower(c.column_name) in ('canonical_patient_id','id_paciente','patient_id','paciente_id')
+        and c.table_name not in ('aos_pacientes','aos_f5_historical_identity_resolution_v2')
+    loop
+      execute format(
+        'select count(*) from %I.%I x where x.%I::text in (select proposed_patient_id from public.aos_f5_historical_identity_resolution_v2 where resolution_status=''NEW_CREATED'')',
+        r.table_schema,r.table_name,r.column_name
+      ) into n;
+      if n>0 then
+        raise exception 'F5_11_RECOVERY_BLOCKED_DOWNSTREAM_REFERENCE %.%(%): % rows',r.table_schema,r.table_name,r.column_name,n;
+      end if;
+    end loop;
+  end if;
+end
+$$;
+
+-- Restore the pre-F5.11 alias bridge exactly, before deleting the overlay.
+create or replace view public.aos_rev_patient_identity_alias_v2 as
+with raw_alias as (
+  select 'CANONICAL_ID'::text identifier_type,p."ID_PACIENTE"::text identifier_key,p."ID_PACIENTE"::text canonical_patient_id,'CANONICAL_CURRENT'::text source_scope
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO'
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('PHONE',coalesce(nullif(p.numero_limpio,''),p."Teléfono")) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',p."N° documento") is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email"),p."ID_PACIENTE"::text,'CANONICAL_CURRENT'
+  from public.aos_pacientes p where coalesce(p."ESTADO_PACIENTE",'')<>'FUSIONADO' and public.aos_rev_normalize_patient_identifier_v2('EMAIL',p."Email") is not null
+  union all
+  select 'PHONE',public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('PHONE',s.phone_key) is not null
+  union all
+  select 'DOCUMENT',public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('DOCUMENT',s.document_key) is not null
+  union all
+  select 'EMAIL',public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key),c.target_patient_id,'F5_REVIEWED_MATCH'
+  from public.aos_f5_canonical_classification_v1 c join public.aos_f5_identity_cluster_members_v1 m on m.cluster_id=c.cluster_id join public.aos_f5_patient_source_rows_v1 s on s.id=m.source_row_id
+  where c.classification='MATCH' and c.target_patient_id is not null and public.aos_rev_normalize_patient_identifier_v2('EMAIL',s.email_key) is not null
+), per_candidate as (
+  select identifier_type,identifier_key,canonical_patient_id,count(*)::integer evidence_rows,
+         bool_or(source_scope='F5_REVIEWED_MATCH') has_reviewed_match,
+         jsonb_agg(distinct source_scope order by source_scope) evidence_scopes
+  from raw_alias where identifier_key is not null and identifier_key<>'' and canonical_patient_id is not null
+  group by identifier_type,identifier_key,canonical_patient_id
+), scored as (
+  select pc.*,count(*) over(partition by identifier_type,identifier_key)::integer candidate_count from per_candidate pc
+)
+select identifier_type,identifier_key,canonical_patient_id,evidence_rows,evidence_scopes,candidate_count,
+       case when candidate_count=1 then 'RESOLVED' else 'CONFLICT' end::text status,
+       case when identifier_type='CANONICAL_ID' then 'EXACT' when has_reviewed_match then 'HIGH' else 'MEDIUM' end::text confidence_band,
+       has_reviewed_match
+from scored;
+
+comment on view public.aos_rev_patient_identity_alias_v2 is
+'REV-F6.1 private identity lookup bridge. All canonical and F5-reviewed aliases are normalized symmetrically; conflicting aliases remain explicit.';
+revoke all on public.aos_rev_patient_identity_alias_v2 from public,anon,authenticated;
+grant select on public.aos_rev_patient_identity_alias_v2 to service_role;
+
+-- Delete only deterministic rows created by this exact workstream.
+delete from public.aos_pacientes p
+using public.aos_f5_historical_identity_resolution_v2 r
+where r.resolution_status='NEW_CREATED'
+  and p."ID_PACIENTE"=r.proposed_patient_id
+  and p."ID_PACIENTE" like 'P-HIST-F511-%'
+  and p.fuente_datos='historico_f5_completion_v2';
+
+delete from public.aos_f5_audit_v1 where action='HISTORICAL_IDENTITY_COMPLETION_APPLIED' and entity_type='REV_F5' and entity_key='REV-F5.11';
+
+drop function if exists public.aos_f5_11_apply_identity_completion_v1(text,integer);
+drop function if exists public.aos_f5_11_identity_completion_snapshot_v1();
+drop view if exists public.aos_f5_historical_identity_completion_preview_v1;
+drop table if exists public.aos_f5_historical_identity_resolution_v2;
+
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Closes the governed historical patient identity completion layer for Issue #441 without importing transactional sales 2024/2025.

Key boundary:
- immutable 15,498-row F5 source/provenance remains authority;
- existing canonical patient identity fields are never updated;
- exact current identifiers + certified strong F5 evidence can resolve to existing non-FUSIONADO patients;
- phone-only/fuzzy identity remains fail-closed;
- only HIGH NEW identities with DNI8 + second signal + repeated coherent evidence can create deterministic `P-HIST-F511-*` PROSPECTO rows;
- historical aliases become queryable through the governed identity bridge;
- stale aliases to FUSIONADO targets are excluded;
- apply is fingerprint/count locked, idempotent, audited and recovery is downstream-reference fail-closed;
- 2024/2025 transactional sales mutation is explicitly blocked.

CI includes synthetic behavioral cases for strong match, target collision, phone-only denial, attribute conflict, safe-new creation, singleton denial, stale fused target, replay and recovery.

WhatsApp remains HOLD / SAFE-OFF while #441 owns the sole HIGH/CRITICAL mutable lock.