### PR TITLE
WA-L4 — Autonomous Authority + Kill Switch (AUTO_OFF)

### DIFF
--- a/.github/workflows/wa-l4-autonomous-authority.yml
+++ b/.github/workflows/wa-l4-autonomous-authority.yml
@@ -6,8 +6,8 @@ on:
     paths:
       - 'app/server-f4.js'
       - 'app/wa-l4-authority.js'
-      - 'supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql'
-      - 'supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql'
+      - 'supabase/migrations/*wa_l4*'
+      - 'supabase/rollbacks/*wa_l4*'
       - 'ci/wa-l4/**'
       - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
       - 'docs/control/WA_L4_*'
@@ -77,8 +77,11 @@ jobs:
           exit 1
       - name: Build synthetic PRE-L4 state
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/schema_contract.sql
-      - name: Apply exact WA-L4 migration
-        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+      - name: Apply exact WA-L4 migrations
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
       - name: Schema and privilege contract
         run: |
           set -euo pipefail
@@ -88,7 +91,12 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = "AUTO_OFF:true"
           test "$(psql "$DB_URL" -X -qAt -c "select auto_reply_enabled from public.aos_wa_ai_control_v1 where id=1")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select ai_send_enabled from public.aos_wa_routing_control_v1 where id=1")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select auto_routing_enabled from public.aos_wa_routing_control_v1 where id=1")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select human_send_enabled from public.aos_wa_routing_control_v1 where id=1")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_auto_authority_v1','UPDATE')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_auto_allowlist_v1','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_auto_decisions_v1','INSERT')")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('service_role','public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text)','EXECUTE')")" = "t"
       - name: Behavioral authority contract
         run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/tests/001_authority_contract.sql
       - name: Recovery must fail closed if AUTO provider lineage exists
@@ -111,12 +119,13 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)') is null")" = "t"
           test "$(psql "$DB_URL" -X -qAt -c "select pg_get_constraintdef(oid) from pg_constraint where conrelid='public.aos_wa_ai_control_v1'::regclass and conname='aos_wa_ai_control_v1_auto_reply_enabled_check'")" = "CHECK ((auto_reply_enabled = false))"
           test "$(psql "$DB_URL" -X -qAt -c "select pg_get_constraintdef(oid) from pg_constraint where conrelid='public.aos_wa_routing_control_v1'::regclass and conname='aos_wa_routing_control_v1_ai_send_enabled_check'")" = "CHECK ((ai_send_enabled = false))"
-      - name: Reapply after recovery is reproducible
+      - name: Reapply after recovery is reproducible and dormant
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
           test "$(psql "$DB_URL" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = "AUTO_OFF:true"
-          test "$(psql "$DB_URL" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = "false:false:true"
+          test "$(psql "$DB_URL" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = "false:false:false:true"
       - name: Stop isolated Supabase
         if: always()
         working-directory: ci/zero-cost-staging

--- a/.github/workflows/wa-l4-autonomous-authority.yml
+++ b/.github/workflows/wa-l4-autonomous-authority.yml
@@ -1,0 +1,123 @@
+name: ASCENDA WA-L4 Autonomous Authority
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/server-f4.js'
+      - 'app/wa-l4-authority.js'
+      - 'supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql'
+      - 'supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql'
+      - 'ci/wa-l4/**'
+      - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
+      - 'docs/control/WA_L4_*'
+      - '.github/workflows/wa-l4-autonomous-authority.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa-l4-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-static:
+    name: WA-L4 runtime / mutation boundary
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Node runtime authority contract
+        shell: powershell
+        run: node --test ci/wa-l4/runtime_contract.js
+      - name: Syntax-check runtime files
+        shell: powershell
+        run: |
+          node --check app/wa-l4-authority.js
+          node --check app/server-f4.js
+
+  db-contract:
+    name: WA-L4 DB authority / replay / recovery
+    needs: runtime-static
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 30
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59742/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce zero-cost runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Configure isolated Supabase
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          sed -i 's/project_id = "ascenda-zero-cost-staging"/project_id = "ascenda-wa-l4"/' supabase/config.toml
+          sed -i 's/port = 54321/port = 59741/' supabase/config.toml
+          sed -i 's/port = 54322/port = 59742/' supabase/config.toml
+          sed -i 's/shadow_port = 54320/shadow_port = 59740/' supabase/config.toml
+      - name: Start isolated Postgres
+        working-directory: ci/zero-cost-staging
+        run: |
+          set -euo pipefail
+          supabase stop --no-backup || true
+          docker ps -aq --filter 'name=ascenda-wa-l4' | xargs -r docker rm -f || true
+          rm -rf supabase/.temp supabase/.branches
+          supabase db start
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 59742 -U postgres >/dev/null 2>&1; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+      - name: Build synthetic PRE-L4 state
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/schema_contract.sql
+      - name: Apply exact WA-L4 migration
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+      - name: Schema and privilege contract
+        run: |
+          set -euo pipefail
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_auto_authority_v1') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_auto_decisions_v1') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)') is not null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = "AUTO_OFF:true"
+          test "$(psql "$DB_URL" -X -qAt -c "select auto_reply_enabled from public.aos_wa_ai_control_v1 where id=1")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select ai_send_enabled from public.aos_wa_routing_control_v1 where id=1")" = "f"
+          test "$(psql "$DB_URL" -X -qAt -c "select human_send_enabled from public.aos_wa_routing_control_v1 where id=1")" = "t"
+      - name: Behavioral authority contract
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/tests/001_authority_contract.sql
+      - name: Recovery must fail closed if AUTO provider lineage exists
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "insert into public.aos_wa_outbound_requests_v1(idempotency_key,actor_id,to_number,message_type,state,recipient_kind,recipient_address,send_origin) values('ci-auto-history-000001','11111111-1111-4111-8111-111111111111','999999999','text','ACCEPTED','PHONE','999999999','AUTO')"
+          set +e
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql > /tmp/l4-recovery-block.log 2>&1
+          rc=$?
+          set -e
+          test "$rc" -ne 0
+          grep -q 'WA_L4_RECOVERY_BLOCKED_AUTO_HISTORY' /tmp/l4-recovery-block.log
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_auto_authority_v1') is not null")" = "t"
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -c "delete from public.aos_wa_outbound_requests_v1 where idempotency_key='ci-auto-history-000001'"
+      - name: Exact recovery restores PRE-L4 structural SAFE-OFF
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_wa_auto_authority_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regprocedure('public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select pg_get_constraintdef(oid) from pg_constraint where conrelid='public.aos_wa_ai_control_v1'::regclass and conname='aos_wa_ai_control_v1_auto_reply_enabled_check'")" = "CHECK ((auto_reply_enabled = false))"
+          test "$(psql "$DB_URL" -X -qAt -c "select pg_get_constraintdef(oid) from pg_constraint where conrelid='public.aos_wa_routing_control_v1'::regclass and conname='aos_wa_routing_control_v1_ai_send_enabled_check'")" = "CHECK ((ai_send_enabled = false))"
+      - name: Reapply after recovery is reproducible
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = "AUTO_OFF:true"
+          test "$(psql "$DB_URL" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = "false:false:true"
+      - name: Stop isolated Supabase
+        if: always()
+        working-directory: ci/zero-cost-staging
+        run: supabase stop --no-backup || true

--- a/.github/workflows/wa-l4-autonomous-authority.yml
+++ b/.github/workflows/wa-l4-autonomous-authority.yml
@@ -97,8 +97,11 @@ jobs:
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_auto_allowlist_v1','INSERT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_auto_decisions_v1','INSERT')")" = "f"
           test "$(psql "$DB_URL" -X -qAt -c "select has_function_privilege('service_role','public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text)','EXECUTE')")" = "t"
-      - name: Behavioral authority contract
-        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/tests/001_authority_contract.sql
+      - name: Behavioral authority / replay / limits contract
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/tests/001_authority_contract.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l4/tests/002_rate_limits.sql
       - name: Recovery must fail closed if AUTO provider lineage exists
         run: |
           set -euo pipefail

--- a/app/server-f4.js
+++ b/app/server-f4.js
@@ -4,6 +4,7 @@ const http=require('http');
 const https=require('https');
 const {spawn}=require('child_process');
 const wa=require('./wa-gateway');
+const l4=require('./wa-l4-authority');
 const {createEmailGateway}=require('./email-gateway');
 const EMAIL_GATEWAY=createEmailGateway();
 
@@ -19,8 +20,9 @@ const WA_PHONE_NUMBER_ID=process.env.WHATSAPP_PHONE_NUMBER_ID||'';
 const WA_GRAPH_VERSION=process.env.WHATSAPP_GRAPH_VERSION||'';
 const WA_CANARY_MODE=process.env.WA_CANARY_MODE||'true';
 const WA_CANARY_ALLOW_TO=process.env.WA_CANARY_ALLOW_TO||'';
+const WA_L4_INTERNAL_TOKEN=process.env.WA_L4_INTERNAL_TOKEN||'';
 
-// Least privilege: WA/service-role secrets belong only to this front proxy.
+// Least privilege: WA/service-role/provider/L4 authority secrets belong only to this front proxy.
 // The legacy/product child does not need them and must never inherit them.
 const childEnv=Object.assign({},process.env,{PORT:String(INNER_PORT)});
 delete childEnv.SUPABASE_SERVICE_ROLE_KEY;
@@ -31,6 +33,7 @@ delete childEnv.WHATSAPP_PHONE_NUMBER_ID;
 delete childEnv.WHATSAPP_GRAPH_VERSION;
 delete childEnv.WA_CANARY_MODE;
 delete childEnv.WA_CANARY_ALLOW_TO;
+delete childEnv.WA_L4_INTERNAL_TOKEN;
 const child=spawn(process.execPath,['server-phase2.js'],{cwd:__dirname,env:childEnv,stdio:['ignore','inherit','inherit']});
 child.on('exit',(code,signal)=>{console.error('[F4-PROXY] backend exited',{code,signal});process.exit(code==null?1:code);});
 
@@ -58,8 +61,10 @@ function sbService(method,endpoint,body,prefer){
     q.on('timeout',()=>q.destroy(new Error('WA_DB_TIMEOUT')));q.on('error',reject);if(data)q.write(data);q.end();
   });
 }
+function sbServiceRpc(name,payload){return sbService('POST','/rest/v1/rpc/'+name,payload||{});}
 function strongToken(req){const t=String(req.headers['x-aos-app-token']||'').trim();return t.length>=32?t:'';}
 async function authorizeWaSender(req){const token=strongToken(req);if(!token)return null;const out=await sbRpc('aos_app_actor_v3',{p_token:token,p_required_panel:'admin-chats',p_require_2fa:true});if(out.status<200||out.status>=300)return null;const actor=out.data;return typeof actor==='string'&&/^[0-9a-f-]{36}$/i.test(actor)?actor:null;}
+function authorizeWaAutoRuntime(req){return l4.internalTokenValid(req.headers['x-aos-wa-auto-token'],WA_L4_INTERNAL_TOKEN);}
 
 async function handleKroniaSaleEdit(req,res,body){
   const appToken=strongToken(req);
@@ -128,12 +133,15 @@ function graphSend(payload){
     q.write(data);q.end();
   });
 }
-async function reserveOutbound(idempotencyKey,actor,payload){
+async function reserveOutbound(idempotencyKey,actor,payload,meta){
+  const m=meta||{};const recipientKind=wa.recipientKind(payload);const recipientAddress=wa.recipientAddress(payload);
   const created=await sbService('POST','/rest/v1/aos_wa_outbound_requests_v1?on_conflict=idempotency_key',{
-    idempotency_key:String(idempotencyKey),actor_id:actor,to_number:payload.to,message_type:payload.type,state:'PENDING',updated_at:new Date().toISOString()
+    idempotency_key:String(idempotencyKey),actor_id:actor,to_number:recipientKind==='PHONE'?recipientAddress:null,
+    recipient_kind:recipientKind,recipient_address:recipientAddress,message_type:payload.type,state:'PENDING',
+    send_origin:m.send_origin||'HUMAN',conversation_id:m.conversation_id||null,authority_decision_id:m.authority_decision_id||null,updated_at:new Date().toISOString()
   },'resolution=ignore-duplicates,return=representation');
   if(Array.isArray(created.data)&&created.data.length===1)return {owner:true,row:created.data[0]};
-  const existing=await sbService('GET','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(idempotencyKey)+'&select=idempotency_key,state,provider_message_id,error_code&limit=1',null);
+  const existing=await sbService('GET','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(idempotencyKey)+'&select=idempotency_key,state,provider_message_id,error_code,send_origin,conversation_id,authority_decision_id&limit=1',null);
   return {owner:false,row:Array.isArray(existing.data)?existing.data[0]||null:null};
 }
 async function handleWaSend(req,res,body){
@@ -144,7 +152,7 @@ async function handleWaSend(req,res,body){
   if(!wa.canaryAllows(payload.to,WA_CANARY_MODE,WA_CANARY_ALLOW_TO)){writeJson(res,403,{ok:false,error:'WA_CANARY_RECIPIENT_BLOCKED'});return;}
   let reservation;
   try{
-    reservation=await reserveOutbound(body.idempotency_key,actor,payload);
+    reservation=await reserveOutbound(body.idempotency_key,actor,payload,{send_origin:'HUMAN'});
     if(!reservation.owner){
       const row=reservation.row||{};
       writeJson(res,row.state==='FAILED'?409:200,{ok:row.state!=='FAILED',idempotent:true,message_id:row.provider_message_id||null,status:row.state||'PENDING',error:row.state==='FAILED'?(row.error_code||'PREVIOUS_SEND_FAILED'):undefined});return;
@@ -153,9 +161,9 @@ async function handleWaSend(req,res,body){
     if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502,ambiguous:true});
     await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'ACCEPTED',provider_message_id:String(messageId),error_code:null,updated_at:new Date().toISOString()},'return=minimal');
     await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',{
-      provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:payload.to,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,received_at:new Date().toISOString(),updated_at:new Date().toISOString()
+      provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:wa.recipientKind(payload)==='PHONE'?wa.recipientAddress(payload):null,to_user_id:wa.recipientKind(payload)==='BSUID'?wa.recipientAddress(payload):null,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,send_origin:'HUMAN',received_at:new Date().toISOString(),updated_at:new Date().toISOString()
     },'resolution=merge-duplicates,return=minimal');
-    await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'outbound:'+String(messageId),event_type:'message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{actor_id:actor,message_type:payload.type}},'resolution=ignore-duplicates,return=minimal');
+    await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'outbound:'+String(messageId),event_type:'message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{actor_id:actor,message_type:payload.type,send_origin:'HUMAN'}},'resolution=ignore-duplicates,return=minimal');
     writeJson(res,200,{ok:true,idempotent:false,message_id:String(messageId),status:'ACCEPTED',canary:String(WA_CANARY_MODE).toLowerCase()==='true'});
   }catch(e){
     if(reservation&&reservation.owner&&e.definite===true){try{await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'FAILED',error_code:String(e.message||'WA_SEND_FAILED').slice(0,128),updated_at:new Date().toISOString()},'return=minimal');}catch(_e){}}
@@ -164,8 +172,64 @@ async function handleWaSend(req,res,body){
     writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED',status:ambiguous?'PENDING':'FAILED',retry_safe:false});
   }
 }
+async function requestL4Handoff(conversationId,reason){
+  try{return await sbServiceRpc('aos_wa3_handoff_request_v1',{p_conversation_id:conversationId,p_box_id:null,p_actor_id:null,p_reason:l4.sanitizeReason(reason)});}catch(e){console.error('[WA-L4] handoff',e.message);return null;}
+}
+async function recordL4ProviderError(conversationId,decisionId,errorCode,ambiguous){
+  try{await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{
+    event_key:'auto-provider-error:'+String(decisionId),event_type:'auto.provider_error',provider_message_id:null,status:'handoff',
+    payload:{conversation_id:conversationId,authority_decision_id:decisionId,error_code:l4.sanitizeReason(errorCode),ambiguous:!!ambiguous,raw_content_stored:false}
+  },'resolution=ignore-duplicates,return=minimal');}catch(e){console.error('[WA-L4] provider audit',e.message);}
+}
+async function handleWaAutoSend(req,res,body){
+  if(!WA_L4_INTERNAL_TOKEN||WA_L4_INTERNAL_TOKEN.length<32){writeJson(res,503,{ok:false,error:'WA_L4_INTERNAL_AUTH_NOT_CONFIGURED'});return;}
+  if(!authorizeWaAutoRuntime(req)){writeJson(res,403,{ok:false,error:'WA_L4_INTERNAL_AUTH_REQUIRED'});return;}
+  if(!wa.validIdempotencyKey(body&&body.idempotency_key)){writeJson(res,400,{ok:false,error:'IDEMPOTENCY_KEY_REQUIRED'});return;}
+  let payload,authorityRequest;
+  try{payload=wa.buildOutboundPayload(body);authorityRequest=l4.authorityPayload(body,payload);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'WA_L4_INVALID_REQUEST'});return;}
+  let authority;
+  try{
+    const authOut=await sbServiceRpc('aos_wa_l4_authorize_autonomous_send_v1',authorityRequest);
+    authority=authOut.data||{};
+  }catch(e){console.error('[WA-L4] authority unavailable',e.message);writeJson(res,503,{ok:false,error:'WA_L4_AUTHORITY_UNAVAILABLE'});return;}
+  if(authority.decision!=='ALLOW'){
+    if(authority.decision==='HANDOFF')await requestL4Handoff(authorityRequest.p_conversation_id,authority.reason||'WA_L4_HANDOFF');
+    writeJson(res,l4.decisionHttpStatus(authority),{ok:false,decision:authority.decision||'BLOCK',reason:authority.reason||'WA_L4_BLOCKED',decision_id:authority.decision_id||null,replay:!!authority.replay,handoff:authority.decision==='HANDOFF'});return;
+  }
+  if(!waConfigReadyOutbound()){await requestL4Handoff(authorityRequest.p_conversation_id,'WA_OUTBOUND_NOT_CONFIGURED');writeJson(res,503,{ok:false,error:'WA_OUTBOUND_NOT_CONFIGURED',decision_id:authority.decision_id,handoff:true});return;}
+  const actor=String(authority.autonomous_actor_id||'00000000-0000-4000-8000-000000000004');
+  let reservation;
+  try{
+    reservation=await reserveOutbound(body.idempotency_key,actor,payload,{send_origin:'AUTO',conversation_id:authorityRequest.p_conversation_id,authority_decision_id:authority.decision_id});
+    if(!reservation.owner){
+      const row=reservation.row||{};
+      writeJson(res,row.state==='FAILED'?409:200,{ok:row.state!=='FAILED',idempotent:true,decision_id:authority.decision_id,message_id:row.provider_message_id||null,status:row.state||'PENDING',send_origin:'AUTO',error:row.state==='FAILED'?(row.error_code||'PREVIOUS_SEND_FAILED'):undefined});return;
+    }
+    const meta=await graphSend(payload);const messageId=meta&&meta.messages&&meta.messages[0]&&meta.messages[0].id;
+    if(!messageId)throw Object.assign(new Error('META_MESSAGE_ID_MISSING'),{status:502,ambiguous:true});
+    await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'ACCEPTED',provider_message_id:String(messageId),error_code:null,updated_at:new Date().toISOString()},'return=minimal');
+    const rk=wa.recipientKind(payload),ra=wa.recipientAddress(payload);
+    await sbService('POST','/rest/v1/aos_wa_messages_v1?on_conflict=provider_message_id',{
+      provider_message_id:String(messageId),idempotency_key:String(body.idempotency_key),direction:'OUTBOUND',from_number:null,to_number:rk==='PHONE'?ra:null,to_user_id:rk==='BSUID'?ra:null,phone_number_id:WA_PHONE_NUMBER_ID,contact_name:null,message_type:payload.type,message_body:payload.type==='text'?payload.text.body:null,media_id:null,status:'accepted',actor_id:actor,conversation_id:authorityRequest.p_conversation_id,send_origin:'AUTO',authority_decision_id:authority.decision_id,received_at:new Date().toISOString(),updated_at:new Date().toISOString()
+    },'resolution=merge-duplicates,return=minimal');
+    await sbService('POST','/rest/v1/aos_wa_events_v1?on_conflict=event_key',{event_key:'auto-outbound:'+String(messageId),event_type:'auto.message.accepted',provider_message_id:String(messageId),status:'accepted',payload:{conversation_id:authorityRequest.p_conversation_id,authority_decision_id:authority.decision_id,message_type:payload.type,send_origin:'AUTO',raw_content_stored:false}},'resolution=ignore-duplicates,return=minimal');
+    writeJson(res,200,{ok:true,idempotent:false,decision_id:authority.decision_id,message_id:String(messageId),status:'ACCEPTED',send_origin:'AUTO',mode:authority.mode});
+  }catch(e){
+    if(reservation&&reservation.owner&&e.definite===true){try{await sbService('PATCH','/rest/v1/aos_wa_outbound_requests_v1?idempotency_key=eq.'+encodeURIComponent(body.idempotency_key),{state:'FAILED',error_code:l4.sanitizeReason(e.message||'WA_SEND_FAILED'),updated_at:new Date().toISOString()},'return=minimal');}catch(_e){}}
+    const ambiguous=!!(reservation&&reservation.owner&&e.definite!==true);
+    await recordL4ProviderError(authorityRequest.p_conversation_id,authority.decision_id,e.message||'WA_SEND_FAILED',ambiguous);
+    await requestL4Handoff(authorityRequest.p_conversation_id,e.message||'WA_SEND_FAILED');
+    console.error('[WA-L4] provider outbound',e.message,ambiguous?'ambiguous_pending':'definite_failure');
+    writeJson(res,e.status||502,{ok:false,error:e.message||'WA_SEND_FAILED',decision_id:authority.decision_id,status:ambiguous?'PENDING':'FAILED',retry_safe:false,handoff:true});
+  }
+}
 async function handleWaStatus(req,res){
-  try{const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}writeJson(res,200,{ok:true,gateway:'v1',inbound_configured:waConfigReadyInbound(),outbound_configured:waConfigReadyOutbound(),canary:String(WA_CANARY_MODE).toLowerCase()==='true',allowlist_count:String(WA_CANARY_ALLOW_TO).split(',').filter(Boolean).length});}catch(e){writeJson(res,503,{ok:false,error:'WA_STATUS_UNAVAILABLE'});}
+  try{
+    const actor=await authorizeWaSender(req);if(!actor){writeJson(res,403,{ok:false,error:'WA_ADMIN_2FA_REQUIRED'});return;}
+    let l4Status={available:false};
+    try{const r=await sbServiceRpc('aos_wa_l4_status_v1',{});l4Status=Object.assign({available:true},r.data||{});}catch(e){l4Status={available:false,error:'WA_L4_STATUS_UNAVAILABLE'};}
+    writeJson(res,200,{ok:true,gateway:'v1+l4',inbound_configured:waConfigReadyInbound(),outbound_configured:waConfigReadyOutbound(),legacy_human_canary:String(WA_CANARY_MODE).toLowerCase()==='true',legacy_human_allowlist_count:String(WA_CANARY_ALLOW_TO).split(',').filter(Boolean).length,l4_internal_auth_configured:WA_L4_INTERNAL_TOKEN.length>=32,l4:l4Status});
+  }catch(e){writeJson(res,503,{ok:false,error:'WA_STATUS_UNAVAILABLE'});}
 }
 
 const server=http.createServer(async(req,res)=>{
@@ -175,8 +239,10 @@ const server=http.createServer(async(req,res)=>{
   if((pathname==='/webhook'||pathname==='/webhook/')&&req.method==='GET'){handleWaVerify(req,res);return;}
   if((pathname==='/webhook'||pathname==='/webhook/')&&req.method==='POST'){await handleWaWebhook(req,res);return;}
   if(pathname==='/api/wa/send'&&req.method==='POST'){try{const parsed=await readJson(req,256*1024);await handleWaSend(req,res,parsed.body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;}
+  if(pathname==='/api/wa/auto-send'&&req.method==='POST'){try{const parsed=await readJson(req,256*1024);await handleWaAutoSend(req,res,parsed.body);}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;}
   if(pathname==='/api/wa/status'&&req.method==='GET'){await handleWaStatus(req,res);return;}
   if(pathname==='/api/wa/send'&&req.method==='OPTIONS'){res.writeHead(204,{'Access-Control-Allow-Methods':'POST,OPTIONS','Access-Control-Allow-Headers':'Content-Type,X-AOS-App-Token','Cache-Control':'no-store'});res.end();return;}
+  if(pathname==='/api/wa/auto-send'){writeJson(res,405,{ok:false,error:'WA_L4_INTERNAL_POST_ONLY'});return;}
   if(pathname==='/api/f4/cartera-read'&&req.method==='POST'){try{const parsed=await readJson(req,64*1024);await handleRevenueRead(req,res,parsed.body,'cartera');}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;}
   if(pathname==='/api/f4/sales-intelligence-read'&&req.method==='POST'){try{const parsed=await readJson(req,64*1024);await handleRevenueRead(req,res,parsed.body,'sales-intelligence');}catch(e){writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}return;}
   if(pathname==='/api/f4/cartera-candidates'&&req.method==='POST'){
@@ -191,4 +257,4 @@ function proxyBuffered(req,res,raw){const headers=Object.assign({},req.headers,{
 function proxyStream(req,res){const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT});const up=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{res.writeHead(r.statusCode||502,r.headers);r.pipe(res);});up.on('error',e=>{if(!res.headersSent)writeJson(res,502,{ok:false,error:'UPSTREAM_UNAVAILABLE'});else res.end();console.error('[F4-PROXY] stream',e.message);});req.pipe(up);}
 function shutdown(sig){console.log('[F4-PROXY] shutdown',sig);server.close(()=>process.exit(0));if(!child.killed)child.kill(sig);setTimeout(()=>process.exit(1),5000).unref();}
 process.on('SIGTERM',()=>shutdown('SIGTERM'));process.on('SIGINT',()=>shutdown('SIGINT'));
-server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[F4-PROXY] listening on :'+EXTERNAL_PORT+' -> :'+INNER_PORT+' | WA gateway v1'));
+server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[F4-PROXY] listening on :'+EXTERNAL_PORT+' -> :'+INNER_PORT+' | WA gateway v1 + L4 authority AUTO_OFF-by-default'));

--- a/app/wa-l4-authority.js
+++ b/app/wa-l4-authority.js
@@ -1,0 +1,49 @@
+'use strict';
+const crypto=require('crypto');
+
+function safeEqual(a,b){
+  const aa=Buffer.from(String(a||''));
+  const bb=Buffer.from(String(b||''));
+  if(!aa.length||aa.length!==bb.length)return false;
+  return crypto.timingSafeEqual(aa,bb);
+}
+function internalTokenValid(headerValue,secret){
+  const expected=String(secret||'').trim();
+  const actual=String(headerValue||'').trim();
+  return expected.length>=32&&safeEqual(actual,expected);
+}
+function uuidValue(v){
+  const s=String(v||'').trim();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)?s:null;
+}
+function sha256Text(v){return crypto.createHash('sha256').update(String(v==null?'':v)).digest('hex');}
+function payloadHash(payload){return sha256Text(JSON.stringify(payload||{}));}
+function authorityPayload(body,payload){
+  const b=body||{};
+  const conversationId=uuidValue(b.conversation_id);
+  if(!conversationId)throw Object.assign(new Error('WA_L4_CONVERSATION_ID_REQUIRED'),{status:400});
+  const recipientKind=String(payload&&payload._recipient_kind||b.recipient_kind||'').trim().toUpperCase();
+  const recipientAddress=String((payload&&(payload.recipient||payload.to))||b.recipient_address||'').trim();
+  if(!['PHONE','BSUID'].includes(recipientKind)||!recipientAddress)throw Object.assign(new Error('WA_L4_RECIPIENT_REQUIRED'),{status:400});
+  return {
+    p_conversation_id:conversationId,
+    p_recipient_kind:recipientKind,
+    p_recipient_address:recipientAddress,
+    p_message_type:String(b.type||'text').trim().toLowerCase(),
+    p_template_name:b.type&&String(b.type).toLowerCase()==='template'?String(b.template_name||'').trim():null,
+    p_idempotency_key:String(b.idempotency_key||''),
+    p_content_hash:payloadHash(payload),
+    p_safety_action:String(b.safety_action||'ALLOW').trim().toUpperCase(),
+    p_identity_state:String(b.identity_state||'NOT_REQUIRED').trim().toUpperCase(),
+    p_requires_identity:b.requires_identity===true,
+    p_campaign_key:b.campaign_key==null?null:String(b.campaign_key).trim()||null
+  };
+}
+function decisionHttpStatus(decision){
+  if(!decision||decision.decision==='BLOCK')return 403;
+  if(decision.decision==='HANDOFF')return 409;
+  return 200;
+}
+function sanitizeReason(v){return String(v||'WA_L4_UNKNOWN').replace(/[^A-Z0-9_.:-]/gi,'_').slice(0,128);}
+
+module.exports={safeEqual,internalTokenValid,uuidValue,sha256Text,payloadHash,authorityPayload,decisionHttpStatus,sanitizeReason};

--- a/ci/wa-l4/runtime_contract.js
+++ b/ci/wa-l4/runtime_contract.js
@@ -1,0 +1,123 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const path=require('node:path');
+
+const root=path.resolve(__dirname,'../..');
+const server=fs.readFileSync(path.join(root,'app/server-f4.js'),'utf8');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql'),'utf8');
+const rollback=fs.readFileSync(path.join(root,'supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql'),'utf8');
+const l4=require(path.join(root,'app/wa-l4-authority.js'));
+const wa=require(path.join(root,'app/wa-gateway.js'));
+
+function pos(haystack,needle){const i=haystack.indexOf(needle);assert.notEqual(i,-1,`missing ${needle}`);return i;}
+
+test('L4 helper requires a long timing-safe internal secret',()=>{
+  assert.equal(l4.internalTokenValid('x','x'),false);
+  const secret='s'.repeat(40);
+  assert.equal(l4.internalTokenValid(secret,secret),true);
+  assert.equal(l4.internalTokenValid(secret+'x',secret),false);
+});
+
+test('L4 authority request hashes provider payload and requires canonical conversation id',()=>{
+  const payload=wa.buildOutboundPayload({to:'999111222',type:'text',text:'hola'});
+  const a=l4.authorityPayload({conversation_id:'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',idempotency_key:'ci-runtime-00000001',type:'text'},payload);
+  assert.equal(a.p_recipient_kind,'PHONE');
+  assert.equal(a.p_recipient_address,'999111222');
+  assert.match(a.p_content_hash,/^[a-f0-9]{64}$/);
+  assert.equal(a.p_requires_identity,false);
+  assert.throws(()=>l4.authorityPayload({conversation_id:'bad',idempotency_key:'ci-runtime-00000002'},payload),/WA_L4_CONVERSATION_ID_REQUIRED/);
+});
+
+test('server strips L4 secret from legacy child process',()=>{
+  assert.match(server,/const WA_L4_INTERNAL_TOKEN=process\.env\.WA_L4_INTERNAL_TOKEN\|\|''/);
+  assert.match(server,/delete childEnv\.WA_L4_INTERNAL_TOKEN/);
+});
+
+test('autonomous endpoint is internal POST only and never exposes browser CORS path',()=>{
+  assert.match(server,/pathname==='\/api\/wa\/auto-send'&&req\.method==='POST'/);
+  assert.match(server,/pathname==='\/api\/wa\/auto-send'\)\{writeJson\(res,405/);
+  assert.doesNotMatch(server,/api\/wa\/auto-send[^\n]{0,180}OPTIONS/);
+  assert.match(server,/x-aos-wa-auto-token/);
+});
+
+test('authority RPC is evaluated before reservation and Meta dispatch',()=>{
+  const fnStart=pos(server,'async function handleWaAutoSend');
+  const fnEnd=pos(server,'async function handleWaStatus');
+  const body=server.slice(fnStart,fnEnd);
+  const auth=pos(body,"sbServiceRpc('aos_wa_l4_authorize_autonomous_send_v1'");
+  const reserve=pos(body,'reserveOutbound(body.idempotency_key');
+  const send=pos(body,'graphSend(payload)');
+  assert.ok(auth<reserve&&reserve<send,'authority -> reservation -> provider order required');
+  assert.match(body,/authority\.decision!=='ALLOW'/);
+  assert.match(body,/authority\.decision==='HANDOFF'/);
+  assert.match(body,/requestL4Handoff/);
+});
+
+test('human send remains separately 2FA governed and marked HUMAN',()=>{
+  const fnStart=pos(server,'async function handleWaSend');
+  const fnEnd=pos(server,'async function requestL4Handoff');
+  const body=server.slice(fnStart,fnEnd);
+  assert.match(body,/authorizeWaSender\(req\)/);
+  assert.match(body,/WA_ADMIN_2FA_REQUIRED/);
+  assert.match(body,/send_origin:'HUMAN'/);
+  assert.match(body,/wa\.canaryAllows/);
+});
+
+test('autonomous send preserves existing idempotency ledger and records AUTO lineage',()=>{
+  const fnStart=pos(server,'async function handleWaAutoSend');
+  const fnEnd=pos(server,'async function handleWaStatus');
+  const body=server.slice(fnStart,fnEnd);
+  assert.match(body,/reserveOutbound\(body\.idempotency_key,actor,payload,\{send_origin:'AUTO'/);
+  assert.match(body,/authority_decision_id:authority\.decision_id/);
+  assert.match(body,/conversation_id:authorityRequest\.p_conversation_id/);
+  assert.match(body,/auto\.message\.accepted/);
+  assert.match(body,/raw_content_stored:false/);
+});
+
+test('provider failures never auto retry and force governed handoff',()=>{
+  const fnStart=pos(server,'async function handleWaAutoSend');
+  const fnEnd=pos(server,'async function handleWaStatus');
+  const body=server.slice(fnStart,fnEnd);
+  assert.match(body,/recordL4ProviderError/);
+  assert.match(body,/requestL4Handoff/);
+  assert.match(body,/retry_safe:false/);
+  assert.match(body,/ambiguous_pending/);
+});
+
+test('SQL contract defaults AUTO_OFF + kill and keeps control server-only',()=>{
+  assert.match(migration,/mode text not null default 'AUTO_OFF'/i);
+  assert.match(migration,/kill_switch_engaged boolean not null default true/i);
+  assert.match(migration,/values\(1,'AUTO_OFF',true\)/i);
+  assert.match(migration,/revoke all on function public\.aos_wa_l4_authorize_autonomous_send_v1[\s\S]*from public,anon,authenticated/i);
+  assert.doesNotMatch(migration,/grant execute on function public\.aos_wa_l4_authorize_autonomous_send_v1[\s\S]{0,250}to (anon|authenticated)/i);
+});
+
+test('SQL contract has safety, identity, template, allowlist and pressure guards',()=>{
+  for(const marker of [
+    'WA_L4_KILL_SWITCH','WA_L4_CANARY_NOT_ALLOWLISTED','WA_L4_TEMPLATE_NOT_PROVIDER_VERIFIED',
+    'WA_L4_IDENTITY_CONFLICT','WA_L4_IDENTITY_REQUIRED','WA_L4_HUMAN_OWNERSHIP_BOUNDARY',
+    'WA_L4_DAILY_MESSAGE_LIMIT','WA_L4_MAX_TURNS_HANDOFF','WA_L4_GLOBAL_RATE_LIMIT',
+    'WA_L4_CONVERSATION_RATE_LIMIT','WA_L4_COOLDOWN','WA_L4_DUPLICATE_GUARD'
+  ])assert.ok(migration.includes(marker),`missing ${marker}`);
+  assert.match(migration,/provider_verified is true/i);
+  assert.match(migration,/pg_catalog\.pg_advisory_xact_lock/);
+});
+
+test('migration does not alter sales/patient/agenda business rows',()=>{
+  const executable=migration.replace(/--.*$/gm,'');
+  assert.doesNotMatch(executable,/\b(insert into|update|delete from)\s+public\.aos_ventas\b/i);
+  assert.doesNotMatch(executable,/\b(insert into|update|delete from)\s+public\.aos_pacientes\b/i);
+  assert.doesNotMatch(executable,/\b(insert into|update|delete from)\s+public\.aos_agenda_citas\b/i);
+  assert.doesNotMatch(executable,/statement_timeout/i);
+});
+
+test('recovery first forces SAFE-OFF and refuses to erase autonomous history',()=>{
+  const safe=pos(rollback,"set ai_send_enabled=false,auto_routing_enabled=false,human_send_enabled=true");
+  const guard=pos(rollback,'WA_L4_RECOVERY_BLOCKED_AUTO_HISTORY');
+  const drops=pos(rollback,'drop table if exists public.aos_wa_auto_decisions_v1');
+  assert.ok(safe<guard&&guard<drops);
+  assert.match(rollback,/check \(auto_reply_enabled=false\)/i);
+  assert.match(rollback,/check \(ai_send_enabled=false\)/i);
+});

--- a/ci/wa-l4/schema_contract.sql
+++ b/ci/wa-l4/schema_contract.sql
@@ -1,0 +1,98 @@
+\set ON_ERROR_STOP on
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+create table public.aos_usuarios(
+  id uuid primary key,
+  activo boolean not null default true,
+  nivel_jerarquia integer,
+  paneles_acceso text[] not null default '{}'::text[]
+);
+
+create table public.aos_wa_ai_control_v1(
+  id smallint primary key default 1 check(id=1),
+  provider text not null default 'groq',
+  fast_model text not null default 'openai/gpt-oss-20b',
+  reasoning_model text not null default 'openai/gpt-oss-120b',
+  safety_model text not null default 'openai/gpt-oss-safeguard-20b',
+  copilot_enabled boolean not null default false,
+  auto_reply_enabled boolean not null default false,
+  daily_budget_usd numeric(10,4) not null default 0.5000,
+  max_context_messages integer not null default 24,
+  max_catalog_items integer not null default 12,
+  updated_by uuid references public.aos_usuarios(id) on delete set null,
+  updated_at timestamptz not null default now(),
+  constraint aos_wa_ai_control_v1_auto_reply_enabled_check check(auto_reply_enabled=false)
+);
+insert into public.aos_wa_ai_control_v1(id,copilot_enabled) values(1,true);
+
+create table public.aos_wa_routing_control_v1(
+  id smallint primary key default 1 check(id=1),
+  auto_routing_enabled boolean not null default false,
+  human_send_enabled boolean not null default true,
+  ai_send_enabled boolean not null default false,
+  updated_by uuid references public.aos_usuarios(id) on delete set null,
+  updated_at timestamptz not null default now(),
+  constraint aos_wa_routing_control_v1_ai_send_enabled_check check(ai_send_enabled=false)
+);
+insert into public.aos_wa_routing_control_v1(id) values(1);
+
+create table public.aos_wa_conversations_v1(
+  id uuid primary key,
+  state text not null,
+  contact_address_type text not null check(contact_address_type in ('PHONE','BSUID')),
+  contact_address text not null,
+  human_takeover_at timestamptz
+);
+
+create table public.aos_agenda_delivery_template_registry_v3(
+  delivery_kind text not null,
+  channel text not null,
+  site_scope text not null default '*',
+  template_key text not null,
+  provider text not null,
+  provider_template_name text,
+  provider_verified boolean not null default false,
+  active boolean not null default true,
+  evidence_ref text not null,
+  updated_at timestamptz not null default now(),
+  primary key(delivery_kind,channel,site_scope,template_key)
+);
+
+create table public.aos_wa_outbound_requests_v1(
+  idempotency_key text primary key,
+  actor_id uuid not null,
+  to_number text,
+  message_type text not null,
+  state text not null default 'PENDING' check(state in ('PENDING','ACCEPTED','FAILED')),
+  provider_message_id text,
+  error_code text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  recipient_kind text not null check(recipient_kind in ('PHONE','BSUID')),
+  recipient_address text not null
+);
+
+create table public.aos_wa_messages_v1(
+  id uuid primary key default gen_random_uuid(),
+  provider_message_id text not null unique,
+  direction text not null,
+  message_type text not null,
+  conversation_id uuid references public.aos_wa_conversations_v1(id) on delete restrict,
+  created_at timestamptz not null default now()
+);
+
+insert into public.aos_usuarios(id,activo,nivel_jerarquia,paneles_acceso) values
+('11111111-1111-4111-8111-111111111111',true,1,array['admin-whatsapp']),
+('22222222-2222-4222-8222-222222222222',true,2,array['admin-whatsapp']);
+
+insert into public.aos_wa_conversations_v1(id,state,contact_address_type,contact_address,human_takeover_at) values
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','AI_ACTIVE','PHONE','999111222',null),
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2','AI_ACTIVE','PHONE','999111333',null),
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3','HUMAN_ACTIVE','PHONE','999111444',now()),
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','AI_ACTIVE','PHONE','999111555',null),
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5','AI_ACTIVE','BSUID','bsuid-test-001',null);
+
+insert into public.aos_agenda_delivery_template_registry_v3(delivery_kind,channel,site_scope,template_key,provider,provider_template_name,provider_verified,active,evidence_ref) values
+('CONFIRMATION','WHATSAPP','*','verified_tpl','META_CLOUD_API','verified_template',true,true,'CI_VERIFIED'),
+('REMINDER_TODAY','WHATSAPP','*','unverified_tpl','META_CLOUD_API','unverified_template',false,true,'CI_UNVERIFIED');

--- a/ci/wa-l4/tests/001_authority_contract.sql
+++ b/ci/wa-l4/tests/001_authority_contract.sql
@@ -1,0 +1,165 @@
+\set ON_ERROR_STOP on
+
+-- Deployment must always land dormant.
+do $$
+declare s jsonb;
+begin
+ s:=public.aos_wa_l4_status_v1();
+ if s->>'mode'<>'AUTO_OFF' then raise exception 'L4_DEFAULT_MODE %',s; end if;
+ if coalesce((s->>'kill_switch_engaged')::boolean,false) is not true then raise exception 'L4_DEFAULT_KILL %',s; end if;
+ if coalesce((s->>'auto_reply_enabled')::boolean,true) then raise exception 'L4_DEFAULT_AUTO_REPLY %',s; end if;
+ if coalesce((s->>'ai_send_enabled')::boolean,true) then raise exception 'L4_DEFAULT_AI_SEND %',s; end if;
+ if coalesce((s->>'auto_routing_enabled')::boolean,true) then raise exception 'L4_DEFAULT_ROUTING %',s; end if;
+ if coalesce((s->>'human_send_enabled')::boolean,false) is not true then raise exception 'L4_DEFAULT_HUMAN_SEND %',s; end if;
+end $$;
+
+-- Browser roles cannot control or read raw authority tables/functions.
+do $$ begin
+ if has_table_privilege('anon','public.aos_wa_auto_authority_v1','SELECT') then raise exception 'L4_ANON_AUTHORITY_READ'; end if;
+ if has_table_privilege('authenticated','public.aos_wa_auto_allowlist_v1','SELECT') then raise exception 'L4_AUTH_ALLOWLIST_READ'; end if;
+ if has_function_privilege('anon','public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)','EXECUTE') then raise exception 'L4_ANON_AUTHORIZE'; end if;
+ if not has_function_privilege('service_role','public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)','EXECUTE') then raise exception 'L4_SERVICE_AUTHORIZE_MISSING'; end if;
+end $$;
+
+-- Level 2 cannot alter authority.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('22222222-2222-4222-8222-222222222222','CANARY',false,null,null,null,null,null,null,'CI-AUTH-REF-LEVEL2');
+ if r->>'error'<>'WA_L4_LEVEL1_ADMIN_REQUIRED' then raise exception 'L4_LEVEL2_CONTROL %',r; end if;
+end $$;
+
+-- AUTO_OFF blocks before provider eligibility and records decision.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1(
+   'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,
+   'ci-auto-off-00000001',repeat('a',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L4_AUTO_OFF' then raise exception 'L4_AUTO_OFF_BLOCK %',r; end if;
+end $$;
+
+-- CANARY needs explicit authorization reference and an allowlist.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,null,null,null,null,null,null,null);
+ if r->>'error'<>'WA_L4_EXPLICIT_AUTHORIZATION_REF_REQUIRED' then raise exception 'L4_AUTH_REF_GATE %',r; end if;
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,null,null,null,null,null,null,'CI-AUTH-REF-0001');
+ if r->>'error'<>'WA_L4_CANARY_ALLOWLIST_REQUIRED' then raise exception 'L4_ALLOWLIST_REQUIRED %',r; end if;
+end $$;
+
+-- Invalid phone must not enter allowlist; valid subject does.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','PHONE','name-only',true,null,'ci');
+ if r->>'error'<>'WA_L4_INVALID_ALLOWLIST_SUBJECT' then raise exception 'L4_INVALID_ALLOWLIST %',r; end if;
+ r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','PHONE','999111222',true,null,'ci');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_ALLOWLIST_SET %',r; end if;
+ r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','PHONE','999111444',true,null,'ci-human');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_ALLOWLIST_HUMAN %',r; end if;
+ r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','PHONE','999111555',true,null,'ci-template');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_ALLOWLIST_TEMPLATE %',r; end if;
+ r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','BSUID','bsuid-test-001',true,null,'ci-bsuid');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_ALLOWLIST_BSUID %',r; end if;
+end $$;
+
+-- Kill switch remains absolute even when CANARY is configured.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',true,50,10,20,10,0,120,'CI-AUTH-REF-0002');
+ if coalesce((r->>'ok')::boolean,false) is not true or coalesce((r->>'effective_autonomous_send')::boolean,true) then raise exception 'L4_KILL_CONTROL %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-kill-000000000001',repeat('b',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_KILL_SWITCH' then raise exception 'L4_KILL_BLOCK %',r; end if;
+end $$;
+
+-- Synthetic CANARY activation is isolated CI only; it proves atomically consistent flags.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,50,10,20,10,0,120,'CI-AUTH-REF-0003');
+ if coalesce((r->>'effective_autonomous_send')::boolean,false) is not true then raise exception 'L4_CANARY_EFFECTIVE %',r; end if;
+ if not (select auto_reply_enabled from public.aos_wa_ai_control_v1 where id=1) then raise exception 'L4_FLAG_AUTO_REPLY'; end if;
+ if not (select ai_send_enabled from public.aos_wa_routing_control_v1 where id=1) then raise exception 'L4_FLAG_AI_SEND'; end if;
+ if (select auto_routing_enabled from public.aos_wa_routing_control_v1 where id=1) then raise exception 'L4_AUTO_ROUTING_MUST_STAY_OFF'; end if;
+ if not (select human_send_enabled from public.aos_wa_routing_control_v1 where id=1) then raise exception 'L4_HUMAN_SEND_MUST_STAY_ON'; end if;
+end $$;
+
+-- Allowlisted conversation can pass; exact decision replay cannot consume budget twice.
+do $$ declare r jsonb; r2 jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-allow-000000000001',repeat('c',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'ALLOW' then raise exception 'L4_ALLOWED_EXPECTED %',r; end if;
+ r2:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-allow-000000000001',repeat('c',64),'ALLOW','NOT_REQUIRED',false,null);
+ if coalesce((r2->>'replay')::boolean,false) is not true or r2->>'decision'<>'ALLOW' then raise exception 'L4_REPLAY %',r2; end if;
+ if (select count(*) from public.aos_wa_auto_decisions_v1 where idempotency_key='ci-allow-000000000001')<>1 then raise exception 'L4_REPLAY_DUPLICATED_DECISION'; end if;
+end $$;
+
+-- Nonallowlisted recipient blocks; recipient mismatch hands off.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2','PHONE','999111333','text',null,'ci-notallow-000000001',repeat('d',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_CANARY_NOT_ALLOWLISTED' then raise exception 'L4_NOT_ALLOWLISTED %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111333','text',null,'ci-mismatch-0000000001',repeat('e',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_RECIPIENT_CONVERSATION_MISMATCH' then raise exception 'L4_RECIPIENT_MISMATCH %',r; end if;
+end $$;
+
+-- Human ownership, safety and identity conflicts hand off, never send.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3','PHONE','999111444','text',null,'ci-human-000000000001',repeat('f',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_HUMAN_OWNERSHIP_BOUNDARY' then raise exception 'L4_HUMAN_BOUNDARY %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-safety-00000000001',repeat('1',64),'CLINICAL','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_SAFETY_HANDOFF' then raise exception 'L4_SAFETY_HANDOFF %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-identconf-000000001',repeat('2',64),'ALLOW','CONFLICT',true,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_IDENTITY_CONFLICT' then raise exception 'L4_IDENTITY_CONFLICT %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-identreq-0000000001',repeat('3',64),'ALLOW','UNRESOLVED',true,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_IDENTITY_REQUIRED' then raise exception 'L4_IDENTITY_REQUIRED %',r; end if;
+end $$;
+
+-- Template send is fail-closed unless provider registry has a verified exact name.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','PHONE','999111555','template','unverified_template','ci-tplbad-000000000001',repeat('4',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_TEMPLATE_NOT_PROVIDER_VERIFIED' then raise exception 'L4_UNVERIFIED_TEMPLATE %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','PHONE','999111555','template','verified_template','ci-tplgood-00000000001',repeat('5',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'ALLOW' then raise exception 'L4_VERIFIED_TEMPLATE %',r; end if;
+end $$;
+
+-- BSUID is allowed only by exact conversation identity/allowlist; no phone fallback.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5','BSUID','bsuid-test-001','text',null,'ci-bsuid-000000000001',repeat('6',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'ALLOW' then raise exception 'L4_BSUID_ALLOW %',r; end if;
+end $$;
+
+-- Duplicate guard after an ALLOW on same conversation/content.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-duplicate-000000001',repeat('c',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_DUPLICATE_GUARD' then raise exception 'L4_DUPLICATE_GUARD %',r; end if;
+end $$;
+
+-- Cooldown and per-minute limits are deterministic after tightening controls.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,50,10,20,10,3600,0,'CI-AUTH-REF-0004');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_COOLDOWN_CONTROL %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-cooldown-0000000001',repeat('7',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_COOLDOWN' then raise exception 'L4_COOLDOWN %',r; end if;
+end $$;
+
+-- Max-turn handoff: set max turns below existing allowed count for conversation 1.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,50,1,20,10,0,0,'CI-AUTH-REF-0005');
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1','PHONE','999111222','text',null,'ci-maxturns-0000000001',repeat('8',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L4_MAX_TURNS_HANDOFF' then raise exception 'L4_MAX_TURNS %',r; end if;
+end $$;
+
+-- Daily and rate controls use ALLOW decisions only; blocked/handoff attempts do not spend quota.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,1,50,120,30,0,0,'CI-AUTH-REF-0006');
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','PHONE','999111555','text',null,'ci-daily-000000000001',repeat('9',64),'ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_DAILY_MESSAGE_LIMIT' then raise exception 'L4_DAILY_LIMIT %',r; end if;
+end $$;
+
+-- AUTO_OFF is atomic: all autonomous flags false, human send true.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','AUTO_OFF',true,null,null,null,null,null,null,null);
+ if r->>'mode'<>'AUTO_OFF' or coalesce((r->>'effective_autonomous_send')::boolean,true) then raise exception 'L4_AUTO_OFF_RESET %',r; end if;
+ if (select auto_reply_enabled from public.aos_wa_ai_control_v1 where id=1) then raise exception 'L4_AUTO_REPLY_NOT_RESET'; end if;
+ if (select ai_send_enabled from public.aos_wa_routing_control_v1 where id=1) then raise exception 'L4_AI_SEND_NOT_RESET'; end if;
+ if not (select human_send_enabled from public.aos_wa_routing_control_v1 where id=1) then raise exception 'L4_HUMAN_SEND_RESET'; end if;
+end $$;
+
+-- Append-only audit surfaces cannot be mutated.
+do $$ begin
+ begin update public.aos_wa_auto_decisions_v1 set reason_code='MUTATED' where false; exception when others then null; end;
+ begin
+  update public.aos_wa_auto_decisions_v1 set reason_code='MUTATED' where id=(select id from public.aos_wa_auto_decisions_v1 limit 1);
+  raise exception 'L4_DECISION_APPEND_GUARD_MISSING';
+ exception when sqlstate '55000' then null; end;
+end $$;

--- a/ci/wa-l4/tests/002_rate_limits.sql
+++ b/ci/wa-l4/tests/002_rate_limits.sql
@@ -1,0 +1,24 @@
+\set ON_ERROR_STOP on
+
+-- Prior behavioral test leaves several fresh ALLOW decisions and AUTO_OFF.
+-- Re-enter synthetic CI CANARY solely to prove rate gates; no provider exists in this fixture.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,50,50,1,30,0,0,'CI-RATE-GLOBAL-0001');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_GLOBAL_RATE_CONTROL %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','PHONE','999111555','text',null,'ci-globalrate-00000001',repeat('a',63)||'b','ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_GLOBAL_RATE_LIMIT' then raise exception 'L4_GLOBAL_RATE %',r; end if;
+end $$;
+
+-- Conversation 4 already has a recent verified-template ALLOW from test 001.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','CANARY',false,50,50,120,1,0,0,'CI-RATE-CONV-00001');
+ if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L4_CONV_RATE_CONTROL %',r; end if;
+ r:=public.aos_wa_l4_authorize_autonomous_send_v1('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4','PHONE','999111555','text',null,'ci-convrate-000000001',repeat('b',63)||'c','ALLOW','NOT_REQUIRED',false,null);
+ if r->>'reason'<>'WA_L4_CONVERSATION_RATE_LIMIT' then raise exception 'L4_CONVERSATION_RATE %',r; end if;
+end $$;
+
+-- Return fixture to exact dormant state.
+do $$ declare r jsonb; begin
+ r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','AUTO_OFF',false,null,null,null,null,null,null,null);
+ if r->>'mode'<>'AUTO_OFF' or coalesce((r->>'kill_switch_engaged')::boolean,false) is not true then raise exception 'L4_AUTO_OFF_MUST_FORCE_KILL %',r; end if;
+end $$;

--- a/ci/wa4c-full-local/run-booking-canary.js
+++ b/ci/wa4c-full-local/run-booking-canary.js
@@ -71,7 +71,9 @@ async function main(){
   assert.strictEqual(notOwner.status,409,'non-owner booking should fail');
   assert.strictEqual(notOwner.data.error,'WA4_BOOKING_NOT_CONVERSATION_OWNER');
 
-  const staleDate=new Date(String(f.target_date)+'T12:00:00Z');staleDate.setUTCDate(staleDate.getUTCDate()+30);
+  const staleDate=new Date(String(f.target_date)+'T12:00:00Z');
+  staleDate.setUTCDate(staleDate.getUTCDate()+30);
+  if(staleDate.getUTCDay()===0) staleDate.setUTCDate(staleDate.getUTCDate()+1);
   const stalePayload=Object.assign({},payload,{date:staleDate.toISOString().slice(0,10)});
   const stale=await runtime('/api/wa4/conversations/'+cid+'/book',{idempotency_key:'wa4c-full-local-booking-stale',payload:stalePayload},AGENT);
   assert.strictEqual(stale.status,409,'stale schedule should fail');

--- a/docs/control/WA_L4_ENTRY_IMPLEMENTATION_20260902.md
+++ b/docs/control/WA_L4_ENTRY_IMPLEMENTATION_20260902.md
@@ -1,0 +1,133 @@
+# WA-L4 — Autonomous Authority + Kill Switch · Entry / Implementation Control
+
+**Date:** 2026-09-02 America/Lima  
+**Authority:** GitHub issue #443  
+**Entry main:** `73a4bab955fffb8a423f8ff07fa8c835df125227`  
+**Active lock commit:** `ee05aee59af5e145d62228a7cab27aaf597bd8f8`  
+**Branch:** `wa-l4-autonomous-authority-20260902`  
+**Operational state during implementation:** `AUTO_OFF · SAFE-OFF`
+
+## Entry readback
+
+Production safety at L4 entry:
+
+- `copilot_enabled=true`;
+- `auto_reply_enabled=false`;
+- `auto_routing_enabled=false`;
+- `ai_send_enabled=false`;
+- `human_send_enabled=true`;
+- Booking Operations V2 = `0`;
+- Agenda Events V2 = `0`;
+- L3 Delivery Outbox V3 = `0`;
+- L3 dispatchable = `0`;
+- active template registry = `10`;
+- active WhatsApp templates = `6`;
+- provider-verified active WhatsApp templates = `0`;
+- existing outbound request ledger = `15` rows, `7` with provider message ID.
+
+No CANARY or autonomous send is authorized by this implementation workstream.
+
+## Frozen architecture
+
+L4 inserts one centralized server-side authority **before** existing provider reservation/dispatch:
+
+`internal agent/runtime -> F4 internal auto-send endpoint -> L4 DB authority -> existing idempotency reservation -> Meta Cloud API`
+
+The LLM never receives direct Meta or arbitrary SQL authority.
+
+### Authority state
+
+- `AUTO_OFF`: autonomous authority always blocks.
+- `CANARY`: requires explicit level-1 authorization reference, kill switch disengaged and an active allowlist match.
+- `PROD`: requires previous CANARY state plus a new explicit authorization reference.
+- global kill switch wins over mode.
+
+Deployment initializes `AUTO_OFF + kill_switch_engaged=true` unconditionally.
+
+### Server boundary
+
+`/api/wa/auto-send`:
+
+- POST only;
+- no browser CORS path;
+- requires a server-only `WA_L4_INTERNAL_TOKEN` (minimum 32 chars, timing-safe compare);
+- secret is stripped from the legacy child process;
+- calls `aos_wa_l4_authorize_autonomous_send_v1` before outbound reservation and before `graphSend()`;
+- BLOCK never reaches Meta;
+- HANDOFF invokes existing governed `aos_wa3_handoff_request_v1`;
+- provider failure is non-auto-retry and requests human handoff.
+
+Existing `/api/wa/send` remains the separate 2FA human route and records `send_origin=HUMAN`.
+
+## Database controls
+
+### `aos_wa_auto_authority_v1`
+Singleton state machine + kill switch + daily message limit + max turns + global/conversation rate + cooldown + duplicate window + authorization metadata.
+
+### `aos_wa_auto_allowlist_v1`
+Server-only allowlist for exact `PHONE | BSUID | CONVERSATION | CAMPAIGN` subjects.
+
+### `aos_wa_auto_decisions_v1`
+Append-only decision ledger. Stores recipient/content hashes and decision metadata; does **not** store raw prompt or raw model reply.
+
+### `aos_wa_auto_control_events_v1`
+Append-only administrative authority/allowlist audit.
+
+### Existing outbound lineage
+Existing `aos_wa_outbound_requests_v1` remains the provider idempotency source of truth; L4 only adds `send_origin`, `conversation_id`, `authority_decision_id`. Existing human history defaults to `HUMAN`.
+
+## Fail-closed decision order
+
+Before autonomous provider dispatch L4 checks:
+
+1. valid idempotency/content hash;
+2. state exists;
+3. `AUTO_OFF`;
+4. kill switch;
+5. AI/routing flag consistency;
+6. conversation existence/terminal state;
+7. human ownership/takeover boundary;
+8. exact recipient ↔ conversation continuity;
+9. safety action;
+10. identity conflict / required canonical identity;
+11. provider-verified template if template send;
+12. CANARY allowlist;
+13. daily message limit;
+14. max turns;
+15. global rate;
+16. conversation rate;
+17. cooldown;
+18. duplicate-content window.
+
+Any unsafe state returns BLOCK or HANDOFF; there is no best-effort autonomous bypass.
+
+## Recovery
+
+Recovery first forces:
+
+- `AUTO_OFF`;
+- kill switch engaged;
+- `auto_reply=false`;
+- `ai_send=false`;
+- `auto_routing=false`;
+- `human_send=true`.
+
+It then refuses structural rollback if any real `send_origin=AUTO` provider history exists. This prevents audit/provider lineage from being silently erased.
+
+## Mandatory exit gates
+
+L4 implementation is not complete until:
+
+- dedicated runtime/static CI PASS;
+- isolated DB apply + behavior + replay + recovery PASS;
+- relevant existing WA/Performance/Ascenda gates PASS;
+- exact-head anti-drift PASS;
+- merge with expected head;
+- Railway exact merge deployment SUCCESS;
+- Supabase migration from merged lineage;
+- LIVE readback proves `AUTO_OFF + kill=true + auto_reply=false + ai_send=false + auto_routing=false + human_send=true`;
+- no autonomous outbound rows/provider IDs are created;
+- full cross-panel regression matrix PASS;
+- shared PostgreSQL/API pressure shows no new L4-attributable timeout/lock amplification.
+
+**CANARY transition is explicitly outside this exit and remains blocked until a separate owner authorization.**

--- a/supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+++ b/supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
@@ -1,0 +1,462 @@
+-- ASCENDA Conversations · WA-L4 Autonomous Authority + Kill Switch V1
+-- Deployment contract: installs dormant authority only. Effective production state remains AUTO_OFF / SAFE-OFF.
+-- CANARY/PROD transitions require explicit level-1 administration plus an authorization reference.
+
+begin;
+
+-- WA-4/WA-3 historically made autonomous sends structurally impossible. L4 replaces
+-- those one-way CHECK constraints with a stronger centralized state machine.
+alter table public.aos_wa_ai_control_v1
+  drop constraint if exists aos_wa_ai_control_v1_auto_reply_enabled_check;
+alter table public.aos_wa_routing_control_v1
+  drop constraint if exists aos_wa_routing_control_v1_ai_send_enabled_check;
+
+create table if not exists public.aos_wa_auto_authority_v1 (
+  id smallint primary key default 1 check (id=1),
+  mode text not null default 'AUTO_OFF' check (mode in ('AUTO_OFF','CANARY','PROD')),
+  kill_switch_engaged boolean not null default true,
+  daily_message_limit integer not null default 20 check (daily_message_limit between 1 and 500),
+  max_turns_per_conversation integer not null default 8 check (max_turns_per_conversation between 1 and 50),
+  global_rate_per_minute integer not null default 6 check (global_rate_per_minute between 1 and 120),
+  conversation_rate_per_minute integer not null default 2 check (conversation_rate_per_minute between 1 and 30),
+  cooldown_seconds integer not null default 15 check (cooldown_seconds between 0 and 3600),
+  duplicate_window_seconds integer not null default 120 check (duplicate_window_seconds between 0 and 86400),
+  autonomous_actor_id uuid not null default '00000000-0000-4000-8000-000000000004'::uuid,
+  authorization_ref text,
+  authorized_by uuid references public.aos_usuarios(id) on delete set null,
+  authorized_at timestamptz,
+  updated_by uuid references public.aos_usuarios(id) on delete set null,
+  updated_at timestamptz not null default now()
+);
+insert into public.aos_wa_auto_authority_v1(id,mode,kill_switch_engaged)
+values(1,'AUTO_OFF',true)
+on conflict(id) do update
+set mode='AUTO_OFF',kill_switch_engaged=true,authorization_ref=null,authorized_by=null,authorized_at=null,updated_at=now();
+alter table public.aos_wa_auto_authority_v1 enable row level security;
+alter table public.aos_wa_auto_authority_v1 force row level security;
+revoke all on table public.aos_wa_auto_authority_v1 from public,anon,authenticated;
+grant select,update on table public.aos_wa_auto_authority_v1 to service_role;
+
+create table if not exists public.aos_wa_auto_allowlist_v1 (
+  id uuid primary key default gen_random_uuid(),
+  subject_kind text not null check (subject_kind in ('PHONE','BSUID','CONVERSATION','CAMPAIGN')),
+  subject_key text not null check (char_length(btrim(subject_key)) between 1 and 256),
+  active boolean not null default true,
+  expires_at timestamptz,
+  reason text,
+  created_by uuid references public.aos_usuarios(id) on delete set null,
+  updated_by uuid references public.aos_usuarios(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(subject_kind,subject_key)
+);
+create index if not exists aos_wa_auto_allowlist_v1_active_idx
+  on public.aos_wa_auto_allowlist_v1(subject_kind,subject_key)
+  where active is true;
+alter table public.aos_wa_auto_allowlist_v1 enable row level security;
+alter table public.aos_wa_auto_allowlist_v1 force row level security;
+revoke all on table public.aos_wa_auto_allowlist_v1 from public,anon,authenticated;
+grant select,insert,update on table public.aos_wa_auto_allowlist_v1 to service_role;
+
+create table if not exists public.aos_wa_auto_decisions_v1 (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique check (idempotency_key ~ '^[A-Za-z0-9._:-]{16,120}$'),
+  conversation_id uuid references public.aos_wa_conversations_v1(id) on delete restrict,
+  recipient_kind text not null check (recipient_kind in ('PHONE','BSUID')),
+  recipient_hash text not null check (recipient_hash ~ '^[a-f0-9]{64}$'),
+  message_type text not null,
+  template_name text,
+  content_hash text not null check (content_hash ~ '^[a-f0-9]{64}$'),
+  decision text not null check (decision in ('ALLOW','BLOCK','HANDOFF')),
+  reason_code text not null,
+  authority_mode text not null check (authority_mode in ('AUTO_OFF','CANARY','PROD')),
+  kill_switch_engaged boolean not null,
+  identity_state text,
+  safety_action text,
+  requires_identity boolean not null default false,
+  daily_count_before integer not null default 0,
+  global_rate_count_before integer not null default 0,
+  conversation_rate_count_before integer not null default 0,
+  turns_count_before integer not null default 0,
+  cooldown_remaining_seconds integer not null default 0,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+create index if not exists aos_wa_auto_decisions_v1_daily_idx on public.aos_wa_auto_decisions_v1(created_at,decision);
+create index if not exists aos_wa_auto_decisions_v1_conv_idx on public.aos_wa_auto_decisions_v1(conversation_id,created_at desc,decision);
+create index if not exists aos_wa_auto_decisions_v1_duplicate_idx on public.aos_wa_auto_decisions_v1(conversation_id,content_hash,created_at desc) where decision='ALLOW';
+alter table public.aos_wa_auto_decisions_v1 enable row level security;
+alter table public.aos_wa_auto_decisions_v1 force row level security;
+revoke all on table public.aos_wa_auto_decisions_v1 from public,anon,authenticated;
+grant select,insert on table public.aos_wa_auto_decisions_v1 to service_role;
+
+create table if not exists public.aos_wa_auto_control_events_v1 (
+  id bigint generated always as identity primary key,
+  event_type text not null,
+  actor_id uuid references public.aos_usuarios(id) on delete set null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+create index if not exists aos_wa_auto_control_events_v1_created_idx on public.aos_wa_auto_control_events_v1(created_at desc,event_type);
+alter table public.aos_wa_auto_control_events_v1 enable row level security;
+alter table public.aos_wa_auto_control_events_v1 force row level security;
+revoke all on table public.aos_wa_auto_control_events_v1 from public,anon,authenticated;
+grant select,insert on table public.aos_wa_auto_control_events_v1 to service_role;
+
+-- Additive lineage only. Existing HUMAN rows remain untouched.
+alter table public.aos_wa_outbound_requests_v1
+  add column if not exists send_origin text not null default 'HUMAN' check (send_origin in ('HUMAN','AUTO')),
+  add column if not exists conversation_id uuid references public.aos_wa_conversations_v1(id) on delete restrict,
+  add column if not exists authority_decision_id uuid references public.aos_wa_auto_decisions_v1(id) on delete restrict;
+create index if not exists aos_wa_outbound_requests_v1_auto_idx
+  on public.aos_wa_outbound_requests_v1(send_origin,created_at desc)
+  where send_origin='AUTO';
+
+alter table public.aos_wa_messages_v1
+  add column if not exists send_origin text not null default 'HUMAN' check (send_origin in ('HUMAN','AUTO')),
+  add column if not exists authority_decision_id uuid references public.aos_wa_auto_decisions_v1(id) on delete restrict;
+create index if not exists aos_wa_messages_v1_auto_idx
+  on public.aos_wa_messages_v1(send_origin,created_at desc)
+  where send_origin='AUTO';
+
+create or replace function public.aos_wa_l4_append_guard_v1()
+returns trigger language plpgsql set search_path='' as $$
+begin
+  raise exception 'WA_L4_APPEND_ONLY' using errcode='55000';
+end
+$$;
+drop trigger if exists trg_aos_wa_l4_decision_append_guard_v1 on public.aos_wa_auto_decisions_v1;
+create trigger trg_aos_wa_l4_decision_append_guard_v1
+before update or delete on public.aos_wa_auto_decisions_v1
+for each row execute function public.aos_wa_l4_append_guard_v1();
+drop trigger if exists trg_aos_wa_l4_control_event_append_guard_v1 on public.aos_wa_auto_control_events_v1;
+create trigger trg_aos_wa_l4_control_event_append_guard_v1
+before update or delete on public.aos_wa_auto_control_events_v1
+for each row execute function public.aos_wa_l4_append_guard_v1();
+
+create or replace function public.aos_wa_l4_is_level1_admin_v1(p_actor_id uuid)
+returns boolean language sql stable set search_path='' as $$
+  select exists(
+    select 1 from public.aos_usuarios u
+    where u.id=p_actor_id and u.activo is true and coalesce(u.nivel_jerarquia,99)=1
+      and coalesce(u.paneles_acceso,'{}'::text[]) @> array['admin-whatsapp']::text[]
+  )
+$$;
+
+create or replace function public.aos_wa_l4_normalize_subject_v1(p_kind text,p_key text)
+returns text language plpgsql immutable set search_path='' as $$
+declare v_kind text:=upper(btrim(coalesce(p_kind,''))); v_key text:=btrim(coalesce(p_key,'')); v_phone text;
+begin
+  if v_kind='PHONE' then
+    if v_key ~ '[A-Za-z]' then return null; end if;
+    v_phone:=regexp_replace(v_key,'[^0-9]','','g');
+    if char_length(v_phone) not between 8 and 20 then return null; end if;
+    return v_phone;
+  elsif v_kind in ('BSUID','CONVERSATION','CAMPAIGN') then
+    if v_key='' or char_length(v_key)>256 then return null; end if;
+    return v_key;
+  end if;
+  return null;
+end
+$$;
+
+create or replace function public.aos_wa_l4_allowlist_set_v1(
+  p_actor_id uuid,
+  p_subject_kind text,
+  p_subject_key text,
+  p_active boolean default true,
+  p_expires_at timestamptz default null,
+  p_reason text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_kind text:=upper(btrim(coalesce(p_subject_kind,''))); v_key text; v_row public.aos_wa_auto_allowlist_v1%rowtype;
+begin
+  if not public.aos_wa_l4_is_level1_admin_v1(p_actor_id) then return jsonb_build_object('ok',false,'error','WA_L4_LEVEL1_ADMIN_REQUIRED'); end if;
+  v_key:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_subject_key);
+  if v_key is null then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_ALLOWLIST_SUBJECT'); end if;
+  if p_expires_at is not null and p_expires_at<=now() and coalesce(p_active,true) then return jsonb_build_object('ok',false,'error','WA_L4_ALLOWLIST_EXPIRY_INVALID'); end if;
+  insert into public.aos_wa_auto_allowlist_v1(subject_kind,subject_key,active,expires_at,reason,created_by,updated_by)
+  values(v_kind,v_key,coalesce(p_active,true),p_expires_at,nullif(btrim(coalesce(p_reason,'')),''),p_actor_id,p_actor_id)
+  on conflict(subject_kind,subject_key) do update
+  set active=excluded.active,expires_at=excluded.expires_at,reason=excluded.reason,updated_by=p_actor_id,updated_at=now()
+  returning * into v_row;
+  insert into public.aos_wa_auto_control_events_v1(event_type,actor_id,payload)
+  values('ALLOWLIST_SET',p_actor_id,jsonb_build_object('subject_kind',v_kind,'subject_hash',encode(extensions.digest(convert_to(v_key,'UTF8'),'sha256'),'hex'),'active',v_row.active,'expires_at',v_row.expires_at));
+  return jsonb_build_object('ok',true,'subject_kind',v_kind,'active',v_row.active,'expires_at',v_row.expires_at);
+end
+$$;
+
+create or replace function public.aos_wa_l4_set_control_v1(
+  p_actor_id uuid,
+  p_mode text default null,
+  p_kill_switch_engaged boolean default null,
+  p_daily_message_limit integer default null,
+  p_max_turns_per_conversation integer default null,
+  p_global_rate_per_minute integer default null,
+  p_conversation_rate_per_minute integer default null,
+  p_cooldown_seconds integer default null,
+  p_duplicate_window_seconds integer default null,
+  p_authorization_ref text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_current public.aos_wa_auto_authority_v1%rowtype;
+  v_mode text;
+  v_kill boolean;
+  v_auth text:=nullif(btrim(coalesce(p_authorization_ref,'')),'');
+  v_row public.aos_wa_auto_authority_v1%rowtype;
+  v_effective_on boolean;
+begin
+  if not public.aos_wa_l4_is_level1_admin_v1(p_actor_id) then return jsonb_build_object('ok',false,'error','WA_L4_LEVEL1_ADMIN_REQUIRED'); end if;
+  select * into v_current from public.aos_wa_auto_authority_v1 where id=1 for update;
+  if v_current.id is null then return jsonb_build_object('ok',false,'error','WA_L4_CONTROL_MISSING'); end if;
+  v_mode:=upper(coalesce(nullif(btrim(p_mode),''),v_current.mode));
+  v_kill:=coalesce(p_kill_switch_engaged,v_current.kill_switch_engaged);
+  if v_mode not in ('AUTO_OFF','CANARY','PROD') then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_MODE'); end if;
+  if p_daily_message_limit is not null and p_daily_message_limit not between 1 and 500 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_DAILY_LIMIT'); end if;
+  if p_max_turns_per_conversation is not null and p_max_turns_per_conversation not between 1 and 50 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_MAX_TURNS'); end if;
+  if p_global_rate_per_minute is not null and p_global_rate_per_minute not between 1 and 120 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_GLOBAL_RATE'); end if;
+  if p_conversation_rate_per_minute is not null and p_conversation_rate_per_minute not between 1 and 30 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_CONVERSATION_RATE'); end if;
+  if p_cooldown_seconds is not null and p_cooldown_seconds not between 0 and 3600 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_COOLDOWN'); end if;
+  if p_duplicate_window_seconds is not null and p_duplicate_window_seconds not between 0 and 86400 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_DUPLICATE_WINDOW'); end if;
+
+  if v_mode in ('CANARY','PROD') then
+    if v_auth is null or char_length(v_auth)<12 then return jsonb_build_object('ok',false,'error','WA_L4_EXPLICIT_AUTHORIZATION_REF_REQUIRED'); end if;
+    if v_mode='CANARY' and not exists(
+      select 1 from public.aos_wa_auto_allowlist_v1 a where a.active is true and (a.expires_at is null or a.expires_at>now())
+    ) then return jsonb_build_object('ok',false,'error','WA_L4_CANARY_ALLOWLIST_REQUIRED'); end if;
+    if v_mode='PROD' and v_current.mode<>'CANARY' then return jsonb_build_object('ok',false,'error','WA_L4_PROD_REQUIRES_CANARY_STATE'); end if;
+  end if;
+
+  update public.aos_wa_auto_authority_v1
+  set mode=v_mode,
+      kill_switch_engaged=v_kill,
+      daily_message_limit=coalesce(p_daily_message_limit,daily_message_limit),
+      max_turns_per_conversation=coalesce(p_max_turns_per_conversation,max_turns_per_conversation),
+      global_rate_per_minute=coalesce(p_global_rate_per_minute,global_rate_per_minute),
+      conversation_rate_per_minute=coalesce(p_conversation_rate_per_minute,conversation_rate_per_minute),
+      cooldown_seconds=coalesce(p_cooldown_seconds,cooldown_seconds),
+      duplicate_window_seconds=coalesce(p_duplicate_window_seconds,duplicate_window_seconds),
+      authorization_ref=case when v_mode='AUTO_OFF' then null else v_auth end,
+      authorized_by=case when v_mode='AUTO_OFF' then null else p_actor_id end,
+      authorized_at=case when v_mode='AUTO_OFF' then null else now() end,
+      updated_by=p_actor_id,updated_at=now()
+  where id=1 returning * into v_row;
+
+  v_effective_on:=(v_row.mode in ('CANARY','PROD') and v_row.kill_switch_engaged is false);
+
+  update public.aos_wa_ai_control_v1
+  set auto_reply_enabled=v_effective_on,updated_by=p_actor_id,updated_at=now()
+  where id=1;
+  update public.aos_wa_routing_control_v1
+  set ai_send_enabled=v_effective_on,
+      auto_routing_enabled=false,
+      human_send_enabled=true,
+      updated_by=p_actor_id,updated_at=now()
+  where id=1;
+
+  insert into public.aos_wa_auto_control_events_v1(event_type,actor_id,payload)
+  values('CONTROL_SET',p_actor_id,jsonb_build_object(
+    'mode',v_row.mode,'kill_switch_engaged',v_row.kill_switch_engaged,'effective_autonomous_send',v_effective_on,
+    'daily_message_limit',v_row.daily_message_limit,'max_turns_per_conversation',v_row.max_turns_per_conversation,
+    'global_rate_per_minute',v_row.global_rate_per_minute,'conversation_rate_per_minute',v_row.conversation_rate_per_minute,
+    'cooldown_seconds',v_row.cooldown_seconds,'duplicate_window_seconds',v_row.duplicate_window_seconds,
+    'authorization_ref_present',v_row.authorization_ref is not null));
+
+  return jsonb_build_object('ok',true,'mode',v_row.mode,'kill_switch_engaged',v_row.kill_switch_engaged,'effective_autonomous_send',v_effective_on,
+    'auto_reply_enabled',v_effective_on,'ai_send_enabled',v_effective_on,'auto_routing_enabled',false,'human_send_enabled',true);
+end
+$$;
+
+create or replace function public.aos_wa_l4_authorize_autonomous_send_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text,
+  p_content_hash text,
+  p_safety_action text default null,
+  p_identity_state text default 'NOT_REQUIRED',
+  p_requires_identity boolean default false,
+  p_campaign_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_control public.aos_wa_auto_authority_v1%rowtype;
+  v_ai public.aos_wa_ai_control_v1%rowtype;
+  v_route public.aos_wa_routing_control_v1%rowtype;
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_existing public.aos_wa_auto_decisions_v1%rowtype;
+  v_kind text:=upper(btrim(coalesce(p_recipient_kind,'')));
+  v_address text;
+  v_type text:=lower(btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(btrim(coalesce(p_template_name,'')),'');
+  v_safety text:=upper(coalesce(nullif(btrim(p_safety_action),''),'ALLOW'));
+  v_identity text:=upper(coalesce(nullif(btrim(p_identity_state),''),'NOT_REQUIRED'));
+  v_campaign text:=nullif(btrim(coalesce(p_campaign_key,'')),'');
+  v_decision text:='ALLOW';
+  v_reason text:='WA_L4_ALLOWED';
+  v_daily integer:=0;
+  v_global integer:=0;
+  v_conv_rate integer:=0;
+  v_turns integer:=0;
+  v_cooldown integer:=0;
+  v_last_allowed timestamptz;
+  v_day_start timestamptz;
+  v_recipient_hash text;
+  v_decision_id uuid;
+  v_allowlisted boolean:=false;
+begin
+  perform pg_catalog.pg_advisory_xact_lock(744,4);
+
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L4_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  if coalesce(p_content_hash,'') !~ '^[a-f0-9]{64}$' then
+    return jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L4_INVALID_CONTENT_HASH');
+  end if;
+
+  select * into v_existing from public.aos_wa_auto_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return jsonb_build_object('ok',v_existing.decision='ALLOW','replay',true,'decision_id',v_existing.id,'decision',v_existing.decision,
+      'reason',v_existing.reason_code,'mode',v_existing.authority_mode,'autonomous_actor_id',(select autonomous_actor_id from public.aos_wa_auto_authority_v1 where id=1));
+  end if;
+
+  v_address:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L4_INVALID_RECIPIENT');
+  end if;
+  if v_type='' or char_length(v_type)>64 then
+    return jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L4_INVALID_MESSAGE_TYPE');
+  end if;
+
+  select * into v_control from public.aos_wa_auto_authority_v1 where id=1;
+  select * into v_ai from public.aos_wa_ai_control_v1 where id=1;
+  select * into v_route from public.aos_wa_routing_control_v1 where id=1;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+
+  v_recipient_hash:=encode(extensions.digest(convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+  v_day_start:=date_trunc('day',now() at time zone 'America/Lima') at time zone 'America/Lima';
+  select count(*)::integer into v_daily from public.aos_wa_auto_decisions_v1 where decision='ALLOW' and created_at>=v_day_start;
+  select count(*)::integer into v_global from public.aos_wa_auto_decisions_v1 where decision='ALLOW' and created_at>=now()-interval '1 minute';
+  select count(*)::integer into v_conv_rate from public.aos_wa_auto_decisions_v1 where decision='ALLOW' and conversation_id=p_conversation_id and created_at>=now()-interval '1 minute';
+  select count(*)::integer into v_turns from public.aos_wa_auto_decisions_v1 where decision='ALLOW' and conversation_id=p_conversation_id and created_at>=now()-interval '24 hours';
+  select max(created_at) into v_last_allowed from public.aos_wa_auto_decisions_v1 where decision='ALLOW' and conversation_id=p_conversation_id;
+  if v_last_allowed is not null and v_control.cooldown_seconds>0 then
+    v_cooldown:=greatest(0,ceil(extract(epoch from (v_last_allowed + make_interval(secs=>v_control.cooldown_seconds) - now())))::integer);
+  end if;
+
+  if v_control.id is null then v_decision:='BLOCK';v_reason:='WA_L4_CONTROL_MISSING';
+  elsif v_control.mode='AUTO_OFF' then v_decision:='BLOCK';v_reason:='WA_L4_AUTO_OFF';
+  elsif v_control.kill_switch_engaged then v_decision:='BLOCK';v_reason:='WA_L4_KILL_SWITCH';
+  elsif v_ai.id is null or v_ai.copilot_enabled is not true or v_ai.auto_reply_enabled is not true then v_decision:='BLOCK';v_reason:='WA_L4_AI_CONTROL_NOT_READY';
+  elsif v_route.id is null or v_route.ai_send_enabled is not true then v_decision:='BLOCK';v_reason:='WA_L4_AI_SEND_DISABLED';
+  elsif v_conv.id is null then v_decision:='BLOCK';v_reason:='WA_L4_CONVERSATION_NOT_FOUND';
+  elsif v_conv.state in ('CLOSED','WON','LOST') then v_decision:='BLOCK';v_reason:='WA_L4_CONVERSATION_TERMINAL';
+  elsif v_conv.state in ('HUMAN_REQUESTED','HUMAN_ACTIVE','AI_COPILOT') or v_conv.human_takeover_at is not null then v_decision:='HANDOFF';v_reason:='WA_L4_HUMAN_OWNERSHIP_BOUNDARY';
+  elsif v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then v_decision:='HANDOFF';v_reason:='WA_L4_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif v_safety in ('BLOCK','DENY') then v_decision:='BLOCK';v_reason:='WA_L4_SAFETY_BLOCK';
+  elsif v_safety in ('HANDOFF','HUMAN','CLINICAL','ESCALATE') then v_decision:='HANDOFF';v_reason:='WA_L4_SAFETY_HANDOFF';
+  elsif v_identity='CONFLICT' then v_decision:='HANDOFF';v_reason:='WA_L4_IDENTITY_CONFLICT';
+  elsif coalesce(p_requires_identity,false) and v_identity not in ('CANONICAL','VERIFIED') then v_decision:='HANDOFF';v_reason:='WA_L4_IDENTITY_REQUIRED';
+  elsif v_type='template' and (v_template is null or not exists(
+    select 1 from public.aos_agenda_delivery_template_registry_v3 t
+    where t.channel='WHATSAPP' and t.provider='META_CLOUD_API' and t.active is true and t.provider_verified is true
+      and t.provider_template_name=v_template
+  )) then v_decision:='BLOCK';v_reason:='WA_L4_TEMPLATE_NOT_PROVIDER_VERIFIED';
+  elsif v_control.mode='CANARY' then
+    select exists(
+      select 1 from public.aos_wa_auto_allowlist_v1 a
+      where a.active is true and (a.expires_at is null or a.expires_at>now()) and (
+        (a.subject_kind=v_kind and a.subject_key=v_address)
+        or (a.subject_kind='CONVERSATION' and a.subject_key=p_conversation_id::text)
+        or (v_campaign is not null and a.subject_kind='CAMPAIGN' and a.subject_key=v_campaign)
+      )
+    ) into v_allowlisted;
+    if not v_allowlisted then v_decision:='BLOCK';v_reason:='WA_L4_CANARY_NOT_ALLOWLISTED'; end if;
+  end if;
+
+  if v_decision='ALLOW' then
+    if v_daily>=v_control.daily_message_limit then v_decision:='BLOCK';v_reason:='WA_L4_DAILY_MESSAGE_LIMIT';
+    elsif v_turns>=v_control.max_turns_per_conversation then v_decision:='HANDOFF';v_reason:='WA_L4_MAX_TURNS_HANDOFF';
+    elsif v_global>=v_control.global_rate_per_minute then v_decision:='BLOCK';v_reason:='WA_L4_GLOBAL_RATE_LIMIT';
+    elsif v_conv_rate>=v_control.conversation_rate_per_minute then v_decision:='BLOCK';v_reason:='WA_L4_CONVERSATION_RATE_LIMIT';
+    elsif v_cooldown>0 then v_decision:='BLOCK';v_reason:='WA_L4_COOLDOWN';
+    elsif v_control.duplicate_window_seconds>0 and exists(
+      select 1 from public.aos_wa_auto_decisions_v1 d where d.decision='ALLOW' and d.conversation_id=p_conversation_id and d.content_hash=p_content_hash
+        and d.created_at>=now()-make_interval(secs=>v_control.duplicate_window_seconds)
+    ) then v_decision:='BLOCK';v_reason:='WA_L4_DUPLICATE_GUARD';
+    end if;
+  end if;
+
+  insert into public.aos_wa_auto_decisions_v1(
+    idempotency_key,conversation_id,recipient_kind,recipient_hash,message_type,template_name,content_hash,decision,reason_code,
+    authority_mode,kill_switch_engaged,identity_state,safety_action,requires_identity,daily_count_before,global_rate_count_before,
+    conversation_rate_count_before,turns_count_before,cooldown_remaining_seconds,metadata)
+  values(p_idempotency_key,p_conversation_id,v_kind,v_recipient_hash,v_type,v_template,p_content_hash,v_decision,v_reason,
+    coalesce(v_control.mode,'AUTO_OFF'),coalesce(v_control.kill_switch_engaged,true),v_identity,v_safety,coalesce(p_requires_identity,false),
+    v_daily,v_global,v_conv_rate,v_turns,v_cooldown,
+    jsonb_build_object('campaign_key_present',v_campaign is not null,'canary_allowlisted',v_allowlisted,'raw_content_stored',false))
+  returning id into v_decision_id;
+
+  return jsonb_build_object(
+    'ok',v_decision='ALLOW','replay',false,'decision_id',v_decision_id,'decision',v_decision,'reason',v_reason,
+    'mode',coalesce(v_control.mode,'AUTO_OFF'),'kill_switch_engaged',coalesce(v_control.kill_switch_engaged,true),
+    'autonomous_actor_id',v_control.autonomous_actor_id,'daily_count_before',v_daily,'turns_count_before',v_turns,
+    'global_rate_count_before',v_global,'conversation_rate_count_before',v_conv_rate,'cooldown_remaining_seconds',v_cooldown
+  );
+end
+$$;
+
+create or replace function public.aos_wa_l4_status_v1()
+returns jsonb language sql stable security definer set search_path='' as $$
+  select jsonb_build_object(
+    'ok',true,'mode',a.mode,'kill_switch_engaged',a.kill_switch_engaged,
+    'effective_autonomous_send',(a.mode in ('CANARY','PROD') and a.kill_switch_engaged is false and ai.auto_reply_enabled and r.ai_send_enabled),
+    'copilot_enabled',ai.copilot_enabled,'auto_reply_enabled',ai.auto_reply_enabled,'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,'human_send_enabled',r.human_send_enabled,
+    'daily_message_limit',a.daily_message_limit,'max_turns_per_conversation',a.max_turns_per_conversation,
+    'global_rate_per_minute',a.global_rate_per_minute,'conversation_rate_per_minute',a.conversation_rate_per_minute,
+    'cooldown_seconds',a.cooldown_seconds,'duplicate_window_seconds',a.duplicate_window_seconds,
+    'active_allowlist',(select count(*) from public.aos_wa_auto_allowlist_v1 w where w.active is true and (w.expires_at is null or w.expires_at>now())),
+    'allowed_today',(select count(*) from public.aos_wa_auto_decisions_v1 d where d.decision='ALLOW' and d.created_at>=date_trunc('day',now() at time zone 'America/Lima') at time zone 'America/Lima'),
+    'handoffs_today',(select count(*) from public.aos_wa_auto_decisions_v1 d where d.decision='HANDOFF' and d.created_at>=date_trunc('day',now() at time zone 'America/Lima') at time zone 'America/Lima'),
+    'blocks_today',(select count(*) from public.aos_wa_auto_decisions_v1 d where d.decision='BLOCK' and d.created_at>=date_trunc('day',now() at time zone 'America/Lima') at time zone 'America/Lima')
+  )
+  from public.aos_wa_auto_authority_v1 a cross join public.aos_wa_ai_control_v1 ai cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+-- Privileges: all L4 authority/control functions are server-side only.
+revoke all on function public.aos_wa_l4_append_guard_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_is_level1_admin_v1(uuid) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_normalize_subject_v1(text,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_allowlist_set_v1(uuid,text,text,boolean,timestamptz,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_status_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa_l4_append_guard_v1() to service_role;
+grant execute on function public.aos_wa_l4_is_level1_admin_v1(uuid) to service_role;
+grant execute on function public.aos_wa_l4_normalize_subject_v1(text,text) to service_role;
+grant execute on function public.aos_wa_l4_allowlist_set_v1(uuid,text,text,boolean,timestamptz,text) to service_role;
+grant execute on function public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text) to service_role;
+grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
+grant execute on function public.aos_wa_l4_status_v1() to service_role;
+
+comment on table public.aos_wa_auto_authority_v1 is 'WA-L4 centralized autonomous authority. Deployment defaults AUTO_OFF + kill switch engaged; CANARY/PROD require explicit level-1 authorization.';
+comment on table public.aos_wa_auto_allowlist_v1 is 'WA-L4 server-only canary allowlist. PHONE/BSUID/CONVERSATION/CAMPAIGN subjects; no browser access.';
+comment on table public.aos_wa_auto_decisions_v1 is 'WA-L4 append-only authority decisions. Stores hashes/decision metadata, never raw model prompt/reply.';
+comment on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) is 'Serialized fail-closed authority decision before any autonomous Meta dispatch: mode/kill/flags/ownership/identity/safety/template/allowlist/budget/rate/cooldown/duplicate gates.';
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+++ b/supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
@@ -1,0 +1,140 @@
+-- WA-L4 hardening V1: close direct table mutation routes and make AUTO_OFF imply kill=true.
+begin;
+
+-- Deployment remains dormant even if an unrelated routing flag drifted before L4.
+update public.aos_wa_ai_control_v1
+set auto_reply_enabled=false,updated_at=now()
+where id=1;
+update public.aos_wa_routing_control_v1
+set ai_send_enabled=false,auto_routing_enabled=false,human_send_enabled=true,updated_at=now()
+where id=1;
+update public.aos_wa_auto_authority_v1
+set mode='AUTO_OFF',kill_switch_engaged=true,authorization_ref=null,authorized_by=null,authorized_at=null,updated_at=now()
+where id=1;
+
+-- Runtime may inspect authority state, but all mutations must pass governed SECURITY DEFINER RPCs.
+revoke all on table public.aos_wa_auto_authority_v1 from service_role;
+grant select on table public.aos_wa_auto_authority_v1 to service_role;
+revoke all on table public.aos_wa_auto_allowlist_v1 from service_role;
+grant select on table public.aos_wa_auto_allowlist_v1 to service_role;
+revoke all on table public.aos_wa_auto_decisions_v1 from service_role;
+grant select on table public.aos_wa_auto_decisions_v1 to service_role;
+revoke all on table public.aos_wa_auto_control_events_v1 from service_role;
+grant select on table public.aos_wa_auto_control_events_v1 to service_role;
+
+create or replace function public.aos_wa_l4_set_control_v1(
+  p_actor_id uuid,
+  p_mode text default null,
+  p_kill_switch_engaged boolean default null,
+  p_daily_message_limit integer default null,
+  p_max_turns_per_conversation integer default null,
+  p_global_rate_per_minute integer default null,
+  p_conversation_rate_per_minute integer default null,
+  p_cooldown_seconds integer default null,
+  p_duplicate_window_seconds integer default null,
+  p_authorization_ref text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_current public.aos_wa_auto_authority_v1%rowtype;
+  v_mode text;
+  v_kill boolean;
+  v_auth text:=nullif(btrim(coalesce(p_authorization_ref,'')),'');
+  v_row public.aos_wa_auto_authority_v1%rowtype;
+  v_effective_on boolean;
+begin
+  if not public.aos_wa_l4_is_level1_admin_v1(p_actor_id) then
+    return jsonb_build_object('ok',false,'error','WA_L4_LEVEL1_ADMIN_REQUIRED');
+  end if;
+
+  select * into v_current
+  from public.aos_wa_auto_authority_v1
+  where id=1
+  for update;
+  if v_current.id is null then return jsonb_build_object('ok',false,'error','WA_L4_CONTROL_MISSING'); end if;
+
+  v_mode:=upper(coalesce(nullif(btrim(p_mode),''),v_current.mode));
+  if v_mode not in ('AUTO_OFF','CANARY','PROD') then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_MODE'); end if;
+  -- AUTO_OFF is semantically SAFE-OFF: kill cannot be disengaged while mode is OFF.
+  v_kill:=case when v_mode='AUTO_OFF' then true else coalesce(p_kill_switch_engaged,v_current.kill_switch_engaged) end;
+
+  if p_daily_message_limit is not null and p_daily_message_limit not between 1 and 500 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_DAILY_LIMIT'); end if;
+  if p_max_turns_per_conversation is not null and p_max_turns_per_conversation not between 1 and 50 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_MAX_TURNS'); end if;
+  if p_global_rate_per_minute is not null and p_global_rate_per_minute not between 1 and 120 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_GLOBAL_RATE'); end if;
+  if p_conversation_rate_per_minute is not null and p_conversation_rate_per_minute not between 1 and 30 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_CONVERSATION_RATE'); end if;
+  if p_cooldown_seconds is not null and p_cooldown_seconds not between 0 and 3600 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_COOLDOWN'); end if;
+  if p_duplicate_window_seconds is not null and p_duplicate_window_seconds not between 0 and 86400 then return jsonb_build_object('ok',false,'error','WA_L4_INVALID_DUPLICATE_WINDOW'); end if;
+
+  if v_mode in ('CANARY','PROD') then
+    if v_auth is null or char_length(v_auth)<12 then return jsonb_build_object('ok',false,'error','WA_L4_EXPLICIT_AUTHORIZATION_REF_REQUIRED'); end if;
+    if v_mode='CANARY' and not exists(
+      select 1 from public.aos_wa_auto_allowlist_v1 a
+      where a.active is true and (a.expires_at is null or a.expires_at>now())
+    ) then return jsonb_build_object('ok',false,'error','WA_L4_CANARY_ALLOWLIST_REQUIRED'); end if;
+    if v_mode='PROD' and v_current.mode<>'CANARY' then return jsonb_build_object('ok',false,'error','WA_L4_PROD_REQUIRES_CANARY_STATE'); end if;
+  end if;
+
+  update public.aos_wa_auto_authority_v1
+  set mode=v_mode,
+      kill_switch_engaged=v_kill,
+      daily_message_limit=coalesce(p_daily_message_limit,daily_message_limit),
+      max_turns_per_conversation=coalesce(p_max_turns_per_conversation,max_turns_per_conversation),
+      global_rate_per_minute=coalesce(p_global_rate_per_minute,global_rate_per_minute),
+      conversation_rate_per_minute=coalesce(p_conversation_rate_per_minute,conversation_rate_per_minute),
+      cooldown_seconds=coalesce(p_cooldown_seconds,cooldown_seconds),
+      duplicate_window_seconds=coalesce(p_duplicate_window_seconds,duplicate_window_seconds),
+      authorization_ref=case when v_mode='AUTO_OFF' then null else v_auth end,
+      authorized_by=case when v_mode='AUTO_OFF' then null else p_actor_id end,
+      authorized_at=case when v_mode='AUTO_OFF' then null else now() end,
+      updated_by=p_actor_id,
+      updated_at=now()
+  where id=1
+  returning * into v_row;
+
+  v_effective_on:=(v_row.mode in ('CANARY','PROD') and v_row.kill_switch_engaged is false);
+
+  update public.aos_wa_ai_control_v1
+  set auto_reply_enabled=v_effective_on,updated_by=p_actor_id,updated_at=now()
+  where id=1;
+  update public.aos_wa_routing_control_v1
+  set ai_send_enabled=v_effective_on,
+      auto_routing_enabled=false,
+      human_send_enabled=true,
+      updated_by=p_actor_id,
+      updated_at=now()
+  where id=1;
+
+  insert into public.aos_wa_auto_control_events_v1(event_type,actor_id,payload)
+  values('CONTROL_SET',p_actor_id,jsonb_build_object(
+    'mode',v_row.mode,
+    'kill_switch_engaged',v_row.kill_switch_engaged,
+    'effective_autonomous_send',v_effective_on,
+    'daily_message_limit',v_row.daily_message_limit,
+    'max_turns_per_conversation',v_row.max_turns_per_conversation,
+    'global_rate_per_minute',v_row.global_rate_per_minute,
+    'conversation_rate_per_minute',v_row.conversation_rate_per_minute,
+    'cooldown_seconds',v_row.cooldown_seconds,
+    'duplicate_window_seconds',v_row.duplicate_window_seconds,
+    'authorization_ref_present',v_row.authorization_ref is not null));
+
+  return jsonb_build_object(
+    'ok',true,
+    'mode',v_row.mode,
+    'kill_switch_engaged',v_row.kill_switch_engaged,
+    'effective_autonomous_send',v_effective_on,
+    'auto_reply_enabled',v_effective_on,
+    'ai_send_enabled',v_effective_on,
+    'auto_routing_enabled',false,
+    'human_send_enabled',true
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text) to service_role;
+
+select pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql
+++ b/supabase/rollbacks/20260902235500_wa_l4_autonomous_authority_v1.rollback.sql
@@ -1,0 +1,61 @@
+-- WA-L4 recovery to pre-L4 structural SAFE-OFF.
+-- Fail closed once any real autonomous outbound history exists; that history must never be silently discarded.
+
+begin;
+
+-- Always force runtime controls safe before attempting structural recovery.
+update public.aos_wa_ai_control_v1 set auto_reply_enabled=false,updated_at=now() where id=1;
+update public.aos_wa_routing_control_v1
+set ai_send_enabled=false,auto_routing_enabled=false,human_send_enabled=true,updated_at=now()
+where id=1;
+
+update public.aos_wa_auto_authority_v1
+set mode='AUTO_OFF',kill_switch_engaged=true,authorization_ref=null,authorized_by=null,authorized_at=null,updated_at=now()
+where id=1;
+
+do $$
+begin
+  if exists(select 1 from public.aos_wa_outbound_requests_v1 where send_origin='AUTO')
+     or exists(select 1 from public.aos_wa_messages_v1 where send_origin='AUTO') then
+    raise exception 'WA_L4_RECOVERY_BLOCKED_AUTO_HISTORY' using errcode='55000';
+  end if;
+end
+$$;
+
+-- Remove additive lineage only after proving no autonomous provider history exists.
+drop index if exists public.aos_wa_outbound_requests_v1_auto_idx;
+drop index if exists public.aos_wa_messages_v1_auto_idx;
+alter table public.aos_wa_outbound_requests_v1 drop column if exists authority_decision_id;
+alter table public.aos_wa_outbound_requests_v1 drop column if exists conversation_id;
+alter table public.aos_wa_outbound_requests_v1 drop column if exists send_origin;
+alter table public.aos_wa_messages_v1 drop column if exists authority_decision_id;
+alter table public.aos_wa_messages_v1 drop column if exists send_origin;
+
+drop function if exists public.aos_wa_l4_status_v1();
+drop function if exists public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text);
+drop function if exists public.aos_wa_l4_set_control_v1(uuid,text,boolean,integer,integer,integer,integer,integer,integer,text);
+drop function if exists public.aos_wa_l4_allowlist_set_v1(uuid,text,text,boolean,timestamptz,text);
+drop function if exists public.aos_wa_l4_normalize_subject_v1(text,text);
+drop function if exists public.aos_wa_l4_is_level1_admin_v1(uuid);
+
+drop trigger if exists trg_aos_wa_l4_control_event_append_guard_v1 on public.aos_wa_auto_control_events_v1;
+drop trigger if exists trg_aos_wa_l4_decision_append_guard_v1 on public.aos_wa_auto_decisions_v1;
+drop function if exists public.aos_wa_l4_append_guard_v1();
+drop table if exists public.aos_wa_auto_control_events_v1;
+drop table if exists public.aos_wa_auto_allowlist_v1;
+drop table if exists public.aos_wa_auto_decisions_v1;
+drop table if exists public.aos_wa_auto_authority_v1;
+
+-- Restore the pre-L4 structural prohibition after flags are known false.
+alter table public.aos_wa_ai_control_v1
+  drop constraint if exists aos_wa_ai_control_v1_auto_reply_enabled_check;
+alter table public.aos_wa_ai_control_v1
+  add constraint aos_wa_ai_control_v1_auto_reply_enabled_check check (auto_reply_enabled=false);
+alter table public.aos_wa_routing_control_v1
+  drop constraint if exists aos_wa_routing_control_v1_ai_send_enabled_check;
+alter table public.aos_wa_routing_control_v1
+  add constraint aos_wa_routing_control_v1_ai_send_enabled_check check (ai_send_enabled=false);
+
+comment on table public.aos_wa_ai_control_v1 is 'WA-4 Groq model/control registry. Copilot defaults OFF; automatic AI reply is structurally forbidden.';
+select pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Implements Issue #443 under the mandatory PRE-L4 reliability doctrine.

## Effective production boundary
This PR installs L4 **dormant**. Migration always initializes `AUTO_OFF + kill_switch_engaged=true`; no CANARY transition is authorized by this PR.

## Architecture
- centralized DB-first `AUTO_OFF | CANARY | PROD` authority;
- global kill switch;
- server-only PHONE/BSUID/CONVERSATION/CAMPAIGN allowlist;
- daily messages / max turns / global+conversation rate / cooldown / duplicate guard;
- provider-verified template gate;
- safety/clinical/identity/human ownership HANDOFF;
- append-only hashed authority/control audit, no raw model prompt/reply;
- existing `aos_wa_outbound_requests_v1` remains provider idempotency authority;
- additive HUMAN/AUTO lineage;
- internal-only `/api/wa/auto-send`, no browser CORS;
- L4 internal secret is stripped from legacy child process;
- authority is evaluated before reservation and before Meta dispatch;
- provider errors are non-auto-retry and request governed human handoff;
- human `/api/wa/send` remains separate 2FA route.

## Recovery
Recovery first forces SAFE-OFF. It refuses destructive structural rollback if any `send_origin=AUTO` provider history exists, preserving audit/provider lineage.

## Tests
Dedicated WA-L4 workflow includes static/runtime contract plus isolated PostgreSQL apply, authority behavior, decision replay, fail-closed recovery, structural SAFE-OFF restoration and reproducible reapply.

Full existing Ascenda/WA/performance regression matrix remains required before merge.

**CANARY remains BLOCKED pending a separate explicit owner authorization after L4 AUTO_OFF production certification.**