### PR TITLE
WA-L8 — Security Gate + Meta 2026 pricing/policy hardening

### DIFF
--- a/.github/workflows/wa-l8-final-closeout.yml
+++ b/.github/workflows/wa-l8-final-closeout.yml
@@ -43,14 +43,17 @@ jobs:
           $bounded=Get-Content 'supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql' -Raw
           $stop=Get-Content 'supabase/migrations/20260903194700_wa_l8_persistent_stop_index_v1.sql' -Raw
           $scope=Get-Content 'supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql' -Raw
-          $all=$base+"`n"+$bounded+"`n"+$stop+"`n"+$scope
+          $p0=Get-Content 'supabase/migrations/20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql' -Raw
+          $null=Get-Content 'supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql' -Raw
+          $all=$base+"`n"+$bounded+"`n"+$stop+"`n"+$scope+"`n"+$p0+"`n"+$null
           if ($all -match '(?i)auto_reply_enabled\s*=\s*true|ai_send_enabled\s*=\s*true|auto_routing_enabled\s*=\s*true|kill_switch_engaged\s*=\s*false') { throw 'L8 final may not activate autonomy' }
           if ($all -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 final may not create global materialization' }
           if ($all -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.(aos_pacientes|aos_leads|aos_agenda_citas|aos_ventas|aos_llamadas)') { throw 'L8 final may not mutate cross-module ledgers' }
-          foreach($marker in @('WA_L8_SCOPED_ELIGIBILITY_REQUIRED','WA_L8_OPT_OUT_ACTIVE','WA_L8_BOOKING_UTILITY_V1','aos_wa_marketing_eligibility_check_v1','aos_wa_l8_meta_monthly_usage_v1','pricing_type')) {
+          foreach($marker in @('WA_L8_SCOPED_ELIGIBILITY_REQUIRED','WA_L8_OPT_OUT_ACTIVE','WA_L8_BOOKING_UTILITY_V1','aos_wa_l8_scoped_eligibility_check_v1','aos_wa_l8_meta_monthly_usage_v1','pricing_type')) {
             if ($all -notmatch [regex]::Escape($marker)) { throw "L8 final marker missing: $marker" }
           }
           if ($scope -match 'grant\s+insert\s+on\s+table\s+public\.aos_wa_l8_consent_events_v1') { throw 'Deprecated L8 consent ledger must stay inert' }
+          if ($p0 -match 'aos_wa_marketing_eligibility_check_v1') { throw 'Final preflight may not use global WA7A4 projection' }
 
   db-final:
     name: L8 final real-DB scoped consent / cost / P0 gate
@@ -109,18 +112,16 @@ jobs:
         run: |
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
-          for f in 20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql; do
-            psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
-          done
+          L8_FILES='20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql 20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql 20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql'
+          for f in $L8_FILES; do psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"; done
           test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text)') is not null")" = 't'
           test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text)') is not null")" = 't'
           test "$(psql "$DB" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_l8_consent_events_v1','INSERT')")" = 'f'
           psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
           test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)') is null")" = 't'
           test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null")" = 't'
-          for f in 20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql; do
-            psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
-          done
+          for f in $L8_FILES; do psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"; done
           psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
       - name: WA-7A.4 regression then L8 final closeout canary
         run: |
@@ -130,14 +131,16 @@ jobs:
           grep -q 'WA7A4_MARKETING_ELIGIBILITY_PASS' /tmp/wa7a4.txt
           psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql 2>&1 | tee /tmp/wa-l8-final.txt
           grep -q 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' /tmp/wa-l8-final.txt
+          test "$(psql "$DB" -X -qAt -c "select position('aos_wa_marketing_eligibility_check_v1' in pg_get_functiondef('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)'::regprocedure))")" = '0'
       - name: P0 bounded-read and stop-index matrix
         run: |
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
           test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_l8_message_stop_idx'")" = 'aos_wa_l8_message_stop_idx'
-          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select public.aos_wa_l8_autonomous_preflight_v1('89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,'l8v2:perf:preflight:000001'); select count(*) from public.aos_wa_l8_meta_monthly_usage_v1 where business_phone_number_id='pn-l8v2';"
-          psql "$DB" -X -qAt -c "set enable_seqscan=off; explain (costs off) select created_at from public.aos_wa_messages_v1 where conversation_id='89888888-8888-4888-8888-888888888802'::uuid and direction='INBOUND' and pg_catalog.regexp_replace(pg_catalog.regexp_replace(pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(message_body,''))),'áéíóúüñ','aeiouun'),'[[:punct:]]',' ','g'),'[[:space:]]+',' ','g') ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$' order by created_at desc limit 1" | tee /tmp/l8-stop-plan.txt
-          grep -q 'aos_wa_l8_message_stop_idx' /tmp/l8-stop-plan.txt
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_marketing_eligibility_events_conversation_idx'")" = 'aos_wa_marketing_eligibility_events_conversation_idx'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select public.aos_wa_l8_scoped_eligibility_check_v1('89888888-8888-4888-8888-888888888802'::uuid,'UTILITY'); select public.aos_wa_l8_autonomous_preflight_v1('89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,'l8v2:perf:preflight:000001'); select count(*) from public.aos_wa_l8_meta_monthly_usage_v1 where business_phone_number_id='pn-l8v2';"
+          psql "$DB" -X -qAt -c "set enable_seqscan=off; explain (costs off) select consent_status from public.aos_wa_marketing_eligibility_events_v1 where conversation_id='89888888-8888-4888-8888-888888888802'::uuid and eligibility_scope='UTILITY' order by observed_at desc,created_at desc limit 1" | tee /tmp/l8-elig-plan.txt
+          grep -q 'aos_wa_marketing_eligibility_events_conversation_idx' /tmp/l8-elig-plan.txt
       - name: Cross-module read-only regression and SAFE-OFF
         run: |
           set -euo pipefail

--- a/.github/workflows/wa-l8-final-closeout.yml
+++ b/.github/workflows/wa-l8-final-closeout.yml
@@ -1,0 +1,170 @@
+name: ASCENDA WA-L8 Final Closeout
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'supabase/migrations/*wa_l8*'
+      - 'supabase/rollbacks/*wa_l8*'
+      - 'ci/wa-l8/**'
+      - '.github/workflows/wa-l8-final-closeout.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa-l8-final-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-final:
+    name: L8 final scoped-policy static gate
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 18
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Gateway regression
+        shell: powershell
+        run: |
+          node --check app/wa-gateway.js
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+          node --test ci/wa-l6/attribution_ingress_contract.test.js
+          node --test app/wa-l5-booking.test.js
+          node --test ci/wa-l4/runtime_contract.js
+      - name: Scoped consent / cost / SAFE-OFF contract
+        shell: powershell
+        run: |
+          $base=Get-Content 'supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql' -Raw
+          $bounded=Get-Content 'supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql' -Raw
+          $stop=Get-Content 'supabase/migrations/20260903194700_wa_l8_persistent_stop_index_v1.sql' -Raw
+          $scope=Get-Content 'supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql' -Raw
+          $all=$base+"`n"+$bounded+"`n"+$stop+"`n"+$scope
+          if ($all -match '(?i)auto_reply_enabled\s*=\s*true|ai_send_enabled\s*=\s*true|auto_routing_enabled\s*=\s*true|kill_switch_engaged\s*=\s*false') { throw 'L8 final may not activate autonomy' }
+          if ($all -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 final may not create global materialization' }
+          if ($all -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.(aos_pacientes|aos_leads|aos_agenda_citas|aos_ventas|aos_llamadas)') { throw 'L8 final may not mutate cross-module ledgers' }
+          foreach($marker in @('WA_L8_SCOPED_ELIGIBILITY_REQUIRED','WA_L8_OPT_OUT_ACTIVE','WA_L8_BOOKING_UTILITY_V1','aos_wa_marketing_eligibility_check_v1','aos_wa_l8_meta_monthly_usage_v1','pricing_type')) {
+            if ($all -notmatch [regex]::Escape($marker)) { throw "L8 final marker missing: $marker" }
+          }
+          if ($scope -match 'grant\s+insert\s+on\s+table\s+public\.aos_wa_l8_consent_events_v1') { throw 'Deprecated L8 consent ledger must stay inert' }
+
+  db-final:
+    name: L8 final real-DB scoped consent / cost / P0 gate
+    needs: static-final
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce zero-cost runner and wait for isolated ports
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          ports='60200 60201 60202'
+          for i in $(seq 1 90); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'WA_L8_FINAL_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+      - name: Build certified CURRENT substrate including WA-7A.4 authority
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/cia_recipient_controls_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005500_wa_l5_conversational_booking_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005600_wa_l5_treatment_resolver_uuid_fix_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/prereq.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903183000_wa_l7_cost_intelligence_v1.sql
+      - name: Apply / recover / reapply complete L8 before history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          for f in 20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql; do
+            psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_l8_consent_events_v1','INSERT')")" = 'f'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)') is null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null")" = 't'
+          for f in 20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql; do
+            psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
+      - name: WA-7A.4 regression then L8 final closeout canary
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/tests/001_marketing_eligibility.sql 2>&1 | tee /tmp/wa7a4.txt
+          grep -q 'WA7A4_MARKETING_ELIGIBILITY_PASS' /tmp/wa7a4.txt
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql 2>&1 | tee /tmp/wa-l8-final.txt
+          grep -q 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' /tmp/wa-l8-final.txt
+      - name: P0 bounded-read and stop-index matrix
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_l8_message_stop_idx'")" = 'aos_wa_l8_message_stop_idx'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select public.aos_wa_l8_autonomous_preflight_v1('89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,'l8v2:perf:preflight:000001'); select count(*) from public.aos_wa_l8_meta_monthly_usage_v1 where business_phone_number_id='pn-l8v2';"
+          psql "$DB" -X -qAt -c "set enable_seqscan=off; explain (costs off) select created_at from public.aos_wa_messages_v1 where conversation_id='89888888-8888-4888-8888-888888888802'::uuid and direction='INBOUND' and pg_catalog.regexp_replace(pg_catalog.regexp_replace(pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(message_body,''))),'áéíóúüñ','aeiouun'),'[[:punct:]]',' ','g'),'[[:space:]]+',' ','g') ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$' order by created_at desc limit 1" | tee /tmp/l8-stop-plan.txt
+          grep -q 'aos_wa_l8_message_stop_idx' /tmp/l8-stop-plan.txt
+      - name: Cross-module read-only regression and SAFE-OFF
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select count(*) from public.aos_agenda_citas; select count(*) from public.aos_llamadas; select count(*) from public.aos_leads; select count(*) from public.aos_ventas; select count(*) from public.aos_pacientes;"
+          test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
+          test "$(psql "$DB" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = 'false:false:false:true'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_messages_v1 where direction='OUTBOUND' and send_origin='AUTO'")" = '0'
+      - name: Recovery fails closed after audit/consent history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          set +e
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql >/tmp/l8-recovery-block.log 2>&1
+          rc=$?
+          set -e
+          test "$rc" -ne 0
+          grep -Eq 'WA_L8_RECOVERY_BLOCKED_(AUDIT_HISTORY|SCOPED_CONSENT_HISTORY)' /tmp/l8-recovery-block.log
+      - name: Database lint
+        working-directory: ci/wa4c-full-local
+        run: |
+          set -euo pipefail
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/wa-l8-final-lint.txt
+          if grep -q '\[ERROR\]' /tmp/wa-l8-final-lint.txt; then exit 1; fi
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/.github/workflows/wa-l8-final-closeout.yml
+++ b/.github/workflows/wa-l8-final-closeout.yml
@@ -129,7 +129,8 @@ jobs:
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
           psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/tests/001_marketing_eligibility.sql 2>&1 | tee /tmp/wa7a4.txt
           grep -q 'WA7A4_MARKETING_ELIGIBILITY_PASS' /tmp/wa7a4.txt
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql 2>&1 | tee /tmp/wa-l8-final.txt
+          python3 ci/wa-l8/render_v3_chronology_canary.py > /tmp/l8-v3-final.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f /tmp/l8-v3-final.sql 2>&1 | tee /tmp/wa-l8-final.txt
           grep -q 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' /tmp/wa-l8-final.txt
           test "$(psql "$DB" -X -qAt -c "select position('aos_wa_marketing_eligibility_check_v1' in pg_get_functiondef('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)'::regprocedure))")" = '0'
       - name: P0 bounded-read and stop-index matrix

--- a/.github/workflows/wa-l8-p0-closeout.yml
+++ b/.github/workflows/wa-l8-p0-closeout.yml
@@ -95,7 +95,8 @@ jobs:
         run: |
           set -euo pipefail
           DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
-          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql 2>&1 | tee /tmp/l8-p0-canary.txt
+          python3 ci/wa-l8/render_v3_chronology_canary.py > /tmp/l8-v3-canary.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f /tmp/l8-v3-canary.sql 2>&1 | tee /tmp/l8-p0-canary.txt
           grep -q 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' /tmp/l8-p0-canary.txt
           test "$(psql "$DB" -X -qAt -c "select position('aos_wa_marketing_eligibility_check_v1' in pg_get_functiondef('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)'::regprocedure))")" = '0'
       - name: Indexed plan matrix + 3s fail-fast

--- a/.github/workflows/wa-l8-p0-closeout.yml
+++ b/.github/workflows/wa-l8-p0-closeout.yml
@@ -27,13 +27,15 @@ jobs:
       - name: No global eligibility projection on autonomous hot path
         shell: powershell
         run: |
+          $stop=Get-Content 'supabase/migrations/20260903194700_wa_l8_persistent_stop_index_v1.sql' -Raw
           $p0=Get-Content 'supabase/migrations/20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql' -Raw
           $null=Get-Content 'supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql' -Raw
+          $all=$stop+"`n"+$p0+"`n"+$null
           if ($p0 -match 'aos_wa_marketing_eligibility_check_v1') { throw 'L8 P0 may not call WA7A4 global projection from autonomous preflight' }
           foreach($marker in @('aos_wa_l8_scoped_eligibility_check_v1','conversation_id=p_conversation_id','eligibility_scope=v_scope','order by e.observed_at desc,e.created_at desc','limit 1','aos_wa_l8_message_stop_idx')) {
-            if (($p0+$null) -notmatch [regex]::Escape($marker)) { throw "L8 P0 marker missing: $marker" }
+            if ($all -notmatch [regex]::Escape($marker)) { throw "L8 P0 marker missing: $marker" }
           }
-          if (($p0+$null) -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 P0 may not materialize global state' }
+          if ($all -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 P0 may not materialize global state' }
 
   db-p0:
     name: L8 bounded authority real-DB gate

--- a/.github/workflows/wa-l8-p0-closeout.yml
+++ b/.github/workflows/wa-l8-p0-closeout.yml
@@ -1,0 +1,123 @@
+name: ASCENDA WA-L8 P0 Closeout
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/*wa_l8*'
+      - 'supabase/rollbacks/*wa_l8*'
+      - 'ci/wa-l8/**'
+      - '.github/workflows/wa-l8-p0-closeout.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa-l8-p0-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-p0:
+    name: L8 bounded authority static gate
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - name: No global eligibility projection on autonomous hot path
+        shell: powershell
+        run: |
+          $p0=Get-Content 'supabase/migrations/20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql' -Raw
+          $null=Get-Content 'supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql' -Raw
+          if ($p0 -match 'aos_wa_marketing_eligibility_check_v1') { throw 'L8 P0 may not call WA7A4 global projection from autonomous preflight' }
+          foreach($marker in @('aos_wa_l8_scoped_eligibility_check_v1','conversation_id=p_conversation_id','eligibility_scope=v_scope','order by e.observed_at desc,e.created_at desc','limit 1','aos_wa_l8_message_stop_idx')) {
+            if (($p0+$null) -notmatch [regex]::Escape($marker)) { throw "L8 P0 marker missing: $marker" }
+          }
+          if (($p0+$null) -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 P0 may not materialize global state' }
+
+  db-p0:
+    name: L8 bounded authority real-DB gate
+    needs: static-p0
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce zero-cost and wait for isolated ports
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          ports='60200 60201 60202'
+          for i in $(seq 1 90); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            sleep 2
+          done
+          exit 1
+      - name: Build CURRENT WA / identity / eligibility / booking substrate
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a4-marketing-eligibility/cia_recipient_controls_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901193000_agv2_l3_delivery_outbox_v3.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005500_wa_l5_conversational_booking_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005600_wa_l5_treatment_resolver_uuid_fix_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/prereq.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903183000_wa_l7_cost_intelligence_v1.sql
+          for f in 20260903194500_wa_l8_security_gate_v1.sql 20260903194600_wa_l8_bounded_preflight_fix_v1.sql 20260903194700_wa_l8_persistent_stop_index_v1.sql 20260903194800_wa_l8_scoped_eligibility_v1.sql 20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql 20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql; do
+            psql "$DB" -X -v ON_ERROR_STOP=1 -f "supabase/migrations/$f"
+          done
+      - name: Final scoped consent + WhatsApp cost canary on bounded resolver
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql 2>&1 | tee /tmp/l8-p0-canary.txt
+          grep -q 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' /tmp/l8-p0-canary.txt
+          test "$(psql "$DB" -X -qAt -c "select position('aos_wa_marketing_eligibility_check_v1' in pg_get_functiondef('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)'::regprocedure))")" = '0'
+      - name: Indexed plan matrix + 3s fail-fast
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_marketing_eligibility_events_conversation_idx'")" = 'aos_wa_marketing_eligibility_events_conversation_idx'
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_channel_aliases_v1_conversation_idx'")" = 'aos_wa_channel_aliases_v1_conversation_idx'
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_l8_message_stop_idx'")" = 'aos_wa_l8_message_stop_idx'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select public.aos_wa_l8_scoped_eligibility_check_v1('89888888-8888-4888-8888-888888888802'::uuid,'UTILITY'); select public.aos_wa_l8_autonomous_preflight_v1('89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,'l8p0:perf:preflight:000001');"
+          psql "$DB" -X -qAt -c "set enable_seqscan=off; explain (costs off) select consent_status from public.aos_wa_marketing_eligibility_events_v1 where conversation_id='89888888-8888-4888-8888-888888888802'::uuid and eligibility_scope='UTILITY' order by observed_at desc,created_at desc limit 1" | tee /tmp/l8-elig-plan.txt
+          grep -q 'aos_wa_marketing_eligibility_events_conversation_idx' /tmp/l8-elig-plan.txt
+      - name: SAFE-OFF + lint
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_messages_v1 where direction='OUTBOUND' and send_origin='AUTO'")" = '0'
+          cd ci/wa4c-full-local
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/l8-p0-lint.txt
+          if grep -q '\[ERROR\]' /tmp/l8-p0-lint.txt; then exit 1; fi
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/.github/workflows/wa-l8-security-gate.yml
+++ b/.github/workflows/wa-l8-security-gate.yml
@@ -151,7 +151,7 @@ jobs:
           test "$(psql "$DB" -X -qAt -c "select cost_state||':'||cost_amount::text||':'||billing_market_code from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8.meta.paid'")" = 'KNOWN:0.03000000:PE'
           test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
           test "$(psql "$DB" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = 'false:false:false:true'
-          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l5_book_v1(uuid,text,jsonb)') is not null and to_regprocedure('public.aos_wa_l5_rebook_v1(uuid,text,jsonb)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regproc('public.aos_wa_l5_commit_confirmed_v1') is not null and to_regproc('public.aos_wa_l5_availability_v1') is not null")" = 't'
       - name: Bounded-read / index / 3s fail-fast matrix
         run: |
           set -euo pipefail

--- a/.github/workflows/wa-l8-security-gate.yml
+++ b/.github/workflows/wa-l8-security-gate.yml
@@ -1,0 +1,195 @@
+name: ASCENDA WA-L8 Security Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/wa-gateway.js'
+      - 'app/server-f4.js'
+      - 'app/ai-router.js'
+      - 'app/wa4-copilot.js'
+      - 'supabase/migrations/*wa_l8*'
+      - 'supabase/rollbacks/*wa_l8*'
+      - 'ci/wa-l8/**'
+      - 'ci/wa1-secure-gateway/wa-gateway.test.js'
+      - 'docs/control/WA_L8_*'
+      - '.github/workflows/wa-l8-security-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wa-l8-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-security:
+    name: L8 static security / ingress / regressions
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
+    timeout-minutes: 18
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Syntax and security contract
+        shell: powershell
+        run: |
+          node --check app/wa-gateway.js
+          node --check app/server-f4.js
+          node --check app/ai-router.js
+          node --check app/wa4-copilot.js
+          node ci/wa-l8/security_contract.js
+      - name: Signed ingress and L6/L5/L4 regressions
+        shell: powershell
+        run: |
+          node --test ci/wa1-secure-gateway/wa-gateway.test.js
+          node --test ci/wa-l6/attribution_ingress_contract.test.js
+          node --test ci/wa7a3-attribution-ingress/attribution_webhook_contract.test.js
+          node --test app/wa-l5-booking.test.js
+          node --test ci/wa-l4/runtime_contract.js
+          node app/wa4-conversation-runtime-v2.test.js
+      - name: Static SAFE-OFF / P0 assertions
+        shell: powershell
+        run: |
+          $base=Get-Content 'supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql' -Raw
+          $fix=Get-Content 'supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql' -Raw
+          $all=$base+"`n"+$fix
+          if ($all -match '(?i)auto_reply_enabled\s*=\s*true|ai_send_enabled\s*=\s*true|auto_routing_enabled\s*=\s*true|kill_switch_engaged\s*=\s*false') { throw 'L8 may not activate autonomy' }
+          if ($all -match '(?i)create\s+materialized\s+view|refresh\s+materialized\s+view') { throw 'L8 may not materialize hot-path analytics' }
+          if ($all -match '(?i)(insert\s+into|update|delete\s+from)\s+public\.(aos_pacientes|aos_leads|aos_agenda_citas|aos_ventas|aos_llamadas)') { throw 'L8 migration may not mutate cross-module business ledgers' }
+          if ($all -notmatch 'WA_L8_OPT_OUT_ACTIVE' -or $all -notmatch 'WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED') { throw 'L8 consent gate missing' }
+          if ($all -notmatch 'aos_wa_l4_authorize_autonomous_send_pre_l8_v1') { throw 'L8 must wrap certified L4 rather than replace its semantics' }
+
+  db-security:
+    name: L8 DB policy / least privilege / bounded-read canary
+    needs: static-security
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Enforce zero-cost runner
+        run: |
+          set -euo pipefail
+          test "${{ runner.environment }}" = "self-hosted"
+          python3 scripts/ci/enforce-zero-cost-policy.py
+      - name: Wait for isolated full-local ports
+        run: |
+          set -euo pipefail
+          ports='60200 60201 60202'
+          for i in $(seq 1 90); do
+            busy=''
+            for p in $ports; do
+              if ss -ltn "sport = :$p" 2>/dev/null | grep -q LISTEN; then busy="$busy $p"; fi
+            done
+            if [ -z "$busy" ]; then exit 0; fi
+            echo "Waiting for ports:$busy"
+            sleep 2
+          done
+          echo 'WA_L8_LOCAL_PORT_CONTENTION' >&2
+          exit 1
+      - name: Build certified WA / identity / booking substrate
+        run: |
+          set -euo pipefail
+          bash ci/wa4c-full-local/bootstrap.sh
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa7a1-identity-resolution/rev_identity_stub.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825213500_wa7a1_identity_resolution_bridge_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260825222500_wa7a2_identity_verification_continuity_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827133000_wa7a3_attribution_ingress_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831224500_wa4c_booking_authority_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260831231500_wa4c_governed_booking_pool_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901000500_wa4c_booking_search_path_fix_v2.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260901013500_agv2_unified_transactional_booking_contract_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005500_wa_l5_conversational_booking_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903005600_wa_l5_treatment_resolver_uuid_fix_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/prereq.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903073000_wa_l6_meta_attribution_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903183000_wa_l7_cost_intelligence_v1.sql
+      - name: L8 structural apply / recovery / reapply before audit history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l8_consent_events_v1') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)') is not null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_l8_consent_events_v1")" = '0'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_l8_preflight_decisions_v1")" = '0'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+          test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l8_consent_events_v1') is null")" = 't'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)') is not null")" = 't'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "notify pgrst, 'reload schema';"
+      - name: L6 strong-key regression
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l6/tests/001_meta_attribution_contract.sql 2>&1 | tee /tmp/wa-l8-l6.txt
+          grep -q 'WA_L6_META_ATTRIBUTION_CONTRACT_PASS' /tmp/wa-l8-l6.txt
+      - name: L8 consent / pricing / least-privilege canary
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l8/tests/001_security_gate_contract.sql 2>&1 | tee /tmp/wa-l8-security.txt
+          grep -q 'WA_L8_SECURITY_GATE_CONTRACT_PASS' /tmp/wa-l8-security.txt
+      - name: L7 read-model and L5/L4 authority regressions after L8
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select cost_state||':'||cost_amount::text||':'||billing_market_code from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8.meta.free'")" = 'KNOWN:0:PE'
+          test "$(psql "$DB" -X -qAt -c "select cost_state||':'||cost_amount::text||':'||billing_market_code from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8.meta.paid'")" = 'KNOWN:0.03000000:PE'
+          test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
+          test "$(psql "$DB" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = 'false:false:false:true'
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l5_book_v1(uuid,text,jsonb)') is not null and to_regprocedure('public.aos_wa_l5_rebook_v1(uuid,text,jsonb)') is not null")" = 't'
+      - name: Bounded-read / index / 3s fail-fast matrix
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select (public.aos_wa_l8_autonomous_preflight_v1('88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000001','text',null,'l8:perf:preflight:0000001')->>'decision')='PASS'; select (public.aos_wa_l7_conversation_cost_v1('88888888-8888-4888-8888-888888888801'::uuid)->>'ok')::boolean;"
+          psql "$DB" -X -qAt -c "set enable_seqscan=off; explain (costs off) select message_body from public.aos_wa_messages_v1 where conversation_id='88888888-8888-4888-8888-888888888801'::uuid and direction='INBOUND' order by created_at desc limit 1" | tee /tmp/l8-inbound-plan.txt
+          grep -q 'aos_wa_messages_v1_conversation_idx' /tmp/l8-inbound-plan.txt
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_l8_consent_recipient_idx'")" = 'aos_wa_l8_consent_recipient_idx'
+          test "$(psql "$DB" -X -qAt -c "select indexname from pg_indexes where schemaname='public' and indexname='aos_wa_l8_preflight_conversation_idx'")" = 'aos_wa_l8_preflight_conversation_idx'
+      - name: Post-canary privilege and SAFE-OFF assertions
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          test "$(psql "$DB" -X -qAt -c "select (public.aos_wa_l8_security_status_v1()->>'browser_message_write')::boolean")" = 'f'
+          test "$(psql "$DB" -X -qAt -c "select (public.aos_wa_l8_security_status_v1()->>'browser_booking_write')::boolean")" = 'f'
+          test "$(psql "$DB" -X -qAt -c "select has_table_privilege('service_role','public.aos_booking_operations_v2','INSERT')")" = 'f'
+          test "$(psql "$DB" -X -qAt -c "select has_table_privilege('service_role','public.aos_wa_ai_runs_v1','UPDATE')")" = 'f'
+          test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_messages_v1 where send_origin='AUTO' and direction='OUTBOUND'")" = '0'
+      - name: Recovery must fail closed after L8 audit history
+        run: |
+          set -euo pipefail
+          DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+          set +e
+          psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql >/tmp/wa-l8-recovery.log 2>&1
+          rc=$?
+          set -e
+          test "$rc" -ne 0
+          grep -q 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY' /tmp/wa-l8-recovery.log
+          test "$(psql "$DB" -X -qAt -c "select to_regprocedure('public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text)') is not null")" = 't'
+      - name: Database lint
+        working-directory: ci/wa4c-full-local
+        run: |
+          set -euo pipefail
+          supabase db lint --local --schema public --level error 2>&1 | tee /tmp/wa-l8-lint.txt
+          if grep -q '\[ERROR\]' /tmp/wa-l8-lint.txt; then exit 1; fi
+      - name: Cleanup local Supabase
+        if: always()
+        run: |
+          set +e
+          cd ci/wa4c-full-local
+          supabase stop --no-backup || true

--- a/app/wa-gateway.js
+++ b/app/wa-gateway.js
@@ -140,7 +140,7 @@ function extractWebhook(payload){
               payload:{business_scope:businessScope,system_type:systemType,previous_user_id:previousUser,user_id:currentUser,previous_parent_user_id:previousParent,parent_user_id:currentParent,wa_id:changedPhone,observed_at:observedAt,source:'META_MESSAGES_SYSTEM'}
             });
           }
-          return; // System identity events are state transitions, not customer chat messages.
+          return;
         }
 
         const contact=contactForMessage(contacts,msg);const profile=contact.profile||{};
@@ -165,18 +165,15 @@ function extractWebhook(payload){
         messages.push(row);
         events.push({event_key:'message:'+row.provider_message_id,event_type:'message.received',provider_message_id:row.provider_message_id,status:'received',payload:{message_type:row.message_type,phone_number_id:row.phone_number_id,has_referral:!!row.raw_referral,sender_kind:row.from_number?'PHONE':(row.from_user_id?'BSUID':'UNKNOWN'),has_user_id:!!row.from_user_id}});
 
-        // WA-L6/WA-7A.3: acquisition provenance is a separate immutable event, never an identity fact.
         const provenance=referralEvidence(referral,businessScope,row.provider_message_id,observedAt);
         if(provenance){
           events.push({event_key:'attribution:touchpoint:'+row.provider_message_id,event_type:'attribution.touchpoint',provider_message_id:row.provider_message_id,status:'observed',payload:provenance});
         }
 
-        // A signed Meta message carrying both identifiers is direct channel-pair evidence.
         if(fromPhone&&fromUser){
           events.push({event_key:'identity:pair:'+row.provider_message_id,event_type:'identity.meta_pair',provider_message_id:row.provider_message_id,status:'observed',payload:{business_scope:businessScope,phone:fromPhone,user_id:fromUser,parent_user_id:parentUser,observed_at:observedAt,source:'META_SIGNED_MESSAGE_PAIR'}});
         }
 
-        // REQUEST_CONTACT_INFO response versus an arbitrary forwarded contact card.
         if(String(msg.type||'').toLowerCase()==='contacts'&&Array.isArray(msg.contacts)){
           msg.contacts.forEach((card,index)=>{
             const phones=contactPhones(card);const origin=String(card&&card.origin||'other').toLowerCase();
@@ -197,10 +194,11 @@ function extractWebhook(payload){
         const observedAt=isoFromUnix(st.timestamp);
         const row={provider_message_id:id,status:state,recipient_id:recipientPhone,recipient_user_id:recipientUser,recipient_parent_user_id:recipientParent,provider_timestamp:observedAt,
           pricing_category:trimText(pricing.category||'',64)||null,pricing_model:trimText(pricing.pricing_model||'',64)||null,
+          pricing_type:trimText(pricing.type||'',64)||null,
           billable:typeof pricing.billable==='boolean'?pricing.billable:null,error_code:null,error_title:null};
         if(Array.isArray(st.errors)&&st.errors[0]){row.error_code=trimText(st.errors[0].code,64)||null;row.error_title=trimText(st.errors[0].title||st.errors[0].message,512)||null;}
         statuses.push(row);
-        events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,recipient_user_id:row.recipient_user_id,recipient_parent_user_id:row.recipient_parent_user_id,recipient_kind:row.recipient_id?'PHONE':(row.recipient_user_id?'BSUID':'UNKNOWN'),pricing_category:row.pricing_category,pricing_model:row.pricing_model,billable:row.billable,error_code:row.error_code}});
+        events.push({event_key:'status:'+id+':'+state+':'+String(st.timestamp||''),event_type:'message.status',provider_message_id:id,status:state,payload:{recipient_id:row.recipient_id,recipient_user_id:row.recipient_user_id,recipient_parent_user_id:row.recipient_parent_user_id,recipient_kind:row.recipient_id?'PHONE':(row.recipient_user_id?'BSUID':'UNKNOWN'),pricing_category:row.pricing_category,pricing_model:row.pricing_model,pricing_type:row.pricing_type,billable:row.billable,error_code:row.error_code}});
         if(recipientUser&&['delivered','read'].includes(String(state).toLowerCase())){
           events.push({event_key:'identity:status:'+id+':'+state+':'+recipientUser,event_type:'identity.status_binding',provider_message_id:id,status:state,payload:{business_scope:businessScope,provider_status:state,recipient_user_id:recipientUser,recipient_parent_user_id:recipientParent,observed_at:observedAt,source:'META_STATUS_RECIPIENT_USER_ID'}});
         }
@@ -216,7 +214,6 @@ function buildOutboundPayload(input){
   if(recipient.kind==='PHONE')out.to=recipient.address;
   else{
     out.recipient=recipient.address;
-    // Compatibility alias for existing ASCENDA server code. Non-enumerable means it is never sent to Meta.
     Object.defineProperty(out,'to',{value:recipient.address,enumerable:false,writable:false});
   }
   Object.defineProperty(out,'_recipient_kind',{value:recipient.kind,enumerable:false,writable:false});

--- a/ci/wa-l6/prereq.sql
+++ b/ci/wa-l6/prereq.sql
@@ -13,6 +13,24 @@ alter table public.aos_ventas add column if not exists moneda text;
 
 grant select,insert,update,delete on public.aos_ventas to service_role;
 
+-- WA-L8 TEST ONLY — mount the cross-module ledgers that the isolated closeout
+-- reads under the 3s fail-fast boundary. These fixtures are intentionally empty
+-- and exist only so the isolated substrate verifies read access without skipping
+-- Call Center, Marketing Leads, Sales or Patients. PROD readback validates real rows.
+create table if not exists public.aos_llamadas(
+  id bigserial primary key
+);
+create table if not exists public.aos_leads(
+  id bigserial primary key
+);
+create table if not exists public.aos_pacientes(
+  id bigserial primary key
+);
+
+grant select on public.aos_llamadas to service_role;
+grant select on public.aos_leads to service_role;
+grant select on public.aos_pacientes to service_role;
+
 -- Deterministic L6 admin authority on the test admin identity.
 update public.aos_usuarios
 set paneles_acceso=array['admin-chats','admin-marketing','admin-whatsapp']::text[], two_factor=true, activo=true

--- a/ci/wa-l8/render_v3_chronology_canary.py
+++ b/ci/wa-l8/render_v3_chronology_canary.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+src = Path('ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql').read_text(encoding='utf-8')
+start = '-- STOP persists even if the customer later sends an ordinary message.'
+end = '-- Meta cost intelligence remains first-class after final consent hardening.'
+
+if src.count(start) != 1 or src.count(end) != 1:
+    raise SystemExit('WA_L8_V3_RENDER_MARKERS_INVALID')
+
+prefix, tail = src.split(start, 1)
+_, suffix = tail.split(end, 1)
+
+replacement = r'''-- STOP V3 chronology: use a dedicated outside-24h conversation so an earlier
+-- Marketing opt-in from another scenario cannot be misread as reconsent-after-STOP.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_address,contact_address_type,contact_name,phone_number_id,state,opened_at,updated_at
+) values (
+  '89888888-8888-4888-8888-888888888803'::uuid,'pn-l8v2:51971000003','51971000003','51971000003','PHONE',
+  'L8 V3 STOP CHRONOLOGY','pn-l8v2','NEW',now()-interval '4 days',now()
+) on conflict(id) do nothing;
+
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at)
+values('pn-l8v2','PHONE','51971000003','89888888-8888-4888-8888-888888888803'::uuid,true,now()-interval '4 days',now())
+on conflict(business_scope,alias_type,alias_value) do update
+set conversation_id=excluded.conversation_id,active=true,last_seen_at=excluded.last_seen_at;
+
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values
+('wamid.l8v3.base','INBOUND','51971000003','519999111222','pn-l8v2','text','Hola','received',now()-interval '72 hours',now()-interval '72 hours','89888888-8888-4888-8888-888888888803'::uuid),
+('wamid.l8v3.stop','INBOUND','51971000003','519999111222','pn-l8v2','text','No más mensajes','received',now()-interval '48 hours',now()-interval '48 hours','89888888-8888-4888-8888-888888888803'::uuid),
+('wamid.l8v3.afterstop','INBOUND','51971000003','519999111222','pn-l8v2','text','Gracias','received',now()-interval '47 hours',now()-interval '47 hours','89888888-8888-4888-8888-888888888803'::uuid)
+on conflict(provider_message_id) do nothing;
+
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888803'::uuid,'PHONE','51971000003','template','l8v2_utility_reminder','l8v3:stop:utility:0000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then
+    raise exception 'WA_L8_V3_PERSISTENT_STOP_UTILITY_FAIL:%',r;
+  end if;
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888803'::uuid,'PHONE','51971000003','template','l8v2_marketing_followup','l8v3:stop:marketing:000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then
+    raise exception 'WA_L8_V3_PERSISTENT_STOP_MARKETING_FAIL:%',r;
+  end if;
+end $$;
+
+-- Explicit Marketing reconsent after STOP reopens Marketing only.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_marketing_eligibility_record_v1(jsonb_build_object(
+    'event_key','l8v3:marketing:reconsent:0001',
+    'conversation_id','89888888-8888-4888-8888-888888888803',
+    'eligibility_scope','MARKETING','consent_status','ALLOWED','suppression_status','CLEAR',
+    'source','CUSTOMER_REQUEST','source_ref','TEST:L8V3:MARKETING_RECONSENT_AFTER_STOP',
+    'policy_version','WA_L8_SCOPED_CONSENT_V1',
+    'evidence',jsonb_build_object('explicit_reconsent',true,'raw_recipient_stored',false),
+    'observed_at',clock_timestamp()
+  ));
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_V3_RECONSENT_APPEND_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888803'::uuid,'PHONE','51971000003','template','l8v2_marketing_followup','l8v3:stop:marketing:reconsent:1');
+  if r->>'decision'<>'PASS' or r->>'eligibility_scope'<>'MARKETING' then raise exception 'WA_L8_V3_MARKETING_RECONSENT_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888803'::uuid,'PHONE','51971000003','template','l8v2_utility_reminder','l8v3:stop:utility:stillblock:1');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then raise exception 'WA_L8_V3_MARKETING_RECONSENT_LEAKED_UTILITY:%',r; end if;
+end $$;
+
+'''
+
+rendered = prefix + replacement + end + suffix
+if 'WA_L8_V2_PERSISTENT_STOP_MARKETING_FAIL' in rendered:
+    raise SystemExit('WA_L8_V3_OLD_STOP_BLOCK_REMAINS')
+if rendered.count("select 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' as result;") != 1:
+    raise SystemExit('WA_L8_V3_PASS_MARKER_INVALID')
+
+print(rendered, end='')

--- a/ci/wa-l8/security_contract.js
+++ b/ci/wa-l8/security_contract.js
@@ -1,0 +1,88 @@
+'use strict';
+const fs=require('fs');
+const assert=require('assert');
+const read=p=>fs.readFileSync(p,'utf8');
+
+const migration=read('supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql');
+const rollback=read('supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql');
+const gateway=read('app/wa-gateway.js');
+const server=read('app/server-f4.js');
+const ai=read('app/ai-router.js');
+const copilot=read('app/wa4-copilot.js');
+const ui=read('app/public/admin-whatsapp.html');
+const low=migration.toLowerCase();
+
+// Safety: L8 installs a gate, never activates autonomy.
+for(const forbidden of [
+  /auto_reply_enabled\s*=\s*true/i,
+  /ai_send_enabled\s*=\s*true/i,
+  /auto_routing_enabled\s*=\s*true/i,
+  /kill_switch_engaged\s*=\s*false/i,
+  /\bmode\s*=\s*['"]canary['"]/i,
+  /\bmode\s*=\s*['"]prod['"]/i
+]) assert(!forbidden.test(migration),'L8 migration may not activate autonomy');
+
+// P0 #432: no global materialization and no triggers on certified hot ledgers.
+assert(!/create\s+materialized\s+view|refresh\s+materialized\s+view/i.test(migration));
+for(const hot of ['aos_wa_messages_v1','aos_wa_ai_runs_v1','aos_booking_operations_v2','aos_agenda_citas','aos_ventas','aos_llamadas']){
+  assert(!new RegExp(`create\\s+trigger[^;]+on\\s+public\\.${hot}\\b`,'is').test(migration),`L8 trigger forbidden on ${hot}`);
+}
+for(const ledger of ['aos_pacientes','aos_leads','aos_agenda_citas','aos_ventas','aos_llamadas']){
+  assert(!new RegExp(`(?:insert\\s+into|update|delete\\s+from)\\s+public\\.${ledger}\\b`,'i').test(migration),`L8 may not mutate ${ledger}`);
+}
+
+// Meta 2026 billing evidence is sanitized, market-specific and fail-closed.
+assert(gateway.includes('pricing_type:trimText(pricing.type'));
+assert(gateway.includes('pricing_type:row.pricing_type'));
+assert(migration.includes('aos_wa_l8_meta_pricing_evidence_v1'));
+assert(migration.includes("m.to_number ~ '^51[0-9]{8,12}$' then 'PE'"));
+assert(migration.includes("provider<>'META_WHATSAPP' or market_code<>'GLOBAL'"));
+assert(migration.includes('aos_wa_l8_meta_monthly_usage_v1'));
+assert(migration.includes('provider_nonbillable_messages'));
+assert(!/1000\s*(?:free|gratis|service)/i.test(migration),'No unverified monthly allowance may be hard-coded as pricing authority');
+
+// Consent/STOP/business-initiation gate precedes the already-certified L4 authority.
+assert(migration.includes('aos_wa_l8_consent_events_v1'));
+assert(migration.includes('aos_wa_l8_autonomous_preflight_v1'));
+assert(migration.includes('WA_L8_OPT_OUT_ACTIVE'));
+assert(migration.includes('WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H'));
+assert(migration.includes('WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED'));
+assert(migration.includes('aos_wa_l4_authorize_autonomous_send_pre_l8_v1'));
+const wrapper=migration.indexOf('v_pre:=public.aos_wa_l8_autonomous_preflight_v1');
+const legacy=migration.indexOf('v_l4:=public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1');
+assert(wrapper>=0&&legacy>wrapper,'L8 preflight must run before L4 authority');
+
+// Human escalation is still direct and auditable in the provider runtime.
+assert(server.includes('aos_wa3_handoff_request_v1'));
+assert(server.includes("authority.decision==='HANDOFF'"));
+
+// Signed webhook + reservation-before-send/idempotency remain binding.
+assert(server.includes("req.headers['x-hub-signature-256']"));
+assert(server.includes('wa.verifyMetaSignature(raw,signature,WA_APP_SECRET)'));
+assert(server.includes('reserveOutbound(body.idempotency_key'));
+assert(server.indexOf('reserveOutbound(body.idempotency_key')<server.lastIndexOf('graphSend(payload)'));
+assert(server.includes("state:'PENDING'"));
+
+// Secrets are server-only; no browser code may receive service/provider credentials.
+for(const secret of ['SUPABASE_SERVICE_ROLE_KEY','WHATSAPP_ACCESS_TOKEN','WHATSAPP_APP_SECRET','WA_L4_INTERNAL_TOKEN','GROQ_API_KEY']){
+  assert(!ui.includes(secret),`Browser secret reference: ${secret}`);
+}
+
+// AI traces remain metadata-only. The runtime redacts direct identifiers from context
+// and the SQL canary independently rejects raw prompt/reply columns.
+assert(ai.includes('function redactPII'));
+assert(copilot.includes('ai.redactPII'));
+assert(copilot.includes("servicePost('/rest/v1/aos_wa_ai_runs_v1',p)"));
+assert(!/aos_wa_ai_runs_v1[^\n]{0,500}(?:raw_prompt|raw_reply|message_body)/i.test(copilot));
+
+// Least privilege is selective rather than blind RLS churn.
+assert(migration.includes('revoke delete,truncate,references,trigger on public.aos_wa_messages_v1 from service_role'));
+assert(migration.includes('revoke update,delete,truncate,references,trigger on public.aos_wa_ai_runs_v1 from service_role'));
+assert(migration.includes('revoke insert,update,delete,truncate,references,trigger on public.aos_booking_operations_v2 from service_role'));
+assert(!/alter\s+table\s+public\.(?:aos_pacientes|aos_ventas|aos_llamadas|aos_leads)\s+.*row\s+level\s+security/is.test(migration));
+
+// Recovery cannot erase consent/security audit history.
+assert(rollback.includes('WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY'));
+assert(rollback.includes('Least-privilege revocations are monotonic security hardening'));
+
+console.log('WA_L8_STATIC_SECURITY_CONTRACT_PASS');

--- a/ci/wa-l8/tests/001_security_gate_contract.sql
+++ b/ci/wa-l8/tests/001_security_gate_contract.sql
@@ -1,0 +1,197 @@
+\set ON_ERROR_STOP on
+
+-- WA-L8 TEST ONLY. Synthetic identities/numbers live only in isolated local CI.
+
+-- Two deterministic conversations: one inside the 24h service window, one outside.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_address,contact_address_type,contact_name,phone_number_id,state,opened_at,updated_at
+) values
+('88888888-8888-4888-8888-888888888801'::uuid,'pn-l8:51970000001','51970000001','51970000001','PHONE','L8 WINDOW','pn-l8','NEW',now()-interval '2 hours',now()),
+('88888888-8888-4888-8888-888888888802'::uuid,'pn-l8:51970000002','51970000002','51970000002','PHONE','L8 OUTSIDE','pn-l8','NEW',now()-interval '3 days',now())
+on conflict(id) do nothing;
+
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values
+('wamid.l8.in.window','INBOUND','51970000001','519999111222','pn-l8','text','Hola, quiero información','received',now()-interval '1 hour',now()-interval '1 hour','88888888-8888-4888-8888-888888888801'::uuid),
+('wamid.l8.in.old','INBOUND','51970000002','519999111222','pn-l8','text','Hola','received',now()-interval '2 days',now()-interval '2 days','88888888-8888-4888-8888-888888888802'::uuid)
+on conflict(provider_message_id) do nothing;
+
+-- Unauthorized consent administration fails closed.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_consent_record_v1('bad-token','88888888-8888-4888-8888-888888888801'::uuid,'OPT_IN','CUSTOMER_REQUEST','TEST:L8:BAD');
+  if coalesce((r->>'ok')::boolean,false) or r->>'error'<>'WA_L8_ADMIN_2FA_REQUIRED' then raise exception 'WA_L8_UNAUTHORIZED_CONSENT_FAIL:%',r; end if;
+end $$;
+
+-- Service-window response passes the policy preflight, but L4 remains AUTO_OFF.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000001','text',null,'l8:window:preflight:00000001');
+  if r->>'decision'<>'PASS' or r->>'reason'<>'WA_L8_SERVICE_WINDOW_OK' or (r->>'service_window_open')::boolean is not true then
+    raise exception 'WA_L8_SERVICE_WINDOW_FAIL:%',r;
+  end if;
+
+  r:=public.aos_wa_l4_authorize_autonomous_send_v1(
+    '88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000001','text',null,
+    'l8:window:wrapper:00000001',repeat('a',64),'ALLOW','NOT_REQUIRED',false,null);
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L4_AUTO_OFF' or r->>'l8_preflight'<>'PASS' then
+    raise exception 'WA_L8_WRAPPER_DID_NOT_PRESERVE_L4_SAFE_OFF:%',r;
+  end if;
+end $$;
+
+-- Explicit STOP has priority over the open service window.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values (
+  'wamid.l8.stop','INBOUND','51970000001','519999111222','pn-l8','text','No más mensajes','received',now(),now(),
+  '88888888-8888-4888-8888-888888888801'::uuid
+) on conflict(provider_message_id) do nothing;
+
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000001','text',null,'l8:stop:preflight:00000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then raise exception 'WA_L8_STOP_FAIL:%',r; end if;
+end $$;
+
+-- A later, evidence-backed opt-in can supersede the earlier STOP.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_consent_record_v1(
+    'admin-token-111111111111111111111111111111111111',
+    '88888888-8888-4888-8888-888888888801'::uuid,'OPT_IN','CUSTOMER_REQUEST','TEST:L8:CUSTOMER_REOPTIN');
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_REOPTIN_APPEND_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000001','text',null,'l8:reoptin:preflight:0001');
+  if r->>'decision'<>'PASS' then raise exception 'WA_L8_REOPTIN_FAIL:%',r; end if;
+end $$;
+
+-- Outside 24h: free-form is blocked; template still requires explicit opt-in.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888802'::uuid,'PHONE','51970000002','text',null,'l8:outside:text:000000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H' then raise exception 'WA_L8_OUTSIDE_TEXT_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888802'::uuid,'PHONE','51970000002','template','recordatorio','l8:outside:tpl:000000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED' then raise exception 'WA_L8_OUTSIDE_TEMPLATE_NO_OPTIN_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_consent_record_v1(
+    'admin-token-111111111111111111111111111111111111',
+    '88888888-8888-4888-8888-888888888802'::uuid,'OPT_IN','PRIVACY_FORM','TEST:L8:FORM:CONSENT');
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_OUTSIDE_OPTIN_APPEND_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888802'::uuid,'PHONE','51970000002','template','recordatorio','l8:outside:tpl:optin:0001');
+  if r->>'decision'<>'PASS' or r->>'reason'<>'WA_L8_BUSINESS_INITIATED_OPT_IN_OK' then raise exception 'WA_L8_OUTSIDE_OPTIN_FAIL:%',r; end if;
+end $$;
+
+-- Recipient mismatch is a handoff, never an autonomous send.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '88888888-8888-4888-8888-888888888801'::uuid,'PHONE','51970000999','text',null,'l8:mismatch:preflight:0001');
+  if r->>'decision'<>'HANDOFF' or r->>'reason'<>'WA_L8_RECIPIENT_CONVERSATION_MISMATCH' then raise exception 'WA_L8_RECIPIENT_MISMATCH_FAIL:%',r; end if;
+end $$;
+
+-- Consent/preflight ledgers are immutable.
+do $$ begin
+  begin
+    update public.aos_wa_l8_consent_events_v1 set source='ADMIN_EVIDENCE';
+    raise exception 'WA_L8_CONSENT_UPDATE_UNEXPECTEDLY_ALLOWED';
+  exception when sqlstate '55000' then null; end;
+  begin
+    delete from public.aos_wa_l8_preflight_decisions_v1;
+    raise exception 'WA_L8_PREFLIGHT_DELETE_UNEXPECTEDLY_ALLOWED';
+  exception when sqlstate '55000' then null; end;
+end $$;
+
+-- Meta 2026 evidence: pricing.type is read from sanitized status events, market is
+-- resolved from recipient strong transport data, and non-billable remains KNOWN zero.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  pricing_category,pricing_model,billable,provider_timestamp,sent_at,delivered_at,conversation_id
+) values
+('wamid.l8.meta.free','OUTBOUND','519999111222','51970000001','pn-l8','text','free','delivered','service','PMP',false,now(),now(),now(),'88888888-8888-4888-8888-888888888801'::uuid),
+('wamid.l8.meta.paid','OUTBOUND','519999111222','51970000001','pn-l8','template',null,'delivered','marketing','PMP',true,now(),now(),now(),'88888888-8888-4888-8888-888888888801'::uuid)
+on conflict(provider_message_id) do nothing;
+
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values
+('status:wamid.l8.meta.free:delivered:l8','message.status','wamid.l8.meta.free','delivered',jsonb_build_object('pricing_category','service','pricing_model','PMP','pricing_type','free_customer_service','billable',false)),
+('status:wamid.l8.meta.paid:delivered:l8','message.status','wamid.l8.meta.paid','delivered',jsonb_build_object('pricing_category','marketing','pricing_model','PMP','pricing_type','regular','billable',true))
+on conflict(event_key) do nothing;
+
+do $$ declare r jsonb; e record; begin
+  r:=public.aos_wa_l7_pricing_authority_append_v1(
+    'admin-token-111111111111111111111111111111111111',
+    jsonb_build_object('provider','META_WHATSAPP','pricing_kind','META_MESSAGE','pricing_category','marketing','pricing_model','PMP',
+      'market_code','PE','currency','USD','flat_cost',0.03,'authority_grade','VERIFIED','evidence_ref','TEST:L8:PE_RATE','valid_from','2026-01-01T00:00:00Z'));
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_PE_RATE_APPEND_FAIL:%',r; end if;
+
+  select * into e from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8.meta.free';
+  if e.cost_state<>'KNOWN' or e.cost_amount<>0 or e.pricing_type<>'free_customer_service' or e.billing_market_code<>'PE' then
+    raise exception 'WA_L8_META_FREE_EVIDENCE_FAIL:%/%/%/%',e.cost_state,e.cost_amount,e.pricing_type,e.billing_market_code;
+  end if;
+  select * into e from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8.meta.paid';
+  if e.cost_state<>'KNOWN' or e.cost_amount<>0.03 or e.cost_currency<>'USD' or e.pricing_type<>'regular' or e.billing_market_code<>'PE' then
+    raise exception 'WA_L8_META_MARKET_RATE_FAIL:%/%/%/%/%',e.cost_state,e.cost_amount,e.cost_currency,e.pricing_type,e.billing_market_code;
+  end if;
+end $$;
+
+-- Meta GLOBAL authority is forbidden after L8; AI GLOBAL remains valid.
+do $$ begin
+  begin
+    insert into public.aos_wa_l7_pricing_authority_v1(
+      provider,pricing_kind,pricing_category,pricing_model,market_code,currency,flat_cost,authority_grade,evidence_ref,valid_from,created_by
+    ) values ('META_WHATSAPP','META_MESSAGE','service','PMP','GLOBAL','USD',0.03,'VERIFIED','TEST:L8:INVALID_GLOBAL',now(),'11111111-1111-4111-8111-111111111111'::uuid);
+    raise exception 'WA_L8_META_GLOBAL_UNEXPECTEDLY_ALLOWED';
+  exception when check_violation then null; end;
+end $$;
+
+-- Monthly view is business-number/market scoped and uses provider-observed billable state.
+do $$ declare n bigint; b bigint; nb bigint; begin
+  select outbound_messages,provider_billable_messages,provider_nonbillable_messages
+    into n,b,nb
+  from public.aos_wa_l8_meta_monthly_usage_v1
+  where business_phone_number_id='pn-l8' and billing_market_code='PE' and pricing_category='marketing';
+  if n is null or n<1 or b<1 then raise exception 'WA_L8_MONTHLY_USAGE_PAID_FAIL:%/%/%',n,b,nb; end if;
+end $$;
+
+-- Least privilege: browser writes are absent; service role retains only runtime-needs.
+do $$ begin
+  if has_table_privilege('anon','public.aos_wa_l8_consent_events_v1','SELECT')
+     or has_table_privilege('authenticated','public.aos_wa_l8_preflight_decisions_v1','SELECT') then raise exception 'WA_L8_BROWSER_AUDIT_LEAK'; end if;
+  if has_table_privilege('service_role','public.aos_wa_messages_v1','DELETE')
+     or has_table_privilege('service_role','public.aos_wa_messages_v1','TRUNCATE') then raise exception 'WA_L8_MESSAGE_DESTRUCTIVE_PRIVILEGE'; end if;
+  if not has_table_privilege('service_role','public.aos_wa_messages_v1','INSERT')
+     or not has_table_privilege('service_role','public.aos_wa_messages_v1','UPDATE') then raise exception 'WA_L8_GATEWAY_REQUIRED_PRIVILEGE_REMOVED'; end if;
+  if has_table_privilege('service_role','public.aos_wa_ai_runs_v1','UPDATE')
+     or has_table_privilege('service_role','public.aos_wa_ai_runs_v1','DELETE') then raise exception 'WA_L8_AI_LEDGER_MUTABLE'; end if;
+  if has_table_privilege('service_role','public.aos_booking_operations_v2','INSERT')
+     or has_table_privilege('service_role','public.aos_booking_operations_v2','UPDATE')
+     or has_table_privilege('service_role','public.aos_booking_operations_v2','DELETE') then raise exception 'WA_L8_BOOKING_DIRECT_DML_STILL_OPEN'; end if;
+  if not has_table_privilege('service_role','public.aos_booking_operations_v2','SELECT') then raise exception 'WA_L8_BOOKING_READ_REMOVED'; end if;
+end $$;
+
+-- AI audit table must remain metadata-only: no raw prompt/reply/body columns.
+do $$ begin
+  if exists(
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='aos_wa_ai_runs_v1'
+      and lower(column_name) in ('prompt','prompt_text','raw_prompt','response','reply','raw_reply','message_body','messages')
+  ) then raise exception 'WA_L8_AI_TRACE_RAW_CONTENT_COLUMN'; end if;
+end $$;
+
+-- Safety remains dormant after every canary fixture.
+do $$ declare s jsonb; begin
+  s:=public.aos_wa_l8_security_status_v1();
+  if s->>'mode'<>'AUTO_OFF' or (s->>'kill_switch_engaged')::boolean is not true
+     or (s->>'auto_reply_enabled')::boolean or (s->>'ai_send_enabled')::boolean
+     or (s->>'auto_routing_enabled')::boolean or (s->>'human_send_enabled')::boolean is not true then
+    raise exception 'WA_L8_SAFE_OFF_FAIL:%',s;
+  end if;
+  if (s->>'autonomous_outbound')::integer<>0 then raise exception 'WA_L8_AUTONOMOUS_OUTBOUND_NOT_ZERO:%',s; end if;
+end $$;
+
+select 'WA_L8_SECURITY_GATE_CONTRACT_PASS' as result;

--- a/ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql
+++ b/ci/wa-l8/tests/002_scoped_consent_cost_closeout.sql
@@ -1,0 +1,226 @@
+\set ON_ERROR_STOP on
+
+-- WA-L8 final TEST ONLY canary. Synthetic numbers/identities never leave local CI.
+
+-- Two conversations: one active service window, one deliberately outside 24h.
+insert into public.aos_wa_conversations_v1(
+  id,conversation_key,contact_number,contact_address,contact_address_type,contact_name,phone_number_id,state,opened_at,updated_at
+) values
+('89888888-8888-4888-8888-888888888801'::uuid,'pn-l8v2:51971000001','51971000001','51971000001','PHONE','L8 V2 WINDOW','pn-l8v2','NEW',now()-interval '2 hours',now()),
+('89888888-8888-4888-8888-888888888802'::uuid,'pn-l8v2:51971000002','51971000002','51971000002','PHONE','L8 V2 OUTSIDE','pn-l8v2','NEW',now()-interval '4 days',now())
+on conflict(id) do nothing;
+
+insert into public.aos_wa_channel_aliases_v1(business_scope,alias_type,alias_value,conversation_id,active,first_seen_at,last_seen_at)
+values
+('pn-l8v2','PHONE','51971000001','89888888-8888-4888-8888-888888888801'::uuid,true,now()-interval '2 hours',now()),
+('pn-l8v2','PHONE','51971000002','89888888-8888-4888-8888-888888888802'::uuid,true,now()-interval '4 days',now())
+on conflict(business_scope,alias_type,alias_value) do update set conversation_id=excluded.conversation_id,active=true,last_seen_at=excluded.last_seen_at;
+
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values
+('wamid.l8v2.window','INBOUND','51971000001','519999111222','pn-l8v2','text','Quiero información','received',now()-interval '1 hour',now()-interval '1 hour','89888888-8888-4888-8888-888888888801'::uuid),
+('wamid.l8v2.old','INBOUND','51971000002','519999111222','pn-l8v2','text','Hola','received',now()-interval '3 days',now()-interval '3 days','89888888-8888-4888-8888-888888888802'::uuid)
+on conflict(provider_message_id) do nothing;
+
+-- Final authority invariant: the draft L8 table is inert; WA-7A.4 is sole authority.
+do $$ begin
+  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is null then raise exception 'WA_L8_V2_WA7A4_AUTHORITY_MISSING'; end if;
+  if has_table_privilege('service_role','public.aos_wa_l8_consent_events_v1','INSERT') then raise exception 'WA_L8_V2_LEGACY_CONSENT_STILL_WRITABLE'; end if;
+  if (select count(*) from public.aos_wa_l8_consent_events_v1)<>0 then raise exception 'WA_L8_V2_LEGACY_CONSENT_NOT_EMPTY'; end if;
+end $$;
+
+-- Inside the customer-service window the conversation remains natural: no extra
+-- consent question is injected, while L4 still owns SAFE-OFF and final authority.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,'l8v2:window:preflight:0001');
+  if r->>'decision'<>'PASS' or r->>'reason'<>'WA_L8_SERVICE_WINDOW_OK' or r->>'eligibility_scope'<>'SERVICE_WINDOW' then
+    raise exception 'WA_L8_V2_SERVICE_WINDOW_FAIL:%',r;
+  end if;
+  r:=public.aos_wa_l4_authorize_autonomous_send_v1(
+    '89888888-8888-4888-8888-888888888801'::uuid,'PHONE','51971000001','text',null,
+    'l8v2:window:wrapper:000001',repeat('a',64),'ALLOW','NOT_REQUIRED',false,null);
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L4_AUTO_OFF' or r->>'l8_preflight'<>'PASS' then
+    raise exception 'WA_L8_V2_L4_SAFE_OFF_FAIL:%',r;
+  end if;
+end $$;
+
+-- Outside 24h free-form is impossible.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','text',null,'l8v2:outside:text:000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H' then
+    raise exception 'WA_L8_V2_OUTSIDE_FREEFORM_FAIL:%',r;
+  end if;
+end $$;
+
+-- Make one synthetic appointment template provider-verified in TEST so L8 can
+-- classify it as UTILITY. Unknown templates remain conservatively MARKETING.
+update public.aos_agenda_delivery_template_registry_v3
+set provider_template_name='l8v2_utility_reminder',provider_verified=true,evidence_ref='TEST:L8V2:META_VERIFIED',updated_at=now()
+where delivery_kind='REMINDER_TODAY' and channel='WHATSAPP' and site_scope='SAN ISIDRO';
+
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_utility_reminder','l8v2:utility:no-consent:001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_SCOPED_ELIGIBILITY_REQUIRED' or r->>'eligibility_scope'<>'UTILITY' then
+    raise exception 'WA_L8_V2_UTILITY_SCOPE_FAIL:%',r;
+  end if;
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_marketing_followup','l8v2:marketing:no-consent:1');
+  if r->>'decision'<>'BLOCK' or r->>'eligibility_scope'<>'MARKETING' then
+    raise exception 'WA_L8_V2_MARKETING_SCOPE_FAIL:%',r;
+  end if;
+end $$;
+
+-- Booking consent without extra UX: same affirmative confirming the booking is
+-- accepted only when a versioned Utility disclosure was shown.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values (
+  'wamid.l8v2.booking.confirm','INBOUND','51971000002','519999111222','pn-l8v2','text','Sí, confirmo','received',
+  now()-interval '50 hours',now()-interval '50 hours','89888888-8888-4888-8888-888888888802'::uuid
+) on conflict(provider_message_id) do nothing;
+
+insert into public.aos_booking_operations_v2(
+  id,idempotency_key,request_hash,operation_type,channel,actor_id,conversation_id,appointment_id,treatment_id,
+  professional_ref,site,appointment_date,appointment_time,identity_state,status,response,created_at
+)
+select
+  '89888888-8888-4888-8888-888888888810'::uuid,'l8v2-booking-op-000001',repeat('b',64),'BOOK','WHATSAPP',
+  '11111111-1111-4111-8111-111111111111'::uuid,'89888888-8888-4888-8888-888888888802'::uuid,'L8V2-APT-1',s.id,
+  'L8V2-PROF','SAN ISIDRO',current_date+2,'15:00'::time,'MATCH','BOOKED','{}'::jsonb,now()-interval '49 hours'
+from public.aos_catalogo_servicios s
+where upper(coalesce(s.estado,'ACTIVO'))='ACTIVO' and upper(coalesce(s.tipo,'SERVICIO'))='SERVICIO'
+order by s.id limit 1
+on conflict(id) do nothing;
+
+insert into public.aos_wa_l5_booking_events_v1(
+  conversation_id,event_type,flow,state,revision,appointment_id,operation_id,metadata,created_at
+) values
+('89888888-8888-4888-8888-888888888802'::uuid,'CONFIRMED','BOOK','CONFIRMED',10,'L8V2-APT-1',null,
+ jsonb_build_object('provider_message_id','wamid.l8v2.booking.confirm','raw_text_stored',false),now()-interval '50 hours'),
+('89888888-8888-4888-8888-888888888802'::uuid,'COMMITTED','BOOK','COMMITTED',11,'L8V2-APT-1','89888888-8888-4888-8888-888888888810'::uuid,
+ jsonb_build_object('status','BOOKED'),now()-interval '49 hours');
+
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_record_booking_utility_optin_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'wamid.l8v2.booking.confirm','WA_L8_BOOKING_UTILITY_V1','TEST:L8V2:BOOKING_DISCLOSURE');
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'scope'<>'UTILITY' or r->>'authority'<>'WA7A4' then
+    raise exception 'WA_L8_V2_BOOKING_UTILITY_OPTIN_FAIL:%',r;
+  end if;
+  r:=public.aos_wa_marketing_eligibility_check_v1('89888888-8888-4888-8888-888888888802'::uuid,'UTILITY');
+  if coalesce((r->>'send_allowed')::boolean,false) is not true then raise exception 'WA_L8_V2_UTILITY_NOT_ELIGIBLE:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_utility_reminder','l8v2:utility:consented:0001');
+  if r->>'decision'<>'PASS' or r->>'reason'<>'WA_L8_SCOPED_ELIGIBILITY_OK' or r->>'eligibility_scope'<>'UTILITY' then
+    raise exception 'WA_L8_V2_UTILITY_AFTER_BOOKING_FAIL:%',r;
+  end if;
+end $$;
+
+-- Utility consent must never silently grant Marketing.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_marketing_followup','l8v2:marketing:still-blocked:1');
+  if r->>'decision'<>'BLOCK' or r->>'eligibility_scope'<>'MARKETING' then raise exception 'WA_L8_V2_SCOPE_LEAK_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_consent_record_v2(
+    'admin-token-111111111111111111111111111111111111','89888888-8888-4888-8888-888888888802'::uuid,
+    'MARKETING','OPT_IN','PRIVACY_FORM','TEST:L8V2:MARKETING_FORM');
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'scope'<>'MARKETING' then raise exception 'WA_L8_V2_MARKETING_OPTIN_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_marketing_followup','l8v2:marketing:consented:001');
+  if r->>'decision'<>'PASS' or r->>'eligibility_scope'<>'MARKETING' then raise exception 'WA_L8_V2_MARKETING_PASS_FAIL:%',r; end if;
+end $$;
+
+-- STOP persists even if the customer later sends an ordinary message. Both messages
+-- are >24h old so category-specific reconsent behavior is visible deterministically.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  provider_timestamp,received_at,conversation_id
+) values
+('wamid.l8v2.stop','INBOUND','51971000002','519999111222','pn-l8v2','text','No más mensajes','received',now()-interval '48 hours',now()-interval '48 hours','89888888-8888-4888-8888-888888888802'::uuid),
+('wamid.l8v2.afterstop','INBOUND','51971000002','519999111222','pn-l8v2','text','Gracias','received',now()-interval '47 hours',now()-interval '47 hours','89888888-8888-4888-8888-888888888802'::uuid)
+on conflict(provider_message_id) do nothing;
+
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_utility_reminder','l8v2:stop:utility:0000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then raise exception 'WA_L8_V2_PERSISTENT_STOP_UTILITY_FAIL:%',r; end if;
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_marketing_followup','l8v2:stop:marketing:000001');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then raise exception 'WA_L8_V2_PERSISTENT_STOP_MARKETING_FAIL:%',r; end if;
+end $$;
+
+-- Explicit MARKETING reconsent after STOP only reopens Marketing; Utility remains blocked.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l8_consent_record_v2(
+    'admin-token-111111111111111111111111111111111111','89888888-8888-4888-8888-888888888802'::uuid,
+    'MARKETING','OPT_IN','CUSTOMER_REQUEST','TEST:L8V2:MARKETING_RECONSENT_AFTER_STOP');
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_V2_RECONSENT_APPEND_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_marketing_followup','l8v2:stop:marketing:reconsent:1');
+  if r->>'decision'<>'PASS' or r->>'eligibility_scope'<>'MARKETING' then raise exception 'WA_L8_V2_MARKETING_RECONSENT_FAIL:%',r; end if;
+
+  r:=public.aos_wa_l8_autonomous_preflight_v1(
+    '89888888-8888-4888-8888-888888888802'::uuid,'PHONE','51971000002','template','l8v2_utility_reminder','l8v2:stop:utility:stillblock:1');
+  if r->>'decision'<>'BLOCK' or r->>'reason'<>'WA_L8_OPT_OUT_ACTIVE' then raise exception 'WA_L8_V2_MARKETING_RECONSENT_LEAKED_UTILITY:%',r; end if;
+end $$;
+
+-- Meta cost intelligence remains first-class after final consent hardening.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,message_type,message_body,status,
+  pricing_category,pricing_model,billable,provider_timestamp,sent_at,delivered_at,conversation_id
+) values
+('wamid.l8v2.cost.free','OUTBOUND','519999111222','51971000001','pn-l8v2','text','free','delivered','service','PMP',false,now(),now(),now(),'89888888-8888-4888-8888-888888888801'::uuid),
+('wamid.l8v2.cost.paid','OUTBOUND','519999111222','51971000001','pn-l8v2','template',null,'delivered','marketing','PMP',true,now(),now(),now(),'89888888-8888-4888-8888-888888888801'::uuid)
+on conflict(provider_message_id) do nothing;
+
+insert into public.aos_wa_events_v1(event_key,event_type,provider_message_id,status,payload)
+values
+('status:wamid.l8v2.cost.free:delivered','message.status','wamid.l8v2.cost.free','delivered',jsonb_build_object('pricing_category','service','pricing_model','PMP','pricing_type','free_customer_service','billable',false)),
+('status:wamid.l8v2.cost.paid:delivered','message.status','wamid.l8v2.cost.paid','delivered',jsonb_build_object('pricing_category','marketing','pricing_model','PMP','pricing_type','regular','billable',true))
+on conflict(event_key) do nothing;
+
+do $$ declare r jsonb; c record; begin
+  r:=public.aos_wa_l7_pricing_authority_append_v1(
+    'admin-token-111111111111111111111111111111111111',
+    jsonb_build_object('provider','META_WHATSAPP','pricing_kind','META_MESSAGE','pricing_category','marketing','pricing_model','PMP',
+      'market_code','PE','currency','USD','flat_cost',0.03,'authority_grade','VERIFIED','evidence_ref','TEST:L8V2:PE_RATE','valid_from','2026-01-01T00:00:00Z'));
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'WA_L8_V2_RATE_APPEND_FAIL:%',r; end if;
+
+  select * into c from public.aos_wa_l7_meta_cost_events_v1 where provider_message_id='wamid.l8v2.cost.paid';
+  if c.cost_state<>'KNOWN' or c.cost_amount<>0.03 or c.billing_market_code<>'PE' or c.pricing_type<>'regular' then
+    raise exception 'WA_L8_V2_COST_EVENT_FAIL:%/%/%/%',c.cost_state,c.cost_amount,c.billing_market_code,c.pricing_type;
+  end if;
+  select * into c from public.aos_wa_l8_meta_monthly_usage_v1
+  where business_phone_number_id='pn-l8v2' and billing_market_code='PE' and pricing_category='marketing';
+  if c.provider_billable_messages<1 or c.known_cost_amount<0.03 then raise exception 'WA_L8_V2_MONTHLY_COST_FAIL:%',row_to_json(c); end if;
+end $$;
+
+-- Final SAFE-OFF / privilege invariants.
+do $$ declare s jsonb; begin
+  s:=public.aos_wa_l8_security_status_v1();
+  if s->>'mode'<>'AUTO_OFF' or (s->>'kill_switch_engaged')::boolean is not true
+     or (s->>'auto_reply_enabled')::boolean or (s->>'ai_send_enabled')::boolean
+     or (s->>'auto_routing_enabled')::boolean or (s->>'human_send_enabled')::boolean is not true then
+    raise exception 'WA_L8_V2_SAFE_OFF_FAIL:%',s;
+  end if;
+  if (s->>'autonomous_outbound')::integer<>0 then raise exception 'WA_L8_V2_AUTO_OUTBOUND_NOT_ZERO:%',s; end if;
+  if (s->>'deprecated_l8_consent_events')::integer<>0 then raise exception 'WA_L8_V2_DEPRECATED_CONSENT_DIRTY:%',s; end if;
+end $$;
+
+do $$ begin
+  begin
+    delete from public.aos_wa_l8_preflight_decisions_v1;
+    raise exception 'WA_L8_V2_PREFLIGHT_DELETE_UNEXPECTEDLY_ALLOWED';
+  exception when sqlstate '55000' then null; end;
+end $$;
+
+select 'WA_L8_SCOPED_CONSENT_COST_CLOSEOUT_PASS' as result;

--- a/ci/wa1-secure-gateway/wa-gateway.test.js
+++ b/ci/wa1-secure-gateway/wa-gateway.test.js
@@ -31,9 +31,12 @@ test('normalizes inbound click-to-whatsapp message without raw payload retention
   assert.equal(e.events[0].event_key,'message:wamid.1');
 });
 
-test('normalizes status pricing and error metadata',()=>{
-  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{statuses:[{id:'wamid.out',status:'delivered',timestamp:'1786807100',recipient_id:'51999999999',pricing:{category:'utility',pricing_model:'PMP',billable:false}}]}}]}]};
-  const e=wa.extractWebhook(p);assert.equal(e.statuses.length,1);assert.equal(e.statuses[0].status,'delivered');assert.equal(e.statuses[0].pricing_category,'utility');assert.equal(e.statuses[0].billable,false);
+test('normalizes status pricing type/category/model/billable without adding it to hot message row',()=>{
+  const p={object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{statuses:[{id:'wamid.out',status:'delivered',timestamp:'1786807100',recipient_id:'51999999999',pricing:{category:'service',pricing_model:'PMP',type:'free_customer_service',billable:false}}]}}]}]};
+  const e=wa.extractWebhook(p);
+  assert.equal(e.statuses.length,1);assert.equal(e.statuses[0].status,'delivered');assert.equal(e.statuses[0].pricing_category,'service');assert.equal(e.statuses[0].pricing_model,'PMP');assert.equal(e.statuses[0].pricing_type,'free_customer_service');assert.equal(e.statuses[0].billable,false);
+  const statusEvent=e.events.find(x=>x.event_type==='message.status');
+  assert.ok(statusEvent);assert.equal(statusEvent.payload.pricing_type,'free_customer_service');assert.equal(statusEvent.payload.billable,false);
 });
 
 test('builds governed text/template/media outbound payloads',()=>{

--- a/docs/control/WA_L8_SCOPED_CONSENT_AND_COST_CLOSEOUT.md
+++ b/docs/control/WA_L8_SCOPED_CONSENT_AND_COST_CLOSEOUT.md
@@ -1,0 +1,99 @@
+# WA-L8 — Scoped Consent & WhatsApp Cost Closeout
+
+Status: implementation contract; certification requires exact-head CI + PROD readback.
+Safety invariant: `AUTO_OFF`, kill switch engaged, auto-reply/send/routing disabled, human-send enabled. This document does not authorize CANARY.
+
+## 1. One consent authority
+
+WA-7A.4 `aos_wa_marketing_eligibility_events_v1` is the sole append-only consent/suppression authority. The early L8-local consent table is inert compatibility structure only and must remain empty/non-writable.
+
+Scopes are independent:
+
+- `UTILITY`: confirmations, reprogramming and appointment reminders.
+- `MARKETING`: offers, commercial follow-up and reactivation.
+- `AUTHENTICATION`: future authentication templates.
+- `GLOBAL`: explicit cross-category grant/denial only when evidence supports it.
+
+Utility consent never grants Marketing consent.
+
+## 2. No bad consent UX
+
+L8 does **not** require a first chatbot message asking the customer to type “I authorize messages”.
+
+Inside the 24-hour customer-service window, the customer may converse normally. Outside 24 hours, free-form is blocked and an approved template is required.
+
+For appointment flows, the existing explicit booking confirmation can also serve as the Utility opt-in action only when the confirmation prompt already displayed a clear, versioned disclosure such as:
+
+> Al confirmar tu cita, Zivital te enviará por este WhatsApp confirmaciones, cambios y recordatorios relacionados con tu cita. Puedes pedir que dejemos de enviarlos en cualquier momento.
+
+The disclosure version is `WA_L8_BOOKING_UTILITY_V1`. The same customer affirmative used by L5 to confirm the booking is therefore sufficient operational evidence; there is no second consent question.
+
+`aos_wa_l8_record_booking_utility_optin_v1(...)` refuses to record consent unless all of these are true:
+
+1. an inbound customer message exists in the same conversation;
+2. L5 recorded that exact provider message as `CONFIRMED`;
+3. the WhatsApp BOOK/REBOOK was actually `COMMITTED`;
+4. a versioned Utility disclosure was declared;
+5. an evidence reference is present.
+
+Merely having an appointment never creates consent.
+
+## 3. STOP / opt-out
+
+A customer STOP/BAJA/no-more-messages signal is persistent. A later ordinary inbound message does not erase it.
+
+The STOP lookup uses a partial conversation index and `LIMIT 1`; no global scan or synchronous analytical view is introduced. This preserves P0 #432.
+
+Only explicit reconsent after the STOP can reopen a scope. Scope isolation remains strict: a later Marketing reconsent does not reopen Utility, and vice versa. A GLOBAL reconsent is only valid when evidence explicitly supports that breadth.
+
+## 4. Template scope
+
+A provider-verified appointment template in `aos_agenda_delivery_template_registry_v3` is classified as `UTILITY`. Unknown future templates fail conservatively to `MARKETING` for the L8 eligibility check; L4 still independently requires provider verification before any autonomous template send.
+
+Final path:
+
+`L8 scope/STOP/24h eligibility -> L4 AUTO_OFF/CANARY/PROD + kill switch + safety + identity + provider template verification + allowlist/limits -> provider send`
+
+L8 PASS is never sufficient by itself to send.
+
+## 5. WhatsApp API cost intelligence
+
+Cost accounting is preserved as a first-class L8 closeout gate:
+
+- Meta status `pricing.type` is retained as sanitized provider evidence.
+- recipient market is resolved conservatively (`PE` only when deterministic; otherwise unresolved).
+- provider `billable=false` is `KNOWN 0`.
+- a billable message is `KNOWN` only with an evidence-backed VERIFIED effective rate for the exact market/category/model/currency.
+- no USD/PEN FX or WABA billing currency is fabricated.
+- `aos_wa_l8_meta_monthly_usage_v1` reconciles monthly outbound count, billable/non-billable count, completeness and known cost by business phone number, market, category, pricing model and pricing type.
+
+The announced October 2026 service-message/free-tier rules must not be inserted as VERIFIED PROD authority until the clinic WABA billing/rate-card evidence is captured. Message counts remain observable even when monetary cost is UNKNOWN.
+
+## 6. Security / privacy
+
+- no browser direct writes to consent, preflight, message or booking authority;
+- no new hot-path trigger;
+- preflight is append-only/idempotent;
+- AI audit stays metadata-only;
+- destructive `service_role` privileges remain removed where runtime does not require them;
+- no new raw phone/BSUID copy is created by the scoped consent authority;
+- recovery fails closed once L8 preflight or L8-scoped consent history exists.
+
+## 7. Exit gate
+
+WA-L8 may close only after:
+
+1. exact-head static + real local DB CI passes;
+2. WA-7A.4 regression passes;
+3. Utility vs Marketing scope isolation passes;
+4. persistent STOP after later inbound passes;
+5. WhatsApp cost event + monthly aggregation passes;
+6. cross-module read-only regression passes;
+7. anti-drift confirms frozen `main`;
+8. PR merges with `expected_head_sha`;
+9. Railway reports SUCCESS;
+10. WA-7A.4 prerequisite + exact L8 migrations are applied to Supabase PROD;
+11. LIVE SAFE-OFF, privileges, zero autonomous outbound and cost/eligibility readbacks pass;
+12. issue/Notion closeout releases the sole HIGH/CRITICAL lock.
+
+Only after that is WA-L9 eligible to start. L8 closure does not authorize CANARY.

--- a/docs/control/WA_L8_SECURITY_GATE_CONTRACT.md
+++ b/docs/control/WA_L8_SECURITY_GATE_CONTRACT.md
@@ -1,0 +1,186 @@
+# WA-L8 — Security Gate for Autonomous Canary
+
+**GitHub authority:** issue `#451`  
+**Parent roadmap:** issue `#410`  
+**ENTRY baseline:** `main@237eda4099e90b4186037678c90078af0c6af89f`  
+**Governance lock:** `main@e57c2c6339134efd79dc71d4e7b0b980b723ea8d`  
+**Branch:** `wa-l8-security-gate-20260903`  
+**Safety:** `AUTO_OFF · kill switch engaged · autonomous send/reply/routing=false · CANARY NOT AUTHORIZED`
+
+## 1. Objective
+
+WA-L8 adds the security/compliance gate required before any future autonomous canary. It does not authorize or activate CANARY.
+
+Authority chain after L8:
+
+`provider ingress → sanitized evidence → conversation/policy preflight → certified L4 autonomous authority → provider reservation/idempotency → Meta send`
+
+A L8 `PASS` is only a prerequisite. L4 still owns AUTO_OFF/CANARY/PROD mode, kill switch, safety, identity, template verification, allowlists, rate limits, cooldown and duplicate guards.
+
+## 2. Meta 2026 pricing/policy hardening
+
+L8 updates the L7 cost layer without fabricating provider prices.
+
+### Provider pricing evidence
+
+The Meta status webhook normalizer now preserves `pricing.type` in the sanitized immutable `message.status` event payload. It does not add a new enrichment write to the hot message row.
+
+`aos_wa_l8_meta_pricing_evidence_v1` resolves:
+
+- provider message;
+- exact conversation;
+- business phone number id;
+- pricing category/model;
+- provider billable flag;
+- provider `pricing.type` evidence;
+- recipient billing market when deterministically known.
+
+### Market authority
+
+Meta pricing may not use a `GLOBAL` authoritative rate after L8. Current deterministic production scope recognizes Peru telephone recipients as `PE`; non-Peru/unresolved recipients fail closed as `UNMAPPED/UNRESOLVED` until a certified market resolver/rate exists.
+
+AI provider pricing may continue to use `GLOBAL` because it is model/token pricing rather than recipient-market pricing.
+
+### Monthly invoice observability
+
+`aos_wa_l8_meta_monthly_usage_v1` groups realized provider evidence by:
+
+- business phone number id;
+- UTC billing month;
+- billing market;
+- category/model/type;
+- provider billable/non-billable counts;
+- KNOWN/PARTIAL/UNKNOWN cost events.
+
+The researched 2026 service-message free allowance is **not hard-coded as a VERIFIED production entitlement**. Forecasting that allowance requires account/WABA primary billing evidence. Provider `billable=false` remains authoritative realized `KNOWN 0`.
+
+## 3. Consent / STOP policy gate
+
+`aos_wa_l8_consent_events_v1` is append-only. It stores:
+
+- conversation id;
+- recipient kind;
+- SHA-256 recipient hash;
+- OPT_IN / OPT_OUT;
+- evidence source/reference;
+- authenticated 2FA administrator provenance.
+
+No raw phone/BSUID is stored in this audit ledger.
+
+`aos_wa_l8_consent_record_v1(...)` requires `admin-whatsapp` + active 2FA authority.
+
+### Autonomous preflight
+
+`aos_wa_l8_autonomous_preflight_v1(...)` uses bounded exact-conversation reads and applies:
+
+1. recipient must match the conversation strong transport identity;
+2. current explicit OPT_OUT or latest customer STOP-like signal blocks;
+3. within 24 hours of the latest customer inbound, a reply may pass if no active opt-out exists;
+4. outside 24 hours, autonomous free-form sends are blocked;
+5. outside 24 hours, a provider template still requires explicit evidence-backed OPT_IN;
+6. any recipient mismatch becomes HANDOFF.
+
+The latest inbound read is `conversation_id + direction + ORDER BY created_at DESC LIMIT 1`, reusing the certified conversation index. Historical consent state comes from the dedicated indexed consent ledger rather than scanning full message history.
+
+CTWA/free-entry pricing evidence is preserved for billing, but L8 intentionally does not use a 72-hour free-entry window to broaden autonomous-send permission without a separate primary-policy certification.
+
+## 4. L4 wrapping, not replacement
+
+The certified L4 function is renamed internally to:
+
+`aos_wa_l4_authorize_autonomous_send_pre_l8_v1(...)`
+
+The public server-side function name remains:
+
+`aos_wa_l4_authorize_autonomous_send_v1(...)`
+
+The new wrapper performs L8 preflight first. Only a L8 PASS reaches the existing certified L4 authority. Therefore all prior L4 safety invariants remain authoritative.
+
+## 5. Human escalation
+
+The existing provider runtime retains direct `aos_wa3_handoff_request_v1` handling for L4/L8 HANDOFF decisions and provider failures. L8 cannot silently convert a required human escalation into an autonomous send.
+
+## 6. Signed webhook / replay / idempotency
+
+The existing gateway contract remains binding:
+
+- exact raw-body HMAC SHA-256 verification before parsing/persistence;
+- deterministic inbound/status event keys;
+- provider message idempotency;
+- outbound reservation by idempotency key before `graphSend`;
+- ambiguous provider outcomes remain PENDING and are not blindly re-sent.
+
+## 7. PII/PHI / AI trace boundary
+
+WA-4 AI run history remains metadata-only. No raw prompt, raw reply or message body column is added.
+
+Conversation history sent to model context uses the existing identifier redactor. Operational gateway logs contain controlled error codes/messages, not raw webhook/message bodies.
+
+Identity/business evidence stored in canonical ledgers remains service-only and is not exposed as browser logs or AI audit traces.
+
+## 8. Selective least privilege
+
+L8 does not perform a blind global RLS rollout.
+
+On the exact autonomous path:
+
+- `aos_wa_messages_v1`: service role keeps runtime-required SELECT/INSERT/UPDATE; destructive/table-management privileges are revoked;
+- `aos_wa_outbound_requests_v1`: same runtime boundary;
+- `aos_wa_conversations_v1`: service role keeps operational read/write but loses destructive/table-management privileges;
+- `aos_wa_ai_runs_v1`: service role is reduced to append/read semantics;
+- `aos_booking_operations_v2`: direct service-role DML is removed; certified SECURITY DEFINER booking contracts own writes; service role retains SELECT.
+
+Browser roles receive no direct table write authority.
+
+## 9. Performance / P0 #432
+
+L8 introduces:
+
+- no materialized view;
+- no synchronous refresh;
+- no trigger on message/AI/booking/Agenda/Sales/Call Center hot ledgers;
+- no global analytical read on the send path;
+- exact conversation predicates;
+- bounded latest-inbound lookup;
+- indexed consent/preflight reads;
+- cost/pricing enrichment remains outside inbox-list polling.
+
+Dedicated CI uses a 3-second fail-fast statement budget only as a test gate; no production timeout is increased.
+
+## 10. Recovery
+
+Structural recovery is allowed only before L8 consent/preflight history exists.
+
+Once any L8 audit history exists, rollback fails closed with:
+
+`WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY`
+
+Least-privilege revocations are monotonic security hardening and are intentionally not reopened by structural recovery.
+
+## 11. Production deployment rule
+
+L8 can be certified only after:
+
+1. dedicated exact-head CI passes;
+2. L7/L6/L5/L4 and ingress regressions pass;
+3. P0 #432 performance/isolation matrix passes;
+4. main anti-drift remains clean;
+5. exact-head merge occurs;
+6. Railway deploy succeeds;
+7. exact merged migrations are applied to Supabase PROD;
+8. live readback proves objects, privileges and SAFE-OFF state;
+9. no autonomous outbound is produced;
+10. Notion/governance authorities are synchronized.
+
+## 12. Explicitly out of scope
+
+WA-L8 does not authorize:
+
+- `AUTO_OFF → CANARY`;
+- kill-switch disengagement;
+- autonomous send/reply/routing;
+- live allowlisted autonomous traffic;
+- broad marketing/broadcast sends;
+- WA-L9/L10 execution.
+
+A future CANARY transition remains a separate explicit owner authorization.

--- a/supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql
+++ b/supabase/migrations/20260903194500_wa_l8_security_gate_v1.sql
@@ -1,0 +1,477 @@
+-- WA-L8 — Security Gate for Autonomous Canary + Meta 2026 pricing/policy hardening
+-- Additive security release. Installs policy/preflight authority while production remains SAFE-OFF.
+-- No CANARY transition, no synthetic provider rates, no business-ledger mutation.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Meta pricing evidence / market-aware reconciliation
+-- ---------------------------------------------------------------------------
+-- Meta message prices are recipient-market specific. GLOBAL remains valid for AI
+-- providers, but must not be accepted as authoritative Meta-message pricing.
+alter table public.aos_wa_l7_pricing_authority_v1
+  add constraint aos_wa_l8_meta_market_specific_ck
+  check (provider<>'META_WHATSAPP' or market_code<>'GLOBAL');
+
+-- `pricing.type` is provider evidence (for example free-service/free-entry semantics)
+-- carried by sanitized message.status events. It is intentionally not added to the
+-- hot message row: no new synchronous enrichment write is introduced.
+create or replace view public.aos_wa_l8_meta_pricing_evidence_v1
+with (security_invoker=true,security_barrier=true)
+as
+select
+  m.id as message_id,
+  m.provider_message_id,
+  m.conversation_id,
+  m.phone_number_id as business_phone_number_id,
+  coalesce(m.delivered_at,m.sent_at,m.provider_timestamp,m.created_at) as cost_event_at,
+  m.pricing_category,
+  m.pricing_model,
+  m.billable,
+  pe.pricing_type,
+  case
+    when m.to_number ~ '^51[0-9]{8,12}$' then 'PE'
+    when m.to_number is not null then 'UNMAPPED'
+    else 'UNRESOLVED'
+  end::text as billing_market_code
+from public.aos_wa_messages_v1 m
+left join lateral (
+  select nullif(pg_catalog.btrim(e.payload->>'pricing_type'),'') as pricing_type
+  from public.aos_wa_events_v1 e
+  where e.provider_message_id=m.provider_message_id
+    and e.event_type='message.status'
+    and nullif(pg_catalog.btrim(e.payload->>'pricing_type'),'') is not null
+  order by e.created_at desc
+  limit 1
+) pe on true
+where m.direction='OUTBOUND';
+
+revoke all on public.aos_wa_l8_meta_pricing_evidence_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l8_meta_pricing_evidence_v1 to service_role;
+
+-- Preserve every existing L7 column in the same order, then append L8 evidence.
+create or replace view public.aos_wa_l7_meta_cost_events_v1
+with (security_invoker=true,security_barrier=true)
+as
+select
+  e.message_id,
+  e.provider_message_id,
+  e.conversation_id,
+  e.cost_event_at,
+  e.pricing_category,
+  e.pricing_model,
+  e.billable,
+  r.id as pricing_authority_id,
+  r.authority_grade,
+  r.evidence_ref as pricing_evidence_ref,
+  case
+    when e.billable is false then 'KNOWN'
+    when e.billable is true and r.id is not null and r.authority_grade='VERIFIED' then 'KNOWN'
+    when e.billable is true and r.id is not null then 'PARTIAL'
+    else 'UNKNOWN'
+  end::text as cost_state,
+  case
+    when e.billable is false then 'PROVIDER_NON_BILLABLE'
+    when e.billable is true and (e.pricing_category is null or e.pricing_model is null) then 'PROVIDER_PRICING_METADATA_INCOMPLETE'
+    when e.billable is true and e.billing_market_code in ('UNMAPPED','UNRESOLVED') then 'PROVIDER_MARKET_UNRESOLVED'
+    when e.billable is true and r.id is null then 'VERIFIED_RATE_NOT_FOUND'
+    when r.authority_grade='LEGACY_ESTIMATE' then 'LEGACY_ESTIMATE_RATE'
+    else 'VERIFIED_PROVIDER_RATE'
+  end::text as cost_reason,
+  case
+    when e.billable is false then 0::numeric
+    when e.billable is true and r.id is not null then r.flat_cost
+    else null::numeric
+  end as cost_amount,
+  case
+    when e.billable is true and r.id is not null then r.currency
+    else null::text
+  end as cost_currency,
+  e.pricing_type,
+  e.billing_market_code,
+  e.business_phone_number_id
+from public.aos_wa_l8_meta_pricing_evidence_v1 e
+left join lateral (
+  select p.*
+  from public.aos_wa_l7_pricing_authority_v1 p
+  where p.provider='META_WHATSAPP'
+    and p.pricing_kind='META_MESSAGE'
+    and pg_catalog.lower(p.pricing_model)=pg_catalog.lower(coalesce(e.pricing_model,''))
+    and pg_catalog.lower(coalesce(p.pricing_category,''))=pg_catalog.lower(coalesce(e.pricing_category,''))
+    and p.market_code=e.billing_market_code
+    and e.billing_market_code not in ('UNMAPPED','UNRESOLVED')
+    and p.valid_from<=e.cost_event_at
+    and (p.valid_to is null or e.cost_event_at<p.valid_to)
+  order by p.valid_from desc,p.created_at desc
+  limit 1
+) r on e.billable is true;
+
+revoke all on public.aos_wa_l7_meta_cost_events_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l7_meta_cost_events_v1 to service_role;
+
+-- Invoice/reconciliation observability. This deliberately reports provider-observed
+-- billable/non-billable counts and does NOT hardcode a monthly free allowance.
+-- A free-tier entitlement becomes a forecast rule only after WABA/account evidence
+-- is loaded through a separately governed authority.
+create or replace view public.aos_wa_l8_meta_monthly_usage_v1
+with (security_invoker=true,security_barrier=true)
+as
+select
+  e.business_phone_number_id,
+  (pg_catalog.date_trunc('month',e.cost_event_at at time zone 'UTC'))::date as billing_month_utc,
+  e.billing_market_code,
+  e.pricing_category,
+  e.pricing_model,
+  e.pricing_type,
+  pg_catalog.count(*)::bigint as outbound_messages,
+  pg_catalog.count(*) filter(where e.billable is true)::bigint as provider_billable_messages,
+  pg_catalog.count(*) filter(where e.billable is false)::bigint as provider_nonbillable_messages,
+  pg_catalog.count(*) filter(where e.cost_state='KNOWN')::bigint as known_cost_events,
+  pg_catalog.count(*) filter(where e.cost_state='PARTIAL')::bigint as partial_cost_events,
+  pg_catalog.count(*) filter(where e.cost_state='UNKNOWN')::bigint as unknown_cost_events,
+  pg_catalog.sum(e.cost_amount) filter(where e.cost_state='KNOWN') as known_cost_amount,
+  case
+    when pg_catalog.count(distinct e.cost_currency) filter(where e.cost_amount<>0 and e.cost_currency is not null)=1
+      then pg_catalog.max(e.cost_currency) filter(where e.cost_amount<>0 and e.cost_currency is not null)
+    else null::text
+  end as known_cost_currency
+from public.aos_wa_l7_meta_cost_events_v1 e
+group by e.business_phone_number_id,(pg_catalog.date_trunc('month',e.cost_event_at at time zone 'UTC'))::date,
+         e.billing_market_code,e.pricing_category,e.pricing_model,e.pricing_type;
+
+revoke all on public.aos_wa_l8_meta_monthly_usage_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l8_meta_monthly_usage_v1 to service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Consent / opt-out evidence and autonomous policy preflight
+-- ---------------------------------------------------------------------------
+create table public.aos_wa_l8_consent_events_v1 (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.aos_wa_conversations_v1(id) on delete restrict,
+  recipient_kind text not null check (recipient_kind in ('PHONE','BSUID')),
+  recipient_hash text not null check (recipient_hash ~ '^[a-f0-9]{64}$'),
+  action text not null check (action in ('OPT_IN','OPT_OUT')),
+  source text not null check (source in ('ADMIN_EVIDENCE','CUSTOMER_REQUEST','PRIVACY_FORM','OTHER_VERIFIED')),
+  evidence_ref text not null check (char_length(btrim(evidence_ref)) between 8 and 1000),
+  actor_id uuid not null references public.aos_usuarios(id) on delete restrict,
+  created_at timestamptz not null default now()
+);
+create index aos_wa_l8_consent_recipient_idx
+  on public.aos_wa_l8_consent_events_v1(recipient_hash,created_at desc);
+create index aos_wa_l8_consent_conversation_idx
+  on public.aos_wa_l8_consent_events_v1(conversation_id,created_at desc);
+
+alter table public.aos_wa_l8_consent_events_v1 enable row level security;
+alter table public.aos_wa_l8_consent_events_v1 force row level security;
+revoke all on public.aos_wa_l8_consent_events_v1 from public,anon,authenticated;
+grant select,insert on public.aos_wa_l8_consent_events_v1 to service_role;
+
+create or replace function public.aos_wa_l8_append_guard_v1()
+returns trigger language plpgsql set search_path='' as $$
+begin
+  raise exception 'WA_L8_APPEND_ONLY' using errcode='55000';
+end
+$$;
+
+drop trigger if exists trg_aos_wa_l8_consent_append_guard_v1 on public.aos_wa_l8_consent_events_v1;
+create trigger trg_aos_wa_l8_consent_append_guard_v1
+before update or delete on public.aos_wa_l8_consent_events_v1
+for each row execute function public.aos_wa_l8_append_guard_v1();
+
+create table public.aos_wa_l8_preflight_decisions_v1 (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique check (idempotency_key ~ '^[A-Za-z0-9._:-]{16,120}$'),
+  conversation_id uuid not null references public.aos_wa_conversations_v1(id) on delete restrict,
+  recipient_hash text not null check (recipient_hash ~ '^[a-f0-9]{64}$'),
+  message_type text not null,
+  template_name text,
+  decision text not null check (decision in ('PASS','BLOCK','HANDOFF')),
+  reason_code text not null,
+  service_window_open boolean not null default false,
+  last_inbound_at timestamptz,
+  latest_stop_at timestamptz,
+  consent_action text,
+  consent_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index aos_wa_l8_preflight_conversation_idx
+  on public.aos_wa_l8_preflight_decisions_v1(conversation_id,created_at desc);
+
+alter table public.aos_wa_l8_preflight_decisions_v1 enable row level security;
+alter table public.aos_wa_l8_preflight_decisions_v1 force row level security;
+revoke all on public.aos_wa_l8_preflight_decisions_v1 from public,anon,authenticated;
+grant select,insert on public.aos_wa_l8_preflight_decisions_v1 to service_role;
+
+drop trigger if exists trg_aos_wa_l8_preflight_append_guard_v1 on public.aos_wa_l8_preflight_decisions_v1;
+create trigger trg_aos_wa_l8_preflight_append_guard_v1
+before update or delete on public.aos_wa_l8_preflight_decisions_v1
+for each row execute function public.aos_wa_l8_append_guard_v1();
+
+create or replace function public.aos_wa_l8_consent_record_v1(
+  p_token text,
+  p_conversation_id uuid,
+  p_action text,
+  p_source text,
+  p_evidence_ref text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_actor uuid;
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_action text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_action,'')));
+  v_source text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_source,'')));
+  v_evidence text:=nullif(pg_catalog.btrim(coalesce(p_evidence_ref,'')),'');
+  v_hash text;
+  v_id uuid;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'admin-whatsapp',true);
+  if v_actor is null then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_ADMIN_2FA_REQUIRED'); end if;
+  if v_action not in ('OPT_IN','OPT_OUT') then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_ACTION_INVALID'); end if;
+  if v_source not in ('ADMIN_EVIDENCE','CUSTOMER_REQUEST','PRIVACY_FORM','OTHER_VERIFIED') then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_SOURCE_INVALID'); end if;
+  if v_evidence is null or pg_catalog.length(v_evidence) not between 8 and 1000 then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_EVIDENCE_REQUIRED'); end if;
+
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.contact_address_type not in ('PHONE','BSUID') or nullif(pg_catalog.btrim(coalesce(v_conv.contact_address,'')),'') is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_RECIPIENT_UNRESOLVED');
+  end if;
+
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_conv.contact_address_type||':'||v_conv.contact_address,'UTF8'),'sha256'),'hex');
+  insert into public.aos_wa_l8_consent_events_v1(conversation_id,recipient_kind,recipient_hash,action,source,evidence_ref,actor_id)
+  values(v_conv.id,v_conv.contact_address_type,v_hash,v_action,v_source,v_evidence,v_actor)
+  returning id into v_id;
+
+  return pg_catalog.jsonb_build_object('ok',true,'status','APPENDED','consent_event_id',v_id,'conversation_id',v_conv.id,'action',v_action,'source',v_source);
+end
+$$;
+
+create or replace function public.aos_wa_l8_autonomous_preflight_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
+  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+  v_hash text;
+  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
+  v_last_inbound timestamptz;
+  v_stop_at timestamptz;
+  v_consent_action text;
+  v_consent_at timestamptz;
+  v_window boolean:=false;
+  v_decision text:='PASS';
+  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
+  v_id uuid;
+begin
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end if;
+
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
+  end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+
+  select pg_catalog.max(coalesce(m.provider_timestamp,m.received_at,m.created_at))
+    into v_last_inbound
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND';
+
+  select pg_catalog.max(coalesce(m.provider_timestamp,m.received_at,m.created_at))
+    into v_stop_at
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
+    and pg_catalog.regexp_replace(
+          pg_catalog.regexp_replace(
+            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(m.message_body,''))),'áéíóúüñ','aeiouun'),
+            '[[:punct:]]',' ','g'),
+          '[[:space:]]+',' ','g')
+        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$';
+
+  select c.action,c.created_at into v_consent_action,v_consent_at
+  from public.aos_wa_l8_consent_events_v1 c
+  where c.recipient_hash=v_hash
+  order by c.created_at desc
+  limit 1;
+
+  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
+
+  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
+    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif (v_consent_action='OPT_OUT' and (v_stop_at is null or v_consent_at>=v_stop_at))
+     or (v_stop_at is not null and (v_consent_at is null or v_consent_action<>'OPT_IN' or v_consent_at<=v_stop_at)) then
+    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
+  elsif v_window then
+    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
+  elsif v_type<>'template' or v_template is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
+  elsif v_consent_action='OPT_IN' and (v_stop_at is null or v_consent_at>v_stop_at) then
+    v_decision:='PASS';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_OK';
+  else
+    v_decision:='BLOCK';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED';
+  end if;
+
+  begin
+    insert into public.aos_wa_l8_preflight_decisions_v1(
+      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
+      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at)
+    values(p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
+      v_window,v_last_inbound,v_stop_at,v_consent_action,v_consent_at)
+    returning id into v_id;
+  exception when unique_violation then
+    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end;
+
+  return pg_catalog.jsonb_build_object('ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,
+    'reason',v_reason,'service_window_open',v_window,'last_inbound_at',v_last_inbound,
+    'consent_action',v_consent_action,'consent_at',v_consent_at,'latest_stop_at',v_stop_at);
+end
+$$;
+
+-- Wrap the already-certified L4 authority instead of duplicating/reimplementing it.
+-- Server/runtime continues to call the same public function signature.
+alter function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)
+  rename to aos_wa_l4_authorize_autonomous_send_pre_l8_v1;
+
+revoke all on function public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
+
+create or replace function public.aos_wa_l4_authorize_autonomous_send_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text,
+  p_content_hash text,
+  p_safety_action text default null,
+  p_identity_state text default 'NOT_REQUIRED',
+  p_requires_identity boolean default false,
+  p_campaign_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_pre jsonb;
+  v_l4 jsonb;
+  v_decision text;
+begin
+  v_pre:=public.aos_wa_l8_autonomous_preflight_v1(
+    p_conversation_id,p_recipient_kind,p_recipient_address,p_message_type,p_template_name,p_idempotency_key
+  );
+  v_decision:=coalesce(v_pre->>'decision','BLOCK');
+  if v_decision<>'PASS' then
+    return pg_catalog.jsonb_build_object(
+      'ok',false,'decision',case when v_decision='HANDOFF' then 'HANDOFF' else 'BLOCK' end,
+      'reason',coalesce(v_pre->>'reason','WA_L8_PREFLIGHT_BLOCKED'),
+      'l8_preflight_id',v_pre->>'preflight_id','l8_preflight',v_decision,'l8',v_pre
+    );
+  end if;
+
+  v_l4:=public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1(
+    p_conversation_id,p_recipient_kind,p_recipient_address,p_message_type,p_template_name,p_idempotency_key,
+    p_content_hash,p_safety_action,p_identity_state,p_requires_identity,p_campaign_key
+  );
+  return coalesce(v_l4,'{}'::jsonb)||pg_catalog.jsonb_build_object(
+    'l8_preflight_id',v_pre->>'preflight_id','l8_preflight','PASS'
+  );
+end
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Least privilege on the exact autonomous path only
+-- ---------------------------------------------------------------------------
+-- Gateway needs SELECT/INSERT/UPDATE on messages/outbound reservation; it never
+-- needs destructive/table-management privileges.
+revoke delete,truncate,references,trigger on public.aos_wa_messages_v1 from service_role;
+revoke delete,truncate,references,trigger on public.aos_wa_outbound_requests_v1 from service_role;
+revoke delete,truncate,references,trigger on public.aos_wa_conversations_v1 from service_role;
+
+-- AI run ledger is append-only metadata. Booking operations are written by the
+-- certified SECURITY DEFINER booking core; direct service-role DML is unnecessary.
+revoke update,delete,truncate,references,trigger on public.aos_wa_ai_runs_v1 from service_role;
+revoke insert,update,delete,truncate,references,trigger on public.aos_booking_operations_v2 from service_role;
+grant select on public.aos_booking_operations_v2 to service_role;
+
+-- L8 functions are server-side except the authenticated consent-admin RPC, whose
+-- own token+2FA check remains authoritative.
+revoke all on function public.aos_wa_l8_append_guard_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l8_consent_record_v1(text,uuid,text,text,text) from public;
+grant execute on function public.aos_wa_l8_append_guard_v1() to service_role;
+grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
+grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
+grant execute on function public.aos_wa_l8_consent_record_v1(text,uuid,text,text,text) to anon,authenticated,service_role;
+
+-- Security/readback surface; no PII or raw content is returned.
+create or replace function public.aos_wa_l8_security_status_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select pg_catalog.jsonb_build_object(
+    'ok',true,
+    'mode',a.mode,
+    'kill_switch_engaged',a.kill_switch_engaged,
+    'auto_reply_enabled',ai.auto_reply_enabled,
+    'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,
+    'human_send_enabled',r.human_send_enabled,
+    'consent_events',(select pg_catalog.count(*) from public.aos_wa_l8_consent_events_v1),
+    'preflight_decisions',(select pg_catalog.count(*) from public.aos_wa_l8_preflight_decisions_v1),
+    'pricing_type_events',(select pg_catalog.count(*) from public.aos_wa_events_v1 e where e.event_type='message.status' and nullif(e.payload->>'pricing_type','') is not null),
+    'pricing_authority_rows',(select pg_catalog.count(*) from public.aos_wa_l7_pricing_authority_v1),
+    'autonomous_outbound',(select pg_catalog.count(*) from public.aos_wa_messages_v1 m where m.direction='OUTBOUND' and m.send_origin='AUTO'),
+    'browser_message_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','INSERT,UPDATE,DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','INSERT,UPDATE,DELETE')
+    ),
+    'browser_booking_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','INSERT,UPDATE,DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','INSERT,UPDATE,DELETE')
+    )
+  )
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+revoke all on function public.aos_wa_l8_security_status_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_security_status_v1() to service_role;
+
+comment on table public.aos_wa_l8_consent_events_v1 is 'WA-L8 append-only consent evidence. Recipient stored only as SHA-256 hash; no raw address.';
+comment on table public.aos_wa_l8_preflight_decisions_v1 is 'WA-L8 append-only autonomous policy preflight. No message body, phone or raw prompt stored.';
+comment on view public.aos_wa_l8_meta_monthly_usage_v1 is 'Provider-observed monthly Meta usage/cost reconciliation by business phone and market. No fabricated free-tier entitlement.';
+comment on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) is 'WA-L8 wrapper: consent/service-window preflight first, then certified L4 send authority. SAFE-OFF remains external control state.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql
+++ b/supabase/migrations/20260903194600_wa_l8_bounded_preflight_fix_v1.sql
@@ -1,0 +1,164 @@
+-- WA-L8 corrective hardening before certification.
+-- Replaces the initial STOP scan with one indexed latest-inbound read and makes
+-- the status privilege probes explicit. No new authority or activation.
+
+begin;
+
+create or replace function public.aos_wa_l8_autonomous_preflight_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
+  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+  v_hash text;
+  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
+  v_last_inbound timestamptz;
+  v_last_inbound_body text;
+  v_latest_signal text;
+  v_stop_at timestamptz;
+  v_consent_action text;
+  v_consent_at timestamptz;
+  v_window boolean:=false;
+  v_decision text:='PASS';
+  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
+  v_id uuid;
+begin
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end if;
+
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
+  end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+
+  -- Bounded/indexed read: the existing conversation index is scanned backwards and
+  -- stops at the first inbound row. Historical opt-out state lives in the consent ledger.
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at),m.message_body
+    into v_last_inbound,v_last_inbound_body
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
+  order by m.created_at desc
+  limit 1;
+
+  v_latest_signal:=pg_catalog.regexp_replace(
+    pg_catalog.regexp_replace(
+      pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(v_last_inbound_body,''))),'áéíóúüñ','aeiouun'),
+      '[[:punct:]]',' ','g'),
+    '[[:space:]]+',' ','g');
+  if v_latest_signal ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$' then
+    v_stop_at:=v_last_inbound;
+  end if;
+
+  select c.action,c.created_at into v_consent_action,v_consent_at
+  from public.aos_wa_l8_consent_events_v1 c
+  where c.recipient_hash=v_hash
+  order by c.created_at desc
+  limit 1;
+
+  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
+
+  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
+    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif (v_consent_action='OPT_OUT' and (v_stop_at is null or v_consent_at>=v_stop_at))
+     or (v_stop_at is not null and (v_consent_at is null or v_consent_action<>'OPT_IN' or v_consent_at<=v_stop_at)) then
+    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
+  elsif v_window then
+    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
+  elsif v_type<>'template' or v_template is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
+  elsif v_consent_action='OPT_IN' and (v_stop_at is null or v_consent_at>v_stop_at) then
+    v_decision:='PASS';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_OK';
+  else
+    v_decision:='BLOCK';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED';
+  end if;
+
+  begin
+    insert into public.aos_wa_l8_preflight_decisions_v1(
+      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
+      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at)
+    values(p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
+      v_window,v_last_inbound,v_stop_at,v_consent_action,v_consent_at)
+    returning id into v_id;
+  exception when unique_violation then
+    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end;
+
+  return pg_catalog.jsonb_build_object('ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,
+    'reason',v_reason,'service_window_open',v_window,'last_inbound_at',v_last_inbound,
+    'consent_action',v_consent_action,'consent_at',v_consent_at,'latest_stop_at',v_stop_at);
+end
+$$;
+
+revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
+
+create or replace function public.aos_wa_l8_security_status_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select pg_catalog.jsonb_build_object(
+    'ok',true,
+    'mode',a.mode,
+    'kill_switch_engaged',a.kill_switch_engaged,
+    'auto_reply_enabled',ai.auto_reply_enabled,
+    'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,
+    'human_send_enabled',r.human_send_enabled,
+    'consent_events',(select pg_catalog.count(*) from public.aos_wa_l8_consent_events_v1),
+    'preflight_decisions',(select pg_catalog.count(*) from public.aos_wa_l8_preflight_decisions_v1),
+    'pricing_type_events',(select pg_catalog.count(*) from public.aos_wa_events_v1 e where e.event_type='message.status' and nullif(e.payload->>'pricing_type','') is not null),
+    'pricing_authority_rows',(select pg_catalog.count(*) from public.aos_wa_l7_pricing_authority_v1),
+    'autonomous_outbound',(select pg_catalog.count(*) from public.aos_wa_messages_v1 m where m.direction='OUTBOUND' and m.send_origin='AUTO'),
+    'browser_message_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','DELETE')
+    ),
+    'browser_booking_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','DELETE')
+    )
+  )
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+revoke all on function public.aos_wa_l8_security_status_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_security_status_v1() to service_role;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903194700_wa_l8_persistent_stop_index_v1.sql
+++ b/supabase/migrations/20260903194700_wa_l8_persistent_stop_index_v1.sql
@@ -1,0 +1,132 @@
+-- WA-L8 persistent customer STOP hardening.
+-- Keeps opt-out effective even when later inbound messages exist, without adding
+-- triggers or scanning a conversation's full history on the autonomous hot path.
+
+begin;
+
+create index if not exists aos_wa_l8_message_stop_idx
+  on public.aos_wa_messages_v1(conversation_id,created_at desc)
+  where direction='INBOUND'
+    and pg_catalog.regexp_replace(
+          pg_catalog.regexp_replace(
+            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(message_body,''))),'áéíóúüñ','aeiouun'),
+            '[[:punct:]]',' ','g'),
+          '[[:space:]]+',' ','g')
+        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$';
+
+create or replace function public.aos_wa_l8_autonomous_preflight_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
+  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+  v_hash text;
+  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
+  v_last_inbound timestamptz;
+  v_stop_at timestamptz;
+  v_consent_action text;
+  v_consent_at timestamptz;
+  v_window boolean:=false;
+  v_decision text:='PASS';
+  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
+  v_id uuid;
+begin
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end if;
+
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
+  end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+
+  -- Latest inbound uses the certified conversation index and stops after one row.
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_last_inbound
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
+  order by m.created_at desc
+  limit 1;
+
+  -- Persistent customer STOP uses the small partial index above. A later ordinary
+  -- inbound does not erase the opt-out. A later evidence-backed OPT_IN may supersede it.
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_stop_at
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id
+    and m.direction='INBOUND'
+    and pg_catalog.regexp_replace(
+          pg_catalog.regexp_replace(
+            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(m.message_body,''))),'áéíóúüñ','aeiouun'),
+            '[[:punct:]]',' ','g'),
+          '[[:space:]]+',' ','g')
+        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$'
+  order by m.created_at desc
+  limit 1;
+
+  select c.action,c.created_at into v_consent_action,v_consent_at
+  from public.aos_wa_l8_consent_events_v1 c
+  where c.recipient_hash=v_hash
+  order by c.created_at desc
+  limit 1;
+
+  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
+
+  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
+    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif (v_consent_action='OPT_OUT' and (v_stop_at is null or v_consent_at>=v_stop_at))
+     or (v_stop_at is not null and (v_consent_at is null or v_consent_action<>'OPT_IN' or v_consent_at<=v_stop_at)) then
+    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
+  elsif v_window then
+    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
+  elsif v_type<>'template' or v_template is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
+  elsif v_consent_action='OPT_IN' and (v_stop_at is null or v_consent_at>v_stop_at) then
+    v_decision:='PASS';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_OK';
+  else
+    v_decision:='BLOCK';v_reason:='WA_L8_BUSINESS_INITIATED_OPT_IN_REQUIRED';
+  end if;
+
+  begin
+    insert into public.aos_wa_l8_preflight_decisions_v1(
+      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
+      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at)
+    values(p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
+      v_window,v_last_inbound,v_stop_at,v_consent_action,v_consent_at)
+    returning id into v_id;
+  exception when unique_violation then
+    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+    return pg_catalog.jsonb_build_object('ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,'service_window_open',v_existing.service_window_open);
+  end;
+
+  return pg_catalog.jsonb_build_object('ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,
+    'reason',v_reason,'service_window_open',v_window,'last_inbound_at',v_last_inbound,
+    'consent_action',v_consent_action,'consent_at',v_consent_at,'latest_stop_at',v_stop_at);
+end
+$$;
+
+revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql
+++ b/supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql
@@ -8,7 +8,6 @@ begin;
 do $$
 begin
   if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is null
-     or to_regprocedure('public.aos_wa_marketing_eligibility_check_v1(uuid,text)') is null
      or to_regprocedure('public.aos_wa_marketing_eligibility_record_v1(jsonb)') is null then
     raise exception 'WA_L8_SCOPED_ELIGIBILITY_AUTHORITY_REQUIRED';
   end if;
@@ -102,7 +101,12 @@ begin
   end if;
 
   v_key:='l8:'||pg_catalog.lower(v_scope)||':'||pg_catalog.lower(v_action)||':'||p_conversation_id::text||':'||
-    pg_catalog.substring(pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_evidence||'|'||pg_catalog.clock_timestamp()::text,'UTF8'),'sha256'),'hex') from 1 for 24);
+    pg_catalog.substr(
+      pg_catalog.encode(
+        extensions.digest(pg_catalog.convert_to(v_evidence||'|'||pg_catalog.clock_timestamp()::text,'UTF8'),'sha256'),
+        'hex'
+      ),1,24
+    );
   v_payload:=pg_catalog.jsonb_build_object(
     'event_key',v_key,
     'conversation_id',p_conversation_id,
@@ -130,7 +134,7 @@ grant execute on function public.aos_wa_l8_consent_record_v2(text,uuid,text,text
 
 -- Zero-friction transactional consent: the same explicit affirmative that confirms a
 -- booking may grant Utility messaging only when a versioned disclosure was shown.
--- This function does not infer consent from merely having a booking.
+-- This function never infers consent merely from the existence of an appointment.
 create or replace function public.aos_wa_l8_record_booking_utility_optin_v1(
   p_conversation_id uuid,
   p_confirmation_provider_message_id text,
@@ -157,7 +161,6 @@ begin
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_EVIDENCE_REQUIRED');
   end if;
 
-  -- Prove the affirmative came from this customer/conversation and was accepted by L5.
   select e.created_at into v_confirmed_at
   from public.aos_wa_l5_booking_events_v1 e
   where e.conversation_id=p_conversation_id
@@ -174,7 +177,6 @@ begin
     return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_CUSTOMER_CONFIRMATION_REQUIRED');
   end if;
 
-  -- Prove the confirmed flow actually committed a WhatsApp BOOK/REBOOK.
   select o.id into v_operation_id
   from public.aos_booking_operations_v2 o
   join public.aos_wa_l5_booking_events_v1 e
@@ -191,7 +193,12 @@ begin
   end if;
 
   v_key:='l8:utility:booking:'||p_conversation_id::text||':'||
-    pg_catalog.substring(pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_provider||'|'||v_disclosure,'UTF8'),'sha256'),'hex') from 1 for 24);
+    pg_catalog.substr(
+      pg_catalog.encode(
+        extensions.digest(pg_catalog.convert_to(v_provider||'|'||v_disclosure,'UTF8'),'sha256'),
+        'hex'
+      ),1,24
+    );
   v_result:=public.aos_wa_marketing_eligibility_record_v1(pg_catalog.jsonb_build_object(
     'event_key',v_key,
     'conversation_id',p_conversation_id,
@@ -219,154 +226,7 @@ $$;
 revoke all on function public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text) from public,anon,authenticated;
 grant execute on function public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text) to service_role;
 
--- Final scoped preflight. Customer service responses inside 24h remain natural.
--- Outside 24h a template is mandatory and its category-specific eligibility must pass.
-create or replace function public.aos_wa_l8_autonomous_preflight_v1(
-  p_conversation_id uuid,
-  p_recipient_kind text,
-  p_recipient_address text,
-  p_message_type text,
-  p_template_name text,
-  p_idempotency_key text
-) returns jsonb
-language plpgsql
-security definer
-set search_path=''
-as $$
-declare
-  v_conv public.aos_wa_conversations_v1%rowtype;
-  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
-  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
-  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
-  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
-  v_hash text;
-  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
-  v_last_inbound timestamptz;
-  v_stop_at timestamptz;
-  v_reconsent_at timestamptz;
-  v_window boolean:=false;
-  v_scope text;
-  v_elig jsonb:='{}'::jsonb;
-  v_elig_status text;
-  v_elig_reason text;
-  v_decision text:='PASS';
-  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
-  v_id uuid;
-begin
-  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
-    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
-  end if;
-  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
-  if v_existing.id is not null then
-    return pg_catalog.jsonb_build_object(
-      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
-      'decision',v_existing.decision,'reason',v_existing.reason_code,
-      'service_window_open',v_existing.service_window_open,
-      'eligibility_scope',v_existing.eligibility_scope,
-      'eligibility_status',v_existing.eligibility_status,
-      'eligibility_reason',v_existing.eligibility_reason
-    );
-  end if;
-  if v_kind not in ('PHONE','BSUID') or v_address is null then
-    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
-  end if;
-  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
-  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
-  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
-  v_scope:=public.aos_wa_l8_scope_for_send_v1(v_type,v_template);
-
-  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
-    into v_last_inbound
-  from public.aos_wa_messages_v1 m
-  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
-  order by m.created_at desc
-  limit 1;
-
-  -- Uses WA-L8 partial STOP index; later ordinary messages do not erase opt-out.
-  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
-    into v_stop_at
-  from public.aos_wa_messages_v1 m
-  where m.conversation_id=p_conversation_id
-    and m.direction='INBOUND'
-    and pg_catalog.regexp_replace(
-          pg_catalog.regexp_replace(
-            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(m.message_body,''))),'áéíóúüñ','aeiouun'),
-            '[[:punct:]]',' ','g'),
-          '[[:space:]]+',' ','g')
-        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$'
-  order by m.created_at desc
-  limit 1;
-
-  if v_stop_at is not null then
-    select pg_catalog.max(e.observed_at) into v_reconsent_at
-    from public.aos_wa_marketing_eligibility_events_v1 e
-    where e.conversation_id=p_conversation_id
-      and e.consent_status='ALLOWED'
-      and e.suppression_status='CLEAR'
-      and coalesce((e.evidence->>'explicit_reconsent')::boolean,false) is true
-      and e.observed_at>v_stop_at
-      and (
-        e.eligibility_scope='GLOBAL'
-        or (v_scope='SERVICE_WINDOW' and e.eligibility_scope in ('UTILITY','MARKETING','AUTHENTICATION'))
-        or e.eligibility_scope=v_scope
-      );
-  end if;
-
-  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
-
-  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
-    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
-  elsif v_stop_at is not null and v_reconsent_at is null then
-    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
-  elsif v_window then
-    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
-  elsif v_type<>'template' or v_template is null then
-    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
-  else
-    v_elig:=public.aos_wa_marketing_eligibility_check_v1(p_conversation_id,v_scope);
-    v_elig_status:=v_elig->>'eligibility_status';
-    v_elig_reason:=v_elig->>'reason_code';
-    if coalesce((v_elig->>'send_allowed')::boolean,false) then
-      v_decision:='PASS';v_reason:='WA_L8_SCOPED_ELIGIBILITY_OK';
-    else
-      v_decision:='BLOCK';v_reason:='WA_L8_SCOPED_ELIGIBILITY_REQUIRED';
-    end if;
-  end if;
-
-  begin
-    insert into public.aos_wa_l8_preflight_decisions_v1(
-      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
-      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at,
-      eligibility_scope,eligibility_status,eligibility_reason
-    ) values(
-      p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
-      v_window,v_last_inbound,v_stop_at,null,v_reconsent_at,
-      v_scope,v_elig_status,v_elig_reason
-    ) returning id into v_id;
-  exception when unique_violation then
-    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
-    return pg_catalog.jsonb_build_object(
-      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
-      'decision',v_existing.decision,'reason',v_existing.reason_code,
-      'service_window_open',v_existing.service_window_open,
-      'eligibility_scope',v_existing.eligibility_scope,
-      'eligibility_status',v_existing.eligibility_status,
-      'eligibility_reason',v_existing.eligibility_reason
-    );
-  end;
-
-  return pg_catalog.jsonb_build_object(
-    'ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,'reason',v_reason,
-    'service_window_open',v_window,'last_inbound_at',v_last_inbound,'latest_stop_at',v_stop_at,
-    'explicit_reconsent_at',v_reconsent_at,'eligibility_scope',v_scope,
-    'eligibility_status',v_elig_status,'eligibility_reason',v_elig_reason
-  );
-end
-$$;
-
-revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
-grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
-
+-- Security/readback surface; no raw PII or message bodies are returned.
 create or replace function public.aos_wa_l8_security_status_v1()
 returns jsonb
 language sql

--- a/supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql
+++ b/supabase/migrations/20260903194800_wa_l8_scoped_eligibility_v1.sql
@@ -1,0 +1,423 @@
+-- WA-L8 final consent hardening: one scoped eligibility authority, zero extra consent UX.
+-- WA-7A.4 is the sole consent/suppression authority. The early L8 consent table stays
+-- inert only for migration compatibility and receives no further writes.
+-- No CANARY transition, provider dispatch, business-ledger mutation or hot-path trigger.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is null
+     or to_regprocedure('public.aos_wa_marketing_eligibility_check_v1(uuid,text)') is null
+     or to_regprocedure('public.aos_wa_marketing_eligibility_record_v1(jsonb)') is null then
+    raise exception 'WA_L8_SCOPED_ELIGIBILITY_AUTHORITY_REQUIRED';
+  end if;
+end $$;
+
+-- The first L8 draft introduced a local consent ledger. It never became PROD authority.
+-- Keep the empty table structurally for rollback compatibility, but make it inert.
+drop function if exists public.aos_wa_l8_consent_record_v1(text,uuid,text,text,text);
+revoke all on table public.aos_wa_l8_consent_events_v1 from public,anon,authenticated,service_role;
+comment on table public.aos_wa_l8_consent_events_v1 is
+  'WA-L8 deprecated/inert compatibility table. WA-7A.4 aos_wa_marketing_eligibility_events_v1 is the sole consent/suppression authority.';
+
+alter table public.aos_wa_l8_preflight_decisions_v1
+  add column if not exists eligibility_scope text,
+  add column if not exists eligibility_status text,
+  add column if not exists eligibility_reason text;
+
+-- Current appointment templates are Utility. Unknown future templates are classified
+-- conservatively as Marketing until their provider/category authority is explicit.
+create or replace function public.aos_wa_l8_scope_for_send_v1(
+  p_message_type text,
+  p_template_name text
+) returns text
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+begin
+  if v_type<>'template' or v_template is null then return 'SERVICE_WINDOW'; end if;
+  if exists(
+    select 1
+    from public.aos_agenda_delivery_template_registry_v3 t
+    where t.channel='WHATSAPP'
+      and t.provider='META_CLOUD_API'
+      and t.active is true
+      and t.provider_verified is true
+      and t.provider_template_name=v_template
+      and t.delivery_kind in ('CONFIRMATION','REPROGRAMMATION','REMINDER_TOMORROW','REMINDER_TODAY')
+  ) then return 'UTILITY'; end if;
+  return 'MARKETING';
+end
+$$;
+
+revoke all on function public.aos_wa_l8_scope_for_send_v1(text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_scope_for_send_v1(text,text) to service_role;
+
+-- Human/admin evidence recorder. No raw phone/BSUID is duplicated; authority is
+-- conversation-scoped and append-only in WA-7A.4.
+create or replace function public.aos_wa_l8_consent_record_v2(
+  p_token text,
+  p_conversation_id uuid,
+  p_scope text,
+  p_action text,
+  p_source text,
+  p_evidence_ref text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_actor uuid;
+  v_scope text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_scope,'')));
+  v_action text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_action,'')));
+  v_source text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_source,'')));
+  v_evidence text:=nullif(pg_catalog.btrim(coalesce(p_evidence_ref,'')),'');
+  v_key text;
+  v_payload jsonb;
+  v_result jsonb;
+begin
+  v_actor:=public.aos_app_actor_v3(p_token,'admin-whatsapp',true);
+  if v_actor is null then return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_ADMIN_2FA_REQUIRED'); end if;
+  if v_scope not in ('GLOBAL','MARKETING','UTILITY','AUTHENTICATION') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_SCOPE_INVALID');
+  end if;
+  if v_action not in ('OPT_IN','OPT_OUT') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_ACTION_INVALID');
+  end if;
+  if v_source not in ('ADMIN_EVIDENCE','CUSTOMER_REQUEST','PRIVACY_FORM','BOOKING_DISCLOSURE','OTHER_VERIFIED') then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_SOURCE_INVALID');
+  end if;
+  if v_evidence is null or pg_catalog.length(v_evidence) not between 8 and 1000 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONSENT_EVIDENCE_REQUIRED');
+  end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 c where c.id=p_conversation_id) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_CONVERSATION_NOT_FOUND');
+  end if;
+
+  v_key:='l8:'||pg_catalog.lower(v_scope)||':'||pg_catalog.lower(v_action)||':'||p_conversation_id::text||':'||
+    pg_catalog.substring(pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_evidence||'|'||pg_catalog.clock_timestamp()::text,'UTF8'),'sha256'),'hex') from 1 for 24);
+  v_payload:=pg_catalog.jsonb_build_object(
+    'event_key',v_key,
+    'conversation_id',p_conversation_id,
+    'eligibility_scope',v_scope,
+    'consent_status',case when v_action='OPT_IN' then 'ALLOWED' else 'DENIED' end,
+    'suppression_status',case when v_action='OPT_IN' then 'CLEAR' else 'SUPPRESSED' end,
+    'source',v_source,
+    'source_ref',v_evidence,
+    'policy_version','WA_L8_SCOPED_CONSENT_V1',
+    'evidence',pg_catalog.jsonb_build_object(
+      'action',v_action,
+      'explicit_reconsent',v_action='OPT_IN',
+      'raw_recipient_stored',false
+    ),
+    'actor_user_id',v_actor,
+    'observed_at',pg_catalog.clock_timestamp()
+  );
+  v_result:=public.aos_wa_marketing_eligibility_record_v1(v_payload);
+  return coalesce(v_result,'{}'::jsonb)||pg_catalog.jsonb_build_object('scope',v_scope,'action',v_action,'authority','WA7A4');
+end
+$$;
+
+revoke all on function public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text) from public;
+grant execute on function public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text) to anon,authenticated,service_role;
+
+-- Zero-friction transactional consent: the same explicit affirmative that confirms a
+-- booking may grant Utility messaging only when a versioned disclosure was shown.
+-- This function does not infer consent from merely having a booking.
+create or replace function public.aos_wa_l8_record_booking_utility_optin_v1(
+  p_conversation_id uuid,
+  p_confirmation_provider_message_id text,
+  p_disclosure_version text,
+  p_evidence_ref text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_provider text:=nullif(pg_catalog.btrim(coalesce(p_confirmation_provider_message_id,'')),'');
+  v_disclosure text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_disclosure_version,'')));
+  v_evidence text:=nullif(pg_catalog.btrim(coalesce(p_evidence_ref,'')),'');
+  v_confirmed_at timestamptz;
+  v_operation_id uuid;
+  v_key text;
+  v_result jsonb;
+begin
+  if v_disclosure<>'WA_L8_BOOKING_UTILITY_V1' then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_DISCLOSURE_VERSION_REQUIRED');
+  end if;
+  if v_provider is null or v_evidence is null or pg_catalog.length(v_evidence) not between 8 and 1000 then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_EVIDENCE_REQUIRED');
+  end if;
+
+  -- Prove the affirmative came from this customer/conversation and was accepted by L5.
+  select e.created_at into v_confirmed_at
+  from public.aos_wa_l5_booking_events_v1 e
+  where e.conversation_id=p_conversation_id
+    and e.event_type='CONFIRMED'
+    and e.metadata->>'provider_message_id'=v_provider
+  order by e.created_at desc
+  limit 1;
+  if v_confirmed_at is null or not exists(
+    select 1 from public.aos_wa_messages_v1 m
+    where m.conversation_id=p_conversation_id
+      and m.provider_message_id=v_provider
+      and m.direction='INBOUND'
+  ) then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_CUSTOMER_CONFIRMATION_REQUIRED');
+  end if;
+
+  -- Prove the confirmed flow actually committed a WhatsApp BOOK/REBOOK.
+  select o.id into v_operation_id
+  from public.aos_booking_operations_v2 o
+  join public.aos_wa_l5_booking_events_v1 e
+    on e.operation_id=o.id and e.conversation_id=p_conversation_id and e.event_type='COMMITTED'
+  where o.conversation_id=p_conversation_id
+    and o.channel='WHATSAPP'
+    and o.operation_type in ('BOOK','REBOOK')
+    and o.status in ('BOOKED','REBOOKED')
+    and e.created_at>=v_confirmed_at
+  order by e.created_at asc
+  limit 1;
+  if v_operation_id is null then
+    return pg_catalog.jsonb_build_object('ok',false,'error','WA_L8_UTILITY_COMMITTED_BOOKING_REQUIRED');
+  end if;
+
+  v_key:='l8:utility:booking:'||p_conversation_id::text||':'||
+    pg_catalog.substring(pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_provider||'|'||v_disclosure,'UTF8'),'sha256'),'hex') from 1 for 24);
+  v_result:=public.aos_wa_marketing_eligibility_record_v1(pg_catalog.jsonb_build_object(
+    'event_key',v_key,
+    'conversation_id',p_conversation_id,
+    'eligibility_scope','UTILITY',
+    'consent_status','ALLOWED',
+    'suppression_status','CLEAR',
+    'source','BOOKING_DISCLOSURE',
+    'source_ref',v_evidence,
+    'policy_version','WA_L8_SCOPED_CONSENT_V1',
+    'evidence',pg_catalog.jsonb_build_object(
+      'explicit_reconsent',true,
+      'disclosure_version',v_disclosure,
+      'confirmation_provider_message_id',v_provider,
+      'operation_id',v_operation_id,
+      'raw_recipient_stored',false
+    ),
+    'observed_at',v_confirmed_at
+  ));
+  return coalesce(v_result,'{}'::jsonb)||pg_catalog.jsonb_build_object(
+    'scope','UTILITY','authority','WA7A4','operation_id',v_operation_id,'disclosure_version',v_disclosure
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text) to service_role;
+
+-- Final scoped preflight. Customer service responses inside 24h remain natural.
+-- Outside 24h a template is mandatory and its category-specific eligibility must pass.
+create or replace function public.aos_wa_l8_autonomous_preflight_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
+  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+  v_hash text;
+  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
+  v_last_inbound timestamptz;
+  v_stop_at timestamptz;
+  v_reconsent_at timestamptz;
+  v_window boolean:=false;
+  v_scope text;
+  v_elig jsonb:='{}'::jsonb;
+  v_elig_status text;
+  v_elig_reason text;
+  v_decision text:='PASS';
+  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
+  v_id uuid;
+begin
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return pg_catalog.jsonb_build_object(
+      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,
+      'service_window_open',v_existing.service_window_open,
+      'eligibility_scope',v_existing.eligibility_scope,
+      'eligibility_status',v_existing.eligibility_status,
+      'eligibility_reason',v_existing.eligibility_reason
+    );
+  end if;
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
+  end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+  v_scope:=public.aos_wa_l8_scope_for_send_v1(v_type,v_template);
+
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_last_inbound
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
+  order by m.created_at desc
+  limit 1;
+
+  -- Uses WA-L8 partial STOP index; later ordinary messages do not erase opt-out.
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_stop_at
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id
+    and m.direction='INBOUND'
+    and pg_catalog.regexp_replace(
+          pg_catalog.regexp_replace(
+            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(m.message_body,''))),'áéíóúüñ','aeiouun'),
+            '[[:punct:]]',' ','g'),
+          '[[:space:]]+',' ','g')
+        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$'
+  order by m.created_at desc
+  limit 1;
+
+  if v_stop_at is not null then
+    select pg_catalog.max(e.observed_at) into v_reconsent_at
+    from public.aos_wa_marketing_eligibility_events_v1 e
+    where e.conversation_id=p_conversation_id
+      and e.consent_status='ALLOWED'
+      and e.suppression_status='CLEAR'
+      and coalesce((e.evidence->>'explicit_reconsent')::boolean,false) is true
+      and e.observed_at>v_stop_at
+      and (
+        e.eligibility_scope='GLOBAL'
+        or (v_scope='SERVICE_WINDOW' and e.eligibility_scope in ('UTILITY','MARKETING','AUTHENTICATION'))
+        or e.eligibility_scope=v_scope
+      );
+  end if;
+
+  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
+
+  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
+    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif v_stop_at is not null and v_reconsent_at is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
+  elsif v_window then
+    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
+  elsif v_type<>'template' or v_template is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
+  else
+    v_elig:=public.aos_wa_marketing_eligibility_check_v1(p_conversation_id,v_scope);
+    v_elig_status:=v_elig->>'eligibility_status';
+    v_elig_reason:=v_elig->>'reason_code';
+    if coalesce((v_elig->>'send_allowed')::boolean,false) then
+      v_decision:='PASS';v_reason:='WA_L8_SCOPED_ELIGIBILITY_OK';
+    else
+      v_decision:='BLOCK';v_reason:='WA_L8_SCOPED_ELIGIBILITY_REQUIRED';
+    end if;
+  end if;
+
+  begin
+    insert into public.aos_wa_l8_preflight_decisions_v1(
+      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
+      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at,
+      eligibility_scope,eligibility_status,eligibility_reason
+    ) values(
+      p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
+      v_window,v_last_inbound,v_stop_at,null,v_reconsent_at,
+      v_scope,v_elig_status,v_elig_reason
+    ) returning id into v_id;
+  exception when unique_violation then
+    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+    return pg_catalog.jsonb_build_object(
+      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,
+      'service_window_open',v_existing.service_window_open,
+      'eligibility_scope',v_existing.eligibility_scope,
+      'eligibility_status',v_existing.eligibility_status,
+      'eligibility_reason',v_existing.eligibility_reason
+    );
+  end;
+
+  return pg_catalog.jsonb_build_object(
+    'ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,'reason',v_reason,
+    'service_window_open',v_window,'last_inbound_at',v_last_inbound,'latest_stop_at',v_stop_at,
+    'explicit_reconsent_at',v_reconsent_at,'eligibility_scope',v_scope,
+    'eligibility_status',v_elig_status,'eligibility_reason',v_elig_reason
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
+
+create or replace function public.aos_wa_l8_security_status_v1()
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select pg_catalog.jsonb_build_object(
+    'ok',true,
+    'mode',a.mode,
+    'kill_switch_engaged',a.kill_switch_engaged,
+    'auto_reply_enabled',ai.auto_reply_enabled,
+    'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,
+    'human_send_enabled',r.human_send_enabled,
+    'scoped_eligibility_events',(select pg_catalog.count(*) from public.aos_wa_marketing_eligibility_events_v1),
+    'deprecated_l8_consent_events',(select pg_catalog.count(*) from public.aos_wa_l8_consent_events_v1),
+    'preflight_decisions',(select pg_catalog.count(*) from public.aos_wa_l8_preflight_decisions_v1),
+    'pricing_type_events',(select pg_catalog.count(*) from public.aos_wa_events_v1 e where e.event_type='message.status' and nullif(e.payload->>'pricing_type','') is not null),
+    'pricing_authority_rows',(select pg_catalog.count(*) from public.aos_wa_l7_pricing_authority_v1),
+    'autonomous_outbound',(select pg_catalog.count(*) from public.aos_wa_messages_v1 m where m.direction='OUTBOUND' and m.send_origin='AUTO'),
+    'browser_message_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','DELETE')
+    ),
+    'browser_booking_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','DELETE')
+    )
+  )
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+revoke all on function public.aos_wa_l8_security_status_v1() from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_security_status_v1() to service_role;
+
+comment on function public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text) is
+  'Records Utility opt-in only after L5 explicit customer confirmation + committed WhatsApp booking + versioned disclosure. No extra consent message required.';
+comment on function public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text) is
+  'Admin/verified scoped consent adapter into sole WA-7A.4 eligibility authority.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql
+++ b/supabase/migrations/20260903194900_wa_l8_bounded_scoped_eligibility_v1.sql
@@ -1,0 +1,280 @@
+-- WA-L8 P0 final hardening.
+-- WA-7A.4 remains the sole consent/suppression evidence authority, but its global
+-- projection is never used on the autonomous hot path. This migration resolves one
+-- conversation + one scope with indexed LIMIT 1 reads only.
+
+begin;
+
+create or replace function public.aos_wa_l8_scoped_eligibility_check_v1(
+  p_conversation_id uuid,
+  p_scope text
+) returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_scope text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_scope,'')));
+  v_alias_count integer:=0;
+  v_phone_alias text;
+  v_contact_key text;
+  v_g_consent text:='UNKNOWN'; v_g_supp text:='UNKNOWN'; v_g_source text; v_g_event text; v_g_exp timestamptz;
+  v_s_consent text:='UNKNOWN'; v_s_supp text:='UNKNOWN'; v_s_source text; v_s_event text; v_s_exp timestamptz;
+  v_cia_consent text; v_cia_supp text; v_cia_source text; v_cia_exp timestamptz;
+  v_consent text; v_supp text; v_send boolean:=false; v_reason text;
+begin
+  if v_scope not in ('MARKETING','UTILITY','AUTHENTICATION','CALL') then
+    raise exception 'WA_L8_SCOPE_INVALID' using errcode='22023';
+  end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 c where c.id=p_conversation_id) then
+    raise exception 'WA_L8_CONVERSATION_NOT_FOUND' using errcode='23503';
+  end if;
+
+  select pg_catalog.count(*)::integer into v_alias_count
+  from public.aos_wa_channel_aliases_v1 a
+  where a.conversation_id=p_conversation_id
+    and a.active is true
+    and a.alias_type in ('PHONE','BSUID','PARENT_BSUID');
+
+  select a.alias_value into v_phone_alias
+  from public.aos_wa_channel_aliases_v1 a
+  where a.conversation_id=p_conversation_id
+    and a.active is true
+    and a.alias_type='PHONE'
+  order by a.last_seen_at desc
+  limit 1;
+
+  if v_phone_alias is not null then
+    v_contact_key:=public.aos_cia_normalize_contact_key_v1(v_phone_alias);
+  end if;
+
+  select e.consent_status,e.suppression_status,e.source,e.event_key,e.expires_at
+    into v_g_consent,v_g_supp,v_g_source,v_g_event,v_g_exp
+  from public.aos_wa_marketing_eligibility_events_v1 e
+  where e.conversation_id=p_conversation_id and e.eligibility_scope='GLOBAL'
+  order by e.observed_at desc,e.created_at desc
+  limit 1;
+  if not found then v_g_consent:='UNKNOWN';v_g_supp:='UNKNOWN';v_g_source:=null;v_g_event:=null;v_g_exp:=null; end if;
+
+  select e.consent_status,e.suppression_status,e.source,e.event_key,e.expires_at
+    into v_s_consent,v_s_supp,v_s_source,v_s_event,v_s_exp
+  from public.aos_wa_marketing_eligibility_events_v1 e
+  where e.conversation_id=p_conversation_id and e.eligibility_scope=v_scope
+  order by e.observed_at desc,e.created_at desc
+  limit 1;
+  if not found then v_s_consent:='UNKNOWN';v_s_supp:='UNKNOWN';v_s_source:=null;v_s_event:=null;v_s_exp:=null; end if;
+
+  if v_g_exp is not null and v_g_exp<=pg_catalog.now() then v_g_consent:='UNKNOWN';v_g_supp:='UNKNOWN'; end if;
+  if v_s_exp is not null and v_s_exp<=pg_catalog.now() then v_s_consent:='UNKNOWN';v_s_supp:='UNKNOWN'; end if;
+
+  if v_contact_key is not null then
+    select c.consent_status,c.suppression_status,c.source,c.expires_at
+      into v_cia_consent,v_cia_supp,v_cia_source,v_cia_exp
+    from public.aos_cia_channel_recipient_controls_v1 c
+    where c.contact_key=v_contact_key and c.channel='WHATSAPP'
+    limit 1;
+    if v_cia_exp is not null and v_cia_exp<=pg_catalog.now() then
+      v_cia_consent:=null;v_cia_supp:=null;v_cia_source:=null;v_cia_exp:=null;
+    end if;
+  end if;
+
+  v_consent:=case
+    when v_g_consent='DENIED' or v_s_consent='DENIED' then 'DENIED'
+    when v_s_consent='ALLOWED' then 'ALLOWED'
+    when v_g_consent='ALLOWED' then 'ALLOWED'
+    else 'UNKNOWN' end;
+  v_supp:=case
+    when v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' then 'SUPPRESSED'
+    when v_s_supp='CLEAR' and v_s_consent='ALLOWED' then 'CLEAR'
+    when v_g_supp='CLEAR' and v_g_consent='ALLOWED' then 'CLEAR'
+    else 'UNKNOWN' end;
+
+  v_send:=v_alias_count>0
+    and not (v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' or v_g_consent='DENIED' or v_s_consent='DENIED')
+    and not (v_cia_supp='SUPPRESSED' or v_cia_consent='DENIED')
+    and ((v_s_consent='ALLOWED' and v_s_supp='CLEAR')
+      or (v_s_consent='UNKNOWN' and v_g_consent='ALLOWED' and v_g_supp='CLEAR'));
+
+  v_reason:=case
+    when v_alias_count=0 then 'UNREACHABLE'
+    when v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' then 'WA_SUPPRESSED'
+    when v_g_consent='DENIED' or v_s_consent='DENIED' then 'WA_DENIED'
+    when v_cia_supp='SUPPRESSED' then 'CIA_SUPPRESSED'
+    when v_cia_consent='DENIED' then 'CIA_DENIED'
+    when v_send then 'ELIGIBLE_EXPLICIT'
+    else 'CONSENT_UNKNOWN' end;
+
+  return pg_catalog.jsonb_build_object(
+    'conversation_id',p_conversation_id,
+    'eligibility_scope',v_scope,
+    'reachability_status',case when v_alias_count>0 then 'REACHABLE' else 'UNREACHABLE' end,
+    'reachability_alias_count',v_alias_count,
+    'consent_status',v_consent,
+    'suppression_status',v_supp,
+    'eligibility_status',case when v_send then 'ELIGIBLE' when v_reason in ('UNREACHABLE','WA_SUPPRESSED','WA_DENIED','CIA_SUPPRESSED','CIA_DENIED') then 'NOT_ELIGIBLE' else 'UNKNOWN' end,
+    'reason_code',v_reason,
+    'send_allowed',v_send,
+    'global_event_key',v_g_event,
+    'scope_event_key',v_s_event,
+    'global_source',v_g_source,
+    'scope_source',v_s_source,
+    'cia_source',v_cia_source
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) to service_role;
+
+-- Replace only the final eligibility read. All prior STOP / 24h / scope semantics remain.
+create or replace function public.aos_wa_l8_autonomous_preflight_v1(
+  p_conversation_id uuid,
+  p_recipient_kind text,
+  p_recipient_address text,
+  p_message_type text,
+  p_template_name text,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_kind text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_recipient_kind,'')));
+  v_address text:=public.aos_wa_l4_normalize_subject_v1(v_kind,p_recipient_address);
+  v_type text:=pg_catalog.lower(pg_catalog.btrim(coalesce(p_message_type,'')));
+  v_template text:=nullif(pg_catalog.btrim(coalesce(p_template_name,'')),'');
+  v_hash text;
+  v_existing public.aos_wa_l8_preflight_decisions_v1%rowtype;
+  v_last_inbound timestamptz;
+  v_stop_at timestamptz;
+  v_reconsent_at timestamptz;
+  v_window boolean:=false;
+  v_scope text;
+  v_elig jsonb:='{}'::jsonb;
+  v_elig_status text;
+  v_elig_reason text;
+  v_decision text:='PASS';
+  v_reason text:='WA_L8_SERVICE_WINDOW_OK';
+  v_id uuid;
+begin
+  if coalesce(p_idempotency_key,'') !~ '^[A-Za-z0-9._:-]{16,120}$' then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_IDEMPOTENCY_KEY');
+  end if;
+  select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+  if v_existing.id is not null then
+    return pg_catalog.jsonb_build_object(
+      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,
+      'service_window_open',v_existing.service_window_open,
+      'eligibility_scope',v_existing.eligibility_scope,
+      'eligibility_status',v_existing.eligibility_status,
+      'eligibility_reason',v_existing.eligibility_reason
+    );
+  end if;
+  if v_kind not in ('PHONE','BSUID') or v_address is null then
+    return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_INVALID_RECIPIENT');
+  end if;
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id;
+  if v_conv.id is null then return pg_catalog.jsonb_build_object('ok',false,'decision','BLOCK','reason','WA_L8_CONVERSATION_NOT_FOUND'); end if;
+  v_hash:=pg_catalog.encode(extensions.digest(pg_catalog.convert_to(v_kind||':'||v_address,'UTF8'),'sha256'),'hex');
+  v_scope:=public.aos_wa_l8_scope_for_send_v1(v_type,v_template);
+
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_last_inbound
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id and m.direction='INBOUND'
+  order by m.created_at desc
+  limit 1;
+
+  select coalesce(m.provider_timestamp,m.received_at,m.created_at)
+    into v_stop_at
+  from public.aos_wa_messages_v1 m
+  where m.conversation_id=p_conversation_id
+    and m.direction='INBOUND'
+    and pg_catalog.regexp_replace(
+          pg_catalog.regexp_replace(
+            pg_catalog.translate(pg_catalog.lower(pg_catalog.btrim(coalesce(m.message_body,''))),'áéíóúüñ','aeiouun'),
+            '[[:punct:]]',' ','g'),
+          '[[:space:]]+',' ','g')
+        ~ '^(stop|baja|cancelar suscripcion|no quiero mensajes|no me escriban|no mas mensajes)$'
+  order by m.created_at desc
+  limit 1;
+
+  if v_stop_at is not null then
+    select pg_catalog.max(e.observed_at) into v_reconsent_at
+    from public.aos_wa_marketing_eligibility_events_v1 e
+    where e.conversation_id=p_conversation_id
+      and e.consent_status='ALLOWED'
+      and e.suppression_status='CLEAR'
+      and coalesce((e.evidence->>'explicit_reconsent')::boolean,false) is true
+      and e.observed_at>v_stop_at
+      and (
+        e.eligibility_scope='GLOBAL'
+        or (v_scope='SERVICE_WINDOW' and e.eligibility_scope in ('UTILITY','MARKETING','AUTHENTICATION'))
+        or e.eligibility_scope=v_scope
+      );
+  end if;
+
+  v_window:=(v_last_inbound is not null and v_last_inbound>=pg_catalog.now()-interval '24 hours');
+
+  if v_conv.contact_address_type<>v_kind or v_conv.contact_address<>v_address then
+    v_decision:='HANDOFF';v_reason:='WA_L8_RECIPIENT_CONVERSATION_MISMATCH';
+  elsif v_stop_at is not null and v_reconsent_at is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_OPT_OUT_ACTIVE';
+  elsif v_window then
+    v_decision:='PASS';v_reason:='WA_L8_SERVICE_WINDOW_OK';
+  elsif v_type<>'template' or v_template is null then
+    v_decision:='BLOCK';v_reason:='WA_L8_TEMPLATE_REQUIRED_OUTSIDE_24H';
+  else
+    v_elig:=public.aos_wa_l8_scoped_eligibility_check_v1(p_conversation_id,v_scope);
+    v_elig_status:=v_elig->>'eligibility_status';
+    v_elig_reason:=v_elig->>'reason_code';
+    if coalesce((v_elig->>'send_allowed')::boolean,false) then
+      v_decision:='PASS';v_reason:='WA_L8_SCOPED_ELIGIBILITY_OK';
+    else
+      v_decision:='BLOCK';v_reason:='WA_L8_SCOPED_ELIGIBILITY_REQUIRED';
+    end if;
+  end if;
+
+  begin
+    insert into public.aos_wa_l8_preflight_decisions_v1(
+      idempotency_key,conversation_id,recipient_hash,message_type,template_name,decision,reason_code,
+      service_window_open,last_inbound_at,latest_stop_at,consent_action,consent_at,
+      eligibility_scope,eligibility_status,eligibility_reason
+    ) values(
+      p_idempotency_key,p_conversation_id,v_hash,v_type,v_template,v_decision,v_reason,
+      v_window,v_last_inbound,v_stop_at,null,v_reconsent_at,
+      v_scope,v_elig_status,v_elig_reason
+    ) returning id into v_id;
+  exception when unique_violation then
+    select * into v_existing from public.aos_wa_l8_preflight_decisions_v1 where idempotency_key=p_idempotency_key;
+    return pg_catalog.jsonb_build_object(
+      'ok',v_existing.decision='PASS','replay',true,'preflight_id',v_existing.id,
+      'decision',v_existing.decision,'reason',v_existing.reason_code,
+      'service_window_open',v_existing.service_window_open,
+      'eligibility_scope',v_existing.eligibility_scope,
+      'eligibility_status',v_existing.eligibility_status,
+      'eligibility_reason',v_existing.eligibility_reason
+    );
+  end;
+
+  return pg_catalog.jsonb_build_object(
+    'ok',v_decision='PASS','replay',false,'preflight_id',v_id,'decision',v_decision,'reason',v_reason,
+    'service_window_open',v_window,'last_inbound_at',v_last_inbound,'latest_stop_at',v_stop_at,
+    'explicit_reconsent_at',v_reconsent_at,'eligibility_scope',v_scope,
+    'eligibility_status',v_elig_status,'eligibility_reason',v_elig_reason
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text) to service_role;
+
+comment on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) is
+  'P0-bounded WA-7A.4 eligibility resolver: one conversation/scope, indexed latest evidence only; no global eligibility projection on autonomous hot path.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql
+++ b/supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql
@@ -1,0 +1,134 @@
+-- WA-L8 bounded eligibility null guard.
+-- Absence of a CIA recipient-control row is neutral, not SQL NULL propagation.
+
+begin;
+
+create or replace function public.aos_wa_l8_scoped_eligibility_check_v1(
+  p_conversation_id uuid,
+  p_scope text
+) returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_scope text:=pg_catalog.upper(pg_catalog.btrim(coalesce(p_scope,'')));
+  v_alias_count integer:=0;
+  v_phone_alias text;
+  v_contact_key text;
+  v_g_consent text:='UNKNOWN'; v_g_supp text:='UNKNOWN'; v_g_source text; v_g_event text; v_g_exp timestamptz;
+  v_s_consent text:='UNKNOWN'; v_s_supp text:='UNKNOWN'; v_s_source text; v_s_event text; v_s_exp timestamptz;
+  v_cia_consent text:='UNKNOWN'; v_cia_supp text:='UNKNOWN'; v_cia_source text; v_cia_exp timestamptz;
+  v_consent text; v_supp text; v_send boolean:=false; v_reason text;
+begin
+  if v_scope not in ('MARKETING','UTILITY','AUTHENTICATION','CALL') then
+    raise exception 'WA_L8_SCOPE_INVALID' using errcode='22023';
+  end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 c where c.id=p_conversation_id) then
+    raise exception 'WA_L8_CONVERSATION_NOT_FOUND' using errcode='23503';
+  end if;
+
+  select pg_catalog.count(*)::integer into v_alias_count
+  from public.aos_wa_channel_aliases_v1 a
+  where a.conversation_id=p_conversation_id
+    and a.active is true
+    and a.alias_type in ('PHONE','BSUID','PARENT_BSUID');
+
+  select a.alias_value into v_phone_alias
+  from public.aos_wa_channel_aliases_v1 a
+  where a.conversation_id=p_conversation_id
+    and a.active is true
+    and a.alias_type='PHONE'
+  order by a.last_seen_at desc
+  limit 1;
+
+  if v_phone_alias is not null then
+    v_contact_key:=public.aos_cia_normalize_contact_key_v1(v_phone_alias);
+  end if;
+
+  select e.consent_status,e.suppression_status,e.source,e.event_key,e.expires_at
+    into v_g_consent,v_g_supp,v_g_source,v_g_event,v_g_exp
+  from public.aos_wa_marketing_eligibility_events_v1 e
+  where e.conversation_id=p_conversation_id and e.eligibility_scope='GLOBAL'
+  order by e.observed_at desc,e.created_at desc
+  limit 1;
+  if not found then v_g_consent:='UNKNOWN';v_g_supp:='UNKNOWN';v_g_source:=null;v_g_event:=null;v_g_exp:=null; end if;
+
+  select e.consent_status,e.suppression_status,e.source,e.event_key,e.expires_at
+    into v_s_consent,v_s_supp,v_s_source,v_s_event,v_s_exp
+  from public.aos_wa_marketing_eligibility_events_v1 e
+  where e.conversation_id=p_conversation_id and e.eligibility_scope=v_scope
+  order by e.observed_at desc,e.created_at desc
+  limit 1;
+  if not found then v_s_consent:='UNKNOWN';v_s_supp:='UNKNOWN';v_s_source:=null;v_s_event:=null;v_s_exp:=null; end if;
+
+  if v_g_exp is not null and v_g_exp<=pg_catalog.now() then v_g_consent:='UNKNOWN';v_g_supp:='UNKNOWN'; end if;
+  if v_s_exp is not null and v_s_exp<=pg_catalog.now() then v_s_consent:='UNKNOWN';v_s_supp:='UNKNOWN'; end if;
+
+  if v_contact_key is not null then
+    select c.consent_status,c.suppression_status,c.source,c.expires_at
+      into v_cia_consent,v_cia_supp,v_cia_source,v_cia_exp
+    from public.aos_cia_channel_recipient_controls_v1 c
+    where c.contact_key=v_contact_key and c.channel='WHATSAPP'
+    limit 1;
+    if not found then
+      v_cia_consent:='UNKNOWN';v_cia_supp:='UNKNOWN';v_cia_source:=null;v_cia_exp:=null;
+    elsif v_cia_exp is not null and v_cia_exp<=pg_catalog.now() then
+      v_cia_consent:='UNKNOWN';v_cia_supp:='UNKNOWN';v_cia_source:=null;v_cia_exp:=null;
+    end if;
+  end if;
+
+  v_cia_consent:=coalesce(v_cia_consent,'UNKNOWN');
+  v_cia_supp:=coalesce(v_cia_supp,'UNKNOWN');
+
+  v_consent:=case
+    when v_g_consent='DENIED' or v_s_consent='DENIED' then 'DENIED'
+    when v_s_consent='ALLOWED' then 'ALLOWED'
+    when v_g_consent='ALLOWED' then 'ALLOWED'
+    else 'UNKNOWN' end;
+  v_supp:=case
+    when v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' then 'SUPPRESSED'
+    when v_s_supp='CLEAR' and v_s_consent='ALLOWED' then 'CLEAR'
+    when v_g_supp='CLEAR' and v_g_consent='ALLOWED' then 'CLEAR'
+    else 'UNKNOWN' end;
+
+  v_send:=v_alias_count>0
+    and not (v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' or v_g_consent='DENIED' or v_s_consent='DENIED')
+    and not (v_cia_supp='SUPPRESSED' or v_cia_consent='DENIED')
+    and ((v_s_consent='ALLOWED' and v_s_supp='CLEAR')
+      or (v_s_consent='UNKNOWN' and v_g_consent='ALLOWED' and v_g_supp='CLEAR'));
+
+  v_reason:=case
+    when v_alias_count=0 then 'UNREACHABLE'
+    when v_g_supp='SUPPRESSED' or v_s_supp='SUPPRESSED' then 'WA_SUPPRESSED'
+    when v_g_consent='DENIED' or v_s_consent='DENIED' then 'WA_DENIED'
+    when v_cia_supp='SUPPRESSED' then 'CIA_SUPPRESSED'
+    when v_cia_consent='DENIED' then 'CIA_DENIED'
+    when v_send then 'ELIGIBLE_EXPLICIT'
+    else 'CONSENT_UNKNOWN' end;
+
+  return pg_catalog.jsonb_build_object(
+    'conversation_id',p_conversation_id,
+    'eligibility_scope',v_scope,
+    'reachability_status',case when v_alias_count>0 then 'REACHABLE' else 'UNREACHABLE' end,
+    'reachability_alias_count',v_alias_count,
+    'consent_status',v_consent,
+    'suppression_status',v_supp,
+    'eligibility_status',case when v_send then 'ELIGIBLE' when v_reason in ('UNREACHABLE','WA_SUPPRESSED','WA_DENIED','CIA_SUPPRESSED','CIA_DENIED') then 'NOT_ELIGIBLE' else 'UNKNOWN' end,
+    'reason_code',v_reason,
+    'send_allowed',v_send,
+    'global_event_key',v_g_event,
+    'scope_event_key',v_s_event,
+    'global_source',v_g_source,
+    'scope_source',v_s_source,
+    'cia_source',v_cia_source
+  );
+end
+$$;
+
+revoke all on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) to service_role;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql
+++ b/supabase/migrations/20260903195000_wa_l8_bounded_eligibility_null_guard_v1.sql
@@ -1,5 +1,7 @@
 -- WA-L8 bounded eligibility null guard.
 -- Absence of a CIA recipient-control row is neutral, not SQL NULL propagation.
+-- The historical WA-7A.4 check API is retained as a compatibility surface but,
+-- once L8 is present, delegates to the bounded conversation+scope resolver.
 
 begin;
 
@@ -98,6 +100,7 @@ begin
     and not (v_cia_supp='SUPPRESSED' or v_cia_consent='DENIED')
     and ((v_s_consent='ALLOWED' and v_s_supp='CLEAR')
       or (v_s_consent='UNKNOWN' and v_g_consent='ALLOWED' and v_g_supp='CLEAR'));
+  v_send:=coalesce(v_send,false);
 
   v_reason:=case
     when v_alias_count=0 then 'UNREACHABLE'
@@ -129,6 +132,29 @@ $$;
 
 revoke all on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) from public,anon,authenticated;
 grant execute on function public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text) to service_role;
+
+-- Compatibility hardening: callers of the historical WA-7A.4 check API now get
+-- the same bounded, non-null decision semantics as L8. The global projection remains
+-- available for cold-path/admin use but is no longer required for point checks.
+create or replace function public.aos_wa_marketing_eligibility_check_v1(
+  p_conversation_id uuid,
+  p_scope text default 'MARKETING'
+) returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+begin
+  return public.aos_wa_l8_scoped_eligibility_check_v1(p_conversation_id,p_scope);
+end
+$$;
+
+revoke all on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) to service_role;
+
+comment on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) is
+  'WA-L8 compatibility surface: bounded conversation/scope eligibility check; no global projection on synchronous decision paths.';
 
 select pg_catalog.pg_notify('pgrst','reload schema');
 commit;

--- a/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+++ b/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
@@ -99,6 +99,7 @@ grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,tex
 -- Final scoped L8 helpers/adapters.
 drop function if exists public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text);
 drop function if exists public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text);
+drop function if exists public.aos_wa_l8_scoped_eligibility_check_v1(uuid,text);
 drop function if exists public.aos_wa_l8_scope_for_send_v1(text,text);
 
 drop function if exists public.aos_wa_l8_security_status_v1();

--- a/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+++ b/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
@@ -1,5 +1,5 @@
 -- WA-L8 recovery. Audit/consent history is immutable: structural recovery is
--- allowed only before any L8 consent/preflight evidence exists.
+-- allowed only before any L8 preflight or scoped-consent evidence exists.
 
 begin;
 
@@ -12,6 +12,13 @@ begin
   if to_regclass('public.aos_wa_l8_preflight_decisions_v1') is not null
      and exists(select 1 from public.aos_wa_l8_preflight_decisions_v1) then
     raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY';
+  end if;
+  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null
+     and exists(
+       select 1 from public.aos_wa_marketing_eligibility_events_v1
+       where policy_version='WA_L8_SCOPED_CONSENT_V1'
+     ) then
+    raise exception 'WA_L8_RECOVERY_BLOCKED_SCOPED_CONSENT_HISTORY';
   end if;
 end $$;
 
@@ -89,9 +96,16 @@ end $$;
 revoke all on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
 grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
 
+-- Final scoped L8 helpers/adapters.
+drop function if exists public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text);
+drop function if exists public.aos_wa_l8_record_booking_utility_optin_v1(uuid,text,text,text);
+drop function if exists public.aos_wa_l8_scope_for_send_v1(text,text);
+
 drop function if exists public.aos_wa_l8_security_status_v1();
 drop function if exists public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text);
 drop function if exists public.aos_wa_l8_consent_record_v1(text,uuid,text,text,text);
+
+drop index if exists public.aos_wa_l8_message_stop_idx;
 
 drop trigger if exists trg_aos_wa_l8_preflight_append_guard_v1 on public.aos_wa_l8_preflight_decisions_v1;
 drop table if exists public.aos_wa_l8_preflight_decisions_v1;

--- a/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+++ b/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
@@ -1,0 +1,107 @@
+-- WA-L8 recovery. Audit/consent history is immutable: structural recovery is
+-- allowed only before any L8 consent/preflight evidence exists.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.aos_wa_l8_consent_events_v1') is not null
+     and exists(select 1 from public.aos_wa_l8_consent_events_v1) then
+    raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY';
+  end if;
+  if to_regclass('public.aos_wa_l8_preflight_decisions_v1') is not null
+     and exists(select 1 from public.aos_wa_l8_preflight_decisions_v1) then
+    raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY';
+  end if;
+end $$;
+
+drop view if exists public.aos_wa_l8_meta_monthly_usage_v1;
+
+-- Restore the exact WA-L7 Meta cost semantics before removing L8 evidence view.
+create or replace view public.aos_wa_l7_meta_cost_events_v1
+with (security_invoker=true,security_barrier=true)
+as
+select
+  m.id as message_id,
+  m.provider_message_id,
+  m.conversation_id,
+  coalesce(m.delivered_at,m.sent_at,m.provider_timestamp,m.created_at) as cost_event_at,
+  m.pricing_category,
+  m.pricing_model,
+  m.billable,
+  r.id as pricing_authority_id,
+  r.authority_grade,
+  r.evidence_ref as pricing_evidence_ref,
+  case
+    when m.billable is false then 'KNOWN'
+    when m.billable is true and r.id is not null and r.authority_grade='VERIFIED' then 'KNOWN'
+    when m.billable is true and r.id is not null then 'PARTIAL'
+    else 'UNKNOWN'
+  end::text as cost_state,
+  case
+    when m.billable is false then 'PROVIDER_NON_BILLABLE'
+    when m.billable is true and (m.pricing_category is null or m.pricing_model is null) then 'PROVIDER_PRICING_METADATA_INCOMPLETE'
+    when m.billable is true and r.id is null then 'VERIFIED_RATE_NOT_FOUND'
+    when r.authority_grade='LEGACY_ESTIMATE' then 'LEGACY_ESTIMATE_RATE'
+    else 'VERIFIED_PROVIDER_RATE'
+  end::text as cost_reason,
+  case
+    when m.billable is false then 0::numeric
+    when m.billable is true and r.id is not null then r.flat_cost
+    else null::numeric
+  end as cost_amount,
+  case
+    when m.billable is true and r.id is not null then r.currency
+    else null::text
+  end as cost_currency
+from public.aos_wa_messages_v1 m
+left join lateral (
+  select p.*
+  from public.aos_wa_l7_pricing_authority_v1 p
+  where p.provider='META_WHATSAPP'
+    and p.pricing_kind='META_MESSAGE'
+    and pg_catalog.lower(p.pricing_model)=pg_catalog.lower(coalesce(m.pricing_model,''))
+    and pg_catalog.lower(coalesce(p.pricing_category,''))=pg_catalog.lower(coalesce(m.pricing_category,''))
+    and p.market_code='GLOBAL'
+    and p.valid_from<=coalesce(m.delivered_at,m.sent_at,m.provider_timestamp,m.created_at)
+    and (p.valid_to is null or coalesce(m.delivered_at,m.sent_at,m.provider_timestamp,m.created_at)<p.valid_to)
+  order by p.valid_from desc,p.created_at desc
+  limit 1
+) r on m.billable is true
+where m.direction='OUTBOUND';
+
+revoke all on public.aos_wa_l7_meta_cost_events_v1 from public,anon,authenticated;
+grant select on public.aos_wa_l7_meta_cost_events_v1 to service_role;
+
+drop view if exists public.aos_wa_l8_meta_pricing_evidence_v1;
+
+-- Restore the certified L4 public function name.
+drop function if exists public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text);
+do $$
+begin
+  if to_regprocedure('public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)') is not null then
+    alter function public.aos_wa_l4_authorize_autonomous_send_pre_l8_v1(uuid,text,text,text,text,text,text,text,text,boolean,text)
+      rename to aos_wa_l4_authorize_autonomous_send_v1;
+  end if;
+end $$;
+revoke all on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
+grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
+
+drop function if exists public.aos_wa_l8_security_status_v1();
+drop function if exists public.aos_wa_l8_autonomous_preflight_v1(uuid,text,text,text,text,text);
+drop function if exists public.aos_wa_l8_consent_record_v1(text,uuid,text,text,text);
+
+drop trigger if exists trg_aos_wa_l8_preflight_append_guard_v1 on public.aos_wa_l8_preflight_decisions_v1;
+drop table if exists public.aos_wa_l8_preflight_decisions_v1;
+drop trigger if exists trg_aos_wa_l8_consent_append_guard_v1 on public.aos_wa_l8_consent_events_v1;
+drop table if exists public.aos_wa_l8_consent_events_v1;
+drop function if exists public.aos_wa_l8_append_guard_v1();
+
+alter table public.aos_wa_l7_pricing_authority_v1
+  drop constraint if exists aos_wa_l8_meta_market_specific_ck;
+
+-- Least-privilege revocations are monotonic security hardening and intentionally
+-- survive structural recovery. They remove privileges no certified runtime needs.
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+++ b/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
@@ -3,24 +3,31 @@
 
 begin;
 
-do $$
+do $guard$
+declare
+  v_has boolean:=false;
 begin
-  if to_regclass('public.aos_wa_l8_consent_events_v1') is not null
-     and exists(select 1 from public.aos_wa_l8_consent_events_v1) then
-    raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY';
+  if to_regclass('public.aos_wa_l8_consent_events_v1') is not null then
+    execute 'select exists(select 1 from public.aos_wa_l8_consent_events_v1)' into v_has;
+    if v_has then raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY'; end if;
   end if;
-  if to_regclass('public.aos_wa_l8_preflight_decisions_v1') is not null
-     and exists(select 1 from public.aos_wa_l8_preflight_decisions_v1) then
-    raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY';
+
+  v_has:=false;
+  if to_regclass('public.aos_wa_l8_preflight_decisions_v1') is not null then
+    execute 'select exists(select 1 from public.aos_wa_l8_preflight_decisions_v1)' into v_has;
+    if v_has then raise exception 'WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY'; end if;
   end if;
-  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null
-     and exists(
-       select 1 from public.aos_wa_marketing_eligibility_events_v1
-       where policy_version='WA_L8_SCOPED_CONSENT_V1'
-     ) then
-    raise exception 'WA_L8_RECOVERY_BLOCKED_SCOPED_CONSENT_HISTORY';
+
+  v_has:=false;
+  if to_regclass('public.aos_wa_marketing_eligibility_events_v1') is not null then
+    execute $$select exists(
+      select 1 from public.aos_wa_marketing_eligibility_events_v1
+      where policy_version='WA_L8_SCOPED_CONSENT_V1'
+    )$$ into v_has;
+    if v_has then raise exception 'WA_L8_RECOVERY_BLOCKED_SCOPED_CONSENT_HISTORY'; end if;
   end if;
-end $$;
+end
+$guard$;
 
 drop view if exists public.aos_wa_l8_meta_monthly_usage_v1;
 
@@ -95,6 +102,45 @@ begin
 end $$;
 revoke all on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) from public,anon,authenticated;
 grant execute on function public.aos_wa_l4_authorize_autonomous_send_v1(uuid,text,text,text,text,text,text,text,text,boolean,text) to service_role;
+
+-- L8 temporarily hardens the historical WA-7A.4 check API to use the bounded
+-- resolver. If WA-7A.4 exists, restore its pre-L8 cold-path implementation before
+-- dropping the L8 resolver. Dynamic DDL keeps this recovery valid for older test
+-- substrates where WA-7A.4 was never installed.
+do $restore$
+begin
+  if to_regclass('public.aos_wa_marketing_eligibility_v1') is not null then
+    execute $ddl$
+create or replace function public.aos_wa_marketing_eligibility_check_v1(p_conversation_id uuid,p_scope text default 'MARKETING')
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path='public','pg_temp'
+as $fn$
+declare
+  v_scope text := upper(trim(coalesce(p_scope,'MARKETING')));
+  v_row record;
+begin
+  if v_scope not in ('MARKETING','UTILITY','AUTHENTICATION','CALL') then raise exception 'WA7A4_SCOPE_INVALID' using errcode='22023'; end if;
+  select * into v_row from public.aos_wa_marketing_eligibility_v1 where conversation_id=p_conversation_id and eligibility_scope=v_scope;
+  if v_row.conversation_id is null then raise exception 'WA7A4_CONVERSATION_NOT_FOUND' using errcode='23503'; end if;
+  return jsonb_build_object(
+    'conversation_id',v_row.conversation_id,'eligibility_scope',v_row.eligibility_scope,
+    'reachability_status',v_row.reachability_status,'consent_status',v_row.consent_status,
+    'suppression_status',v_row.suppression_status,'eligibility_status',v_row.eligibility_status,
+    'reason_code',v_row.reason_code,'send_allowed',v_row.send_allowed
+  );
+end
+$fn$;
+$ddl$;
+    revoke all on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) from public,anon,authenticated;
+    grant execute on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) to service_role;
+    comment on function public.aos_wa_marketing_eligibility_check_v1(uuid,text) is
+      'WA-7A.4 service-only eligibility check; send_allowed requires reachability + explicit allowed/clear evidence and no suppression.';
+  end if;
+end
+$restore$;
 
 -- Final scoped L8 helpers/adapters.
 drop function if exists public.aos_wa_l8_consent_record_v2(text,uuid,text,text,text,text);

--- a/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
+++ b/supabase/rollbacks/20260903194500_wa_l8_security_gate_v1.rollback.sql
@@ -17,8 +17,10 @@ end $$;
 
 drop view if exists public.aos_wa_l8_meta_monthly_usage_v1;
 
--- Restore the exact WA-L7 Meta cost semantics before removing L8 evidence view.
-create or replace view public.aos_wa_l7_meta_cost_events_v1
+-- CREATE OR REPLACE cannot remove L8's appended view columns, so drop/recreate
+-- the L7 view while no L8 audit history exists.
+drop view if exists public.aos_wa_l7_meta_cost_events_v1;
+create view public.aos_wa_l7_meta_cost_events_v1
 with (security_invoker=true,security_barrier=true)
 as
 select


### PR DESCRIPTION
Implements issue #451 under SAFE-OFF from frozen entry `main@237eda4099e90b4186037678c90078af0c6af89f` and governance lock `e57c2c6339134efd79dc71d4e7b0b980b723ea8d`.

### Scope
- preserve Meta `pricing.type` in sanitized status-event evidence;
- make Meta pricing recipient-market specific (`PE` when deterministically known) and reject authoritative Meta `GLOBAL` rates;
- add monthly provider-observed usage/cost reconciliation by business phone without fabricating the researched monthly allowance;
- append-only hashed OPT_IN/OPT_OUT evidence;
- bounded latest-inbound STOP/business-initiation preflight;
- wrap the already-certified L4 authority rather than replacing it;
- selective service-role least privilege on messages/outbound/conversations, AI runs and Booking Ops V2;
- dedicated Windows static + Linux real local-DB CI, recovery and P0 #432 matrix;
- explicit contract documentation.

### Policy evidence incorporated
- WhatsApp automation requires timely/clear human escalation;
- AI provider is treated as a third-party service provider; WhatsApp data is not authorized for general-model training/improvement;
- 2026 pricing changes are represented as versionable evidence, but no unverified PROD Meta rate/free-tier entitlement is seeded.

### Safety
This PR does **not** authorize or perform:
- `AUTO_OFF -> CANARY`;
- kill-switch disengagement;
- autonomous reply/send/routing;
- live allowlisted autonomous traffic;
- WA-L9/L10.

Expected closeout order: exact-head CI → anti-drift → merge with expected head → Railway SUCCESS → exact merged Supabase PROD migrations → live SAFE-OFF/security readback → close #451 → Notion sync.