### PR TITLE
WA-L6 — Meta Campaign Context & Attribution under SAFE-OFF

### DIFF
--- a/.github/workflows/wa-l6-meta-attribution.yml
+++ b/.github/workflows/wa-l6-meta-attribution.yml
@@ -1,0 +1,157 @@
+name: ASCENDA WA-L6 Meta Attribution
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa_l6*'
+      - 'supabase/rollbacks/*wa_l6*'
+      - 'ci/wa-l6/**'
+      - 'ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js'
+      - 'docs/control/WA_L6_*'
+      - '.github/workflows/wa-l6-meta-attribution.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa-l6-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  ingress-contract:
+    name: L6 provider evidence and fail-closed parser
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Static safety contract
+        shell: powershell
+        run: |
+          node --check app/wa-gateway.js
+          $sql=Get-Content 'supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql' -Raw
+          if ($sql -match '(?i)auto_reply_enabled\s*=\s*true') { throw 'L6 may not enable auto reply' }
+          if ($sql -match '(?i)ai_send_enabled\s*=\s*true') { throw 'L6 may not enable AI send' }
+          if ($sql -match '(?i)auto_routing_enabled\s*=\s*true') { throw 'L6 may not enable auto routing' }
+          if ($sql -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.(aos_pacientes|aos_leads|aos_agenda_citas|aos_ventas)') { throw 'L6 migration may not mutate patient/lead/Agenda/Sales ledgers' }
+          if ($sql -match '(?i)(from|join)\s+public\.aos_(pacientes|rev_patient_identity_alias_v2).*(numero|telefono|nombres|apellidos)') { throw 'L6 attribution may not use patient phone/name joins' }
+          if ($sql -notmatch 'venta_id_match' -or $sql -notmatch 'aos_booking_operations_v2') { throw 'Strong-key booking/sale stitch missing' }
+          if ($sql -notmatch 'MULTIPLE_TOUCHPOINTS_REVIEW' -or $sql -notmatch 'CONFLICT_FAIL_CLOSED') { throw 'Ambiguity fail-closed states missing' }
+      - name: Provider parser and historical ingress regressions
+        shell: powershell
+        run: |
+          node --test ci/wa-l6/attribution_ingress_contract.test.js
+          node --test ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+          node --test ci/wa7a2-identity-verification/identity_webhook_contract.test.js
+          node --test ci/wa7a0-identity-compatibility/identity_contract.test.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+          node --test app/wa-l5-booking.test.js
+          node app/wa4-conversation-runtime-v2.test.js
+
+  db-contract:
+    name: L6 strong-key journey and governance canary
+    needs: ingress-contract
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce zero-cost runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Wait for isolated full-local ports
+        run: |
+          set -euo pipefail
+          ports='60200 60201 60202'
+          for i in $(seq 1 90); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'WA_L6_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+      - name: Build certified WA/identity/booking substrate
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005500_wa_l5_conversational_booking_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005600_wa_l5_treatment_resolver_uuid_fix_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/prereq.sql
+      - name: L6 structural apply recovery reapply before history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l6_campaign_context_audit_v1') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_l6_campaign_context_audit_v1")" = '0'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l6_campaign_context_audit_v1') is null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa4_campaign_context_map_v1') is not null")" = 't'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
+      - name: L6 mapping and end-to-end synthetic strong-key canary
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/tests/001_meta_attribution_contract.sql 2>&1 | tee /tmp/wa-l6-canary.txt
+          grep -q 'WA_L6_META_ATTRIBUTION_CONTRACT_PASS' /tmp/wa-l6-canary.txt
+      - name: Post-canary safety and privilege assertions
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
+          test "$(psql "$DB" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = 'false:false:false:true'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_l5_booking_memory_v1")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_messages_v1 where send_origin='AUTO' and direction='OUTBOUND'")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select has_table_privilege('anon','public.aos_wa4_campaign_context_map_v1','INSERT') or has_table_privilege('authenticated','public.aos_wa4_campaign_context_map_v1','INSERT')")" = 'f'
+          test "$(psql "$DB" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_l6_campaign_context_audit_v1','SELECT') or has_table_privilege('authenticated','public.aos_wa_l6_campaign_context_audit_v1','SELECT')")" = 'f'
+      - name: Recovery must fail closed after governed history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          set +e
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql >/tmp/wa-l6-recovery.log 2>&1
+          rc=$?
+          set -e
+          test "$rc" -ne 0
+          grep -q 'WA_L6_RECOVERY_BLOCKED_HISTORY' /tmp/wa-l6-recovery.log
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l6_attribution_journey_v1') is not null")" = 't'
+      - name: Database lint
+        working-directory: ci/wa4c-full-local
+        run: |
+          set -euo pipefail
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/wa-l6-lint.txt
+          if grep -q '\[ERROR\]' /tmp/wa-l6-lint.txt; then exit 1; fi
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -97,15 +97,19 @@ function referralEvidence(referral,businessScope,providerMessageId,observedAt){
   const sourceUrl=safeHttpsUrl(r.source_url);
   const ctwaClid=userIdValue(r.ctwa_clid);
   const providerLeadId=userIdValue(r.lead_id);
+  const campaignId=userIdValue(r.campaign_id);
+  const adsetId=userIdValue(r.adset_id);
+  const explicitAdId=userIdValue(r.ad_id);
   const campaignSource=trimText(r.campaign_source,256).trim()||null;
   const headline=trimText(r.headline,512)||null;
   const body=trimText(r.body,1000)||null;
   const mediaType=trimText(r.media_type,64).trim().toLowerCase()||null;
-  if(![sourceId,sourceType,sourceUrl,ctwaClid,providerLeadId,campaignSource,headline,body,mediaType].some(Boolean))return null;
+  const adId=explicitAdId||(sourceType==='ad'?sourceId:null);
+  if(![sourceId,sourceType,sourceUrl,ctwaClid,providerLeadId,campaignId,adsetId,explicitAdId,campaignSource,headline,body,mediaType].some(Boolean))return null;
   return {
-    evidence_version:'WA_7A_3_V1',channel:'WHATSAPP',provider:'META_CLOUD_API',business_scope:businessScope,
+    evidence_version:'WA_L6_V1',channel:'WHATSAPP',provider:'META_CLOUD_API',business_scope:businessScope,
     provider_message_id:providerMessageId,ctwa_clid:ctwaClid,source_id:sourceId,source_type:sourceType,source_url:sourceUrl,
-    ad_id:sourceType==='ad'?sourceId:null,provider_lead_id:providerLeadId,campaign_source:campaignSource,
+    ad_id:adId,campaign_id:campaignId,adset_id:adsetId,provider_lead_id:providerLeadId,campaign_source:campaignSource,
     headline,body,media_type:mediaType,observed_at:observedAt
   };
 }
@@ -151,7 +155,7 @@ function extractWebhook(payload){
           phone_number_id:trimText(meta.phone_number_id,128)||null,
           contact_name:trimText(profile.name,256)||null,contact_username:usernameValue(profile.username),
           message_type:trimText(msg.type||'unknown',64),message_body:messageBody(msg)||null,media_id:mediaId(msg),status:'received',
-          campaign_source:trimText(referral.headline||referral.source_type||'',512)||null,ad_id:trimText(referral.source_id||'',256)||null,
+          campaign_source:trimText(referral.headline||referral.source_type||'',512)||null,ad_id:trimText(referral.ad_id||referral.source_id||'',256)||null,
           raw_referral:Object.keys(referral).length?{
             source_id:trimText(referral.source_id,256)||null,source_type:trimText(referral.source_type,64)||null,
             headline:trimText(referral.headline,512)||null,body:trimText(referral.body,1000)||null
@@ -161,7 +165,7 @@ function extractWebhook(payload){
         messages.push(row);
         events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral,sender_kind:row.from_number?'PHONE':(row.from_user_id?'BSUID':'UNKNOWN'),has_user_id:!!row.from_user_id}});
 
-        // WA-7A.3: acquisition provenance is a separate immutable event, never an identity fact.
+        // WA-L6/WA-7A.3: acquisition provenance is a separate immutable event, never an identity fact.
         const provenance=referralEvidence(referral,businessScope,row.provider_message_id,observedAt);
         if(provenance){
           events.push({event_key:'attribution:touchpoint:'+row.provider_message_id,event_type:'attribution.touchpoint',provider_message_id:row.provider_message_id,status:'observed',payload:provenance});

--- a/ci/wa-l6/attribution_ingress_contract.test.js
+++ b/ci/wa-l6/attribution_ingress_contract.test.js
@@ -1,0 +1,39 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const wa=require('../../app/wa-gateway');
+
+function payload(message){
+  return {object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{metadata:{display_phone_number:'+51 999 111 222',phone_number_id:'pn-l6'},contacts:[],messages:[message]}}]}]};
+}
+function tp(out){return out.events.find(e=>e.event_type==='attribution.touchpoint');}
+
+test('standard CTWA referral remains explicit and source_id ad fallback is preserved',()=>{
+  const out=wa.extractWebhook(payload({id:'wamid.l6.std',from:'51911111111',timestamp:'1786807000',type:'text',text:{body:'Hola'},referral:{source_id:'ad-standard-1',source_type:'ad',source_url:'https://www.facebook.com/ads/x',headline:'Creative',ctwa_clid:'clid-1'}}));
+  const t=tp(out);
+  assert.ok(t);assert.equal(t.payload.ad_id,'ad-standard-1');assert.equal(t.payload.ctwa_clid,'clid-1');
+  assert.equal(t.payload.campaign_id,null);assert.equal(t.payload.adset_id,null);assert.equal(t.payload.evidence_version,'WA_L6_V1');
+});
+
+test('provider extension campaign/adset/ad identifiers are preserved only when explicitly supplied',()=>{
+  const out=wa.extractWebhook(payload({id:'wamid.l6.ext',from:'51911111111',timestamp:'1786807001',type:'text',text:{body:'Hola'},referral:{source_id:'creative-source',source_type:'ad',ad_id:'ad-explicit-9',campaign_id:'campaign-explicit-7',adset_id:'adset-explicit-8',ctwa_clid:'clid-2'}}));
+  const t=tp(out);
+  assert.equal(t.payload.ad_id,'ad-explicit-9');assert.equal(t.payload.campaign_id,'campaign-explicit-7');assert.equal(t.payload.adset_id,'adset-explicit-8');
+});
+
+test('campaign ids are never inferred from headline source URL phone username or source id',()=>{
+  const out=wa.extractWebhook(payload({id:'wamid.l6.noinfer',from:'51911111111',timestamp:'1786807002',type:'text',text:{body:'Hola'},referral:{source_id:'post-44',source_type:'post',source_url:'https://example.com/campaign/secret-123',headline:'Campaign 999'}}));
+  const t=tp(out);
+  assert.ok(t);assert.equal(t.payload.campaign_id,null);assert.equal(t.payload.adset_id,null);assert.equal(t.payload.ad_id,null);
+});
+
+test('no provider referral produces no attribution touchpoint',()=>{
+  const out=wa.extractWebhook(payload({id:'wamid.l6.unattributed',from:'51911111111',from_user_id:'bsuid-x',timestamp:'1786807003',type:'text',text:{body:'Direct'}}));
+  assert.equal(tp(out),undefined);
+});
+
+test('invalid explicit campaign extension is stripped rather than normalized from another field',()=>{
+  const out=wa.extractWebhook(payload({id:'wamid.l6.invalid',from:'51911111111',timestamp:'1786807004',type:'text',text:{body:'Hola'},referral:{source_id:'ad-1',source_type:'ad',campaign_id:'bad\u0001campaign',adset_id:'good-adset'}}));
+  const t=tp(out);
+  assert.equal(t.payload.campaign_id,null);assert.equal(t.payload.adset_id,'good-adset');assert.equal(t.payload.ad_id,'ad-1');
+});

--- a/ci/wa-l6/prereq.sql
+++ b/ci/wa-l6/prereq.sql
@@ -1,0 +1,19 @@
+-- WA-L6 TEST ONLY — minimal sales boundary used by the explicit appointment->sale join.
+create table if not exists public.aos_ventas(
+  id bigserial primary key,
+  venta_id text,
+  fecha date,
+  monto numeric,
+  moneda text
+);
+alter table public.aos_ventas add column if not exists venta_id text;
+alter table public.aos_ventas add column if not exists fecha date;
+alter table public.aos_ventas add column if not exists monto numeric;
+alter table public.aos_ventas add column if not exists moneda text;
+
+grant select,insert,update,delete on public.aos_ventas to service_role;
+
+-- Deterministic L6 admin authority on the test admin identity.
+update public.aos_usuarios
+set paneles_acceso=array['admin-chats','admin-marketing','admin-whatsapp']::text[], two_factor=true, activo=true
+where id='11111111-1111-4111-8111-111111111111'::uuid;

--- a/ci/wa-l6/tests/001_meta_attribution_contract.sql
+++ b/ci/wa-l6/tests/001_meta_attribution_contract.sql
@@ -92,6 +92,10 @@ begin
   select treatment_entity_id into v_tid from public.aos_wa4_campaign_context_map_v1 where ad_id='ad-l6-1';
   select nombre into v_name from public.aos_catalogo_servicios where id=v_tid;
 
+  -- Fixture-only transaction-local setup, matching existing WA CI fixtures. This does
+  -- not alter or disable trg_001_aos_wa4_governed_booking_v1; production direct writes
+  -- remain blocked. The behavior under test is the downstream L6 strong-key stitch.
+  perform set_config('aos.wa4_governed_booking_write','1',true);
   insert into public.aos_agenda_citas(
     id,fecha_cita,tratamiento,tipo_cita,sede,numero,nombre,apellido,estado_cita,venta_id_match,
     ts_creado,ts_actualizado,hora_cita,etiqueta_campana,origen_cita,numero_limpio,origen

--- a/ci/wa-l6/tests/001_meta_attribution_contract.sql
+++ b/ci/wa-l6/tests/001_meta_attribution_contract.sql
@@ -1,0 +1,155 @@
+\set ON_ERROR_STOP on
+
+-- Fixed synthetic identities only.
+delete from public.aos_booking_operations_v2 where idempotency_key like 'wa-l6-%';
+delete from public.aos_ventas where venta_id like 'L6-SALE-%';
+delete from public.aos_agenda_citas where id like 'L6-APT-%';
+delete from public.aos_wa_events_v1 where provider_message_id like 'wamid.l6.db.%';
+delete from public.aos_wa_messages_v1 where provider_message_id like 'wamid.l6.db.%';
+delete from public.aos_wa_conversations_v1 where conversation_key like 'pn-l6:%';
+delete from public.aos_wa4_campaign_context_map_v1 where ad_id like 'ad-l6-%';
+
+-- Mapping authority: explicit ad + active service + evidence required, 2FA admin required.
+do $$
+declare v_tid uuid; r jsonb; n integer;
+begin
+  select id into v_tid from public.aos_catalogo_servicios
+  where upper(coalesce(estado,'ACTIVO'))='ACTIVO' and upper(coalesce(tipo,'SERVICIO'))='SERVICIO'
+  order by id limit 1;
+  if v_tid is null then raise exception 'WA_L6_NO_ACTIVE_TREATMENT_FIXTURE'; end if;
+
+  r:=public.aos_wa_l6_campaign_context_upsert_v1(
+    'bad-token',
+    jsonb_build_object('ad_id','ad-l6-1','campaign_id','campaign-l6-1','treatment_entity_id',v_tid,'booking_goal','BOOKING','evidence_ref','TEST:SIGNED_META_EVIDENCE')
+  );
+  if coalesce((r->>'ok')::boolean,false) or r->>'error'<>'WA_L6_UNAUTHORIZED' then raise exception 'WA_L6_UNAUTHORIZED_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l6_campaign_context_upsert_v1(
+    'admin-token-111111111111111111111111111111111111',
+    jsonb_build_object('ad_id','ad-l6-1','campaign_id','campaign-l6-1','treatment_entity_id',v_tid,'booking_goal','BOOKING','evidence_ref','TEST:SIGNED_META_EVIDENCE')
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L6_MAPPING_SAVE_FAIL:%',r; end if;
+  select count(*) into n from public.aos_wa4_campaign_context_map_v1 where ad_id='ad-l6-1' and campaign_id='campaign-l6-1' and treatment_entity_id=v_tid and active;
+  if n<>1 then raise exception 'WA_L6_MAPPING_NOT_PERSISTED:%',n; end if;
+  select count(*) into n from public.aos_wa_l6_campaign_context_audit_v1 where ad_id='ad-l6-1' and operation='CREATE';
+  if n<>1 then raise exception 'WA_L6_MAPPING_AUDIT_MISSING:%',n; end if;
+
+  r:=public.aos_wa_l6_campaign_context_upsert_v1(
+    'admin-token-111111111111111111111111111111111111',
+    jsonb_build_object('ad_id','ad-l6-bad','campaign_id','campaign-x','booking_goal','BOOKING','evidence_ref','TEST:X')
+  );
+  if r->>'error'<>'WA_L6_TREATMENT_ID_REQUIRED' then raise exception 'WA_L6_TREATMENT_REQUIRED_FAIL:%',r; end if;
+end
+$$;
+
+-- Audit must be append-only.
+do $$ begin
+  begin
+    update public.aos_wa_l6_campaign_context_audit_v1 set evidence_ref='MUTATED' where ad_id='ad-l6-1';
+    raise exception 'WA_L6_AUDIT_UPDATE_UNEXPECTEDLY_ALLOWED';
+  exception when sqlstate '55000' then null; end;
+end $$;
+
+-- Explicit CTWA touchpoint and exact conversation binding.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_name,phone_number_id,state,campaign_source,ad_id,lead_id,opened_at,updated_at
+) values (
+  '77777777-7777-4777-8777-777777777761'::uuid,'pn-l6:51977777771','51977777771','L6 TEST','pn-l6','AI_COPILOT','META_CTWA','ad-l6-1','lead-l6-1',now(),now()
+) on conflict(id) do update set conversation_key=excluded.conversation_key,state='AI_COPILOT',campaign_source='META_CTWA',ad_id='ad-l6-1',lead_id='lead-l6-1';
+
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at
+) values (
+  'wamid.l6.db.1','INBOUND','51977777771','519999111222','pn-l6','text','Hola','received',now(),now()
+);
+
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values(
+  'attribution:touchpoint:wamid.l6.db.1','attribution.touchpoint','wamid.l6.db.1','observed',
+  jsonb_build_object(
+    'evidence_version','WA_L6_V1','channel','WHATSAPP','provider','META_CLOUD_API','business_scope','pn-l6',
+    'provider_message_id','wamid.l6.db.1','ctwa_clid','clid-l6-1','source_id','ad-l6-1','source_type','ad',
+    'source_url','https://www.facebook.com/ads/l6','ad_id','ad-l6-1','campaign_id','campaign-l6-1','adset_id','adset-l6-1',
+    'provider_lead_id','lead-l6-1','campaign_source','META_CTWA','observed_at',now()::text
+  )
+);
+
+-- A second conversation with the same phone-like name but NO provider evidence must remain un-attributed.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_name,phone_number_id,state,opened_at,updated_at
+) values (
+  '77777777-7777-4777-8777-777777777762'::uuid,'pn-l6:51977777772','51977777772','L6 TEST','pn-l6','AI_COPILOT',now(),now()
+) on conflict(id) do nothing;
+
+-- Strong booking chain. No phone/name join participates in the view.
+do $$
+declare v_tid uuid; v_name text;
+begin
+  select treatment_entity_id into v_tid from public.aos_wa4_campaign_context_map_v1 where ad_id='ad-l6-1';
+  select nombre into v_name from public.aos_catalogo_servicios where id=v_tid;
+
+  insert into public.aos_agenda_citas(
+    id,fecha_cita,tratamiento,tipo_cita,sede,numero,nombre,apellido,estado_cita,venta_id_match,
+    ts_creado,ts_actualizado,hora_cita,etiqueta_campana,origen_cita,numero_limpio,origen
+  ) values (
+    'L6-APT-1',current_date,v_name,'CONSULTA NUEVA','SAN ISIDRO','51977777771','L6','TEST','ASISTIO','L6-SALE-1',
+    now(),now(),'10:00','META_CTWA','WHATSAPP','51977777771','WHATSAPP_META'
+  );
+
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,conversation_id,appointment_id,treatment_id,
+    professional_ref,site,appointment_date,appointment_time,identity_state,campaign_source,ad_id,lead_id,status,response,created_at
+  ) values (
+    '88888888-8888-4888-8888-888888888861'::uuid,'wa-l6-book-00000001','hash-l6-book','BOOK','WHATSAPP',
+    '11111111-1111-4111-8111-111111111111'::uuid,'77777777-7777-4777-8777-777777777761'::uuid,'L6-APT-1',v_tid,
+    'WA4C-DOC','SAN ISIDRO',current_date,'10:00'::time,'UNRESOLVED','META_CTWA','ad-l6-1','lead-l6-1','BOOKED','{}'::jsonb,now()-interval '1 minute'
+  );
+  insert into public.aos_booking_operations_v2(
+    id,idempotency_key,request_hash,operation_type,channel,actor_id,conversation_id,appointment_id,treatment_id,
+    professional_ref,site,appointment_date,appointment_time,identity_state,campaign_source,ad_id,lead_id,status,response,created_at
+  ) values (
+    '88888888-8888-4888-8888-888888888862'::uuid,'wa-l6-rebook-000001','hash-l6-rebook','REBOOK','WHATSAPP',
+    '11111111-1111-4111-8111-111111111111'::uuid,'77777777-7777-4777-8777-777777777761'::uuid,'L6-APT-1',v_tid,
+    'WA4C-DOC','SAN ISIDRO',current_date,'10:30'::time,'UNRESOLVED','META_CTWA','ad-l6-1','lead-l6-1','REBOOKED','{}'::jsonb,now()
+  );
+end
+$$;
+
+insert into public.aos_ventas(venta_id,fecha,monto,moneda)
+values('L6-SALE-1',current_date,899.00,'PEN');
+
+-- Exact chain assertions.
+do $$ declare r record; n integer; begin
+  select * into r from public.aos_wa_l6_attribution_journey_v1
+  where conversation_id='77777777-7777-4777-8777-777777777761'::uuid and appointment_id='L6-APT-1';
+  if r.touchpoint_ad_id<>'ad-l6-1' or r.effective_campaign_id<>'campaign-l6-1' then raise exception 'WA_L6_PROVIDER_CHAIN_FAIL'; end if;
+  if r.campaign_resolution_status<>'PROVIDER_EVIDENCE' then raise exception 'WA_L6_CAMPAIGN_SOURCE_FAIL:%',r.campaign_resolution_status; end if;
+  if r.book_count<>1 or r.rebook_count<>1 then raise exception 'WA_L6_BOOK_REBOOK_CHAIN_FAIL:%/%',r.book_count,r.rebook_count; end if;
+  if r.attended is not true or r.sale_link_venta_id<>'L6-SALE-1' or r.revenue_amount<>899.00 then raise exception 'WA_L6_OUTCOME_CHAIN_FAIL'; end if;
+  if r.attribution_chain_status<>'EXPLICIT_CHAIN_COMPLETE' then raise exception 'WA_L6_CHAIN_STATUS_FAIL:%',r.attribution_chain_status; end if;
+  if r.booking_ad_matches_touchpoint is not true then raise exception 'WA_L6_AD_PARITY_FAIL'; end if;
+
+  select count(*) into n from public.aos_wa_l6_conversation_acquisition_v1
+  where conversation_id='77777777-7777-4777-8777-777777777762'::uuid and acquisition_class='NO_PROVIDER_ATTRIBUTION' and touchpoint_id is null;
+  if n<>1 then raise exception 'WA_L6_UNATTRIBUTED_SEPARATION_FAIL:%',n; end if;
+end $$;
+
+-- Multiple provider touchpoints remain explicit and fail closed for single-touch revenue attribution.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at
+) values (
+  'wamid.l6.db.2','INBOUND','51977777771','519999111222','pn-l6','text','Segundo click','received',now(),now()
+);
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values(
+  'attribution:touchpoint:wamid.l6.db.2','attribution.touchpoint','wamid.l6.db.2','observed',
+  jsonb_build_object('evidence_version','WA_L6_V1','channel','WHATSAPP','provider','META_CLOUD_API','business_scope','pn-l6','provider_message_id','wamid.l6.db.2','ctwa_clid','clid-l6-2','source_id','ad-l6-2','source_type','ad','ad_id','ad-l6-2','observed_at',now()::text)
+);
+
+do $$ declare n integer; begin
+  select count(*) into n from public.aos_wa_l6_attribution_journey_v1
+  where conversation_id='77777777-7777-4777-8777-777777777761'::uuid and appointment_id='L6-APT-1' and attribution_chain_status='MULTIPLE_TOUCHPOINTS_REVIEW';
+  if n<>2 then raise exception 'WA_L6_MULTITOUCH_FAIL:%',n; end if;
+end $$;
+
+select 'WA_L6_META_ATTRIBUTION_CONTRACT_PASS' as result;

--- a/ci/wa-l6/tests/001_meta_attribution_contract.sql
+++ b/ci/wa-l6/tests/001_meta_attribution_contract.sql
@@ -57,10 +57,14 @@ insert into public.aos_wa_conversations_v1(
   '77777777-7777-4777-8777-777777777761'::uuid,'pn-l6:51977777771','51977777771','L6 TEST','pn-l6','AI_COPILOT','META_CTWA','ad-l6-1','lead-l6-1',now(),now()
 ) on conflict(id) do update set conversation_key=excluded.conversation_key,state='AI_COPILOT',campaign_source='META_CTWA',ad_id='ad-l6-1',lead_id='lead-l6-1';
 
+-- The fixture binds through the certified WA7A0/WA2 authority by presenting the
+-- already-existing canonical conversation_id; the trigger validates existence and
+-- registers the presented phone alias instead of guessing a parallel conversation.
 insert into public.aos_wa_messages_v1(
-  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at,conversation_id
 ) values (
-  'wamid.l6.db.1','INBOUND','51977777771','519999111222','pn-l6','text','Hola','received',now(),now()
+  'wamid.l6.db.1','INBOUND','51977777771','519999111222','pn-l6','text','Hola','received',now(),now(),
+  '77777777-7777-4777-8777-777777777761'::uuid
 );
 
 insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
@@ -136,9 +140,10 @@ end $$;
 
 -- Multiple provider touchpoints remain explicit and fail closed for single-touch revenue attribution.
 insert into public.aos_wa_messages_v1(
-  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,provider_timestamp,received_at,conversation_id
 ) values (
-  'wamid.l6.db.2','INBOUND','51977777771','519999111222','pn-l6','text','Segundo click','received',now(),now()
+  'wamid.l6.db.2','INBOUND','51977777771','519999111222','pn-l6','text','Segundo click','received',now(),now(),
+  '77777777-7777-4777-8777-777777777761'::uuid
 );
 insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
 values(

--- a/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+++ b/ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
@@ -17,7 +17,8 @@ test('preserves explicit Meta referral provenance as a separate touchpoint event
   assert.equal(t[0].payload.source_id,'ad-77');assert.equal(t[0].payload.source_type,'ad');assert.equal(t[0].payload.ad_id,'ad-77');
   assert.equal(t[0].payload.ctwa_clid,'ctwa-click-001');assert.equal(t[0].payload.provider_lead_id,'provider-lead-8');
   assert.equal(t[0].payload.campaign_source,'META_CTWA');assert.equal(t[0].payload.channel,'WHATSAPP');
-  assert.equal(t[0].payload.provider,'META_CLOUD_API');assert.equal(t[0].payload.evidence_version,'WA_7A_3_V1');
+  assert.equal(t[0].payload.provider,'META_CLOUD_API');assert.equal(t[0].payload.evidence_version,'WA_L6_V1');
+  assert.equal(t[0].payload.campaign_id,null);assert.equal(t[0].payload.adset_id,null);
   assert.equal('phone' in t[0].payload,false);assert.equal('bsuid' in t[0].payload,false);assert.equal('username' in t[0].payload,false);
 });
 

--- a/docs/control/WA_L6_META_ATTRIBUTION_CONTRACT.md
+++ b/docs/control/WA_L6_META_ATTRIBUTION_CONTRACT.md
@@ -1,0 +1,129 @@
+# ASCENDA OS — WA-L6 Meta Campaign Context & Attribution Contract
+
+Status: IMPLEMENTATION / SAFE-OFF  
+Authority: GitHub issue #447  
+Entry main: `e790153523c4cc0d842b57cd57544dadc1a0c85a`
+
+## Objective
+
+Build an evidence-driven chain:
+
+`Meta/CTWA referral evidence → WhatsApp conversation → governed campaign context → AGV2 BOOK/REBOOK → same appointment → attendance → explicit sale link → revenue`.
+
+WA-L6 is attribution infrastructure. It does not activate autonomous WhatsApp and it does not manufacture campaign, customer, lead, booking or sales data.
+
+## Provider evidence boundary
+
+The signed WhatsApp webhook remains the first-mile authority. Standard Click-to-WhatsApp referral evidence is preserved exactly as supplied by Meta. Optional provider-extension `ad_id`, `campaign_id` and `adset_id` are accepted only when they are explicit fields in the provider referral object.
+
+Rules:
+
+- `source_id + source_type=ad` may establish `ad_id`, matching the existing WA-7A.3 contract;
+- an explicit provider `ad_id` overrides that fallback because it is stronger direct evidence;
+- `campaign_id` and `adset_id` are never parsed from a headline, URL, campaign name, phone, username, BSUID or free text;
+- no referral object means no attribution touchpoint;
+- acquisition evidence remains separate from patient identity.
+
+## Acquisition classes
+
+`aos_wa_attribution_touchpoints_v1` now appends:
+
+- `provider_campaign_id`;
+- `provider_adset_id`;
+- `acquisition_class`.
+
+Classification is deterministic:
+
+- `META_CTWA_PAID`: explicit `ctwa_clid` or provider `source_type=ad`;
+- `META_POST_REFERRAL`: provider `source_type=post`;
+- `PROVIDER_REFERRAL_OTHER`: another explicit referral type;
+- conversations without any provider touchpoint appear in the L6 conversation view as `NO_PROVIDER_ATTRIBUTION`.
+
+`NO_PROVIDER_ATTRIBUTION` is intentionally not renamed to “organic”. Absence of a provider referral cannot prove whether traffic came from QR, direct contact, web, saved number or another untracked source.
+
+## Governed campaign context
+
+The pre-existing `aos_wa4_campaign_context_map_v1` remains the only treatment/promotion/booking-goal map and remains fail-closed when empty.
+
+L6 adds `aos_wa_l6_campaign_context_upsert_v1(token,payload)`:
+
+- 2FA + `admin-marketing` or `admin-whatsapp` required;
+- explicit `ad_id` required;
+- exact active SERVICE `treatment_entity_id` UUID required;
+- non-empty `evidence_ref` required;
+- optional explicit `campaign_id`, `promotion_id`, safe-token `booking_goal`, `media_strategy`, `active`;
+- no treatment-by-name inference;
+- browser/runtime direct table writes remain denied;
+- every CREATE/UPDATE is written to append-only `aos_wa_l6_campaign_context_audit_v1` with before/after snapshots.
+
+## Campaign resolution
+
+`aos_wa_l6_conversation_acquisition_v1` keeps provider evidence and governed mapping distinguishable.
+
+- provider campaign ID + same governed campaign ID → provider evidence wins as the direct source;
+- provider campaign ID only → `PROVIDER_EVIDENCE`;
+- governed mapping only → `GOVERNED_AD_MAPPING`;
+- neither → `UNRESOLVED`;
+- provider and governed IDs disagree → `CONFLICT_FAIL_CLOSED`, effective campaign ID becomes NULL.
+
+No campaign name heuristics are allowed.
+
+## Booking, attendance and revenue stitch
+
+`aos_wa_l6_attribution_journey_v1` is service-role-only and read-only. Its join keys are explicitly limited to:
+
+1. touchpoint provider message → `aos_wa_messages_v1.conversation_id`;
+2. conversation → `aos_booking_operations_v2.conversation_id`;
+3. booking operation → exact `appointment_id`;
+4. appointment → `aos_agenda_citas.id`;
+5. appointment → exact `venta_id_match`;
+6. sale → exact `aos_ventas.venta_id`.
+
+Forbidden joins/fallbacks:
+
+- phone;
+- patient/customer name;
+- username;
+- BSUID;
+- canonical patient ID by itself;
+- closest timestamp;
+- treatment text similarity.
+
+Attendance is derived only from the appointment status. `ASISTIO` and `EFECTIVA` are attended; `NO ASISTIO` and `CANCELADA` are non-attended; other states remain unresolved/pending rather than guessed.
+
+## Multi-touch behavior
+
+Multiple provider touchpoints for one conversation are legitimate evidence. L6 does not silently select first-touch or last-touch. The journey exposes every touchpoint and returns `MULTIPLE_TOUCHPOINTS_REVIEW` until an explicit future attribution policy is authorized.
+
+## Attribution chain statuses
+
+- `NO_PROVIDER_ATTRIBUTION`
+- `TOUCHPOINT_ONLY`
+- `MULTIPLE_TOUCHPOINTS_REVIEW`
+- `CAMPAIGN_ID_CONFLICT`
+- `BOOKING_AD_MISMATCH`
+- `APPOINTMENT_MISSING`
+- `APPOINTMENT_NO_EXPLICIT_SALE_LINK`
+- `SALE_LINK_UNRESOLVED`
+- `EXPLICIT_CHAIN_COMPLETE`
+
+Only `EXPLICIT_CHAIN_COMPLETE` demonstrates a single unambiguous provider touchpoint connected through strong IDs to an explicitly linked sale.
+
+## Production safety
+
+Certification MUST NOT:
+
+- create a synthetic production CTWA touchpoint;
+- populate campaign mappings with invented Meta IDs;
+- create leads or patients;
+- create/rebook a real appointment;
+- edit attendance;
+- create/edit a sale;
+- populate `venta_id_match` merely to make the chain green;
+- enable AUTO_OFF→CANARY or autonomous provider sends.
+
+A fresh real Meta CTWA click remains `LIVE_PENDING` until real provider evidence naturally arrives. Code/DB production certification can close while that external business canary remains pending, provided the absence is stated explicitly.
+
+## Recovery
+
+Pre-history recovery may remove only L6-owned views/function/audit table and restore the WA-7A.3 touchpoint view. The pre-existing campaign map is never dropped. Once L6 campaign audit history exists, recovery fails closed with `WA_L6_RECOVERY_BLOCKED_HISTORY`.

--- a/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+++ b/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
@@ -121,10 +121,10 @@ begin
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_PAYLOAD_INVALID');
   end if;
 
-  v_ad:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'ad_id'),'');
-  v_campaign:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'campaign_id'),'');
-  v_goal:=pg_catalog.nullif(pg_catalog.upper(pg_catalog.btrim(p_payload->>'booking_goal')),'');
-  v_evidence:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'evidence_ref'),'');
+  v_ad:=nullif(pg_catalog.btrim(p_payload->>'ad_id'),'');
+  v_campaign:=nullif(pg_catalog.btrim(p_payload->>'campaign_id'),'');
+  v_goal:=nullif(pg_catalog.upper(pg_catalog.btrim(p_payload->>'booking_goal')),'');
+  v_evidence:=nullif(pg_catalog.btrim(p_payload->>'evidence_ref'),'');
   if v_ad is null or pg_catalog.length(v_ad)>256 then
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_AD_ID_REQUIRED');
   end if;
@@ -146,13 +146,13 @@ begin
   if not exists(
     select 1 from public.aos_catalogo_servicios s
     where s.id=v_treatment
-      and pg_catalog.upper(pg_catalog.coalesce(s.estado,'ACTIVO'))='ACTIVO'
-      and pg_catalog.upper(pg_catalog.coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+      and pg_catalog.upper(coalesce(s.estado,'ACTIVO'))='ACTIVO'
+      and pg_catalog.upper(coalesce(s.tipo,'SERVICIO'))='SERVICIO'
   ) then
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_TREATMENT_NOT_ACTIVE');
   end if;
 
-  if pg_catalog.nullif(pg_catalog.btrim(p_payload->>'promotion_id'),'') is not null then
+  if nullif(pg_catalog.btrim(p_payload->>'promotion_id'),'') is not null then
     begin
       v_promotion:=(p_payload->>'promotion_id')::uuid;
     exception when others then
@@ -232,7 +232,7 @@ select
   t.touchpoint_key,
   t.provider_message_id,
   t.touchpoint_at,
-  pg_catalog.coalesce(t.acquisition_class,'NO_PROVIDER_ATTRIBUTION')::text as acquisition_class,
+  coalesce(t.acquisition_class,'NO_PROVIDER_ATTRIBUTION')::text as acquisition_class,
   t.ctwa_clid,
   t.ad_id,
   t.source_id,
@@ -245,7 +245,7 @@ select
   case
     when t.provider_campaign_id is not null and m.campaign_id is not null and t.provider_campaign_id<>m.campaign_id
       then null
-    else pg_catalog.coalesce(t.provider_campaign_id,m.campaign_id)
+    else coalesce(t.provider_campaign_id,m.campaign_id)
   end::text as effective_campaign_id,
   case
     when t.provider_campaign_id is not null and m.campaign_id is not null and t.provider_campaign_id<>m.campaign_id
@@ -327,11 +327,11 @@ select
   end as booking_ad_matches_touchpoint,
   a.estado_cita as appointment_status,
   case
-    when pg_catalog.upper(pg_catalog.coalesce(a.estado_cita,'')) in ('ASISTIO','EFECTIVA') then true
-    when pg_catalog.upper(pg_catalog.coalesce(a.estado_cita,'')) in ('NO ASISTIO','CANCELADA') then false
+    when pg_catalog.upper(coalesce(a.estado_cita,'')) in ('ASISTIO','EFECTIVA') then true
+    when pg_catalog.upper(coalesce(a.estado_cita,'')) in ('NO ASISTIO','CANCELADA') then false
     else null
   end as attended,
-  pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'') as sale_link_venta_id,
+  nullif(pg_catalog.btrim(a.venta_id_match),'') as sale_link_venta_id,
   s.sale_row_count,
   s.sale_date,
   s.revenue_amount,
@@ -343,8 +343,8 @@ select
     when acq.campaign_resolution_status='CONFLICT_FAIL_CLOSED' then 'CAMPAIGN_ID_CONFLICT'
     when b.booking_ad_id is not null and acq.ad_id is not null and b.booking_ad_id<>acq.ad_id then 'BOOKING_AD_MISMATCH'
     when a.id is null then 'APPOINTMENT_MISSING'
-    when pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'') is null then 'APPOINTMENT_NO_EXPLICIT_SALE_LINK'
-    when pg_catalog.coalesce(s.sale_row_count,0)=0 then 'SALE_LINK_UNRESOLVED'
+    when nullif(pg_catalog.btrim(a.venta_id_match),'') is null then 'APPOINTMENT_NO_EXPLICIT_SALE_LINK'
+    when coalesce(s.sale_row_count,0)=0 then 'SALE_LINK_UNRESOLVED'
     else 'EXPLICIT_CHAIN_COMPLETE'
   end::text as attribution_chain_status
 from acquisition acq
@@ -359,12 +359,12 @@ left join lateral (
     pg_catalog.sum(v.monto) as revenue_amount,
     case
       when pg_catalog.count(*)=0 then null
-      when pg_catalog.count(distinct pg_catalog.coalesce(pg_catalog.nullif(pg_catalog.btrim(v.moneda),''),'PEN'))=1
-        then pg_catalog.max(pg_catalog.coalesce(pg_catalog.nullif(pg_catalog.btrim(v.moneda),''),'PEN'))
+      when pg_catalog.count(distinct coalesce(nullif(pg_catalog.btrim(v.moneda),''),'PEN'))=1
+        then pg_catalog.max(coalesce(nullif(pg_catalog.btrim(v.moneda),''),'PEN'))
       else 'MIXED'
     end::text as revenue_currency
   from public.aos_ventas v
-  where v.venta_id=pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'')
+  where v.venta_id=nullif(pg_catalog.btrim(a.venta_id_match),'')
 ) s on true;
 
 comment on view public.aos_wa_l6_attribution_journey_v1 is

--- a/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+++ b/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
@@ -1,0 +1,376 @@
+-- WA-L6 — Meta Campaign Context & Attribution V1
+-- Evidence-driven only: no phone/name attribution, no lead/patient/Agenda/Sales mutation.
+
+begin;
+
+-- Extend the existing immutable WA-7A.3 adapter without changing its original column contract.
+create or replace view public.aos_wa_attribution_touchpoints_v1
+with (security_invoker=true, security_barrier=true)
+as
+select
+  e.id as touchpoint_id,
+  e.event_key as touchpoint_key,
+  e.provider_message_id,
+  m.conversation_id,
+  case when i.resolution_status='MATCH' then i.canonical_patient_id else null end::text as canonical_patient_id,
+  coalesce(i.resolution_status,'UNRESOLVED')::text as identity_resolution_status,
+  i.confidence_band::text as identity_confidence_band,
+  nullif(e.payload->>'ctwa_clid','')::text as ctwa_clid,
+  nullif(e.payload->>'source_id','')::text as source_id,
+  nullif(e.payload->>'source_type','')::text as source_type,
+  nullif(e.payload->>'source_url','')::text as source_url,
+  nullif(e.payload->>'ad_id','')::text as ad_id,
+  nullif(e.payload->>'provider_lead_id','')::text as provider_lead_id,
+  nullif(e.payload->>'campaign_source','')::text as campaign_source,
+  nullif(e.payload->>'headline','')::text as headline,
+  nullif(e.payload->>'body','')::text as body,
+  nullif(e.payload->>'media_type','')::text as media_type,
+  coalesce(m.provider_timestamp,e.created_at) as touchpoint_at,
+  e.created_at as persisted_at,
+  coalesce(nullif(e.payload->>'evidence_version',''),'WA_7A_3_V1')::text as evidence_version,
+  nullif(e.payload->>'campaign_id','')::text as provider_campaign_id,
+  nullif(e.payload->>'adset_id','')::text as provider_adset_id,
+  case
+    when nullif(e.payload->>'ctwa_clid','') is not null
+      or lower(coalesce(e.payload->>'source_type',''))='ad' then 'META_CTWA_PAID'
+    when lower(coalesce(e.payload->>'source_type',''))='post' then 'META_POST_REFERRAL'
+    else 'PROVIDER_REFERRAL_OTHER'
+  end::text as acquisition_class
+from public.aos_wa_events_v1 e
+join public.aos_wa_messages_v1 m
+  on m.provider_message_id=e.provider_message_id
+left join public.aos_wa_identity_resolution_v1 i
+  on i.conversation_id=m.conversation_id
+where e.event_type='attribution.touchpoint';
+
+comment on view public.aos_wa_attribution_touchpoints_v1 is
+'WA-L6 extends WA-7A.3 immutable provider acquisition evidence with optional explicit provider campaign/adset ids and paid/referral classification. No phone/name attribution and no identity mutation.';
+revoke all on public.aos_wa_attribution_touchpoints_v1 from public,anon,authenticated;
+grant select on public.aos_wa_attribution_touchpoints_v1 to service_role;
+
+-- Governance audit for the pre-existing fail-closed campaign map.
+create table if not exists public.aos_wa_l6_campaign_context_audit_v1 (
+  id uuid primary key default gen_random_uuid(),
+  ad_id text not null,
+  operation text not null check (operation in ('CREATE','UPDATE')),
+  actor_id uuid not null,
+  evidence_ref text not null,
+  before_snapshot jsonb,
+  after_snapshot jsonb not null,
+  created_at timestamptz not null default now(),
+  constraint aos_wa_l6_campaign_context_audit_evidence_ck
+    check (nullif(btrim(evidence_ref),'') is not null)
+);
+
+create index if not exists aos_wa_l6_campaign_context_audit_ad_idx
+  on public.aos_wa_l6_campaign_context_audit_v1(ad_id,created_at desc);
+
+alter table public.aos_wa_l6_campaign_context_audit_v1 enable row level security;
+revoke all on public.aos_wa_l6_campaign_context_audit_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l6_campaign_context_audit_v1 to service_role;
+
+create or replace function public.aos_wa_l6_campaign_context_audit_guard_v1()
+returns trigger
+language plpgsql
+set search_path=''
+as $$
+begin
+  raise exception 'WA_L6_CAMPAIGN_AUDIT_APPEND_ONLY' using errcode='55000';
+end
+$$;
+
+revoke all on function public.aos_wa_l6_campaign_context_audit_guard_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa_l6_campaign_context_audit_guard_v1() to service_role;
+
+drop trigger if exists trg_aos_wa_l6_campaign_context_audit_guard_v1 on public.aos_wa_l6_campaign_context_audit_v1;
+create trigger trg_aos_wa_l6_campaign_context_audit_guard_v1
+before update or delete on public.aos_wa_l6_campaign_context_audit_v1
+for each row execute function public.aos_wa_l6_campaign_context_audit_guard_v1();
+
+-- The existing map remains read-only to runtime/browser. All writes pass this explicit 2FA authority.
+create or replace function public.aos_wa_l6_campaign_context_upsert_v1(
+  p_token text,
+  p_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_actor uuid;
+  v_ad text;
+  v_campaign text;
+  v_treatment uuid;
+  v_promotion uuid;
+  v_goal text;
+  v_evidence text;
+  v_active boolean:=true;
+  v_media jsonb:='{}'::jsonb;
+  v_before public.aos_wa4_campaign_context_map_v1%rowtype;
+  v_after public.aos_wa4_campaign_context_map_v1%rowtype;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'admin-marketing',true);
+  if v_actor is null then
+    v_actor:=public.aos_app_actor_v3(p_token,'admin-whatsapp',true);
+  end if;
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_UNAUTHORIZED');
+  end if;
+  if p_payload is null or pg_catalog.jsonb_typeof(p_payload)<>'object' then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_PAYLOAD_INVALID');
+  end if;
+
+  v_ad:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'ad_id'),'');
+  v_campaign:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'campaign_id'),'');
+  v_goal:=pg_catalog.nullif(pg_catalog.upper(pg_catalog.btrim(p_payload->>'booking_goal')),'');
+  v_evidence:=pg_catalog.nullif(pg_catalog.btrim(p_payload->>'evidence_ref'),'');
+  if v_ad is null or pg_catalog.length(v_ad)>256 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_AD_ID_REQUIRED');
+  end if;
+  if v_campaign is not null and pg_catalog.length(v_campaign)>256 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_CAMPAIGN_ID_INVALID');
+  end if;
+  if v_evidence is null or pg_catalog.length(v_evidence)>1000 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_EVIDENCE_REQUIRED');
+  end if;
+  if v_goal is not null and v_goal !~ '^[A-Z0-9_]{1,40}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_BOOKING_GOAL_INVALID');
+  end if;
+
+  begin
+    v_treatment:=(p_payload->>'treatment_entity_id')::uuid;
+  exception when others then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_TREATMENT_ID_REQUIRED');
+  end;
+  if not exists(
+    select 1 from public.aos_catalogo_servicios s
+    where s.id=v_treatment
+      and pg_catalog.upper(pg_catalog.coalesce(s.estado,'ACTIVO'))='ACTIVO'
+      and pg_catalog.upper(pg_catalog.coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+  ) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_TREATMENT_NOT_ACTIVE');
+  end if;
+
+  if pg_catalog.nullif(pg_catalog.btrim(p_payload->>'promotion_id'),'') is not null then
+    begin
+      v_promotion:=(p_payload->>'promotion_id')::uuid;
+    exception when others then
+      return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_PROMOTION_ID_INVALID');
+    end;
+    if not exists(select 1 from public.aos_promociones p where p.id=v_promotion) then
+      return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_PROMOTION_NOT_FOUND');
+    end if;
+  end if;
+
+  if p_payload ? 'active' then
+    begin
+      v_active:=(p_payload->>'active')::boolean;
+    exception when others then
+      return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_ACTIVE_INVALID');
+    end;
+  end if;
+  if p_payload ? 'media_strategy' then
+    if pg_catalog.jsonb_typeof(p_payload->'media_strategy')<>'object' then
+      return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_MEDIA_STRATEGY_INVALID');
+    end if;
+    v_media:=p_payload->'media_strategy';
+  end if;
+
+  select * into v_before
+  from public.aos_wa4_campaign_context_map_v1 m
+  where m.ad_id=v_ad
+  for update;
+
+  insert into public.aos_wa4_campaign_context_map_v1(
+    ad_id,campaign_id,treatment_entity_id,treatment_code,promotion_id,booking_goal,
+    media_strategy,active,evidence_ref,created_at,updated_at
+  ) values (
+    v_ad,v_campaign,v_treatment,null,v_promotion,v_goal,
+    v_media,v_active,v_evidence,pg_catalog.now(),pg_catalog.now()
+  )
+  on conflict(ad_id) do update set
+    campaign_id=excluded.campaign_id,
+    treatment_entity_id=excluded.treatment_entity_id,
+    treatment_code=null,
+    promotion_id=excluded.promotion_id,
+    booking_goal=excluded.booking_goal,
+    media_strategy=excluded.media_strategy,
+    active=excluded.active,
+    evidence_ref=excluded.evidence_ref,
+    updated_at=pg_catalog.now()
+  returning * into v_after;
+
+  insert into public.aos_wa_l6_campaign_context_audit_v1(
+    ad_id,operation,actor_id,evidence_ref,before_snapshot,after_snapshot
+  ) values (
+    v_ad,
+    case when v_before.ad_id is null then 'CREATE' else 'UPDATE' end,
+    v_actor,v_evidence,
+    case when v_before.ad_id is null then null else pg_catalog.to_jsonb(v_before) end,
+    pg_catalog.to_jsonb(v_after)
+  );
+
+  return pg_catalog.jsonb_build_object(
+    'ok',true,'status','SAVED','ad_id',v_after.ad_id,'campaign_id',v_after.campaign_id,
+    'treatment_entity_id',v_after.treatment_entity_id,'promotion_id',v_after.promotion_id,
+    'booking_goal',v_after.booking_goal,'active',v_after.active,'evidence_ref',v_after.evidence_ref
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l6_campaign_context_upsert_v1(text,jsonb) from public;
+grant execute on function public.aos_wa_l6_campaign_context_upsert_v1(text,jsonb) to anon,authenticated,service_role;
+
+-- One row per conversation/touchpoint. Conversations without provider provenance remain explicitly un-attributed.
+create or replace view public.aos_wa_l6_conversation_acquisition_v1
+with (security_invoker=true, security_barrier=true)
+as
+select
+  c.id as conversation_id,
+  t.touchpoint_id,
+  t.touchpoint_key,
+  t.provider_message_id,
+  t.touchpoint_at,
+  pg_catalog.coalesce(t.acquisition_class,'NO_PROVIDER_ATTRIBUTION')::text as acquisition_class,
+  t.ctwa_clid,
+  t.ad_id,
+  t.source_id,
+  t.source_type,
+  t.source_url,
+  t.provider_lead_id,
+  t.provider_campaign_id,
+  t.provider_adset_id,
+  m.campaign_id as governed_campaign_id,
+  case
+    when t.provider_campaign_id is not null and m.campaign_id is not null and t.provider_campaign_id<>m.campaign_id
+      then null
+    else pg_catalog.coalesce(t.provider_campaign_id,m.campaign_id)
+  end::text as effective_campaign_id,
+  case
+    when t.provider_campaign_id is not null and m.campaign_id is not null and t.provider_campaign_id<>m.campaign_id
+      then 'CONFLICT_FAIL_CLOSED'
+    when t.provider_campaign_id is not null then 'PROVIDER_EVIDENCE'
+    when m.campaign_id is not null then 'GOVERNED_AD_MAPPING'
+    else 'UNRESOLVED'
+  end::text as campaign_resolution_status,
+  m.treatment_entity_id as mapped_treatment_id,
+  m.promotion_id as mapped_promotion_id,
+  m.booking_goal,
+  m.evidence_ref as mapping_evidence_ref
+from public.aos_wa_conversations_v1 c
+left join public.aos_wa_attribution_touchpoints_v1 t
+  on t.conversation_id=c.id
+left join public.aos_wa4_campaign_context_map_v1 m
+  on m.ad_id=t.ad_id and m.active is true;
+
+revoke all on public.aos_wa_l6_conversation_acquisition_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l6_conversation_acquisition_v1 to service_role;
+
+-- Strong-key-only attribution journey. Never joins on phone, name, username, BSUID or patient identity.
+create or replace view public.aos_wa_l6_attribution_journey_v1
+with (security_invoker=true, security_barrier=true)
+as
+with booking_chain as (
+  select
+    o.conversation_id,
+    o.appointment_id,
+    pg_catalog.min(o.created_at) filter (where o.operation_type='BOOK') as booked_at,
+    pg_catalog.max(o.created_at) as last_booking_activity_at,
+    pg_catalog.count(*) filter (where o.operation_type='BOOK')::integer as book_count,
+    pg_catalog.count(*) filter (where o.operation_type='REBOOK')::integer as rebook_count,
+    (pg_catalog.array_agg(o.treatment_id order by o.created_at))[1] as booking_treatment_id,
+    (pg_catalog.array_agg(o.ad_id order by o.created_at) filter (where o.ad_id is not null))[1] as booking_ad_id,
+    (pg_catalog.array_agg(o.campaign_source order by o.created_at) filter (where o.campaign_source is not null))[1] as booking_campaign_source,
+    (pg_catalog.array_agg(o.lead_id order by o.created_at) filter (where o.lead_id is not null))[1] as booking_lead_id
+  from public.aos_booking_operations_v2 o
+  where o.channel='WHATSAPP' and o.conversation_id is not null
+  group by o.conversation_id,o.appointment_id
+), acquisition as (
+  select
+    a.*,
+    pg_catalog.count(a.touchpoint_id) over(partition by a.conversation_id)::integer as conversation_touchpoint_count
+  from public.aos_wa_l6_conversation_acquisition_v1 a
+)
+select
+  acq.conversation_id,
+  acq.touchpoint_id,
+  acq.touchpoint_key,
+  acq.provider_message_id,
+  acq.touchpoint_at,
+  acq.acquisition_class,
+  acq.ctwa_clid,
+  acq.ad_id as touchpoint_ad_id,
+  acq.provider_campaign_id,
+  acq.provider_adset_id,
+  acq.governed_campaign_id,
+  acq.effective_campaign_id,
+  acq.campaign_resolution_status,
+  acq.mapped_treatment_id,
+  acq.mapped_promotion_id,
+  acq.booking_goal,
+  acq.mapping_evidence_ref,
+  acq.conversation_touchpoint_count,
+  b.appointment_id,
+  b.booked_at,
+  b.last_booking_activity_at,
+  b.book_count,
+  b.rebook_count,
+  b.booking_treatment_id,
+  b.booking_ad_id,
+  b.booking_campaign_source,
+  b.booking_lead_id,
+  case
+    when acq.touchpoint_id is null then null
+    when b.booking_ad_id is null then null
+    else b.booking_ad_id=acq.ad_id
+  end as booking_ad_matches_touchpoint,
+  a.estado_cita as appointment_status,
+  case
+    when pg_catalog.upper(pg_catalog.coalesce(a.estado_cita,'')) in ('ASISTIO','EFECTIVA') then true
+    when pg_catalog.upper(pg_catalog.coalesce(a.estado_cita,'')) in ('NO ASISTIO','CANCELADA') then false
+    else null
+  end as attended,
+  pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'') as sale_link_venta_id,
+  s.sale_row_count,
+  s.sale_date,
+  s.revenue_amount,
+  s.revenue_currency,
+  case
+    when acq.touchpoint_id is null then 'NO_PROVIDER_ATTRIBUTION'
+    when b.appointment_id is null then 'TOUCHPOINT_ONLY'
+    when acq.conversation_touchpoint_count>1 then 'MULTIPLE_TOUCHPOINTS_REVIEW'
+    when acq.campaign_resolution_status='CONFLICT_FAIL_CLOSED' then 'CAMPAIGN_ID_CONFLICT'
+    when b.booking_ad_id is not null and acq.ad_id is not null and b.booking_ad_id<>acq.ad_id then 'BOOKING_AD_MISMATCH'
+    when a.id is null then 'APPOINTMENT_MISSING'
+    when pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'') is null then 'APPOINTMENT_NO_EXPLICIT_SALE_LINK'
+    when pg_catalog.coalesce(s.sale_row_count,0)=0 then 'SALE_LINK_UNRESOLVED'
+    else 'EXPLICIT_CHAIN_COMPLETE'
+  end::text as attribution_chain_status
+from acquisition acq
+left join booking_chain b
+  on b.conversation_id=acq.conversation_id
+left join public.aos_agenda_citas a
+  on a.id=b.appointment_id
+left join lateral (
+  select
+    pg_catalog.count(*)::integer as sale_row_count,
+    pg_catalog.min(v.fecha) as sale_date,
+    pg_catalog.sum(v.monto) as revenue_amount,
+    case
+      when pg_catalog.count(*)=0 then null
+      when pg_catalog.count(distinct pg_catalog.coalesce(pg_catalog.nullif(pg_catalog.btrim(v.moneda),''),'PEN'))=1
+        then pg_catalog.max(pg_catalog.coalesce(pg_catalog.nullif(pg_catalog.btrim(v.moneda),''),'PEN'))
+      else 'MIXED'
+    end::text as revenue_currency
+  from public.aos_ventas v
+  where v.venta_id=pg_catalog.nullif(pg_catalog.btrim(a.venta_id_match),'')
+) s on true;
+
+comment on view public.aos_wa_l6_attribution_journey_v1 is
+'WA-L6 read-only strong-key journey: immutable provider touchpoint -> conversation_id -> AGV2 appointment_id -> Agenda attendance -> explicit venta_id_match -> canonical sale. No phone/name fallback; multiple touchpoints remain reviewable.';
+revoke all on public.aos_wa_l6_attribution_journey_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l6_attribution_journey_v1 to service_role;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+++ b/supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
@@ -138,6 +138,9 @@ begin
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_BOOKING_GOAL_INVALID');
   end if;
 
+  if nullif(pg_catalog.btrim(p_payload->>'treatment_entity_id'),'') is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L6_TREATMENT_ID_REQUIRED');
+  end if;
   begin
     v_treatment:=(p_payload->>'treatment_entity_id')::uuid;
   exception when others then

--- a/supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql
+++ b/supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql
@@ -1,0 +1,56 @@
+-- WA-L6 recovery. Existing WA-7A.3 touchpoint view and pre-L6 campaign map are preserved.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.aos_wa_l6_campaign_context_audit_v1') is not null
+     and exists(select 1 from public.aos_wa_l6_campaign_context_audit_v1) then
+    raise exception 'WA_L6_RECOVERY_BLOCKED_HISTORY';
+  end if;
+end
+$$;
+
+drop view if exists public.aos_wa_l6_attribution_journey_v1;
+drop view if exists public.aos_wa_l6_conversation_acquisition_v1;
+drop function if exists public.aos_wa_l6_campaign_context_upsert_v1(text,jsonb);
+drop trigger if exists trg_aos_wa_l6_campaign_context_audit_guard_v1 on public.aos_wa_l6_campaign_context_audit_v1;
+drop function if exists public.aos_wa_l6_campaign_context_audit_guard_v1();
+drop table if exists public.aos_wa_l6_campaign_context_audit_v1;
+
+-- Restore the WA-7A.3 adapter to its pre-L6 exact column contract.
+create or replace view public.aos_wa_attribution_touchpoints_v1
+with (security_invoker=true, security_barrier=true)
+as
+select
+  e.id as touchpoint_id,
+  e.event_key as touchpoint_key,
+  e.provider_message_id,
+  m.conversation_id,
+  case when i.resolution_status='MATCH' then i.canonical_patient_id else null end::text as canonical_patient_id,
+  coalesce(i.resolution_status,'UNRESOLVED')::text as identity_resolution_status,
+  i.confidence_band::text as identity_confidence_band,
+  nullif(e.payload->>'ctwa_clid','')::text as ctwa_clid,
+  nullif(e.payload->>'source_id','')::text as source_id,
+  nullif(e.payload->>'source_type','')::text as source_type,
+  nullif(e.payload->>'source_url','')::text as source_url,
+  nullif(e.payload->>'ad_id','')::text as ad_id,
+  nullif(e.payload->>'provider_lead_id','')::text as provider_lead_id,
+  nullif(e.payload->>'campaign_source','')::text as campaign_source,
+  nullif(e.payload->>'headline','')::text as headline,
+  nullif(e.payload->>'body','')::text as body,
+  nullif(e.payload->>'media_type','')::text as media_type,
+  coalesce(m.provider_timestamp,e.created_at) as touchpoint_at,
+  e.created_at as persisted_at,
+  coalesce(nullif(e.payload->>'evidence_version',''),'WA_7A_3_V1')::text as evidence_version
+from public.aos_wa_events_v1 e
+join public.aos_wa_messages_v1 m
+  on m.provider_message_id=e.provider_message_id
+left join public.aos_wa_identity_resolution_v1 i
+  on i.conversation_id=m.conversation_id
+where e.event_type='attribution.touchpoint';
+
+revoke all on public.aos_wa_attribution_touchpoints_v1 from public,anon,authenticated;
+grant select on public.aos_wa_attribution_touchpoints_v1 to service_role;
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql
+++ b/supabase/rollbacks/20260903073000_wa_l6_meta_attribution_v1.rollback.sql
@@ -1,4 +1,4 @@
--- WA-L6 recovery. Existing WA-7A.3 touchpoint view and pre-L6 campaign map are preserved.
+-- WA-L6 recovery. Existing WA-7A.3 touchpoint semantics and pre-L6 campaign map are preserved.
 
 begin;
 
@@ -18,8 +18,10 @@ drop trigger if exists trg_aos_wa_l6_campaign_context_audit_guard_v1 on public.a
 drop function if exists public.aos_wa_l6_campaign_context_audit_guard_v1();
 drop table if exists public.aos_wa_l6_campaign_context_audit_v1;
 
--- Restore the WA-7A.3 adapter to its pre-L6 exact column contract.
-create or replace view public.aos_wa_attribution_touchpoints_v1
+-- CREATE OR REPLACE cannot remove appended columns from a view. L6-owned dependents are
+-- already gone, so explicitly drop the adapter and recreate the certified WA-7A.3 shape.
+drop view if exists public.aos_wa_attribution_touchpoints_v1;
+create view public.aos_wa_attribution_touchpoints_v1
 with (security_invoker=true, security_barrier=true)
 as
 select
@@ -50,6 +52,8 @@ left join public.aos_wa_identity_resolution_v1 i
   on i.conversation_id=m.conversation_id
 where e.event_type='attribution.touchpoint';
 
+comment on view public.aos_wa_attribution_touchpoints_v1 is
+'WA-7A.3 private derived attribution adapter over sanitized WA evidence. Read-only; identity and attribution remain separate facts.';
 revoke all on public.aos_wa_attribution_touchpoints_v1 from public,anon,authenticated;
 grant select on public.aos_wa_attribution_touchpoints_v1 to service_role;
 select pg_catalog.pg_notify('pgrst','reload schema');


### PR DESCRIPTION
Implements WA-L6 as the sole HIGH/CRITICAL lane under existing AUTO_OFF / kill-switch authority.

Scope:
- preserves explicit provider CTWA/referral evidence and optional provider-supplied campaign/adset/ad identifiers without name/URL inference;
- distinguishes paid CTWA, provider referral and no-provider-attribution traffic;
- adds 2FA-governed evidence-backed campaign-context upsert over the existing fail-closed map;
- adds append-only campaign mapping audit;
- adds service-role-only strong-key attribution journey: touchpoint -> conversation -> AGV2 BOOK/REBOOK -> same appointment -> attendance -> explicit venta_id_match -> canonical sale;
- phone/name/username/BSUID/patient identity are forbidden as revenue attribution joins;
- multiple touchpoints remain explicit and fail closed to review rather than silently choosing first/last touch;
- no production patient/lead/Agenda/Sales mutation and no synthetic production attribution are authorized;
- AUTO_OFF -> CANARY remains separately gated and NOT AUTHORIZED.

Dedicated L6 CI includes provider parser regressions, local DB governance, explicit-chain synthetic canary, multi-touch fail-closed, recovery-before-history/recovery-blocked-after-history, L4/L5 safety assertions and DB lint.

Refs #447. Issue closes only after exact-head CI, anti-drift, protected merge, dormant PROD deployment/readback and CURRENT/Notion closeout.