### PR TITLE
P0 #457: make aos_panel_admin indexable

### DIFF
--- a/.github/workflows/asc-perf-performance-guard.yml
+++ b/.github/workflows/asc-perf-performance-guard.yml
@@ -8,6 +8,8 @@ on:
       - 'sentinel/**'
       - 'tools/perf-audit/**'
       - 'ci/performance/**'
+      - 'supabase/migrations/*p0_457*'
+      - 'supabase/rollbacks/*p0_457*'
       - '.github/workflows/asc-perf-performance-guard.yml'
       - 'docs/control/PERFORMANCE_*'
       - 'docs/control/READ_OWNERSHIP_*'
@@ -18,6 +20,8 @@ on:
       - 'sentinel/**'
       - 'tools/perf-audit/**'
       - 'ci/performance/**'
+      - 'supabase/migrations/*p0_457*'
+      - 'supabase/rollbacks/*p0_457*'
       - '.github/workflows/asc-perf-performance-guard.yml'
       - 'docs/control/PERFORMANCE_*'
       - 'docs/control/READ_OWNERSHIP_*'
@@ -62,6 +66,10 @@ jobs:
         run: |
           set -euo pipefail
           node ci/performance/performance-guard.mjs "$RUNNER_TEMP/asc-perf-runtime-census.json"
+      - name: P0 #457 admin-panel indexability contract
+        run: |
+          set -euo pipefail
+          node ci/performance/p0-457-panel-admin-indexable.test.js
       - name: No persisted runtime artifacts
         if: always()
         run: |

--- a/ci/performance/p0-457-panel-admin-indexable.test.js
+++ b/ci/performance/p0-457-panel-admin-indexable.test.js
@@ -1,0 +1,25 @@
+'use strict';
+const fs=require('fs');
+const assert=require('assert');
+
+const migration=fs.readFileSync('supabase/migrations/20260904004500_p0_457_panel_admin_indexable_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260904004500_p0_457_panel_admin_indexable_v1.rollback.sql','utf8');
+
+assert(/create or replace function public\.aos_panel_admin\(p_hoy text, p_ayer text, p_mes_inicio text\)/i.test(migration));
+assert(/returns json/i.test(migration));
+assert(/America\/Lima/i.test(migration));
+assert(!/fecha::text/i.test(migration),'panel admin migration must not cast indexed date columns to text');
+assert(!/fecha_cita::text/i.test(migration),'agenda date predicate must stay native date');
+assert(/where fecha in \(v_hoy, v_ayer\)/i.test(migration));
+assert(/where fecha >= v_mes_inicio/i.test(migration));
+assert(/where fecha_cita = v_hoy/i.test(migration));
+assert(/where l\.fecha = v_hoy/i.test(migration));
+assert(/where l2\.id_asesor = l\.id_asesor[\s\S]*l2\.fecha = v_hoy/i.test(migration));
+assert(!/create\s+index|create\s+materialized\s+view|refresh\s+materialized\s+view|create\s+trigger/i.test(migration));
+assert(!/(?:set|alter[^;]*)\s+statement_timeout/i.test(migration));
+assert(!/(insert\s+into|update|delete\s+from)\s+public\.(aos_ventas|aos_llamadas|aos_agenda_citas|aos_leads)/i.test(migration));
+for(const key of ['businessDate','businessTimezone','factHoy','factHoySI','factHoyPL','nVentasHoy','deltaVentasHoy','llamHoy','llamMes','citasHoy','citasAgHoy','leadsMes','alertas','ventasHoy','semaforo','tipif','fromSupabase']){
+  assert(migration.includes(`'${key}'`),`payload key missing: ${key}`);
+}
+assert(/fecha::text/i.test(rollback),'rollback must restore prior implementation');
+console.log('P0_457_PANEL_ADMIN_INDEXABLE_CONTRACT=PASS');

--- a/supabase/migrations/20260904004500_p0_457_panel_admin_indexable_v1.sql
+++ b/supabase/migrations/20260904004500_p0_457_panel_admin_indexable_v1.sql
@@ -1,0 +1,125 @@
+-- P0 #457 / P0 #432 — remove non-sargable date casts from aos_panel_admin.
+-- Business payload and Lima business-date semantics are preserved exactly.
+-- No new indexes, triggers, materialized views, retries, caches or timeout changes.
+
+begin;
+
+create or replace function public.aos_panel_admin(p_hoy text, p_ayer text, p_mes_inicio text)
+returns json
+language plpgsql
+security definer
+as $function$
+declare
+  v_hoy date := (now() at time zone 'America/Lima')::date;
+  v_ayer date := ((now() at time zone 'America/Lima')::date - 1);
+  v_mes_inicio date := date_trunc('month', (now() at time zone 'America/Lima'))::date;
+  v_fact_hoy numeric := 0;
+  v_fact_si numeric := 0;
+  v_fact_pl numeric := 0;
+  v_fact_ayer numeric := 0;
+  v_n_ventas integer := 0;
+  v_llam_hoy integer := 0;
+  v_llam_mes integer := 0;
+  v_citas_hoy integer := 0;
+  v_citas_ag integer := 0;
+  v_leads_mes integer := 0;
+  v_semaforo json;
+  v_tipif json;
+  v_ventas_hoy json;
+begin
+  select
+    coalesce(sum(case when fecha = v_hoy then monto else 0 end), 0),
+    coalesce(sum(case when fecha = v_hoy and (sede ilike '%ISIDRO%' or sede ilike '%SAN%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha = v_hoy and (sede ilike '%PUEBLO%' or sede ilike '%LIBRE%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha = v_ayer then monto else 0 end), 0),
+    count(*) filter (where fecha = v_hoy)
+  into v_fact_hoy, v_fact_si, v_fact_pl, v_fact_ayer, v_n_ventas
+  from public.aos_ventas
+  where fecha in (v_hoy, v_ayer);
+
+  select json_agg(row_to_json(v)) into v_ventas_hoy from (
+    select nombres, apellidos, tratamiento, monto, tipo, asesor, sede, numero_limpio as num
+    from public.aos_ventas
+    where fecha = v_hoy
+    order by created_at desc
+    limit 20
+  ) v;
+
+  select
+    count(*) filter (where fecha = v_hoy),
+    count(*)
+  into v_llam_hoy, v_llam_mes
+  from public.aos_llamadas
+  where fecha >= v_mes_inicio;
+
+  select
+    count(*),
+    count(*) filter (where estado_cita not in ('CANCELADA','NO ASISTIO'))
+  into v_citas_hoy, v_citas_ag
+  from public.aos_agenda_citas
+  where fecha_cita = v_hoy;
+
+  select count(*) into v_leads_mes
+  from public.aos_leads
+  where fecha >= v_mes_inicio;
+
+  select json_agg(row_to_json(s)) into v_semaforo from (
+    select
+      l.id_asesor,
+      l.asesor,
+      count(*) as llamadas,
+      count(*) filter (where l.estado = 'CITA CONFIRMADA') as citas,
+      max(coalesce(l.ult_ts, l.created_at)) as ult_ts,
+      round(extract(epoch from (now() - max(coalesce(l.ult_ts, l.created_at)))) / 60) as mins_sin,
+      (select l2.numero_limpio
+       from public.aos_llamadas l2
+       where l2.id_asesor = l.id_asesor
+         and l2.fecha = v_hoy
+       order by coalesce(l2.ult_ts, l2.created_at) desc nulls last
+       limit 1) as ult_numero,
+      to_char(max(coalesce(l.ult_ts, l.created_at)) at time zone 'America/Lima', 'HH12:MI AM') as ult_hora
+    from public.aos_llamadas l
+    where l.fecha = v_hoy
+      and l.id_asesor is not null and l.id_asesor != ''
+    group by l.id_asesor, l.asesor
+    order by llamadas desc
+  ) s;
+
+  select json_agg(row_to_json(t)) into v_tipif from (
+    select estado, count(*) as total
+    from public.aos_llamadas
+    where fecha = v_hoy
+    group by estado
+    order by total desc
+    limit 10
+  ) t;
+
+  return json_build_object(
+    'businessDate', v_hoy::text,
+    'businessTimezone', 'America/Lima',
+    'kpis', json_build_object(
+      'factHoy', v_fact_hoy,
+      'factHoySI', v_fact_si,
+      'factHoyPL', v_fact_pl,
+      'nVentasHoy', v_n_ventas,
+      'deltaVentasHoy', case when v_fact_ayer > 0 then round((v_fact_hoy - v_fact_ayer) / v_fact_ayer * 100) / 100.0 else null end,
+      'llamHoy', v_llam_hoy,
+      'llamMes', v_llam_mes,
+      'citasHoy', v_citas_hoy,
+      'citasAgHoy', v_citas_ag,
+      'leadsMes', v_leads_mes,
+      'alertas', 0
+    ),
+    'ventasHoy', coalesce(v_ventas_hoy, '[]'::json),
+    'semaforo', coalesce(v_semaforo, '[]'::json),
+    'tipif', coalesce(v_tipif, '[]'::json),
+    'fromSupabase', true
+  );
+end;
+$function$;
+
+comment on function public.aos_panel_admin(text,text,text) is
+  'P0 #457 indexable admin summary. Preserves Lima business-date payload while using native date predicates and existing indexes.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260904004500_p0_457_panel_admin_indexable_v1.rollback.sql
+++ b/supabase/rollbacks/20260904004500_p0_457_panel_admin_indexable_v1.rollback.sql
@@ -1,0 +1,110 @@
+begin;
+
+create or replace function public.aos_panel_admin(p_hoy text, p_ayer text, p_mes_inicio text)
+returns json
+language plpgsql
+security definer
+as $function$
+declare
+  v_hoy text := ((now() at time zone 'America/Lima')::date)::text;
+  v_ayer text := (((now() at time zone 'America/Lima')::date - 1))::text;
+  v_mes_inicio text := date_trunc('month', (now() at time zone 'America/Lima'))::date::text;
+  v_fact_hoy numeric := 0;
+  v_fact_si numeric := 0;
+  v_fact_pl numeric := 0;
+  v_fact_ayer numeric := 0;
+  v_n_ventas integer := 0;
+  v_llam_hoy integer := 0;
+  v_llam_mes integer := 0;
+  v_citas_hoy integer := 0;
+  v_citas_ag integer := 0;
+  v_leads_mes integer := 0;
+  v_semaforo json;
+  v_tipif json;
+  v_ventas_hoy json;
+begin
+  select
+    coalesce(sum(case when fecha::text = v_hoy then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_hoy and (sede ilike '%ISIDRO%' or sede ilike '%SAN%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_hoy and (sede ilike '%PUEBLO%' or sede ilike '%LIBRE%') then monto else 0 end), 0),
+    coalesce(sum(case when fecha::text = v_ayer then monto else 0 end), 0),
+    count(*) filter (where fecha::text = v_hoy)
+  into v_fact_hoy, v_fact_si, v_fact_pl, v_fact_ayer, v_n_ventas
+  from public.aos_ventas;
+
+  select json_agg(row_to_json(v)) into v_ventas_hoy from (
+    select nombres, apellidos, tratamiento, monto, tipo, asesor, sede, numero_limpio as num
+    from public.aos_ventas where fecha::text = v_hoy
+    order by created_at desc limit 20
+  ) v;
+
+  select
+    count(*) filter (where fecha::text = v_hoy),
+    count(*) filter (where fecha::text >= v_mes_inicio)
+  into v_llam_hoy, v_llam_mes
+  from public.aos_llamadas;
+
+  select
+    count(*),
+    count(*) filter (where estado_cita not in ('CANCELADA','NO ASISTIO'))
+  into v_citas_hoy, v_citas_ag
+  from public.aos_agenda_citas where fecha_cita::text = v_hoy;
+
+  select count(*) into v_leads_mes
+  from public.aos_leads where fecha::text >= v_mes_inicio;
+
+  select json_agg(row_to_json(s)) into v_semaforo from (
+    select
+      l.id_asesor,
+      l.asesor,
+      count(*) as llamadas,
+      count(*) filter (where l.estado = 'CITA CONFIRMADA') as citas,
+      max(coalesce(l.ult_ts, l.created_at)) as ult_ts,
+      round(extract(epoch from (now() - max(coalesce(l.ult_ts, l.created_at)))) / 60) as mins_sin,
+      (select l2.numero_limpio
+       from public.aos_llamadas l2
+       where l2.id_asesor = l.id_asesor
+         and l2.fecha::text = v_hoy
+       order by coalesce(l2.ult_ts, l2.created_at) desc nulls last
+       limit 1) as ult_numero,
+      to_char(max(coalesce(l.ult_ts, l.created_at)) at time zone 'America/Lima', 'HH12:MI AM') as ult_hora
+    from public.aos_llamadas l
+    where l.fecha::text = v_hoy
+      and l.id_asesor is not null and l.id_asesor != ''
+    group by l.id_asesor, l.asesor
+    order by llamadas desc
+  ) s;
+
+  select json_agg(row_to_json(t)) into v_tipif from (
+    select estado, count(*) as total
+    from public.aos_llamadas
+    where fecha::text = v_hoy
+    group by estado order by total desc limit 10
+  ) t;
+
+  return json_build_object(
+    'businessDate', v_hoy,
+    'businessTimezone', 'America/Lima',
+    'kpis', json_build_object(
+      'factHoy', v_fact_hoy,
+      'factHoySI', v_fact_si,
+      'factHoyPL', v_fact_pl,
+      'nVentasHoy', v_n_ventas,
+      'deltaVentasHoy', case when v_fact_ayer > 0 then round((v_fact_hoy - v_fact_ayer) / v_fact_ayer * 100) / 100.0 else null end,
+      'llamHoy', v_llam_hoy,
+      'llamMes', v_llam_mes,
+      'citasHoy', v_citas_hoy,
+      'citasAgHoy', v_citas_ag,
+      'leadsMes', v_leads_mes,
+      'alertas', 0
+    ),
+    'ventasHoy', coalesce(v_ventas_hoy, '[]'::json),
+    'semaforo', coalesce(v_semaforo, '[]'::json),
+    'tipif', coalesce(v_tipif, '[]'::json),
+    'fromSupabase', true
+  );
+end;
+$function$;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Continuation of active P0 #457 after Auth recovery and WA certification-readback hardening.

Production evidence after owner/Wilmer recovery still showed intermittent statement timeouts. API correlation identified existing operational RPCs, especially `aos_panel_admin`, `aos_ticker_mkt`, and `aos_get_historial_paciente`.

`pg_stat_statements` at incident time:
- aos_panel_admin: 376 calls, 1140.7 ms mean, 2976.5 ms max
- aos_ticker_mkt: 385 calls, 898.1 ms mean, 2944.2 ms max
- aos_get_historial_paciente: 411 calls, 615.6 ms mean, 2966.5 ms max

Root cause addressed in this PR:
- `aos_panel_admin` casts indexed DATE columns to text (`fecha::text`, `fecha_cita::text`), preventing selective index conditions.
- planner comparison on `aos_llamadas`: old cast predicate cost ~1534 vs native date predicate cost ~6.4 with `idx_aos_llam_fecha` Index Cond (~240x lower estimated cost for that block).

Change:
- preserve exact function signature, payload keys and America/Lima business-date semantics;
- replace text-cast date filters with native DATE predicates;
- bound sales aggregation to today/yesterday and calls aggregation to current-month range without changing output semantics;
- reuse existing indexes only; no new indexes, materialized views, triggers, caches, retries or timeout changes;
- include exact rollback and a performance architecture contract bound into Performance Guard.

P0 #457 remains the sole HIGH/CRITICAL mutable lane. WA-L10 remains paused, AUTO_OFF remains required, CANARY remains NOT AUTHORIZED.