### PR TITLE
P0 #457: specialize marketing ticker read path

### DIFF
--- a/.github/workflows/asc-perf-performance-guard.yml
+++ b/.github/workflows/asc-perf-performance-guard.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           set -euo pipefail
           node ci/performance/p0-457-panel-admin-indexable.test.js
+      - name: P0 #457 bounded marketing ticker contract
+        run: |
+          set -euo pipefail
+          node ci/performance/p0-457-ticker-specialized.test.js
       - name: No persisted runtime artifacts
         if: always()
         run: |

--- a/ci/performance/p0-457-ticker-specialized.test.js
+++ b/ci/performance/p0-457-ticker-specialized.test.js
@@ -1,0 +1,24 @@
+'use strict';
+const fs=require('fs');
+const assert=require('assert');
+
+const migration=fs.readFileSync('supabase/migrations/20260904010500_p0_457_ticker_specialized_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260904010500_p0_457_ticker_specialized_v1.rollback.sql','utf8');
+
+assert(/create or replace function public\.aos_ticker_mkt\(p_mes_inicio text\)/i.test(migration));
+assert(/returns jsonb/i.test(migration));
+assert(!/aos_marketing_period_summary_v2\s*\(/i.test(migration),'ticker must not invoke full marketing period summary');
+assert(/aos_marketing_attribution_v2_preview\s*\(v_desde,v_hasta\)/i.test(migration),'M0 revenue must stay on canonical Marketing Attribution V2');
+assert(/period_seed as materialized/i.test(migration));
+assert(/cohort as materialized/i.test(migration));
+assert(/person_flags as materialized/i.test(migration));
+assert(/l\.fecha between c\.first_lead_date and v_hasta/i.test(migration));
+assert(/a\.fecha_cita between c\.first_lead_date and v_hasta/i.test(migration));
+assert(!/touch_flags|aos_marketing_touchpoints_v2/i.test(migration),'ticker must not calculate discarded touchpoint metrics');
+assert(!/create\s+index|create\s+materialized\s+view|refresh\s+materialized\s+view|create\s+trigger/i.test(migration));
+assert(!/(?:set|alter[^;]*)\s+statement_timeout/i.test(migration));
+for(const key of ['leads','contactados','con_cita','asistio','con_venta','facturacion','inversion','roas','pct_contacto']){
+  assert(migration.includes(`'${key}'`),`ticker payload key missing: ${key}`);
+}
+assert(/aos_marketing_period_summary_v2\s*\(/i.test(rollback),'rollback must restore certified full-summary implementation');
+console.log('P0_457_TICKER_SPECIALIZED_CONTRACT=PASS');

--- a/supabase/migrations/20260904010500_p0_457_ticker_specialized_v1.sql
+++ b/supabase/migrations/20260904010500_p0_457_ticker_specialized_v1.sql
@@ -1,0 +1,112 @@
+-- P0 #457 / P0 #432 — specialize the synchronous marketing ticker.
+--
+-- aos_ticker_mkt only exposes a small subset of aos_marketing_period_summary_v2,
+-- but the legacy implementation computes the entire marketing/touchpoint summary
+-- (including discarded touchpoint metrics) on every ticker read. Production
+-- evidence showed ~1.66s / 9,336 shared hits / 227 temp blocks for one ticker call.
+--
+-- This implementation preserves the exact ticker contract and the same canonical
+-- business rules for the fields it actually returns. It keeps M0 revenue on the
+-- existing Marketing Attribution V2 authority and does not alter that authority.
+-- No new indexes, triggers, materialized views, caches, retries or timeout changes.
+
+begin;
+
+create or replace function public.aos_ticker_mkt(p_mes_inicio text)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_desde date := p_mes_inicio::date;
+  v_hasta date := (date_trunc('month', p_mes_inicio::date) + interval '1 month - 1 day')::date;
+  v_leads integer := 0;
+  v_contactados integer := 0;
+  v_con_cita integer := 0;
+  v_asistio integer := 0;
+  v_con_venta integer := 0;
+  v_facturacion numeric := 0;
+  v_inversion numeric := 0;
+  v_mes_num integer;
+  v_anio integer;
+begin
+  v_mes_num := extract(month from v_desde);
+  v_anio := extract(year from v_desde);
+
+  with period_seed as materialized (
+    select l.numero_limpio,l.fecha
+    from public.aos_leads l
+    where l.fecha between v_desde and v_hasta
+      and l.numero_limpio is not null
+      and l.numero_limpio<>''
+  ),
+  cohort as materialized (
+    select numero_limpio,min(fecha) first_lead_date
+    from period_seed
+    group by numero_limpio
+  ),
+  person_flags as materialized (
+    select
+      c.numero_limpio,
+      exists(
+        select 1
+        from public.aos_llamadas l
+        where l.numero_limpio=c.numero_limpio
+          and l.fecha between c.first_lead_date and v_hasta
+      ) managed,
+      exists(
+        select 1
+        from public.aos_llamadas l
+        where l.numero_limpio=c.numero_limpio
+          and l.fecha between c.first_lead_date and v_hasta
+          and upper(l.estado)='CITA CONFIRMADA'
+      ) cita_tel,
+      exists(
+        select 1
+        from public.aos_agenda_citas a
+        where a.numero_limpio=c.numero_limpio
+          and a.fecha_cita between c.first_lead_date and v_hasta
+          and upper(a.estado_cita) in ('ASISTIO','EFECTIVA')
+      ) asistio
+    from cohort c
+  ),
+  attrs_m0 as materialized (
+    select a.numero_limpio,a.monto
+    from public.aos_marketing_attribution_v2_preview(v_desde,v_hasta) a
+    where a.lead_fecha between v_desde and v_hasta
+      and a.venta_fecha between v_desde and v_hasta
+  )
+  select
+    (select count(*) from cohort)::integer,
+    (select count(*) from person_flags where managed)::integer,
+    (select count(*) from person_flags where cita_tel)::integer,
+    (select count(*) from person_flags where asistio)::integer,
+    (select count(distinct numero_limpio) from attrs_m0)::integer,
+    (select coalesce(sum(monto),0) from attrs_m0)::numeric
+  into v_leads,v_contactados,v_con_cita,v_asistio,v_con_venta,v_facturacion;
+
+  select coalesce(sum(inversion),0)
+  into v_inversion
+  from public.aos_inversion_campanas
+  where mes_num=v_mes_num and anio=v_anio;
+
+  return jsonb_build_object(
+    'leads',v_leads,
+    'contactados',v_contactados,
+    'con_cita',v_con_cita,
+    'asistio',v_asistio,
+    'con_venta',v_con_venta,
+    'facturacion',v_facturacion,
+    'inversion',v_inversion,
+    'roas',case when v_inversion>0 then round(v_facturacion/v_inversion,1) else 0 end,
+    'pct_contacto',case when v_leads>0 then round(v_contactados::numeric/v_leads*100) else 0 end
+  );
+end;
+$function$;
+
+comment on function public.aos_ticker_mkt(text) is
+  'P0 #457 bounded marketing ticker. Computes only ticker-exposed cohort metrics while preserving Marketing Attribution V2 for M0 revenue; avoids full period-summary/touchpoint fanout.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260904010500_p0_457_ticker_specialized_v1.rollback.sql
+++ b/supabase/rollbacks/20260904010500_p0_457_ticker_specialized_v1.rollback.sql
@@ -1,0 +1,43 @@
+begin;
+
+create or replace function public.aos_ticker_mkt(p_mes_inicio text)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_desde date := p_mes_inicio::date;
+  v_hasta date := (date_trunc('month', p_mes_inicio::date) + interval '1 month - 1 day')::date;
+  s jsonb;
+  v_inversion numeric;
+  v_mes_num int;
+  v_anio int;
+begin
+  v_mes_num := extract(month from v_desde);
+  v_anio := extract(year from v_desde);
+
+  select public.aos_marketing_period_summary_v2(v_desde,v_hasta) into s;
+
+  select coalesce(sum(inversion),0) into v_inversion
+  from public.aos_inversion_campanas
+  where mes_num=v_mes_num and anio=v_anio;
+
+  return jsonb_build_object(
+    'leads',coalesce((s->>'personasUnicas')::int,0),
+    'contactados',coalesce((s->>'personasGestionadas')::int,0),
+    'con_cita',coalesce((s->>'personasCitaTel')::int,0),
+    'asistio',coalesce((s->>'personasAsistieron')::int,0),
+    'con_venta',coalesce((s->>'clientesM0')::int,0),
+    'facturacion',coalesce((s->>'factM0')::numeric,0),
+    'inversion',v_inversion,
+    'roas',case when v_inversion>0 then round(coalesce((s->>'factM0')::numeric,0)/v_inversion,1) else 0 end,
+    'pct_contacto',case when coalesce((s->>'personasUnicas')::numeric,0)>0
+      then round(coalesce((s->>'personasGestionadas')::numeric,0)/(s->>'personasUnicas')::numeric*100)
+      else 0 end
+  );
+end;
+$function$;
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
Continuation of the sole active HIGH/CRITICAL lane P0 #457 after Auth recovery, bounded WA certification readbacks, and indexable admin-panel reads.

Production evidence:
- legacy `aos_ticker_mkt` live EXPLAIN ANALYZE: ~1659 ms execution, 9,336 shared buffer hits, 227 temp blocks read/written;
- under shared DB pressure it reached ~2.94s and returned 500 in the incident window, coinciding with foreground Call Center failures;
- the ticker calls the full `aos_marketing_period_summary_v2`, which calculates touchpoint metrics the ticker never returns;
- current month has only 128 unique lead phones, so the expensive discarded full-summary/attribution work—not cohort size—is the issue.

Change:
- preserve exact `aos_ticker_mkt(text) -> jsonb` contract, month boundaries, investment calculation and all 9 output fields;
- compute only ticker-exposed cohort/person flags;
- keep `aos_marketing_attribution_v2_preview(v_desde,v_hasta)` as the canonical Marketing Attribution V2 authority for M0 revenue;
- do not calculate discarded `touch_flags` or invoke the full period summary;
- no new indexes, materialized views, triggers, caches, retries or statement_timeout changes;
- exact rollback restores the previous certified full-summary implementation;
- Performance Guard contract prevents reintroduction of the full-summary fanout.

Live candidate evidence before code change:
- specialized equivalent query ~0.66s vs legacy ~1.66s (~60% lower latency in sampled production load);
- current ticker JSON vs candidate JSON returned `exact_equal=true` in PROD for all fields: leads, contactados, con_cita, asistio, con_venta, facturacion, inversion, roas, pct_contacto.

P0 #457 remains open until exact-head CI, PROD apply/readback, and post-cutoff timeout observation pass. WA-L10 remains paused. AUTO_OFF/kill-switch posture is unchanged. CANARY remains NOT AUTHORIZED.