### PR TITLE
docs: synchronize WA memory and roadmap through L11

### DIFF
--- a/ci/wa-closeout/wa-closeout-runtime-contract.js
+++ b/ci/wa-closeout/wa-closeout-runtime-contract.js
@@ -89,9 +89,13 @@ assert(alerts.includes("r.last_message_direction==='INBOUND'"),'human alert dire
 assert(alerts.includes('body:safePreview(r)'),'human alert sanitizer missing');
 assert(s13.includes("status==='delivered'")&&s13.includes("status==='read'"),'delivery/read UX missing');
 
-// 402 containment must stay narrow and credential-agnostic.
-assert(quota.includes('Phase-S|WA2|WA3|WA3V2|WA4|WA-Gateway|F17'),'full WA quota allowlist missing');
+// 402 containment is project-host scoped and credential-agnostic. Fair Use 402 is
+// project-wide, so the current hardened preload intentionally covers every request
+// to the configured Supabase host instead of maintaining a legacy WA User-Agent list.
+assert(quota.includes('isConfiguredSupabaseRequest(args, configuredHost)'),'quota breaker must classify by configured Supabase host');
+assert(quota.includes("scope: 'ALL_CONFIGURED_SUPABASE_RUNTIME_REQUESTS'"),'project-wide 402 breaker scope must remain explicit');
 assert(quota.includes('configuredHost'),'quota breaker host scope missing');
+assert(!quota.includes('userAgentRe'),'project-wide quota breaker must not depend on legacy User-Agent allowlists');
 assert(!quota.includes('SUPABASE_SERVICE_ROLE_KEY'),'quota breaker must not inspect service-role credential');
 assert(railway.includes('--require ./supabase-quota-circuit-preload.cjs'),'Railway quota preload missing');
 

--- a/docs/MEMORY_CURRENT.md
+++ b/docs/MEMORY_CURRENT.md
@@ -1,11 +1,12 @@
 # ASCENDA OS — MEMORY CURRENT
 
-**Captured:** 2026-08-27 America/Lima  
+**Captured:** 2026-09-03 America/Lima  
 **ACTIVE PROGRAM:** `WHATSAPP-REVENUE-HUB-V2`  
-**CURRENT GATE / MUTABLE LOCK:** `WA-4A — KNOWLEDGE FABRIC`  
-**WA-7A.4 CERT HEAD:** `ac58ceced7b6d06bec1792bbb4aa27d97f8e3db3`  
-**WA-7A.4 MERGE:** `95bd4acb806c2cee8b7e6d5dadba8b078beb15f6`  
-**WA-7A.4 PROD STATE:** `NOT APPLIED / PROMOTION QUEUED`
+**CURRENT MAIN AT CAPTURE:** `bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`  
+**ACTIVE HIGH/CRITICAL LOCK:** `NONE`  
+**LAST CLOSED LANE:** `WA-L9 — AUTONOMOUS DEMO READY`  
+**NEXT ELIGIBLE:** `WA-L10 — AUTONOMOUS PRODUCTION CANARY · NOT STARTED`  
+**CANARY:** `NOT AUTHORIZED · REQUIRES SEPARATE EXPLICIT OWNER AUTHORIZATION`
 
 ## Authority order
 
@@ -14,112 +15,204 @@
 3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`;
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
 5. this file;
-6. `docs/control/WHATSAPP_REVENUE_HUB_CURRENT.md`;
-7. latest WA certificate;
-8. `docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md`;
-9. exact GitHub + Supabase + Railway/runtime evidence;
-10. Notion executive continuity.
+6. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`;
+7. `docs/control/WA_AUTO_L9_TO_L11_CONTINUITY_CURRENT.md`;
+8. `docs/control/WHATSAPP_REVENUE_HUB_CURRENT.md`;
+9. `docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md`;
+10. `docs/control/ASCENDA_RELIABILITY_PERFORMANCE_DOCTRINE_CURRENT.md`;
+11. exact GitHub + Supabase + Railway/runtime evidence;
+12. Notion Control Maestro / Roadmap / Closeout / WA-AUTO continuity.
 
-Historical chat/doc snapshots never override exact CURRENT + runtime evidence.
+Historical chat/doc snapshots never override exact CURRENT + persisted runtime evidence.
 
-## Portfolio state
+## Global execution governance
 
-- REV-F5 = PRODUCTION CERTIFIED 100%.
-- REV-F6 = PRODUCTION CERTIFIED 100%.
-- REV-F7 = paused while WA owns the mutable lane.
-- WhatsApp Revenue Hub V2 = ACTIVE.
-- Notifications S13–S15.5 = CLOSED / regression-only.
-- CIA, Sentinel, KronIA and unrelated HIGH/CRITICAL work = read-only/regression-only unless strict WA dependency.
+- Exactly one mutable HIGH/CRITICAL lane at a time.
+- Every advance of `main` invalidates stale exact-head certification and requires revalidation for the active lane.
+- Protected merges use the certified PR head through `expected_head_sha` plus anti-drift verification.
+- `CODE PASS != DEPLOY PASS != PROD PASS`.
+- A completed lane does not implicitly authorize the next lane.
+- `AUTO_OFF -> CANARY` is a distinct owner decision. It must never be inferred from implementation, CI, deployment or broad continuation language.
+- `CANARY -> PROD` is also evidence-gated; no direct `AUTO_OFF -> PROD` transition is allowed by the L4 authority contract.
+- No synthetic production rows may be presented as real customer/provider evidence.
 
-## WhatsApp V2 current
+## Reliability doctrine retained from P0 #432
 
-- `WA-V2-0` = CLOSED.
-- `WA-3` = OFFLINE CERTIFIED / LIVE recovery debt.
-- `WA-3.5` = OFFLINE CERTIFIED 100% / LIVE recovery debt.
-- `WA-7A.0` = CLOSED at demonstrated identity-compatibility boundary.
-- `WA-7A.1` = CLOSED at demonstrated identity-resolution boundary.
-- `WA-7A.2` = CLOSED at demonstrated CODE/CI/ZERO-COST/PROD-SCHEMA/READBACK/RAILWAY boundary.
-- `WA-7A.3` = CLOSED at demonstrated CODE/CI/ZERO-COST/PROD-SCHEMA/READBACK/RAILWAY boundary.
-- `WA-7A.4` = `TEST CERTIFIED / PROD-READY / PROD-PROMOTION PENDING`.
-- `WA-4A` = ACTIVE MUTABLE LOCK.
-- existing WA4/Copilot runtime remains SAFE-OFF and does not certify WA-4A/B/C.
+Binding across all future WA work:
 
-## Foundation through WA-7A.4
+- no heavy global analytical views on synchronous message/call/booking/sales hot paths;
+- no synchronous materialized-view refresh/rebuild on transactional writes;
+- no timeout inflation to hide query defects;
+- bounded/indexed operational reads;
+- no legacy+new duplicate generation;
+- browser fan-out governed by single-flight / bounded concurrency / jitter / cooldown;
+- enrichment and analytical work stay on cold paths;
+- mandatory regressions: Agenda + Call Center + Marketing + Sales/Commissions + Patients/Identity + shared Supabase/background;
+- exact-head, deploy and LIVE readbacks are separate proof layers.
 
-Canonical person identity remains REV/F5/F6. WhatsApp does not create another customer/person master.
+## WhatsApp Revenue Agent — closed foundation through WA-L9
 
-- WA-7A.0: PHONE / BSUID / PARENT_BSUID transport and conversation continuity.
-- WA-7A.1: read-only WA conversation → REV canonical identity projection.
-- WA-7A.2: channel verification/evidence + non-destructive identifier lineage.
-- WA-7A.3: explicit provider acquisition provenance as immutable attribution touchpoints.
-- WA-7A.4: conversation-scoped marketing eligibility evidence, category scopes, suppression, opt-out and explicit re-consent semantics.
+The product is no longer merely a chatbot. The certified architecture connects:
 
-Hard separation:
+`Meta/WhatsApp ingress -> campaign/referral context -> governed identity -> conversation -> governed facts/pricing -> intent/readiness -> real availability -> BOOK/REBOOK -> handoff/follow-up -> attendance/sale -> attribution -> WhatsApp/AI cost`.
 
-`channel alias != canonical patient identity != acquisition touchpoint != marketing eligibility`.
+### Safety / authority foundation
 
-`IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
+Production remains deliberately dormant:
 
-`ATTRIBUTION EVIDENCE != CONSENT`.
+- `mode=AUTO_OFF`;
+- kill switch engaged;
+- `auto_reply=false`;
+- `ai_send=false`;
+- `auto_routing=false`;
+- `human_send=true`;
+- autonomous provider dispatch disabled;
+- active canary allowlist required before any CANARY transition.
 
-## WA-7A.4 certification evidence
+### L4 — Autonomous Authority + Kill Switch
 
-PR #378 exact head `ac58ceced7b6d06bec1792bbb4aa27d97f8e3db3` merged with expected head to `95bd4acb806c2cee8b7e6d5dadba8b078beb15f6`.
+Production-certified authority layer with `AUTO_OFF | CANARY | PROD`, kill switch, allowlist, rate/daily/max-turn/cooldown/duplicate guards, provider/template/identity/safety gates, append-only decisions and fail-closed transitions.
 
-Exact-head TEST SUCCESS:
+Important transition invariant: `AUTO_OFF -> CANARY` requires an active allowlisted conversation; `AUTO_OFF -> PROD` is forbidden; PROD requires prior CANARY evidence.
 
-- WA-7A.4 Marketing Eligibility Foundation `33103975948`;
-- Ascenda CI `33103975951`.
+### L5 — Conversational BOOK/REBOOK
 
-TEST delivered and proved:
+Production-certified conversational booking wiring. Reuses canonical availability/booking authority; BOOK/REBOOK must follow real sede/date/slot evidence and explicit confirmation. REBOOK preserves the same appointment identity where contractually required. No invented slot/provider/appointment state.
 
-- immutable eligibility evidence ledger;
-- GLOBAL / MARKETING / UTILITY / AUTHENTICATION / CALL scopes;
-- BSUID/PARENT_BSUID reachability without phone;
-- phone/BSUID/username/CTWA/message receipt never imply consent;
-- explicit opt-in + opt-out + re-consent evidence;
-- suppression precedence;
-- CIA-F17 controls reused read-only as deny/suppression guard;
-- CIA ALLOWED never grants WA consent;
-- replay/idempotency + conflict guard;
-- RLS/ACL/immutable rollback boundary;
-- WA-7A.3/2/1/0 regressions.
+### L6 — Meta Campaign Context & Attribution
 
-No `aos_pacientes`, `aos_leads`, REV or Marketing Attribution V2 write. No WA runtime modification. No bulk sender, Meta Ads Sync, campaign router, AI send, auto-reply or auto-routing activation.
+Production-certified strong-key attribution chain:
 
-## Production promotion queue
+`provider touchpoint -> conversation_id -> governed BOOK/REBOOK -> appointment_id -> attendance -> explicit venta_id_match -> canonical venta_id`.
 
-WA-7A.4 migration and rollback are committed but intentionally unapplied to production under the owner-directed TEST-first strategy while Supabase renewal/recovery is pending.
+No revenue/cost attribution by phone/name/username/BSUID alone. Marketing Attribution V2 remains authoritative.
 
-Post-merge production proof:
+### L7 — WhatsApp / AI Cost Intelligence
 
-- WA-7A.4 migration recorded = false;
-- WA-7A.4 table/view absent;
-- patients = 7702;
-- leads = 6061;
-- WA messages = 21;
-- conversations = 2;
-- WA events = 39;
-- real attribution touchpoints = 0.
+Production-certified effective-dated pricing authority and scoped cost/journey reads. Missing/unverified rates fail closed as PARTIAL/UNKNOWN; zero provider-billable evidence may be KNOWN zero. No fabricated FX/rates and no global heavy cost view on hot paths.
 
-Railway merge `95bd4acb806c2cee8b7e6d5dadba8b078beb15f6` = SUCCESS; this is runtime revalidation only, not WA-7A.4 schema promotion.
+### L8 — Security Gate + Meta 2026 Hardening
 
-When PROD recovers, promotion uses: exact-main revalidation → production drift/fingerprint → ordered queued migrations → ACL/readback → REST/Auth health → physical provider/human canaries → PROD certificate. No bypass.
+Production-certified under SAFE-OFF. Includes:
 
-## WA-4A active execution
+- provider `pricing.type` evidence;
+- recipient-market-aware pricing authority;
+- per-business-phone/category billing observability;
+- consent/opt-in/opt-out/STOP evidence;
+- business-initiated messaging preflight;
+- signed webhook/idempotency/secrets/server-only boundaries;
+- PII/PHI minimization and redacted audit;
+- least privilege and cross-module P0 regressions.
 
-Goal: build a governed Knowledge Fabric that supplies approved business facts and evidence references to human/Copilot workflows without duplicating canonical product/patient/revenue truth.
+### L9 — AUTONOMOUS DEMO READY
 
-Discover first:
+**CLOSED · PRODUCTION CERTIFIED · DORMANT SAFE-OFF.**  
+Issue `#453` CLOSED/completed.  
+Certified exact-head: `b0a65d5b340896263a3f75cb66ab7850fdb3c5fa`.  
+PR `#454` merged with `expected_head_sha`.  
+Merge/deploy: `f909e972aab243af954fc8e2fb15e5a37c68d1b6`.  
+Supabase PROD: `20260903225152 · wa_l9_shadow_demo_v1`.
 
-1. inventory existing catalog/service/price/branch/FAQ/protocol/business-rule knowledge sources;
-2. inspect existing WA4 Copilot/context retrieval and authority boundaries;
-3. define knowledge authority hierarchy and evidence references;
-4. reuse certified source systems instead of copying truth into a second knowledge master;
-5. define freshness/versioning/conflict/fallback rules;
-6. build TEST-only minimum required adapters/index/read models;
-7. prove no sensitive clinical overexposure and no generic-LLM authority over approved business facts;
-8. exact-head Zero-Cost + regressions;
-9. leave PROD-ready promotion package queued if schema/runtime changes are needed.
+L9 executes the exact L4+L8 authority inside rollback-only shadow execution. It can produce deterministic would-send evidence but structurally forbids provider dispatch and raw-content storage.
 
-Hard rule: approved governed business facts + evidence refs outrank generic LLM knowledge. No autonomous send activation in WA-4A.
+Production closeout evidence:
+
+- Agenda 3209;
+- Call Center 37195;
+- Leads 6694;
+- Ventas 1393;
+- Pacientes 7760;
+- WA messages 21;
+- autonomous outbound 0;
+- L9 demo runs 0;
+- L9 would-send rows 0;
+- L9 provider-dispatch rows 0;
+- L9 raw-content rows 0.
+
+Final governance closeout: `main@bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`, HIGH/CRITICAL lock `NONE`.
+
+## Meta pricing / policy 2026 — retained operational knowledge
+
+Current observed policy/rate logic must remain evidence-backed and effective-dated.
+
+Through 2026-09-30, Meta’s public pricing model charges delivered messages by recipient market/category. Service replies inside the customer-service window and qualifying utility replies are currently free; eligible Click-to-WhatsApp / Facebook CTA entry can create a 72-hour free-entry window.
+
+Peru current July-2026 public list evidence used during the L8 audit:
+
+- Marketing: USD 0.0703 / delivered message;
+- Utility: USD 0.0200;
+- Authentication: USD 0.0200.
+
+PEN rate-card evidence observed: Marketing PEN 0.2339; Utility/Auth PEN 0.0665. Actual WABA billing currency and invoice authority must be confirmed in Meta Billing Hub; do not replace an official WABA card with spot FX.
+
+For changes announced effective 2026-10-01, external corroboration indicates Service becomes billable after the first 1,000 Service messages per business phone number/month, Utility inside the open 24h window becomes billable, inbound remains free and Free Entry Point remains. Peru USD 0.0300 for Utility/Auth/Service was strongly corroborated but not directly fetched from Meta during the audit because the official developer card returned 429. Therefore **do not seed the October USD 0.0300 as VERIFIED in PROD until the clinic’s official Meta Billing Hub/WABA rate card is read.**
+
+Meta policy boundaries retained:
+
+- business-initiated conversations require approved templates;
+- free-form replies are governed by the customer-service window;
+- explicit opt-in and STOP/opt-out must be respected;
+- automation must preserve clear human escalation;
+- health/privacy data requires minimum-data discipline;
+- WhatsApp data must not be used to train/improve a general-purpose AI model;
+- the agent must remain business-specific, not a generic ask-anything AI service.
+
+Meta terms have an announced update effective 2026-09-23; recheck official terms before L10 live canary.
+
+## Groq cost baseline retained
+
+Verified current public rates at the L7/L8 audit:
+
+- GPT-OSS 20B: USD 0.075/M input, USD 0.30/M output;
+- GPT-OSS 120B: USD 0.15/M input, USD 0.60/M output.
+
+Once Meta service-message charging applies, provider delivery can dominate inference cost. Product default should remain one useful outbound message per turn where conversational UX allows; do not split one answer into multiple provider messages purely for style.
+
+## Remaining final roadmap
+
+### WA-L10 — AUTONOMOUS PRODUCTION CANARY
+
+`NEXT ELIGIBLE · NOT STARTED · CANARY NOT AUTHORIZED`.
+
+Purpose: controlled real autonomous traffic to a tiny allowlisted cohort, with L4/L8 authority, budgets, duplicate/idempotency guards, human handoff, rollback/kill-switch, provider delivery evidence, cost and cross-module regression monitoring.
+
+L10 can be prepared/certified up to the activation boundary under SAFE-OFF, but actual `AUTO_OFF -> CANARY`, allowlisting of live customer conversations, autonomous Meta dispatch and kill-switch disengagement require separate explicit owner authorization.
+
+### WA-L11 — GENERAL PRODUCTION
+
+May start only after L10 has real canary evidence and an explicit go/no-go decision. Requires controlled ramp, no direct AUTO_OFF->PROD shortcut, stable customer outcomes, provider/invoice reconciliation, performance/P0 regression proof, operational runbook, rollback and ownership/on-call controls.
+
+### Post-L11 — Customer Experience & Conversation Validation
+
+After general-production certification, run an explicit real-customer validation program. It is not a substitute for L10/L11 safety certification.
+
+Measure at minimum:
+
+- naturalness / non-robotic conversation;
+- first useful answer and full-turn latency;
+- intent understanding and context retention;
+- no repetitive loops or duplicate sends;
+- one outbound provider message per turn by default where appropriate;
+- governed facts/prices only;
+- booking ease, booking conversion and correct REBOOK continuity;
+- safe identity/privacy behavior;
+- clear human handoff and escalation;
+- STOP/opt-out behavior;
+- drop-off/friction by conversation stage;
+- WhatsApp + AI cost per qualified conversation / booking / attended appointment / sale;
+- attribution continuity from campaign to sale;
+- customer feedback and operator review;
+- auditability of every autonomous decision.
+
+Use real consented/allowlisted pilots and redacted evidence. Never fabricate production customer experience evidence.
+
+## Immediate execution boundary
+
+1. keep `AUTO_OFF + kill switch engaged`;
+2. refresh all technical memory/roadmap/Notion authority to this state;
+3. perform read-only L10 entry audit;
+4. build/certify any SAFE-OFF L10 preflight package if needed;
+5. stop at the explicit `AUTO_OFF -> CANARY` owner gate;
+6. after explicit authorization, execute real L10 canary;
+7. only with L10 PASS, proceed to L11;
+8. after L11 certification, run the real Customer Experience & Conversation Validation program.

--- a/docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md
+++ b/docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md
@@ -1,106 +1,169 @@
 # ASCENDA OS — AGENT BOOTSTRAP CURRENT
 
-**Captured:** 2026-08-22 America/Lima  
-**Entry baseline:** `main@26171abe38bb4bb6f6364aff6624ddc3d0d39580`  
-**ACTIVE WORKSTREAM:** `WHATSAPP-REVENUE-HUB-V2`  
-**ACTIVE GATE:** `WA-V2-0 — BASELINE & GOVERNANCE`
+**Captured:** 2026-09-03 America/Lima  
+**Canonical baseline at capture:** `main@bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`  
+**ACTIVE PROGRAM:** `WHATSAPP-REVENUE-HUB-V2`  
+**ACTIVE HIGH/CRITICAL LOCK:** `NONE`  
+**LAST CLOSED:** `WA-L9 — AUTONOMOUS DEMO READY`  
+**NEXT ELIGIBLE:** `WA-L10 — AUTONOMOUS PRODUCTION CANARY · NOT STARTED`  
+**CANARY:** `NOT AUTHORIZED`
 
 ## Mandatory bootstrap before any write
+
+Read in this order:
 
 1. root `AGENTS.md`;
 2. root `SECURITY.md`;
 3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`;
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
 5. `docs/MEMORY_CURRENT.md`;
-6. `docs/adn/AGENTS_CURRENT.md`;
+6. `docs/control/WA_AUTO_L9_TO_L11_CONTINUITY_CURRENT.md`;
 7. `docs/control/WHATSAPP_REVENUE_HUB_CURRENT.md`;
 8. `docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md`;
 9. `docs/control/ASCENDA_RELIABILITY_PERFORMANCE_DOCTRINE_CURRENT.md`;
-10. exact GitHub `main`, Railway exact deploy/runtime and live Supabase WA state;
-11. WhatsApp Control Maestro / Roadmap Maestro V2 in Notion only after technical truth is read.
+10. relevant latest WA phase contract/certificate/migrations/CI;
+11. exact GitHub `main` and current PR/head;
+12. Railway exact deploy status;
+13. live Supabase safety + scoped boundary readbacks;
+14. Notion Control Maestro / Roadmap Maestro / Master Closeout / WA-AUTO continuity last.
 
-Historical docs/chat checkpoints never override CURRENT + live persisted state.
+Historical docs, chat snapshots or stale Notion callouts never override exact CURRENT + persisted runtime evidence.
 
-## Reliability / performance gate
+## Non-negotiable execution governance
 
-For every HIGH/CRITICAL mutation, the reliability doctrine is a transversal exit gate. Preserve operational critical paths, keep analytics/background work out of synchronous revenue writes, do not mask slow SQL by raising browser timeouts, and require realistic LIVE readback when the defect or risk is user-, browser-, load- or concurrency-dependent.
+- exactly one mutable HIGH/CRITICAL lane at a time;
+- do not start the next lane because the previous one closed unless the owner authorized continuation;
+- every `main` advance requires exact-head revalidation for the active lane;
+- merge only after exact-head gates and anti-drift; use `expected_head_sha`;
+- `CODE PASS != DEPLOY PASS != PROD PASS`;
+- Railway SUCCESS does not prove Supabase PROD correctness;
+- migration presence does not prove runtime behavior;
+- no production evidence may be fabricated with synthetic rows;
+- Notion is synchronized after technical truth, never used to override it.
 
-A WhatsApp phase is not complete if it regresses Agenda, Call Center, Marketing, Sales/Commissions or shared Supabase pressure.
+## P0 #432 reliability/performance gate
 
-## Portfolio ownership
+Every HIGH/CRITICAL phase must preserve:
 
-`WHATSAPP-REVENUE-HUB-V2` owns the single HIGH/CRITICAL mutable lane by explicit owner directive dated 2026-08-22.
+- Agenda;
+- Call Center;
+- Marketing/Leads;
+- Sales/Commissions;
+- Patients/Identity;
+- shared Supabase/background pressure.
 
-Previous `MKT-INTEGRITY-HOTFIX-V3 / LOOP 6 V2.3` is PAUSED / recoverable at 0/5 genuine post-cutover operations. It is not terminally certified and must not mutate while WA owns the lane.
+Forbidden patterns:
 
-REV-F5 and REV-F6 are production-certified upstream inputs. REV-F7, CIA feature mutation, KronIA and unrelated work remain paused/read-only.
+- heavy global analytics on synchronous hot paths;
+- synchronous materialized-view refresh/rebuild on message/call/booking/sales writes;
+- timeout inflation;
+- duplicate legacy/new execution;
+- unbounded browser fan-out;
+- expensive enrichment inside transactional paths.
 
-## Exact-current runtime
+Required patterns:
 
-Railway production chain:
+- bounded/indexed reads;
+- single-flight/bounded concurrency where browser fan-out exists;
+- cold-path enrichment/analytics;
+- fail-closed provider/identity/pricing/consent decisions;
+- exact-head + deploy + LIVE readbacks.
 
-`server-phase-s-f17.js → server-phase-s.js → server-f17.js → server-f5.js → server-wa4.js → server-wa3.js → server-wa2.js → server-f4.js → lower/core`
+## Current product architecture
 
-`app/railway.json` preloads Sentry and backend-only email compatibility before the outer runtime. Current source still mounts `wa-shell-integration.js`, and that bootstrap still mounts `notification-push-s14.js` S15.5.
+The governed Revenue Agent loop is:
 
-## Certified WA evidence — regression only
+`Meta lead/referral -> WhatsApp conversation -> campaign context -> canonical identity -> governed knowledge/pricing -> intent/readiness -> real availability -> BOOK/REBOOK -> follow-up/handoff -> attendance -> sale -> attribution -> WhatsApp/AI cost`.
 
-Do not re-open without a demonstrated regression:
+Consume canonical sources; do not create parallel CRM, patient, sales, agenda, marketing-attribution, pricing or identity masters.
 
-- signed Meta inbound;
-- canonical WA message/event ledger;
-- WA-2 live inbox/conversation store;
-- WA-3 ownership/human-send boundary;
-- native shell integration;
-- Web Push subscription self-heal;
-- closed-PWA Windows notification;
-- notification click opens installed PWA and respects Auth;
-- final notification ACL cutover.
+Hard separations retained:
 
-## Live WA entry baseline
+- channel alias != canonical patient identity;
+- acquisition touchpoint != consent;
+- identity != reachability != marketing eligibility;
+- attribution evidence != consent;
+- provider delivery/billing evidence != inferred invoice;
+- generic LLM knowledge != governed business fact authority.
 
-- 15 messages: 11 inbound / 4 outbound;
-- 2 conversations;
-- 25 events;
-- 9 outbound requests;
-- 11 routing events;
-- 2 active boxes (`VENTAS_GENERAL`, `WA_TEST`);
-- 2 active memberships for the current single operational actor;
-- 1 active assignment;
-- 0 AI runs;
-- human send ON;
-- auto routing OFF;
-- AI send OFF;
-- Copilot OFF;
-- auto reply OFF.
+## Production safety at WA-L9 closeout
 
-Historical outbound outcomes include 4 ACCEPTED, 4 `META_190` failures and 1 `META_SEND_REJECTED`. Provider credential health must be re-certified before selling.
+Binding until a separately authorized transition:
 
-## Upstream ecosystem now available to WA
+- `mode=AUTO_OFF`;
+- kill switch engaged;
+- `auto_reply=false`;
+- `ai_send=false`;
+- `auto_routing=false`;
+- `human_send=true`;
+- autonomous provider dispatch = 0;
+- active canary allowlist required for `AUTO_OFF -> CANARY`.
 
-- patients: 7,702;
-- sales: 1,331;
-- leads: 5,880;
-- CIA contact/email facts: 11,911;
-- F5 provenance: 15,498 rows / 15,498 memberships / 8,716 clusters / 8,716 previews;
-- catalog: 221 active services.
+The L4 authority structurally forbids direct `AUTO_OFF -> PROD`; general production must follow demonstrated CANARY.
 
-Consume canonical sources; do not create parallel CRM, identity, sales, agenda, email or attribution truth.
+## Closed WA autonomy layers
 
-## WA-V2-0 rule
+Treat as regression dependencies unless evidence proves a defect:
 
-WA-V2-0 is control/docs/baseline only. No runtime, schema, routing, AI or Meta mutation belongs in this gate.
+- L4 Autonomous Authority + Kill Switch;
+- L5 Conversational BOOK/REBOOK;
+- L6 Meta campaign context + strong-key attribution;
+- L7 WhatsApp/AI Cost Intelligence;
+- L8 Security Gate + Meta 2026 hardening;
+- L9 Autonomous Demo Ready shadow certification.
 
-Exit only after exact-head GitHub merge, Railway SUCCESS/readback, live Supabase baseline reconciliation, `aos_memory` update and Notion-last reconciliation.
+WA-L9 exact evidence:
 
-## Next functional gate
+- certified head `b0a65d5b340896263a3f75cb66ab7850fdb3c5fa`;
+- PR #454 merge/deploy `f909e972aab243af954fc8e2fb15e5a37c68d1b6`;
+- Supabase PROD `20260903225152 · wa_l9_shadow_demo_v1`;
+- issue #453 CLOSED/completed;
+- final closeout main `bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`;
+- lock NONE;
+- PROD L9 demo/would-send/provider-dispatch/raw-content rows all 0;
+- autonomous outbound 0.
 
-After WA-V2-0 PASS, run `WA-3 — HUMAN OPERATIONS MULTIAGENT` in discover-first mode.
+## Meta / AI business rules agents must remember
 
-Preserve fail-closed defaults during the first canary:
+- Meta charging is based on delivered messages and recipient market/category.
+- Do not seed unverified future Meta rates as VERIFIED pricing authority.
+- Confirm actual WABA billing currency/rate card in Meta Billing Hub before invoice-grade certification.
+- Recheck Meta terms before live canary; an announced terms update is effective 2026-09-23.
+- Business-initiated sends require approved template/eligibility evidence.
+- Respect explicit consent, STOP/opt-out and human escalation.
+- Keep the AI business-specific; do not turn WhatsApp into a generic ask-anything AI service.
+- Do not use WhatsApp Business Solution Data to train/improve a general-purpose AI model.
+- Prefer one useful outbound provider message per turn where UX permits; unnecessary bubble splitting increases provider cost and duplicate/fan-out risk.
 
-- `auto_routing_enabled=false`;
-- `ai_send_enabled=false`;
-- `auto_reply_enabled=false`.
+## Current execution boundary — WA-L10
 
-`WA-3.5 Revenue Inbox UX` remains planned but must not contaminate ownership/security contracts before WA-3 closes.
+`WA-L10 — AUTONOMOUS PRODUCTION CANARY` is **NEXT ELIGIBLE / NOT STARTED / CANARY NOT AUTHORIZED**.
+
+An agent may, under SAFE-OFF and explicit work authorization, audit/build/certify the L10 preflight package, observability, rollback, allowlist tooling and CI. It must stop before any real autonomous Meta dispatch unless the owner separately authorizes the CANARY transition.
+
+L10 real activation requires at minimum:
+
+- exact-current anti-drift;
+- live authority/kill-switch readback;
+- explicitly selected minimal allowlisted conversation/cohort;
+- L8 consent/STOP/security preflight PASS;
+- provider credential/template readiness;
+- cost/budget/rate/duplicate/idempotency boundaries;
+- human handoff and emergency kill path;
+- PRE fingerprints for cross-module regressions;
+- owner authorization for `AUTO_OFF -> CANARY`;
+- real provider delivery/outcome evidence;
+- immediate rollback criteria;
+- POST fingerprints and no unrelated mutation.
+
+## WA-L11 — General Production
+
+L11 remains blocked until L10 closes with real canary evidence. Do not shortcut CANARY.
+
+L11 must prove controlled ramp, stable provider delivery, customer safety, conversation quality, attribution/cost integrity, P0 performance, operating ownership, rollback and production runbook before general autonomy is certified.
+
+## Post-L11 customer experience validation
+
+After L11 technical/production certification, execute a separate real-customer validation program covering conversation naturalness, intent/context quality, latency, duplicate/repetition rate, booking/REBOOK usability, human handoff, STOP behavior, privacy/identity, drop-off, cost per qualified conversation/booking/attendance/sale and customer/operator feedback.
+
+Real customer-experience evidence must come from consented real pilots; never manufacture it in PROD.

--- a/docs/control/WA_AUTO_L9_TO_L11_CONTINUITY_CURRENT.md
+++ b/docs/control/WA_AUTO_L9_TO_L11_CONTINUITY_CURRENT.md
@@ -1,0 +1,271 @@
+# ASCENDA OS — WA AUTO L9 TO L11 CONTINUITY CURRENT
+
+**Captured:** 2026-09-03 America/Lima  
+**Purpose:** single operational continuity checkpoint from certified WA-L9 through final autonomous production and customer-experience validation.  
+**Source baseline:** `main@bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`  
+**Current lock:** `NONE`  
+**Current safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
+**Next:** `WA-L10 · NOT STARTED · CANARY NOT AUTHORIZED`
+
+## 1. Exact WA-L9 closeout
+
+WA-L9 is closed and must not be reopened absent a demonstrated regression.
+
+- issue #453 = CLOSED / completed;
+- certified exact head = `b0a65d5b340896263a3f75cb66ab7850fdb3c5fa`;
+- PR #454 merged with `expected_head_sha`;
+- merge/deploy = `f909e972aab243af954fc8e2fb15e5a37c68d1b6`;
+- Railway exact-merge = SUCCESS;
+- Supabase PROD = `20260903225152 · wa_l9_shadow_demo_v1`;
+- final closeout main = `bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`;
+- HIGH/CRITICAL lock = NONE.
+
+PROD readback at closeout:
+
+- Agenda = 3209;
+- Call Center = 37195;
+- Leads = 6694;
+- Ventas = 1393;
+- Pacientes = 7760;
+- WA messages = 21;
+- autonomous outbound = 0;
+- L9 demo runs = 0;
+- L9 would-send = 0;
+- L9 provider dispatch = 0;
+- L9 raw-content rows = 0.
+
+L9 shadow authority calls the exact L4 authority (which is wrapped by L8 preflight) inside a rollback-only subtransaction. It returns deterministic would-send evidence while rolling back L4/L8 side effects. Provider dispatch and raw-content storage are structurally false.
+
+## 2. What is already built before L10
+
+Do not duplicate these layers:
+
+### L4 authority
+
+- modes `AUTO_OFF | CANARY | PROD`;
+- kill switch;
+- active conversation allowlist;
+- daily/rate/max-turn/cooldown/duplicate limits;
+- provider/template/identity/safety/handoff gates;
+- audit/idempotency;
+- CANARY requires active allowlist;
+- direct AUTO_OFF->PROD forbidden.
+
+### L5 booking/rebooking
+
+- real availability only;
+- explicit confirmation;
+- governed BOOK/REBOOK;
+- correct canonical appointment continuity;
+- no invented provider/slot.
+
+### L6 attribution
+
+Strong-key path only:
+
+`provider touchpoint -> conversation_id -> BOOK/REBOOK -> appointment_id -> attendance -> explicit venta_id_match -> canonical venta_id`.
+
+No revenue attribution by phone/name/username/BSUID alone.
+
+### L7 cost
+
+- effective-dated pricing authority;
+- Meta provider billability/category/market evidence;
+- Groq token rates/evidence;
+- scoped conversation/journey cost;
+- PARTIAL/UNKNOWN rather than fabricated precision.
+
+### L8 security/Meta hardening
+
+- pricing type and recipient market;
+- per-business-phone/category billing observability;
+- consent/opt-in/opt-out/STOP ledger;
+- business-initiation preflight;
+- signed webhook/idempotency/secrets;
+- PHI/PII minimization;
+- least privilege;
+- P0 #432 regressions.
+
+### L9 shadow
+
+- deterministic exact-authority dry run;
+- would-send evidence;
+- rollback-only side effects;
+- no provider dispatch;
+- no raw content evidence table.
+
+## 3. WA-L10 mission — real autonomous production canary
+
+L10 is the first boundary permitted to create real autonomous provider traffic, but **only after separate explicit owner authorization**.
+
+### L10 preparation allowed under SAFE-OFF
+
+Before the owner activation gate, the active L10 implementation may:
+
+- revalidate exact main and upstream contracts;
+- audit provider/template/payment/billing readiness;
+- audit live consent/STOP/identity/allowlist state;
+- add minimal canary-only observability/ramp/rollback instrumentation if genuinely missing;
+- extend CI for live-canary invariants without sending live traffic;
+- run L9 shadow on approved non-sensitive evidence paths;
+- freeze PRE fingerprints;
+- verify kill-switch/operator runbook;
+- verify customer-facing message economy and handoff behavior in local/staging/shadow;
+- produce a complete activation checklist.
+
+It may not:
+
+- transition AUTO_OFF->CANARY;
+- disengage kill switch for real autonomous sending;
+- add live customer conversations to an autonomous allowlist for dispatch;
+- autonomously call Meta/provider send;
+- infer that broad owner intent equals activation consent.
+
+### Owner activation statement required
+
+A valid activation must explicitly authorize the production CANARY transition. The authorization should identify or approve the minimal governed cohort/selection method. It does not authorize PROD/general rollout.
+
+### Real L10 evidence
+
+Once authorized, collect real evidence for:
+
+- authority ALLOW/BLOCK/HANDOFF decisions;
+- L8 preflight and consent/STOP outcomes;
+- provider accepted/delivered/failed statuses;
+- no duplicate delivery;
+- latency per autonomous turn;
+- correct governed facts/pricing;
+- booking/rebooking state where exercised;
+- human handoff;
+- attribution touchpoint/conversation/appointment/sale continuity;
+- Meta + AI cost;
+- provider/local reconciliation;
+- PRE/POST protected-module counts/fingerprints;
+- kill/rollback behavior.
+
+Immediate stop criteria include any privacy/identity breach, consent/STOP violation, duplicate send, provider/local divergence, wrong price/fact, invalid booking mutation, unsafe clinical response, runaway loop/fan-out, material latency/P0 regression or budget breach.
+
+## 4. WA-L11 mission — general production
+
+L11 is blocked until L10 closes PASS using real canary evidence.
+
+L11 is not simply `mode=PROD`. It is a controlled operational transition that must prove:
+
+- owner authorization for general rollout;
+- current Meta terms/rate/billing verified;
+- provider/payment credentials healthy;
+- staged traffic ramp;
+- kill/rollback remains functional;
+- human escalation capacity exists;
+- conversation quality stable;
+- no duplicate/retry storm;
+- booking/REBOOK reliable;
+- cost/attribution reconcile;
+- P0 #432 performance remains healthy;
+- operating owner/on-call/runbook established.
+
+A general-production certificate requires exact-head CODE PASS, Railway deploy PASS, merged-lineage Supabase PASS and real production behavior PASS.
+
+## 5. Customer Experience & Conversation Validation after L11
+
+Technical autonomy certification is necessary but not sufficient for a good customer product. After L11, run a separate customer-experience program against real consented customers.
+
+### Scorecard
+
+For each reviewed conversation or cohort measure:
+
+- **Naturalness:** human-like but professional; no robotic scripts or excessive enthusiasm.
+- **Relevance:** answers the actual client question before over-selling.
+- **Conciseness:** avoids unnecessary multi-bubble fragmentation.
+- **Context retention:** does not ask repeatedly for facts already provided.
+- **Intent progression:** detects information-seeking, objection, buying intent, scheduling readiness and handoff need.
+- **Fact integrity:** uses governed service/product/process/pricing sources only.
+- **Clinical boundary:** escalates medical diagnosis/risk rather than inventing clinical advice.
+- **Booking friction:** number of turns and failures from intent to confirmed real appointment.
+- **REBOOK continuity:** preserves correct appointment and makes rescheduling understandable.
+- **Handoff quality:** human receives enough context without forcing customer repetition.
+- **Privacy/identity:** minimum-data, no unsafe disclosure, no name-only binding.
+- **Consent/STOP:** immediate respectful stop; no further persuasion.
+- **Latency:** time to first useful answer and total turn completion.
+- **Reliability:** duplicate sends, loops, orphan actions, provider/local mismatch.
+- **Commercial outcome:** qualified conversations, bookings, attendance, sales.
+- **Cost efficiency:** provider + AI cost per qualified conversation/booked/attended/sale.
+- **Trust:** customer qualitative feedback and operator review.
+
+### Conversation review taxonomy
+
+Review samples across:
+
+1. new Meta lead asking basic information;
+2. price-first customer;
+3. uncertain/educational customer;
+4. objection on price/timing/trust;
+5. customer asking for a specific sede/date;
+6. successful BOOK;
+7. unavailable slot -> alternative path;
+8. natural-language REBOOK;
+9. existing patient with identity/privacy boundary;
+10. clinical question requiring escalation;
+11. customer asks for human;
+12. STOP/opt-out;
+13. repeated/ambiguous message;
+14. provider failure/retry boundary;
+15. campaign/referral -> booking -> attendance/sale attribution when naturally present.
+
+### Evidence rules
+
+- real customer evidence only after proper production gate;
+- consented/authorized cohort;
+- redacted transcript review;
+- no copying raw PHI/PII into analytical notes unnecessarily;
+- no synthetic rows described as customers;
+- improvements are versioned, tested and re-certified if they change authority, booking, consent, provider dispatch or hot paths.
+
+## 6. Meta 2026 checkpoint
+
+Before any live L10/L11 traffic:
+
+- re-read current official WhatsApp Business Messaging Policy and applicable terms;
+- specifically recheck the announced 2026-09-23 terms update;
+- read the clinic WABA Billing Hub/rate card if accessible;
+- confirm billing currency/payment health;
+- do not promote future October pricing to VERIFIED authority from third-party corroboration alone.
+
+Operational rate knowledge retained from the 2026-09-03 audit:
+
+- current Peru public list: Marketing USD 0.0703, Utility USD 0.0200, Authentication USD 0.0200;
+- PEN card evidence: Marketing PEN 0.2339, Utility/Auth PEN 0.0665;
+- announced Oct model materially expands billable service/utility messages;
+- first 1,000 monthly Service messages per business phone number expected free;
+- Peru Oct USD 0.0300 Utility/Auth/Service strongly corroborated but not directly retrieved from the official developer card due HTTP 429;
+- actual invoice authority remains Meta/WABA billing evidence.
+
+## 7. AI cost / message economy
+
+Groq public rate baseline verified during L7/L8:
+
+- GPT-OSS 20B: USD 0.075/M input, USD 0.30/M output;
+- GPT-OSS 120B: USD 0.15/M input, USD 0.60/M output.
+
+Provider message cost can dominate inference cost under the Oct Meta model. Default conversation design should therefore use one complete useful outbound message per turn where that improves UX; do not split responses into multiple provider messages just to imitate chat style.
+
+## 8. Do not forget the legacy CI anomaly
+
+`.github/workflows/f16-provider-outcomes-test-adapt.yml` has produced instant failures with no jobs across unrelated historical commits including L8/L9 governance commits. It is legacy noise, not evidence that L9 failed. Do not use it as a substitute for relevant exact-head gates, and do not silently call it green. If it is ever remediated, do so under its own justified scope rather than contaminating L10/L11.
+
+## 9. Resume protocol
+
+Any future agent/chat resuming this project must state and verify before mutation:
+
+1. exact current `main`;
+2. current HIGH/CRITICAL lock;
+3. L9 remains closed;
+4. whether L10 has actually started;
+5. whether explicit CANARY authorization exists;
+6. current live `AUTO_OFF/CANARY/PROD` + kill-switch state;
+7. active allowlist count;
+8. latest Meta terms/rate evidence;
+9. relevant Railway/Supabase health;
+10. next exact gate.
+
+If any of those disagree with this document, exact current GitHub/runtime evidence wins and this document must be refreshed before proceeding.

--- a/docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md
+++ b/docs/control/WHATSAPP_REVENUE_HUB_V2_ROADMAP_CURRENT.md
@@ -1,192 +1,301 @@
 # ASCENDA Conversations — WhatsApp Revenue Hub V2 — ROADMAP CURRENT
 
-**Captured:** 2026-08-28 America/Lima  
-**WA-7A.0:** CLOSED  
-**WA-7A.1:** CLOSED  
-**WA-7A.2:** CLOSED AT DEMONSTRATED BOUNDARY  
-**WA-7A.3:** CLOSED AT DEMONSTRATED BOUNDARY  
-**WA-7A.4:** `TEST CERTIFIED / PROD-READY / PROD-PROMOTION PENDING`  
-**WA-4A.1B:** `TEST CERTIFIED / PROD-READY GRAPH / BUSINESS-CONTENT DML READBACK VERIFIED`  
-**ACTIVE NEXT:** `WA-4A.1C — TREATMENT & PRICING ARCHITECTURE`  
-**BLOCKED NEXT:** `WA-4B — SALES PLAYBOOK ENGINE`  
-**PROD recovery debt:** queued TEST-certified promotions remain separated from business-content DML
+**Captured:** 2026-09-03 America/Lima  
+**Program:** `WHATSAPP-REVENUE-HUB-V2`  
+**Canonical main at capture:** `bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`  
+**L1-L9:** `CLOSED / CERTIFIED AT THEIR DEMONSTRATED BOUNDARIES`  
+**WA-L9:** `AUTONOMOUS DEMO READY · PROD CERTIFIED · DORMANT SAFE-OFF`  
+**ACTIVE HIGH/CRITICAL LOCK:** `NONE`  
+**NEXT ELIGIBLE:** `WA-L10 — AUTONOMOUS PRODUCTION CANARY · NOT STARTED`  
+**CANARY:** `NOT AUTHORIZED · SEPARATE EXPLICIT OWNER GATE`  
+**FINAL AUTONOMY BOUNDARY:** `WA-L11 — GENERAL PRODUCTION`  
+**POST-L11:** `CUSTOMER EXPERIENCE & CONVERSATION VALIDATION`
 
 ## North Star
 
-`Meta Ads / Business Username / Organic / QR / Web → WhatsApp → explicit provenance + channel identity → canonical identity → conversation → governed eligibility → knowledge → process/pricing context → human/AI sales playbook → business tools → appointment/follow-up/call → attendance → sale → revenue attribution → learning`.
+`Meta Ads / CTWA / Business Username / Organic / QR / Web -> WhatsApp -> acquisition context -> governed channel/canonical identity -> consent/security preflight -> natural business conversation -> governed facts/pricing -> real availability -> BOOK/REBOOK -> confirmation/follow-up/handoff -> attendance -> sale -> strong-key attribution -> provider/AI cost -> learning and customer-experience improvement`.
 
-## Architecture rules
+The target is a governed autonomous Revenue Agent, not a generic chatbot and not a replacement CRM.
 
-- WA is a governed conversation/channel product, not a CRM replacement.
-- Canonical patient identity remains governed by REV/F5/F6.
-- Acquisition touchpoints remain separate from channel/person identity.
-- Marketing eligibility remains separate from identity/reachability/attribution.
-- Knowledge references governed source authority instead of duplicating canonical truth.
-- Current price authority remains the runtime catalog, never document examples or generic model knowledge.
-- Treatment process architecture must preserve clinical authority and must not create rigid clinical prescriptions.
-- `BSUID != ctwa_clid/touchpoint`.
-- `IDENTITY != REACHABILITY != MARKETING ELIGIBILITY`.
-- `ATTRIBUTION EVIDENCE != CONSENT`.
-- TEST certification and PROD promotion remain separate gates under the current hold.
+## Authority / architecture rules
 
-## Phase graph
+- Canonical patient identity stays in the governed patient/REV identity stack.
+- WA channel aliases do not become a second person master.
+- Marketing Attribution V2 remains authoritative for marketing attribution.
+- Acquisition evidence, consent, identity and reachability are separate concerns.
+- Catalog/runtime price authority outranks document examples and LLM memory.
+- No clinical necessity, diagnosis or treatment prescription may be inferred autonomously from commercial categories.
+- Booking/rebooking must use real governed availability and explicit confirmation.
+- REBOOK continuity must preserve the canonical appointment contract.
+- WhatsApp/AI costs use provider/rate evidence and effective-dated authority; never fabricate invoice truth.
+- Human escalation remains a first-class path.
+- `AUTO_OFF -> CANARY` and `CANARY -> PROD` are separate evidence/owner gates.
+- Direct `AUTO_OFF -> PROD` is structurally forbidden by L4 authority.
+- P0 #432 reliability doctrine applies to every remaining phase.
 
-`WA-V2-0 ✅ → WA-3 ✅ OFFLINE → WA-3.5 ✅ OFFLINE → WA-7A.0 ✅ → WA-7A.1 ✅ → WA-7A.2 ✅ → WA-7A.3 ✅ → WA-7A.4 ✅ TEST/PROD-READY → WA-4A → WA-4A.1 ✅ → WA-4A.1B ✅ → WA-4A.1C ACTIVE → WA-4B BLOCKED → WA-4C → WA-5 → WA-6 → WA-7B → WA-7C → WA-7D → WA-8 → WA-9..WA-14`
+## Current phase graph
 
-## WA-4A.1B — Zi Vital Commercial Knowledge Graph — CERTIFIED
+`WA foundation / identity / eligibility / knowledge / playbook / Copilot / booking prerequisites ✅`
 
-Certified exact head `23ceb7bc8b5b0afb9b077773bd781c079223ef14` merged via PR #383 to `03efd22cdacc61a8c2f1de351afc6315926e4263`.
+`WA-L1 ✅ -> WA-L2 ✅ -> WA-L3 ✅ -> WA-L4 ✅ -> WA-L5 ✅ -> WA-L6 ✅ -> WA-L7 ✅ -> WA-L8 ✅ -> WA-L9 ✅ -> WA-L10 NEXT -> WA-L11 BLOCKED -> POST-L11 CX/CONVERSATION VALIDATION`.
 
-Certified scope:
+Older WA-3 / WA-4A / WA-4B / WA-4C / WA-7A.x labels remain historical implementation ancestry. They do not override the current L1-L11 closeout graph.
 
-- 114-page commercial architecture transformed into governed knowledge;
-- third source `ZV_COMMERCIAL_ARCH_2026`;
-- commercial phases normalized separately from clinical lifecycle;
-- approach aliases normalized;
-- commercial principles, dictionary, quotation/no-discount/payment/topping/upsell/continuity rules;
-- OWNER_ADMIN KPI/OKR knowledge;
-- exact-shape graph for 167 services + 50 products;
-- explicit exception semantics;
-- 17 composition N/A vs 26 real missing review;
-- 39 Vitaminas formula templates explicitly review-gated;
-- 41 Vitaminas/Detox services enriched in canonical PROD business content;
-- internal product residual gaps closed; Prunex public claims hardened.
+## Closed autonomy path
 
-Final exact-head gates:
+### WA-L1 — Unified BOOK/REBOOK foundation
 
-- specialized Zero-Cost run `33137921448` = SUCCESS;
-- Ascenda CI run `33137921445` = SUCCESS;
-- DB lint, graph certification, WA regressions and rollback = SUCCESS.
+Closed. Governed booking/rebooking contract and canonical availability/identity dependencies established.
 
-Post-merge PROD business-content readback:
+### WA-L2 — Operational continuity / dependent wiring
 
-- 167/167 active services with description + indications + FAQ coverage; 6,926 service FAQs;
-- 50/50 active products with description + indications + FAQ coverage; 480 product FAQs;
-- graph feature DDL remains unapplied to PROD under TEST-first hold.
+Closed at certified boundary. Reuses existing WA operational foundations without creating a parallel booking/CRM truth.
 
-Certification boundary:
+### WA-L3 — Production-safe dependent layer
 
-`SERVICE + PRODUCT COMMERCIAL KNOWLEDGE GRAPH = COMPLETE` at CURRENT 167 + 50 shape.
+Closed and dormant under SAFE-OFF. Its security/performance regressions remain mandatory dependencies.
 
-Open evidence debt is explicit, not silent:
+### WA-L4 — Autonomous Authority + Kill Switch
 
-- 26 exact service formulas;
-- 39 per-SKU Vitaminas formulas.
+Production-certified authority layer:
 
-## WA-4A.1C — Treatment & Pricing Architecture — ACTIVE
+- `AUTO_OFF | CANARY | PROD`;
+- global kill switch;
+- explicit allowlist;
+- daily/rate/max-turn/cooldown/duplicate controls;
+- template/provider verification;
+- identity/safety/handoff gates;
+- append-only audit and idempotency.
 
-**Goal:** create a governed treatment-process and quotation architecture that combines live price authority with Zi Vital Domain/Approach/Phase/Function semantics, without turning processes into rigid packages or allowing autonomous clinical/pricing decisions.
+Transition invariant: CANARY requires active allowlist; PROD requires prior CANARY. No direct AUTO_OFF->PROD.
 
-### 1C.0 — Revalidate & inventory
+### WA-L5 — Conversational BOOK/REBOOK Wiring
 
-- revalidate exact `main`;
-- inventory active service/product pricing fields and presentation/session semantics;
-- identify current quote/payment/package/topping tables, RPCs and UI;
-- identify current discounts/promotions and any duplicate price truth;
-- fingerprint current catalog price state.
+Production-certified. Conversation can progress through booking readiness, sede/date/real slot, explicit confirmation and BOOK/REBOOK using governed authority. No invented provider/slot/appointment state.
 
-### 1C.1 — Price authority contract
+### WA-L6 — Meta Campaign Context & Attribution
 
-- `aos_catalogo_servicios` = current service/product price authority unless an already-governed source proves otherwise;
-- document examples never override runtime price;
-- stale/missing/conflicting prices fail closed;
-- no hardcoded price inside playbook knowledge.
+Production-certified. Strong-key chain:
 
-### 1C.2 — Process component model
+`provider touchpoint -> conversation_id -> BOOK/REBOOK -> appointment_id -> attendance -> explicit venta_id_match -> canonical venta_id`.
 
-Model components as:
+No revenue attribution by phone/name/username/BSUID alone.
 
-- `REQUIRED_BY_PLAN` — medically/operationally required only when explicitly selected by authorized plan;
-- `OPTIONAL_SUPPORT` — useful support, not mandatory;
-- `ALTERNATIVE` — mutually substitutable under authorized choice;
-- `DEPENDENT` — valid only if another component exists;
-- `CONTROL` — follow-up/control;
-- `MAINTENANCE` — continuity;
-- `PRODUCT_SUPPORT` — approved home/support product;
-- `TOPPING_ELIGIBLE` — commercial benefit candidate subject to rules.
+### WA-L7 — WhatsApp / AI Cost Intelligence
 
-The model must never infer clinical necessity from category alone.
+Production-certified, scoped and cold-path oriented. Effective-dated pricing authority, provider billability evidence, AI token cost and journey cost remain fail-closed when rate/currency evidence is incomplete.
 
-### 1C.3 — F1/F2/F3 quotation architecture
+### WA-L8 — Security Gate + Meta 2026 Hardening
 
-- F1 preparation/activation;
-- F2 personalized intervention;
-- F3 accompaniment/maintenance/continuity;
-- support complete-payment and progressive-payment views;
-- progressive payment cannot silently remove clinical scope or create hidden debt semantics.
+Production-certified under SAFE-OFF:
 
-### 1C.4 — Unit/session/control semantics
+- `pricing.type` persistence;
+- recipient-market-aware pricing;
+- per-business-phone/category billing observability;
+- consent/opt-in/opt-out/STOP evidence;
+- business-initiation preflight;
+- signed webhook/idempotency/secrets boundaries;
+- PII/PHI minimization;
+- service-role/least-privilege controls;
+- P0 #432/cross-module regressions.
 
-- distinguish row / session / unit / vial / ml / zone / control / package count;
-- no assumption that one catalog row equals one treatment unit;
-- price math must use explicit semantics.
+No unverified future Meta rate was seeded as VERIFIED authority.
 
-### 1C.5 — Toppings / no-discount / margin boundary
+### WA-L9 — AUTONOMOUS DEMO READY
 
-- benefit increases value; it does not rewrite canonical base price;
-- no autonomous discounting;
-- topping eligibility requires commercial + clinical coherence;
-- internal cost/margin evidence is private OWNER_ADMIN data;
-- no public exposure of cost/margin fields.
+**CLOSED · PRODUCTION CERTIFIED · DORMANT SAFE-OFF.**
 
-### 1C.6 — Process templates
+Evidence:
 
-Governed templates by Domain/Approach, not fixed combos:
+- issue #453 CLOSED/completed;
+- exact-head `b0a65d5b340896263a3f75cb66ab7850fdb3c5fa`;
+- exact-head Ascenda CI SUCCESS;
+- dedicated WA-L9 workflow SUCCESS across static/privacy, canonical WA-4C beta and CURRENT L5-L9/P0/parity;
+- PR #454 merged using `expected_head_sha`;
+- merge/deploy `f909e972aab243af954fc8e2fb15e5a37c68d1b6`;
+- Railway exact-merge SUCCESS;
+- Supabase PROD `20260903225152 · wa_l9_shadow_demo_v1`;
+- L9 shadow uses exact L4+L8 authority in rollback-only execution;
+- provider dispatch structurally false;
+- raw content structurally not stored;
+- demo runs=0, would-send=0, provider dispatch=0 after PROD deployment;
+- autonomous outbound=0;
+- final governance `main@bab9f0865f779217aadc7c88af4ebf0e1fb0b3ee`;
+- lock NONE.
 
-- Facial / Skin Signature;
-- Facial / Harmony Design;
-- Facial / BioRegen Face;
-- Corporal / Body Reset;
-- Corporal / Sculpt Body;
-- Corporal / Sculpt Booty;
-- Capilar / Activación & Regeneración;
-- Capilar / Mantenimiento & Prevención;
-- cross-domain support/evaluation where appropriate.
+## WA-L10 — AUTONOMOUS PRODUCTION CANARY
 
-Templates define allowed structure and explanatory logic, not patient-specific medical prescriptions.
+**Status:** `NEXT ELIGIBLE · NOT STARTED · CANARY NOT AUTHORIZED`.
 
-### 1C.7 — Safety / evidence / CI
+### Objective
 
-- service-role/private owner boundaries;
-- no patient mutation;
-- no REV mutation;
-- no price mutation during architecture certification;
-- no AI send/auto-reply/auto-routing activation;
-- exact-head Zero-Cost tests;
-- anti-drift + expected-head merge;
-- PROD unchanged for feature DDL unless separately promoted.
+Prove the full autonomous loop against a tiny, explicit, real production cohort while maintaining immediate human/kill-switch recovery and preventing uncontrolled fan-out.
 
-### 1C exit gate
+### L10.0 — Entry / anti-drift / safety freeze
 
-Only after 1C exact-head certification may the lock move to:
+Before mutation:
 
-`WA-4B — Sales Playbook Engine`.
+- re-read exact `main` and workstream lock;
+- verify L9 closeout lineage;
+- read live L4/L8/L9 safety state;
+- freeze PRE counts/fingerprints for Agenda, Call Center, Marketing, Ventas/Comisiones, Pacientes/Identity and WA;
+- verify autonomous outbound remains 0;
+- verify active allowlist state;
+- verify provider credentials/template readiness without exposing secrets;
+- verify current Meta policy/rate-card authority before live traffic.
 
-## WA-4B — Sales Playbook Engine — BLOCKED CONTRACT
+Do not increase DB/browser timeouts to make this pass.
 
-WA-4B will consume, not recreate:
+### L10.1 — Canary authority package
 
-- WA identity/reachability/eligibility;
-- governed Knowledge Fabric;
-- Zi Vital Domains/Approaches;
-- WA-4A.1B commercial principles/language;
-- WA-4A.1C treatment/process/pricing context.
+Reuse, do not duplicate:
 
-Target behaviors after unblock:
+- L4 mode/kill-switch/allowlist/budgets/idempotency;
+- L8 consent/STOP/security preflight;
+- L5 booking authority;
+- L6 attribution;
+- L7 cost;
+- L9 shadow/dry-run evidence.
 
-- concise client-facing explanations;
-- richer advisor/owner copilot explanations;
-- intent/objective detection;
-- objection handling;
-- process explanation before price fragmentation;
-- safe quotation scenario support;
-- continuity and ethical upsell suggestions;
-- human approval first;
-- evidence-required business facts;
-- clinical escalation where required.
+Any additive code must be narrowly scoped to canary observability/ramp/rollback and must remain dormant under AUTO_OFF until owner authorization.
 
-WA-4B does not activate autonomous send; WA-4C remains the later AI Sales Copilot canary.
+### L10.2 — Exact-head SAFE-OFF certification
 
-## Standard TEST-first phase loop
+Required before owner activation gate:
 
-`REVALIDATE CURRENT → DISCOVER → NECESSITY GATE → BUILD MINIMUM IN ISOLATED TEST → CONTRACT/SECURITY/REGRESSION TESTS → EXACT-HEAD ZERO-COST CI → ANTI-DRIFT → MERGE EXPECTED HEAD → VERIFY PROD BOUNDARY → TEST CERTIFICATE / PROD-READY PACKAGE → GitHub CURRENT → Notion LAST → NEXT LOCK`.
+- positive and fail-closed CI;
+- canonical WA-4C/L5 BOOK/REBOOK regressions;
+- L8 consent/security regressions;
+- L6 attribution and L7 cost regressions;
+- P0 #432 cross-module performance/parity;
+- no raw prompt/reply storage beyond governed message ledger;
+- no provider dispatch in SAFE-OFF;
+- exact-head anti-drift.
+
+### L10.3 — Explicit owner activation gate
+
+**STOP HERE until the owner explicitly authorizes `AUTO_OFF -> CANARY`.**
+
+Authorization must define the smallest safe cohort/conversation allowlist and does not imply PROD/general rollout.
+
+### L10.4 — Real production canary
+
+After explicit authorization only:
+
+- add minimal real allowlist through governed authority;
+- transition AUTO_OFF->CANARY using the certified mode function;
+- keep kill/rollback path immediately available according to the certified authority/runbook;
+- run a very small number of real conversations/turns;
+- verify delivered provider statuses, idempotency/no duplicates, L8 preflight, costs, bookings/rebooks/handoff and attribution;
+- capture redacted evidence only;
+- stop/rollback immediately on safety, privacy, duplicate, provider, cost, booking, latency or cross-module regression.
+
+### L10.5 — Canary exit / closeout
+
+Required evidence:
+
+- no unauthorized recipient/conversation escaped allowlist;
+- no duplicate autonomous sends;
+- STOP/opt-out and human handoff work;
+- no identity/privacy violation;
+- real booking/REBOOK semantics correct when exercised;
+- provider delivery reconciles with local ledger;
+- costs reconcile at demonstrated boundary;
+- PRE->POST protected-module parity or explained legitimate deltas only;
+- P0 #432 operational paths healthy;
+- clear go/no-go decision;
+- return to safe state if L11 is not immediately and separately authorized.
+
+Only then may L10 close and L11 become eligible.
+
+## WA-L11 — GENERAL PRODUCTION
+
+**Status:** `BLOCKED BY WA-L10 REAL CANARY EVIDENCE`.
+
+### Objective
+
+Move from tiny allowlisted canary to governed general autonomous production without losing kill-switch, consent, human escalation, cost, attribution or performance controls.
+
+### L11 entry gates
+
+- L10 CLOSED/PASS with real evidence;
+- explicit owner authorization for general production/ramp;
+- official current Meta terms/rate/billing verification;
+- operational owner/on-call and rollback runbook;
+- provider credential/payment health;
+- stable real-conversation quality and latency;
+- no unresolved P0/cross-module regression.
+
+### L11 controlled ramp
+
+Do not jump directly to unrestricted traffic. Expand scope in bounded stages with:
+
+- explicit cohort/ramp criteria;
+- budgets/rate limits;
+- kill-switch and rollback;
+- provider/invoice reconciliation;
+- human handoff capacity;
+- performance/error monitoring;
+- conversation-quality review;
+- booked/attended/sale attribution and cost KPIs.
+
+### L11 exit gate
+
+`GENERAL PRODUCTION CERTIFIED` only when:
+
+- autonomous authority is demonstrably correct under real load;
+- customer safety/privacy/consent are preserved;
+- provider delivery and billing reconcile;
+- booking/rebooking and attribution are correct;
+- no cross-module or P0 performance regression exists;
+- human escalation/kill path is tested;
+- operating runbook and ownership are complete;
+- final exact-head/deploy/PROD evidence is recorded in GitHub + Notion.
+
+## Post-L11 — Customer Experience & Conversation Validation
+
+This is the business/UX validation layer after technical production certification.
+
+### Real-customer experience dimensions
+
+1. **Naturalness:** conversational, concise, non-robotic, no canned-loop feeling.
+2. **Intent comprehension:** understands treatment interest, objection, timing, branch/date and continuity without repeatedly asking known facts.
+3. **Memory quality:** retains conversation context within governed bounds and does not hallucinate prior facts.
+4. **Message economy:** one useful outbound provider message per turn by default where UX permits; no gratuitous bubble splitting.
+5. **Fact/pricing integrity:** only governed current business facts/prices; uncertainty fails closed/escalates.
+6. **Booking UX:** minimum friction from intent to real slot to confirmation.
+7. **REBOOK UX:** natural-language rescheduling preserves the correct appointment and state.
+8. **Human handoff:** clear, fast and context-preserving transfer.
+9. **STOP/consent:** opt-out immediately respected; no continued autonomous persuasion.
+10. **Identity/privacy:** no unsafe disclosure or name-only binding.
+11. **Latency:** first useful response and end-to-end turn latency remain acceptable under real traffic.
+12. **Reliability:** no duplicate sends, loops, orphan actions or provider/local divergence.
+13. **Commercial outcome:** qualified conversation -> booking -> attendance -> sale.
+14. **Cost:** WhatsApp + AI cost per qualified conversation / booking / attendance / sale.
+15. **Customer/operator feedback:** structured qualitative review of clarity, trust, usefulness and friction.
+
+### Evidence method
+
+- real consented customers/pilots only;
+- start with small cohorts;
+- redact evidence and protect PHI/PII;
+- pair quantitative funnel/latency/cost metrics with reviewed transcripts/conversation samples;
+- never create synthetic PROD rows and label them customer evidence;
+- iterate copy/prompt/playbook only through governed versioned changes and re-certify relevant gates.
+
+## Meta 2026 checkpoint before L10/L11
+
+Before live canary/general production, recheck official Meta sources and the clinic’s Billing Hub/WABA card.
+
+Known current operational constraints from the 2026-09-03 audit:
+
+- charging is based on delivered message + recipient market/category;
+- service/utility billing rules change materially on 2026-10-01 according to announced/corroborated rate-card changes;
+- first 1,000 monthly Service messages per business phone number are expected to be free under the new model;
+- Peru USD 0.0300 Utility/Auth/Service for Oct was strongly corroborated but not directly fetched from Meta due official endpoint 429;
+- therefore do not mark that future rate VERIFIED until official WABA/Billing Hub evidence is obtained;
+- Meta terms have an announced 2026-09-23 update: re-read before canary.
+
+## Standard remaining-phase loop
+
+`REVALIDATE CURRENT -> DISCOVER -> NECESSITY GATE -> BUILD MINIMUM -> SAFE-OFF CONTRACT/SECURITY/P0 TESTS -> EXACT-HEAD CI -> ANTI-DRIFT -> MERGE expected_head_sha -> RAILWAY -> MERGED-LINEAGE SUPABASE -> PROD READBACK/PARITY -> OWNER ACTIVATION GATE WHEN REQUIRED -> REAL CANARY/RAMP -> CLOSEOUT -> NOTION LAST -> NEXT BOUNDARY`.


### PR DESCRIPTION
Durable continuity sync after WA-L9 closeout. Updates canonical MEMORY_CURRENT, modernizes agent bootstrap, replaces stale WA roadmap with the L1-L11 closeout graph, and adds a dedicated L9→L11 + post-L11 Customer Experience/Conversation Validation continuity contract.

The PR also aligns one stale WA-CLOSEOUT test assertion with the already-current project-wide Supabase 402 breaker semantics (`ALL_CONFIGURED_SUPABASE_RUNTIME_REQUESTS`). The old test still expected a legacy WA User-Agent allowlist; runtime is unchanged by this PR.

No product runtime, Supabase schema, Railway configuration, provider dispatch or safety-mode mutation. Production remains AUTO_OFF with kill switch engaged; CANARY remains NOT AUTHORIZED and requires separate explicit owner authorization.