### PR TITLE
P0 #457: bound WA production certification readbacks

### DIFF
--- a/ci/wa-l8/p0_certification_status_v2_contract.js
+++ b/ci/wa-l8/p0_certification_status_v2_contract.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const fs=require('fs')
+const assert=require('assert')
+
+const sql=fs.readFileSync('supabase/migrations/20260904002000_wa_l8_l9_p0_certification_status_v2.sql','utf8')
+
+assert(sql.includes('aos_wa_l8_safety_status_v2'),'L8 bounded safety status missing')
+assert(sql.includes('aos_wa_l9_safety_status_v2'),'L9 bounded safety status missing')
+assert(sql.includes("'readback_class','SAFETY_BOUNDED_V2'"),'bounded readback marker missing')
+assert(sql.includes("where m.send_origin='AUTO' and m.direction='OUTBOUND'"),'autonomous outbound safety probe missing')
+assert(sql.includes('where d.provider_dispatch is true'),'provider dispatch safety probe missing')
+assert(sql.includes('COLD_AUDIT_ONLY'),'legacy global status must be explicitly cold-audit only')
+assert(!/create\s+materialized\s+view|refresh\s+materialized\s+view/i.test(sql),'certification status may not create/refresh materialized views')
+assert(!/statement_timeout/i.test(sql),'P0 certification fix may not change statement_timeout')
+
+const l8=sql.match(/create or replace function public\.aos_wa_l8_safety_status_v2\(\)[\s\S]*?revoke all on function public\.aos_wa_l8_safety_status_v2\(\)/i)
+const l9=sql.match(/create or replace function public\.aos_wa_l9_safety_status_v2\(\)[\s\S]*?revoke all on function public\.aos_wa_l9_safety_status_v2\(\)/i)
+assert(l8&&l9,'unable to isolate bounded status definitions')
+assert(!/count\s*\(/i.test(l8[0]),'L8 production safety readback must not use global COUNT')
+assert(!/count\s*\(/i.test(l9[0]),'L9 production safety readback must not use global COUNT')
+assert(/exists\s*\(/i.test(l8[0]),'L8 must use existence probe')
+assert(/exists\s*\(/i.test(l9[0]),'L9 must use existence probe')
+
+console.log('P0_457_CERTIFICATION_STATUS_V2_CONTRACT=PASS')

--- a/ci/wa-l8/p0_certification_status_v2_contract.js
+++ b/ci/wa-l8/p0_certification_status_v2_contract.js
@@ -12,7 +12,7 @@ assert(sql.includes("where m.send_origin='AUTO' and m.direction='OUTBOUND'"),'au
 assert(sql.includes('where d.provider_dispatch is true'),'provider dispatch safety probe missing')
 assert(sql.includes('COLD_AUDIT_ONLY'),'legacy global status must be explicitly cold-audit only')
 assert(!/create\s+materialized\s+view|refresh\s+materialized\s+view/i.test(sql),'certification status may not create/refresh materialized views')
-assert(!/statement_timeout/i.test(sql),'P0 certification fix may not change statement_timeout')
+assert(!/(?:set|alter\s+(?:role|database)[^;]*)\s+statement_timeout\b/i.test(sql),'P0 certification fix may not mutate statement_timeout')
 
 const l8=sql.match(/create or replace function public\.aos_wa_l8_safety_status_v2\(\)[\s\S]*?revoke all on function public\.aos_wa_l8_safety_status_v2\(\)/i)
 const l9=sql.match(/create or replace function public\.aos_wa_l9_safety_status_v2\(\)[\s\S]*?revoke all on function public\.aos_wa_l9_safety_status_v2\(\)/i)

--- a/ci/wa-l8/security_contract.js
+++ b/ci/wa-l8/security_contract.js
@@ -85,4 +85,7 @@ assert(!/alter\s+table\s+public\.(?:aos_pacientes|aos_ventas|aos_llamadas|aos_le
 assert(rollback.includes('WA_L8_RECOVERY_BLOCKED_AUDIT_HISTORY'));
 assert(rollback.includes('Least-privilege revocations are monotonic security hardening'));
 
+// P0 #457: production deploy/readbacks use bounded safety-only status v2.
+require('./p0_certification_status_v2_contract');
+
 console.log('WA_L8_STATIC_SECURITY_CONTRACT_PASS');

--- a/ci/wa-l9/P0_457_CERTIFICATION_READBACK_CROSS_REGRESSION.md
+++ b/ci/wa-l9/P0_457_CERTIFICATION_READBACK_CROSS_REGRESSION.md
@@ -1,0 +1,5 @@
+# P0 #457 — WA-L9 cross-regression marker
+
+This file intentionally scopes PR #459 into the canonical WA-L9 workflow because the additive bounded certification migration also defines `aos_wa_l9_safety_status_v2()`.
+
+The v2 source itself is statically enforced by `ci/wa-l8/p0_certification_status_v2_contract.js`; the WA-L9 workflow remains responsible for proving the existing shadow authority, privacy, no-dispatch and SAFE-OFF contracts are unchanged.

--- a/docs/control/P0_457_AUTH_DB_INCIDENT_20260903.md
+++ b/docs/control/P0_457_AUTH_DB_INCIDENT_20260903.md
@@ -1,0 +1,38 @@
+# P0 #457 — Auth outage / DB pressure incident — 2026-09-03
+
+Status: ACTIVE — WA-L10 paused; AUTO_OFF; kill switch engaged; CANARY NOT AUTHORIZED.
+
+## Proven timeline
+
+- WA-L10/L11 introduced no production runtime implementation before the outage. Between merged WA-L9 and the P0 lock, the main-line changes were governance/docs and a CI contract adjustment.
+- Production then entered a broad PostgreSQL/PostgREST degradation window with 504 responses, statement timeouts and idle-in-transaction terminations. Auth V3 and 2FA depend on the same project and became unavailable.
+- The login boundary also synchronously reconciled the Resend private vault before canonical Auth V3. P0 #457 PR #458 removed that transient single point of failure without bypassing 2FA and restored the canonical logo/password visibility UX.
+
+## Pressure evidence
+
+Production is already a mixed operational workload. Historical pg_stat_statements includes material cost from advisor/admin panels, Call Center identity/action reads, notifications and analytics.
+
+During L8/L9 certification, cold audit/readback work overlapped this workload. `aos_wa_l8_security_status_v1()` mixes safety controls with several global COUNT(*) scans and one production invocation reached approximately 10.6 seconds. A global L7 cost reconciliation readback also reached approximately 1.8 seconds.
+
+This violates the P0 #432 separation principle for production certification: a safety deploy/readback must be bounded and must not run global audit aggregation synchronously against live clinic traffic.
+
+## Hypothesis explicitly disproved
+
+The old `trg_refresh_llammap` foreground materialized-view refresh trigger is NOT present in production. `aos_llamadas` currently retains the governed-write guard, commercial guard, manual-agenda cleanup, audit and sync-key triggers only. `aos_refresh_llammap()` remains available for explicit cold refresh.
+
+## Remediation
+
+1. PR #458 / merge `13d508d586423668f1c55df2b380920c8a5fa1b9`: Auth resilience + login UX, no timer/polling and no timeout increase.
+2. Add `aos_wa_l8_safety_status_v2()` and `aos_wa_l9_safety_status_v2()` as service-role-only bounded production certification surfaces.
+3. Keep legacy L8/L9 global-count status functions as COLD_AUDIT_ONLY; never invoke them as synchronous deploy/prod readbacks.
+4. Safety v2 uses singleton control rows plus existence probes only. Production EXPLAIN of the equivalent L8 safety query: ~9 ms execution, 10 shared buffer hits, zero reads.
+5. No change to autonomous authority, routing, booking, patient/sales ledgers, 2FA, statement_timeout or browser polling.
+
+## Closure gates
+
+- exact-head CI including WA-L8/WA-L9 + Performance Guard + Audit 360;
+- apply additive migration to PROD;
+- bounded safety readback under existing timeout;
+- Railway exact-line health/login asset readback;
+- real owner + Wilmer login/2FA smoke;
+- observe DB/API for recurrence before releasing the P0 lock.

--- a/supabase/migrations/20260904002000_wa_l8_l9_p0_certification_status_v2.sql
+++ b/supabase/migrations/20260904002000_wa_l8_l9_p0_certification_status_v2.sql
@@ -1,0 +1,111 @@
+-- P0 #457 / #432 — isolate production certification readbacks from global audit scans.
+--
+-- Root evidence (2026-09-03 incident): the legacy WA-L8 security status mixes
+-- constant-time safety flags with several global COUNT(*) scans. One production
+-- certification invocation reached ~10.6s while operational Call Center traffic
+-- was active. Certification must never compete with foreground clinic work.
+--
+-- This migration is additive. It does not alter autonomous authority, message
+-- routing, 2FA, statement_timeout, business ledgers, or the legacy cold-audit
+-- functions. The v2 surfaces are intentionally safety-only and use indexed EXISTS
+-- probes instead of global counts.
+
+begin;
+
+create or replace function public.aos_wa_l8_safety_status_v2()
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select pg_catalog.jsonb_build_object(
+    'ok',true,
+    'mode',a.mode,
+    'kill_switch_engaged',a.kill_switch_engaged,
+    'auto_reply_enabled',ai.auto_reply_enabled,
+    'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,
+    'human_send_enabled',r.human_send_enabled,
+    'autonomous_outbound',case when exists(
+      select 1
+      from public.aos_wa_messages_v1 m
+      where m.send_origin='AUTO' and m.direction='OUTBOUND'
+      limit 1
+    ) then 1 else 0 end,
+    'browser_message_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_wa_messages_v1','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_wa_messages_v1','DELETE')
+    ),
+    'browser_booking_write',(
+      pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('anon','public.aos_booking_operations_v2','DELETE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','INSERT')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','UPDATE')
+      or pg_catalog.has_table_privilege('authenticated','public.aos_booking_operations_v2','DELETE')
+    ),
+    'readback_class','SAFETY_BOUNDED_V2'
+  )
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+revoke all on function public.aos_wa_l8_safety_status_v2() from public,anon,authenticated;
+grant execute on function public.aos_wa_l8_safety_status_v2() to service_role;
+
+create or replace function public.aos_wa_l9_safety_status_v2()
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select pg_catalog.jsonb_build_object(
+    'ok',true,
+    'mode',a.mode,
+    'kill_switch_engaged',a.kill_switch_engaged,
+    'auto_reply_enabled',ai.auto_reply_enabled,
+    'ai_send_enabled',r.ai_send_enabled,
+    'auto_routing_enabled',r.auto_routing_enabled,
+    'human_send_enabled',r.human_send_enabled,
+    'provider_dispatch_runs',case when exists(
+      select 1
+      from public.aos_wa_l9_demo_runs_v1 d
+      where d.provider_dispatch is true
+      limit 1
+    ) then 1 else 0 end,
+    'autonomous_outbound',case when exists(
+      select 1
+      from public.aos_wa_messages_v1 m
+      where m.send_origin='AUTO' and m.direction='OUTBOUND'
+      limit 1
+    ) then 1 else 0 end,
+    'readback_class','SAFETY_BOUNDED_V2'
+  )
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1
+$$;
+
+revoke all on function public.aos_wa_l9_safety_status_v2() from public,anon,authenticated;
+grant execute on function public.aos_wa_l9_safety_status_v2() to service_role;
+
+comment on function public.aos_wa_l8_safety_status_v2() is
+  'P0-bounded WA-L8 production safety readback. No global audit counts; indexed EXISTS only. Use for deploy/prod certification.';
+comment on function public.aos_wa_l9_safety_status_v2() is
+  'P0-bounded WA-L9 production safety readback. No global audit counts; use for deploy/prod certification.';
+comment on function public.aos_wa_l8_security_status_v1() is
+  'COLD_AUDIT_ONLY after P0 #457. Includes global counts and MUST NOT be used as synchronous production deploy/readback gate; use aos_wa_l8_safety_status_v2().';
+comment on function public.aos_wa_l9_status_v1() is
+  'COLD_AUDIT_ONLY after P0 #457. Includes global counts and MUST NOT be used as synchronous production deploy/readback gate; use aos_wa_l9_safety_status_v2().';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260904002000_wa_l8_l9_p0_certification_status_v2.rollback.sql
+++ b/supabase/rollbacks/20260904002000_wa_l8_l9_p0_certification_status_v2.rollback.sql
@@ -1,0 +1,15 @@
+-- P0 #457 bounded certification status rollback.
+-- Removes only additive v2 safety readback surfaces and restores legacy comments.
+
+begin;
+
+drop function if exists public.aos_wa_l9_safety_status_v2();
+drop function if exists public.aos_wa_l8_safety_status_v2();
+
+comment on function public.aos_wa_l8_security_status_v1() is
+  'WA-L8 security/readback surface. Includes audit counts; no raw PII or message bodies are returned.';
+comment on function public.aos_wa_l9_status_v1() is
+  'WA-L9 shadow/demo status surface.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Continuation of P0 #457 after restoring Auth/login UX.

Root-cause hardening:
- WA-L10/L11 did not introduce production runtime code before the outage.
- Production evidence shows the outage was a DB/PostgREST pressure event; L8/L9 certification overlapped active clinic load.
- `aos_wa_l8_security_status_v1()` mixes safety flags with global COUNT scans and one live certification call reached ~10.6s.
- the old call-ledger MV refresh trigger is already absent in PROD, so this PR does not touch Call Center write triggers.

Change:
- add service-role-only `aos_wa_l8_safety_status_v2()` and `aos_wa_l9_safety_status_v2()` for bounded deploy/prod readback;
- singleton control reads + existence probes only; no global COUNT in v2;
- legacy global-count status surfaces remain available but are explicitly `COLD_AUDIT_ONLY`;
- no materialized views, no triggers, no timeout change, no browser polling, no authority/routing mutation;
- static P0 contract is bound into the WA-L8 gate.

Production benchmark of equivalent L8 v2 query before DDL: ~9ms execution, 10 shared buffer hits, 0 disk reads. WA-L10 remains paused; AUTO_OFF / kill switch engaged / CANARY NOT AUTHORIZED.