### PR TITLE
WA-L10: event-driven autonomous canary bridge + governed ownership return

### DIFF
--- a/.github/workflows/wa-l10-safe-off.yml
+++ b/.github/workflows/wa-l10-safe-off.yml
@@ -7,6 +7,9 @@ on:
       - 'supabase/migrations/*wa_l10*'
       - 'supabase/rollbacks/*wa_l10*'
       - 'ci/wa-l10/**'
+      - 'app/server-wa4.js'
+      - 'app/wa-l10-autonomous-bridge.js'
+      - 'app/wa-l10-autonomous-bridge.test.js'
       - 'docs/control/WA_L10_*'
       - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
       - '.github/workflows/wa-l10-safe-off.yml'
@@ -32,6 +35,13 @@ jobs:
       - name: L10 static contract
         shell: powershell
         run: node ci/wa-l10/safe_off_contract.test.js
+      - name: L10 event-driven autonomous bridge contract
+        shell: powershell
+        run: |
+          node --check app/server-wa4.js
+          node --check app/wa-l10-autonomous-bridge.js
+          node --test app/wa-l10-autonomous-bridge.test.js
+          node ci/wa-l10/autonomous_bridge_contract.test.js
       - name: Existing bounded safety contract
         shell: powershell
         run: node ci/wa-l8/p0_certification_status_v2_contract.js
@@ -64,10 +74,6 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/ci/enforce-zero-cost-policy.py
-          # A cancelled prior exact-head run can bypass the EXIT trap and leave the
-          # canonical WA full-local Supabase stack listening. Reclaim only that
-          # named synthetic test stack before enforcing isolation; never kill
-          # arbitrary listeners and never relax the bounded port wait.
           (cd ci/wa4c-full-local && supabase stop --no-backup >/dev/null 2>&1) || true
           docker ps -aq --filter 'name=ascenda-wa4c-full-local' | xargs -r docker rm -f >/dev/null 2>&1 || true
           for i in $(seq 1 90); do
@@ -97,8 +103,6 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/ci/enforce-zero-cost-policy.py
-          # Same cancellation hardening for L10's dedicated namespace. The
-          # container-name filter is intentionally narrow and test-only.
           (cd ci/zero-cost-staging && supabase stop --no-backup >/dev/null 2>&1) || true
           docker ps -aq --filter 'name=ascenda-wa-l10' | xargs -r docker rm -f >/dev/null 2>&1 || true
           for i in $(seq 1 90); do
@@ -114,4 +118,34 @@ jobs:
         if: success()
         run: |
           echo 'WA-L10 candidate passed SAFE-OFF-only observability, L4 authority boundary, L5-L9 CURRENT prerequisite regression, hash-only scope, bounded status, replay, RLS and fail-closed recovery.' >> "$GITHUB_STEP_SUMMARY"
-          echo 'No provider dispatch, active CANARY allowlist or AUTO_OFF→CANARY transition was created or authorized.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'No provider dispatch, active CANARY allowlist or AUTO_OFF→CANARY transition was created or authorized by the SAFE-OFF preparation layer.' >> "$GITHUB_STEP_SUMMARY"
+
+  l10-autonomous-bridge-db:
+    name: L10 CANARY bridge DB / exact scope / ownership return / no duplicate
+    needs: l10-observability-db
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 55
+    env:
+      ASCENDA_FULL_LOCAL: '1'
+      AOS_STUDIO_BACKGROUND_ENABLED: 'false'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.101.0
+      - name: Reclaim canonical full-local namespace
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/enforce-zero-cost-policy.py
+          (cd ci/wa4c-full-local && supabase stop --no-backup >/dev/null 2>&1) || true
+          docker ps -aq --filter 'name=ascenda-wa4c-full-local' | xargs -r docker rm -f >/dev/null 2>&1 || true
+      - name: Run L10 event-driven bridge DB certification
+        run: bash ci/wa-l10/run-autonomous-bridge-db.sh
+      - name: Bridge certification summary
+        if: success()
+        run: |
+          echo 'WA-L10 bridge passed durable enqueue, bounded crash lease, exact-conversation allowlist, governed human→AI_ACTIVE return, append-only audit, RLS, replay and SAFE-OFF exit.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'The test never calls Meta; real provider traffic remains gated by L4/L8 and the explicit production canary activation.' >> "$GITHUB_STEP_SUMMARY"

--- a/app/server-wa4.js
+++ b/app/server-wa4.js
@@ -1,69 +1,169 @@
 'use strict';
-// WA-4 outer boundary. Copilot only; WA-3 V2/V1 remain ownership/human-send authority.
+// WA-4 outer boundary: human Copilot + server-only L10 autonomous CANARY orchestration.
+// L4/L8 remain the sole autonomous send/preflight authority; WA-3 remains human ownership authority.
 const http=require('http'),https=require('https'),path=require('path');
 const {spawn}=require('child_process');
 const ai=require('./ai-router');
+const l4=require('./wa-l4-authority');
 const {createCopilot}=require('./wa4-copilot');
 const {createL5Booking}=require('./wa-l5-booking');
+const {createAutonomousBridge}=require('./wa-l10-autonomous-bridge');
 const {buildSupabaseHeaders}=require('./supabase-runtime-auth.cjs');
+
 const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10),INNER_PORT=EXTERNAL_PORT===4198?4199:4198;
-const SB_URL=process.env.SUPABASE_URL||'https://ituyqwstonmhnfshnaqz.supabase.co',SB_ANON_KEY=process.env.SUPABASE_ANON_KEY||'',SB_SERVICE_KEY=process.env.SUPABASE_SERVICE_ROLE_KEY||'';
-const HOOK=path.join(__dirname,'legacy-groq-model-hook.js'),UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SB_URL=process.env.SUPABASE_URL||'https://ituyqwstonmhnfshnaqz.supabase.co';
+const SB_ANON_KEY=process.env.SUPABASE_ANON_KEY||'';
+const SB_SERVICE_KEY=process.env.SUPABASE_SERVICE_ROLE_KEY||'';
+const WA_L4_INTERNAL_TOKEN=process.env.WA_L4_INTERNAL_TOKEN||'';
+const HOOK=path.join(__dirname,'legacy-groq-model-hook.js');
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 let child=null,startupHealth={checked_at:null,configured:false,active:{},legacy_compat_ready:false,copilot_ready:false,error:'NOT_CHECKED'},healthExpiresAt=0;
+
 function writeJson(res,status,obj){res.writeHead(status,{'Content-Type':'application/json; charset=utf-8','Cache-Control':'no-store','X-Content-Type-Options':'nosniff','X-Ascenda-WA4-AI':'v1'});res.end(JSON.stringify(obj));}
 function readJson(req,max=262144){return new Promise((ok,bad)=>{let raw='',over=false;req.on('data',c=>{if(over)return;raw+=c;if(Buffer.byteLength(raw)>max)over=true;});req.on('end',()=>{if(over)return bad(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413}));try{ok(JSON.parse(raw||'{}'));}catch(_){bad(Object.assign(new Error('INVALID_JSON'),{status:400}));}});req.on('error',bad);});}
+function readRaw(req,max=1048576){return new Promise((ok,bad)=>{const chunks=[];let total=0,over=false;req.on('data',c=>{if(over)return;total+=c.length;if(total>max){over=true;return;}chunks.push(c);});req.on('end',()=>over?bad(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413})):ok(Buffer.concat(chunks)));req.on('error',bad);});}
 function parseData(raw){try{return raw?JSON.parse(raw):null;}catch(_){return null;}}
 function sbRequest(method,endpoint,body,service,prefer){return new Promise((ok,bad)=>{const key=service?SB_SERVICE_KEY:SB_ANON_KEY;if(!key)return bad(Object.assign(new Error(service?'SUPABASE_SERVICE_ROLE_NOT_CONFIGURED':'SUPABASE_ANON_KEY_NOT_CONFIGURED'),{status:503}));let u;try{u=new URL(SB_URL);}catch(e){return bad(e);}const data=body==null?'':JSON.stringify(body),headers=buildSupabaseHeaders(key,{'Content-Type':'application/json','User-Agent':'AscendaOS-WA4/1.0'});if(data)headers['Content-Length']=Buffer.byteLength(data);if(prefer)headers.Prefer=prefer;const q=https.request({hostname:u.hostname,port:u.port||443,path:endpoint,method,headers,timeout:12000},r=>{let raw='';r.on('data',c=>raw+=c);r.on('end',()=>{const out={status:r.statusCode||502,data:parseData(raw),raw};if(out.status>=200&&out.status<300)ok(out);else bad(Object.assign(new Error('WA4_DB_UNAVAILABLE'),{status:502,upstreamStatus:out.status,data:out.data}));});});q.on('timeout',()=>q.destroy(new Error('WA4_DB_TIMEOUT')));q.on('error',bad);if(data)q.write(data);q.end();});}
-const sbRpc=(n,p)=>sbRequest('POST','/rest/v1/rpc/'+n,p,false),serviceRpc=(n,p)=>sbRequest('POST','/rest/v1/rpc/'+n,p,true),serviceGet=e=>sbRequest('GET',e,null,true),servicePost=(e,b)=>sbRequest('POST',e,b,true,'return=minimal');
+const sbRpc=(n,p)=>sbRequest('POST','/rest/v1/rpc/'+n,p,false);
+const serviceRpc=(n,p)=>sbRequest('POST','/rest/v1/rpc/'+n,p,true);
+const serviceGet=e=>sbRequest('GET',e,null,true);
+const servicePost=(e,b)=>sbRequest('POST',e,b,true,'return=minimal');
+
 function token(req){const t=String(req.headers['x-aos-app-token']||'').trim();return t.length>=32?t:'';}
 async function actor(req){const t=token(req);if(!t)return null;try{const o=await sbRpc('aos_wa3_actor_v1',{p_token:t}),a=o.data;return a&&a.ok===true&&UUID_RE.test(String(a.actor_id||''))?a:null;}catch(_){return null;}}
 async function requireActor(req,res,admin){const a=await actor(req);if(!a){writeJson(res,403,{ok:false,error:'WA4_2FA_PANEL_REQUIRED'});return null;}if(admin&&a.is_admin!==true){writeJson(res,403,{ok:false,error:'WA4_ADMIN_REQUIRED'});return null;}return a;}
+
 async function getProviderSecret(tipo,nombreLike){const t=String(tipo||'').toLowerCase();if(!/^[a-z0-9_-]{2,32}$/.test(t))return '';try{const o=await serviceGet('/rest/v1/aos_integration_secrets_v1?tipo=eq.'+encodeURIComponent(t)+'&select=api_key,nombre&limit=20'),rows=Array.isArray(o.data)?o.data:[],r=nombreLike?rows.find(x=>String(x.nombre||'').toLowerCase().includes(String(nombreLike).toLowerCase())):rows[0],k=r&&typeof r.api_key==='string'?r.api_key:'';if(k.length>10)return k;}catch(_){}try{const o=await serviceGet('/rest/v1/aos_integraciones?tipo=eq.'+encodeURIComponent(t)+'&estado=eq.conectado&select=api_key,nombre&limit=20'),rows=Array.isArray(o.data)?o.data:[],r=nombreLike?rows.find(x=>String(x.nombre||'').toLowerCase().includes(String(nombreLike).toLowerCase())):rows[0];return r&&typeof r.api_key==='string'&&r.api_key.length>10?r.api_key:'';}catch(_){return '';}}
 async function loadSecrets(){const [groq,gemini,openai,resend]=await Promise.all([getProviderSecret('groq'),getProviderSecret('gemini'),getProviderSecret('api','openai'),getProviderSecret('resend')]);return{groq,gemini,openai,resend};}
 async function modelHealth(force){const now=Date.now();if(!force&&now<healthExpiresAt)return startupHealth;try{const key=(await loadSecrets()).groq;if(!key)throw new Error('GROQ_KEY_NOT_CONFIGURED');const m=await ai.listModels(key);startupHealth={checked_at:new Date().toISOString(),configured:true,models:ai.MODELS,active:m.active,legacy_compat_ready:m.active.fast===true&&m.active.reasoning===true,copilot_ready:m.active.fast===true&&m.active.reasoning===true&&m.active.safety===true,error:null};}catch(e){startupHealth={checked_at:new Date().toISOString(),configured:false,models:ai.MODELS,active:{},legacy_compat_ready:false,copilot_ready:false,error:String(e&&e.message||'MODEL_HEALTH_FAILED').slice(0,120)};}healthExpiresAt=now+300000;return startupHealth;}
-async function authorize(req,id){const t=token(req);if(!t)return{ok:false,error:'WA4_2FA_PANEL_REQUIRED'};const o=await sbRpc('aos_wa4_authorize_copilot_v1',{p_token:t,p_conversation_id:id});return o.data||{};}
+
+async function effectiveCanary(){
+  try{
+    const [a,c,r]=await Promise.all([
+      serviceGet('/rest/v1/aos_wa_auto_authority_v1?select=mode,kill_switch_engaged&id=eq.1'),
+      serviceGet('/rest/v1/aos_wa_ai_control_v1?select=copilot_enabled,auto_reply_enabled&id=eq.1'),
+      serviceGet('/rest/v1/aos_wa_routing_control_v1?select=ai_send_enabled,auto_routing_enabled,human_send_enabled&id=eq.1')
+    ]);
+    const aa=Array.isArray(a.data)?a.data[0]:null,cc=Array.isArray(c.data)?c.data[0]:null,rr=Array.isArray(r.data)?r.data[0]:null;
+    return !!(aa&&cc&&rr&&aa.mode==='CANARY'&&aa.kill_switch_engaged===false&&cc.copilot_enabled===true&&cc.auto_reply_enabled===true&&rr.ai_send_enabled===true&&rr.auto_routing_enabled===false&&rr.human_send_enabled===true);
+  }catch(_){return false;}
+}
+async function authorizeInternalCanary(id){
+  if(!UUID_RE.test(String(id||'')))return{ok:false,error:'WA_L10_CONVERSATION_ID_REQUIRED'};
+  try{
+    const [a,c,r,conv,allow]=await Promise.all([
+      serviceGet('/rest/v1/aos_wa_auto_authority_v1?select=mode,kill_switch_engaged&id=eq.1'),
+      serviceGet('/rest/v1/aos_wa_ai_control_v1?select=copilot_enabled,auto_reply_enabled,max_context_messages,max_catalog_items&id=eq.1'),
+      serviceGet('/rest/v1/aos_wa_routing_control_v1?select=ai_send_enabled,auto_routing_enabled,human_send_enabled&id=eq.1'),
+      serviceGet('/rest/v1/aos_wa_conversations_v1?id=eq.'+encodeURIComponent(id)+'&select=id,state,owner_user_id,human_takeover_at,handoff_requested_at&limit=1'),
+      serviceGet('/rest/v1/aos_wa_auto_allowlist_v1?subject_kind=eq.CONVERSATION&subject_key=eq.'+encodeURIComponent(id)+'&active=eq.true&select=subject_key,expires_at&limit=5')
+    ]);
+    const aa=Array.isArray(a.data)?a.data[0]:null,cc=Array.isArray(c.data)?c.data[0]:null,rr=Array.isArray(r.data)?r.data[0]:null,cv=Array.isArray(conv.data)?conv.data[0]:null;
+    const rows=Array.isArray(allow.data)?allow.data:[],active=rows.some(x=>!x.expires_at||new Date(x.expires_at).getTime()>Date.now());
+    if(!(aa&&cc&&rr&&cv&&active))return{ok:false,error:'WA_L10_INTERNAL_CANARY_NOT_SCOPED'};
+    if(aa.mode!=='CANARY'||aa.kill_switch_engaged!==false||cc.copilot_enabled!==true||cc.auto_reply_enabled!==true||rr.ai_send_enabled!==true||rr.auto_routing_enabled!==false||rr.human_send_enabled!==true)return{ok:false,error:'WA_L10_INTERNAL_CANARY_NOT_EFFECTIVE'};
+    if(cv.state!=='AI_ACTIVE'||cv.owner_user_id!=null||cv.human_takeover_at!=null||cv.handoff_requested_at!=null)return{ok:false,error:'WA_L10_INTERNAL_HUMAN_BOUNDARY_ACTIVE'};
+    return{ok:true,actor_id:null,max_context_messages:Number(cc.max_context_messages||24),max_catalog_items:Number(cc.max_catalog_items||12),internal_canary:true};
+  }catch(_){return{ok:false,error:'WA_L10_INTERNAL_AUTH_UNAVAILABLE'};}
+}
+async function authorize(req,id){
+  if(l4.internalTokenValid(req&&req.headers&&req.headers['x-aos-wa-auto-token'],WA_L4_INTERNAL_TOKEN))return authorizeInternalCanary(id);
+  const t=token(req);if(!t)return{ok:false,error:'WA4_2FA_PANEL_REQUIRED'};
+  const o=await sbRpc('aos_wa4_authorize_copilot_v1',{p_token:t,p_conversation_id:id});return o.data||{};
+}
 async function requireConversationAccess(req,res,id){const a=await requireActor(req,res,false);if(!a)return null;let z;try{z=await authorize(req,id);}catch(_){z=null;}if(!z||z.ok!==true){writeJson(res,403,z||{ok:false,error:'WA5_CONVERSATION_NOT_AUTHORIZED'});return null;}return {actor:a,authorization:z};}
+
 const suggest=createCopilot({serviceGet,servicePost,serviceRpc,authorize,getGroqKey:()=>getProviderSecret('groq'),modelHealth,writeJson});
 const l5=createL5Booking({serviceRpc});
+
+async function suggestInternal(conversationId){
+  return new Promise(resolve=>{
+    let status=200,raw='';let done=false;
+    const finish=()=>{if(done)return;done=true;resolve({status,body:parseData(raw)||{}});};
+    const req={headers:{'x-aos-wa-auto-token':WA_L4_INTERNAL_TOKEN}};
+    const res={writeHead(s){status=Number(s)||500;},end(chunk){if(chunk)raw+=Buffer.isBuffer(chunk)?chunk.toString('utf8'):String(chunk);finish();}};
+    Promise.resolve(suggest(req,res,conversationId)).catch(e=>{status=503;raw=JSON.stringify({ok:false,error:String(e&&e.message||'WA4_INTERNAL_SUGGEST_FAILED')});finish();});
+  });
+}
+function internalPost(pathname,body){
+  return new Promise((resolve,reject)=>{
+    if(WA_L4_INTERNAL_TOKEN.length<32)return reject(new Error('WA_L4_INTERNAL_AUTH_NOT_CONFIGURED'));
+    const data=JSON.stringify(body||{});
+    const q=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:pathname,method:'POST',headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(data),'X-AOS-WA-Auto-Token':WA_L4_INTERNAL_TOKEN,'User-Agent':'AscendaOS-WA-L10/1.0'},timeout:20000},r=>{let raw='';r.on('data',c=>raw+=c);r.on('end',()=>resolve({status:r.statusCode||502,body:parseData(raw)||{}}));});
+    q.on('timeout',()=>q.destroy(new Error('WA_L10_INTERNAL_SEND_TIMEOUT')));q.on('error',reject);q.write(data);q.end();
+  });
+}
+async function requestHandoff(conversationId,reason){
+  const o=await serviceRpc('aos_wa3_handoff_request_v1',{p_conversation_id:conversationId,p_box_id:null,p_actor_id:null,p_reason:l4.sanitizeReason(reason)});
+  return o.data||{};
+}
+const bridge=createAutonomousBridge({serviceRpc,suggestInternal,autoSend:body=>internalPost('/api/wa/auto-send',body),requestHandoff,log:console});
+
 async function bootstrap(req,res){const a=await requireActor(req,res,false);if(!a)return;try{const [c,h]=await Promise.all([serviceGet('/rest/v1/aos_wa_ai_control_v1?select=provider,fast_model,reasoning_model,safety_model,copilot_enabled,auto_reply_enabled,daily_budget_usd,max_context_messages,max_catalog_items,updated_at&id=eq.1'),modelHealth(false)]);writeJson(res,200,{ok:true,version:'WA4-V1',actor:{id:a.actor_id,is_admin:a.is_admin===true},control:Array.isArray(c.data)?c.data[0]||{}:{},health:h,l5:{version:l5.version,autonomous_commit:'L4_GATED',canary_authorized:false}});}catch(_){writeJson(res,503,{ok:false,error:'WA4_BOOTSTRAP_UNAVAILABLE'});}}
 async function control(req,res,body){const a=await requireActor(req,res,true);if(!a)return;const h=await modelHealth(false);if(body.copilot_enabled===true&&h.copilot_ready!==true)return writeJson(res,409,{ok:false,error:'WA4_MODELS_NOT_READY',health:h});try{const o=await serviceRpc('aos_wa4_admin_set_control_v1',{p_actor_id:a.actor_id,p_copilot_enabled:typeof body.copilot_enabled==='boolean'?body.copilot_enabled:null,p_daily_budget_usd:body.daily_budget_usd==null?null:Number(body.daily_budget_usd)});writeJson(res,o.data&&o.data.ok===false?409:200,o.data||{ok:false,error:'WA4_CONTROL_EMPTY'});}catch(_){writeJson(res,503,{ok:false,error:'WA4_CONTROL_UNAVAILABLE'});}}
 async function book(req,res,conversationId,body){
   const a=await requireActor(req,res,false);if(!a)return;
   const idem=String(body&&body.idempotency_key||'').trim(),payload=body&&body.payload;
   if(idem.length<16||idem.length>160||!payload||typeof payload!=='object'||Array.isArray(payload))return writeJson(res,400,{ok:false,error:'WA4_BOOKING_REQUEST_INVALID'});
-  try{
-    const o=await serviceRpc('aos_wa4_commit_booking_v1',{p_actor_id:a.actor_id,p_idempotency_key:idem,p_conversation_id:conversationId,p_payload:payload});
-    const out=o.data||{ok:false,error:'WA4_BOOKING_EMPTY'};
-    return writeJson(res,out.ok===true?200:409,Object.assign({auto_send:false,send_authority:'HUMAN_ONLY'},out));
-  }catch(_){return writeJson(res,503,{ok:false,error:'WA4_BOOKING_UNAVAILABLE',auto_send:false,send_authority:'HUMAN_ONLY'});}
+  try{const o=await serviceRpc('aos_wa4_commit_booking_v1',{p_actor_id:a.actor_id,p_idempotency_key:idem,p_conversation_id:conversationId,p_payload:payload});const out=o.data||{ok:false,error:'WA4_BOOKING_EMPTY'};return writeJson(res,out.ok===true?200:409,Object.assign({auto_send:false,send_authority:'HUMAN_ONLY'},out));}
+  catch(_){return writeJson(res,503,{ok:false,error:'WA4_BOOKING_UNAVAILABLE',auto_send:false,send_authority:'HUMAN_ONLY'});}
 }
 async function rebook(req,res,conversationId,body){
   const a=await requireActor(req,res,false);if(!a)return;
   const idem=String(body&&body.idempotency_key||'').trim(),appointmentId=String(body&&body.appointment_id||'').trim(),payload=body&&body.payload;
   if(idem.length<16||idem.length>160||!appointmentId||!payload||typeof payload!=='object'||Array.isArray(payload))return writeJson(res,400,{ok:false,error:'WA4_REBOOK_REQUEST_INVALID'});
-  try{
-    const o=await serviceRpc('aos_wa4_rebook_booking_v2',{p_actor_id:a.actor_id,p_idempotency_key:idem,p_conversation_id:conversationId,p_appointment_id:appointmentId,p_payload:payload});
-    const out=o.data||{ok:false,error:'WA4_REBOOK_EMPTY'};
-    return writeJson(res,out.ok===true?200:409,Object.assign({auto_send:false,send_authority:'HUMAN_ONLY',booking_contract:'AGV2_V2'},out));
-  }catch(_){return writeJson(res,503,{ok:false,error:'WA4_REBOOK_UNAVAILABLE',auto_send:false,send_authority:'HUMAN_ONLY'});}
+  try{const o=await serviceRpc('aos_wa4_rebook_booking_v2',{p_actor_id:a.actor_id,p_idempotency_key:idem,p_conversation_id:conversationId,p_appointment_id:appointmentId,p_payload:payload});const out=o.data||{ok:false,error:'WA4_REBOOK_EMPTY'};return writeJson(res,out.ok===true?200:409,Object.assign({auto_send:false,send_authority:'HUMAN_ONLY',booking_contract:'AGV2_V2'},out));}
+  catch(_){return writeJson(res,503,{ok:false,error:'WA4_REBOOK_UNAVAILABLE',auto_send:false,send_authority:'HUMAN_ONLY'});}
 }
 async function l5Call(req,res,id,method,body){
   const access=await requireConversationAccess(req,res,id);if(!access)return;
   try{
     let out;
-    if(method==='status')out=await l5.status(id);
-    else if(method==='availability')out=await l5.availability(id,body);
-    else if(method==='verify')out=await l5.verify(id,body);
-    else if(method==='appointments')out=await l5.appointments(id);
-    else if(method==='prepare')out=await l5.prepare(id,body);
-    else if(method==='confirm')out=await l5.confirm(id,body);
-    else return writeJson(res,404,{ok:false,error:'WA5_METHOD_NOT_FOUND'});
+    if(method==='status')out=await l5.status(id);else if(method==='availability')out=await l5.availability(id,body);else if(method==='verify')out=await l5.verify(id,body);else if(method==='appointments')out=await l5.appointments(id);else if(method==='prepare')out=await l5.prepare(id,body);else if(method==='confirm')out=await l5.confirm(id,body);else return writeJson(res,404,{ok:false,error:'WA5_METHOD_NOT_FOUND'});
     const status=out&&out.ok===false?(String(out.error||'').includes('INVALID')?400:409):200;
     return writeJson(res,status,Object.assign({l5_version:l5.version,auto_send:false,autonomous_commit_authority:'L4_PLUS_AGV2'},out||{ok:false,error:'WA_L5_EMPTY_RESPONSE'}));
   }catch(_){return writeJson(res,503,{ok:false,error:'WA_L5_UNAVAILABLE',l5_version:l5.version,auto_send:false});}
 }
+
 function proxy(req,res){const q=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers:Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT})},r=>{res.writeHead(r.statusCode||502,r.headers);r.pipe(res);});q.on('error',()=>{if(!res.headersSent)res.writeHead(502,{'Content-Type':'application/json'});res.end(JSON.stringify({ok:false,error:'WA4_UPSTREAM_UNAVAILABLE'}));});req.pipe(q);}
-const proxyServer=http.createServer(async(req,res)=>{let u;try{u=new URL(req.url,'http://localhost');}catch(_){return writeJson(res,400,{ok:false,error:'INVALID_URL'});}const p=u.pathname;if(p==='/api/wa4/health'&&req.method==='GET')return writeJson(res,200,{ok:true,version:'WA4-V1',l5_version:l5.version,auto_send:false,health:await modelHealth(false)});if(p==='/api/wa4/bootstrap'&&req.method==='GET')return bootstrap(req,res);if(p==='/api/wa4/control'&&req.method==='POST'){try{return control(req,res,await readJson(req));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}const suggestMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/suggest$/i);if(suggestMatch&&req.method==='POST'){try{await readJson(req);}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}return suggest(req,res,suggestMatch[1]);}const bookMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/book$/i);if(bookMatch&&req.method==='POST'){try{return book(req,res,bookMatch[1],await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}const rebookMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/rebook$/i);if(rebookMatch&&req.method==='POST'){try{return rebook(req,res,rebookMatch[1],await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}const l5Match=p.match(/^\/api\/wa5\/conversations\/([0-9a-f-]+)\/(status|availability|verify|appointments|prepare|confirm)$/i);if(l5Match){const method=l5Match[2].toLowerCase();if((method==='status'||method==='appointments')&&req.method==='GET')return l5Call(req,res,l5Match[1],method,null);if(['availability','verify','prepare','confirm'].includes(method)&&req.method==='POST'){try{return l5Call(req,res,l5Match[1],method,await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}return writeJson(res,405,{ok:false,error:'WA5_METHOD_NOT_ALLOWED'});}return proxy(req,res);});
-proxyServer.on('clientError',(_,s)=>s.end('HTTP/1.1 400 Bad Request\r\n\r\n'));function shutdown(sig){proxyServer.close(()=>process.exit(0));if(child&&!child.killed)child.kill(sig);setTimeout(()=>process.exit(1),5000).unref();}process.on('SIGTERM',()=>shutdown('SIGTERM'));process.on('SIGINT',()=>shutdown('SIGINT'));
-async function start(){const secrets=await loadSecrets(),h=await modelHealth(true),legacy=h.legacy_compat_ready===true&&!!secrets.groq,inherited=String(process.env.NODE_OPTIONS||'').trim(),nodeOptions=(inherited+' --require='+HOOK).trim();child=spawn(process.execPath,['server-wa3-v2.js'],{cwd:__dirname,env:Object.assign({},process.env,{PORT:String(INNER_PORT),NODE_OPTIONS:nodeOptions,ASCENDA_GROQ_COMPAT:legacy?'1':'0',GROQ_API_KEY:secrets.groq||'',GEMINI_API_KEY:secrets.gemini||'',OPENAI_API_KEY:process.env.OPENAI_API_KEY||secrets.openai||'',RESEND_API_KEY:process.env.RESEND_API_KEY||secrets.resend||''}),stdio:['ignore','inherit','inherit']});child.on('exit',code=>process.exit(code==null?1:code));proxyServer.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[WA4] listening',{external:EXTERNAL_PORT,inner:INNER_PORT,legacyCompat:legacy,copilotReady:h.copilot_ready===true,l5:l5.version}));}
+function relayBuffered(res,status,headers,body){const h=Object.assign({},headers||{});delete h['transfer-encoding'];delete h['content-length'];h['content-length']=Buffer.byteLength(body||Buffer.alloc(0));res.writeHead(status||502,h);res.end(body);}
+function proxyWebhook(req,res,raw){
+  return new Promise(resolve=>{
+    const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT,'content-length':raw.length});delete headers['transfer-encoding'];
+    const q=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{const chunks=[];r.on('data',c=>chunks.push(c));r.on('end',async()=>{const body=Buffer.concat(chunks),status=r.statusCode||502;if(status<200||status>=300){relayBuffered(res,status,r.headers,body);resolve();return;}let queued=[];try{const enq=await bridge.enqueueWebhook(raw);queued=enq.queued||[];}catch(e){const strict=await effectiveCanary();console.error('[WA-L10-BRIDGE] enqueue failed',l4.sanitizeReason(e&&e.message));if(strict){writeJson(res,503,{ok:false,error:'WA_L10_BRIDGE_ENQUEUE_UNAVAILABLE'});resolve();return;}}relayBuffered(res,status,r.headers,body);if(queued.length)setImmediate(()=>bridge.processProviderIds(queued).then(()=>bridge.recoverPending()).catch(e=>console.error('[WA-L10-BRIDGE] async',l4.sanitizeReason(e&&e.message))));resolve();});});
+    q.on('error',()=>{if(!res.headersSent)writeJson(res,502,{ok:false,error:'WA4_UPSTREAM_UNAVAILABLE'});resolve();});q.write(raw);q.end();
+  });
+}
+
+const proxyServer=http.createServer(async(req,res)=>{
+  let u;try{u=new URL(req.url,'http://localhost');}catch(_){return writeJson(res,400,{ok:false,error:'INVALID_URL'});}const p=u.pathname;
+  if((p==='/webhook'||p==='/webhook/')&&req.method==='POST'){
+    try{return proxyWebhook(req,res,await readRaw(req));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message||'INVALID_REQUEST'});}
+  }
+  if(p==='/api/wa4/health'&&req.method==='GET')return writeJson(res,200,{ok:true,version:'WA4-V1',l5_version:l5.version,auto_send:false,autonomous_bridge:'WA-L10-BRIDGE-V1',health:await modelHealth(false)});
+  if(p==='/api/wa4/bootstrap'&&req.method==='GET')return bootstrap(req,res);
+  if(p==='/api/wa4/control'&&req.method==='POST'){try{return control(req,res,await readJson(req));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}
+  const suggestMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/suggest$/i);
+  if(suggestMatch&&req.method==='POST'){try{await readJson(req);}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}return suggest(req,res,suggestMatch[1]);}
+  const bookMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/book$/i);
+  if(bookMatch&&req.method==='POST'){try{return book(req,res,bookMatch[1],await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}
+  const rebookMatch=p.match(/^\/api\/wa4\/conversations\/([0-9a-f-]+)\/rebook$/i);
+  if(rebookMatch&&req.method==='POST'){try{return rebook(req,res,rebookMatch[1],await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}
+  const l5Match=p.match(/^\/api\/wa5\/conversations\/([0-9a-f-]+)\/(status|availability|verify|appointments|prepare|confirm)$/i);
+  if(l5Match){const method=l5Match[2].toLowerCase();if((method==='status'||method==='appointments')&&req.method==='GET')return l5Call(req,res,l5Match[1],method,null);if(['availability','verify','prepare','confirm'].includes(method)&&req.method==='POST'){try{return l5Call(req,res,l5Match[1],method,await readJson(req,65536));}catch(e){return writeJson(res,e.status||400,{ok:false,error:e.message});}}return writeJson(res,405,{ok:false,error:'WA5_METHOD_NOT_ALLOWED'});}
+  return proxy(req,res);
+});
+
+proxyServer.on('clientError',(_,s)=>s.end('HTTP/1.1 400 Bad Request\r\n\r\n'));
+function shutdown(sig){proxyServer.close(()=>process.exit(0));if(child&&!child.killed)child.kill(sig);setTimeout(()=>process.exit(1),5000).unref();}
+process.on('SIGTERM',()=>shutdown('SIGTERM'));process.on('SIGINT',()=>shutdown('SIGINT'));
+async function start(){
+  const secrets=await loadSecrets(),h=await modelHealth(true),legacy=h.legacy_compat_ready===true&&!!secrets.groq,inherited=String(process.env.NODE_OPTIONS||'').trim(),nodeOptions=(inherited+' --require='+HOOK).trim();
+  child=spawn(process.execPath,['server-wa3-v2.js'],{cwd:__dirname,env:Object.assign({},process.env,{PORT:String(INNER_PORT),NODE_OPTIONS:nodeOptions,ASCENDA_GROQ_COMPAT:legacy?'1':'0',GROQ_API_KEY:secrets.groq||'',GEMINI_API_KEY:secrets.gemini||'',OPENAI_API_KEY:process.env.OPENAI_API_KEY||secrets.openai||'',RESEND_API_KEY:process.env.RESEND_API_KEY||secrets.resend||''}),stdio:['ignore','inherit','inherit']});
+  child.on('exit',code=>process.exit(code==null?1:code));
+  proxyServer.listen(EXTERNAL_PORT,'0.0.0.0',()=>{
+    console.log('[WA4] listening',{external:EXTERNAL_PORT,inner:INNER_PORT,legacyCompat:legacy,copilotReady:h.copilot_ready===true,l5:l5.version,l10Bridge:'EVENT_DRIVEN_NO_POLL'});
+    setImmediate(async()=>{try{if(await effectiveCanary())await bridge.recoverPending();}catch(e){console.error('[WA-L10-BRIDGE] startup recovery',l4.sanitizeReason(e&&e.message));}});
+  });
+}
 start().catch(e=>{console.error('[WA4] startup failed',e.message);process.exit(1);});

--- a/app/wa-l10-autonomous-bridge.js
+++ b/app/wa-l10-autonomous-bridge.js
@@ -1,0 +1,145 @@
+'use strict';
+const crypto=require('crypto');
+
+function parseJson(v){try{return JSON.parse(String(v||''));}catch(_){return null;}}
+function cleanReason(v){return String(v||'WA_L10_UNKNOWN').toUpperCase().replace(/[^A-Z0-9_.:-]/g,'_').slice(0,128);}
+function deterministicIdempotency(providerMessageId){
+  return 'l10:auto:'+crypto.createHash('sha256').update(String(providerMessageId||'')).digest('hex');
+}
+function extractInboundProviderIds(raw){
+  const payload=parseJson(Buffer.isBuffer(raw)?raw.toString('utf8'):raw);
+  const ids=[];const seen=new Set();
+  if(!payload||payload.object!=='whatsapp_business_account'||!Array.isArray(payload.entry))return ids;
+  for(const entry of payload.entry){
+    for(const change of (entry&&Array.isArray(entry.changes)?entry.changes:[])){
+      if(change.field!=='messages')continue;
+      const value=change.value||{};
+      for(const msg of (Array.isArray(value.messages)?value.messages:[])){
+        const id=String(msg&&msg.id||'').trim();
+        if(id&&!seen.has(id)){seen.add(id);ids.push(id);}
+      }
+    }
+  }
+  return ids;
+}
+function dataOf(out){return out&&Object.prototype.hasOwnProperty.call(out,'data')?out.data:out;}
+function bodyOf(out){return out&&out.body&&typeof out.body==='object'?out.body:{};}
+function statusOf(out){const n=Number(out&&out.status);return Number.isFinite(n)?n:200;}
+
+function createAutonomousBridge(deps){
+  const {serviceRpc,suggestInternal,autoSend,requestHandoff}=deps;
+  const log=deps.log||console;
+  if(typeof serviceRpc!=='function'||typeof suggestInternal!=='function'||typeof autoSend!=='function'||typeof requestHandoff!=='function')throw new Error('WA_L10_BRIDGE_DEPS_REQUIRED');
+
+  async function record(claim,eventType,reason,extra){
+    const x=extra||{};
+    try{
+      await serviceRpc('aos_wa_l10_bridge_event_v1',{
+        p_provider_message_id:claim.provider_message_id,
+        p_attempt_id:claim.attempt_id,
+        p_event_type:eventType,
+        p_reason_code:cleanReason(reason),
+        p_authority_decision_id:x.authority_decision_id||null,
+        p_outbound_provider_message_id:x.outbound_provider_message_id||null,
+        p_latency_ms:x.latency_ms==null?null:Math.max(0,Math.min(Number(x.latency_ms)||0,120000))
+      });
+    }catch(e){
+      log.error&&log.error('[WA-L10-BRIDGE] audit event failed',cleanReason(e&&e.message));
+    }
+  }
+
+  async function handoff(claim,reason){
+    try{await requestHandoff(claim.conversation_id,cleanReason(reason));}
+    catch(e){log.error&&log.error('[WA-L10-BRIDGE] handoff failed',cleanReason(e&&e.message));}
+  }
+
+  async function enqueueWebhook(raw){
+    const ids=extractInboundProviderIds(raw),queued=[];
+    for(const providerMessageId of ids){
+      const out=dataOf(await serviceRpc('aos_wa_l10_bridge_enqueue_v1',{p_provider_message_id:providerMessageId}))||{};
+      if(out.ok===false)throw new Error(out.error||'WA_L10_ENQUEUE_REJECTED');
+      if(out.queued===true)queued.push(providerMessageId);
+    }
+    return {ids,queued};
+  }
+
+  async function processProviderMessage(providerMessageId){
+    let claim=dataOf(await serviceRpc('aos_wa_l10_bridge_claim_v1',{p_provider_message_id:String(providerMessageId||'')}))||{};
+    if(claim.ok===false)throw new Error(claim.error||'WA_L10_CLAIM_REJECTED');
+    if(claim.claimed!==true)return {ok:true,processed:false,reason:claim.reason||'WA_L10_NOT_CLAIMED'};
+    claim=Object.assign({provider_message_id:String(providerMessageId)},claim);
+    const started=Date.now();
+
+    try{
+      const suggestionResult=await suggestInternal(claim.conversation_id);
+      const suggestionBody=bodyOf(suggestionResult),suggestion=suggestionBody.suggestion;
+      const nextAction=String((suggestion&&suggestion.next_action)||suggestionBody.next_action||'').toUpperCase();
+      const needsHuman=suggestionBody.needs_human===true||(suggestion&&suggestion.needs_human===true)||nextAction.startsWith('HUMAN_');
+      if(statusOf(suggestionResult)<200||statusOf(suggestionResult)>=300||!suggestion||!String(suggestion.reply||'').trim()||needsHuman){
+        const reason=cleanReason(suggestionBody.blocked_by&&suggestionBody.blocked_by.guard||suggestionBody.error||nextAction||'WA_L10_AI_HANDOFF');
+        await handoff(claim,reason);
+        await record(claim,'HANDOFF',reason,{latency_ms:Date.now()-started});
+        return {ok:true,processed:true,outcome:'HANDOFF',reason};
+      }
+
+      await record(claim,'SUGGESTED','WA_L10_GOVERNED_SUGGESTION',{latency_ms:Date.now()-started});
+      const identity=((suggestionBody.contexts||{}).identity||{}).identity_state||'NOT_REQUIRED';
+      const sendResult=await autoSend({
+        conversation_id:claim.conversation_id,
+        recipient_kind:claim.recipient_kind,
+        recipient_address:claim.recipient_address,
+        to:claim.recipient_address,
+        type:'text',
+        text:String(suggestion.reply).trim(),
+        idempotency_key:deterministicIdempotency(providerMessageId),
+        safety_action:'ALLOW',
+        identity_state:String(identity||'NOT_REQUIRED').toUpperCase(),
+        requires_identity:false,
+        campaign_key:claim.campaign_key||null
+      });
+      const sendBody=bodyOf(sendResult),sendStatus=statusOf(sendResult);
+      const audit={
+        authority_decision_id:sendBody.decision_id||null,
+        outbound_provider_message_id:sendBody.message_id||null,
+        latency_ms:Date.now()-started
+      };
+      if(sendStatus>=200&&sendStatus<300&&sendBody.ok===true){
+        await record(claim,'SENT','WA_L10_AUTO_SENT',audit);
+        return {ok:true,processed:true,outcome:'SENT',message_id:sendBody.message_id||null};
+      }
+      if(sendBody.decision==='HANDOFF'||sendBody.handoff===true){
+        await record(claim,'HANDOFF',sendBody.reason||sendBody.error||'WA_L10_L4_HANDOFF',audit);
+        return {ok:true,processed:true,outcome:'HANDOFF',reason:sendBody.reason||sendBody.error||null};
+      }
+      if(sendStatus>=500){
+        await handoff(claim,sendBody.error||'WA_L10_PROVIDER_ERROR');
+        await record(claim,'ERROR',sendBody.error||'WA_L10_PROVIDER_ERROR',audit);
+        return {ok:false,processed:true,outcome:'ERROR',reason:sendBody.error||null};
+      }
+      await record(claim,'BLOCKED',sendBody.reason||sendBody.error||'WA_L10_L4_BLOCKED',audit);
+      return {ok:true,processed:true,outcome:'BLOCKED',reason:sendBody.reason||sendBody.error||null};
+    }catch(e){
+      const reason=cleanReason(e&&e.message||'WA_L10_BRIDGE_ERROR');
+      await handoff(claim,reason);
+      await record(claim,'ERROR',reason,{latency_ms:Date.now()-started});
+      log.error&&log.error('[WA-L10-BRIDGE] processing failed',reason);
+      return {ok:false,processed:true,outcome:'ERROR',reason};
+    }
+  }
+
+  async function processProviderIds(ids){
+    const out=[];
+    for(const id of Array.from(new Set((ids||[]).map(String))).slice(0,10))out.push(await processProviderMessage(id));
+    return out;
+  }
+
+  async function recoverPending(){
+    const rows=dataOf(await serviceRpc('aos_wa_l10_bridge_pending_v1',{p_limit:5}));
+    const ids=Array.isArray(rows)?rows.map(r=>String(r&&r.provider_message_id||'')).filter(Boolean):[];
+    return processProviderIds(ids);
+  }
+
+  return {enqueueWebhook,processProviderMessage,processProviderIds,recoverPending};
+}
+
+module.exports={createAutonomousBridge,extractInboundProviderIds,deterministicIdempotency,cleanReason};

--- a/app/wa-l10-autonomous-bridge.test.js
+++ b/app/wa-l10-autonomous-bridge.test.js
@@ -1,0 +1,99 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {createAutonomousBridge,extractInboundProviderIds,deterministicIdempotency}=require('./wa-l10-autonomous-bridge');
+
+function webhook(ids){
+  return Buffer.from(JSON.stringify({object:'whatsapp_business_account',entry:[{changes:[{field:'messages',value:{messages:ids.map(id=>({id,type:'text'})),statuses:[{id:'status-only'}]}}]}]}));
+}
+function claim(id){return {ok:true,claimed:true,provider_message_id:id,attempt_id:'11111111-1111-4111-8111-111111111111',conversation_id:'22222222-2222-4222-8222-222222222222',recipient_kind:'PHONE',recipient_address:'51911111111',run_key:'WA-L10-TEST-RUN-0001',campaign_key:null};}
+function safeSuggestion(){return {status:200,body:{ok:true,needs_human:false,contexts:{identity:{identity_state:'NOT_REQUIRED'}},suggestion:{reply:'Hola, ¿en qué te ayudo?',next_action:'REPLY',needs_human:false}}};}
+
+
+test('extracts only inbound provider message ids and de-duplicates them',()=>{
+  const ids=extractInboundProviderIds(webhook(['wamid.1','wamid.1','wamid.2']));
+  assert.deepEqual(ids,['wamid.1','wamid.2']);
+  assert.deepEqual(extractInboundProviderIds(Buffer.from('{bad')),[]);
+});
+
+test('deterministic idempotency is stable and L4-valid shaped',()=>{
+  const a=deterministicIdempotency('wamid.same'),b=deterministicIdempotency('wamid.same');
+  assert.equal(a,b);assert.match(a,/^l10:auto:[a-f0-9]{64}$/);assert.ok(a.length>=16&&a.length<=120);
+});
+
+test('non-canary enqueue does not invoke AI or outbound',async()=>{
+  let suggests=0,sends=0;
+  const bridge=createAutonomousBridge({
+    serviceRpc:async(name)=>name==='aos_wa_l10_bridge_enqueue_v1'?{data:{ok:true,queued:false,reason:'WA_L10_CANARY_NOT_EFFECTIVE'}}:{data:{ok:true}},
+    suggestInternal:async()=>{suggests++;return safeSuggestion();},
+    autoSend:async()=>{sends++;return {status:200,body:{ok:true}};},
+    requestHandoff:async()=>{}
+  });
+  const q=await bridge.enqueueWebhook(webhook(['wamid.off']));
+  assert.deepEqual(q.queued,[]);assert.equal(suggests,0);assert.equal(sends,0);
+});
+
+test('eligible inbound produces one governed suggestion and one auto-send',async()=>{
+  let sends=0,handoffs=0;const events=[];
+  const bridge=createAutonomousBridge({
+    serviceRpc:async(name,p)=>{
+      if(name==='aos_wa_l10_bridge_claim_v1')return {data:claim(p.p_provider_message_id)};
+      if(name==='aos_wa_l10_bridge_event_v1'){events.push(p);return {data:{ok:true}};}
+      return {data:{ok:true}};
+    },
+    suggestInternal:async()=>safeSuggestion(),
+    autoSend:async(body)=>{sends++;assert.equal(body.conversation_id,'22222222-2222-4222-8222-222222222222');assert.equal(body.recipient_kind,'PHONE');assert.match(body.idempotency_key,/^l10:auto:/);return {status:200,body:{ok:true,decision_id:'33333333-3333-4333-8333-333333333333',message_id:'wamid.out.1'}};},
+    requestHandoff:async()=>{handoffs++;}
+  });
+  const r=await bridge.processProviderMessage('wamid.in.1');
+  assert.equal(r.outcome,'SENT');assert.equal(sends,1);assert.equal(handoffs,0);
+  assert.deepEqual(events.map(x=>x.p_event_type),['SUGGESTED','SENT']);
+});
+
+test('human-required suggestion hands off and never sends',async()=>{
+  let sends=0,handoffs=0;const events=[];
+  const bridge=createAutonomousBridge({
+    serviceRpc:async(name,p)=>{
+      if(name==='aos_wa_l10_bridge_claim_v1')return {data:claim(p.p_provider_message_id)};
+      if(name==='aos_wa_l10_bridge_event_v1'){events.push(p.p_event_type);return {data:{ok:true}};}
+      return {data:{ok:true}};
+    },
+    suggestInternal:async()=>({status:200,body:{ok:true,needs_human:true,next_action:'HUMAN_CLINICAL',suggestion:null}}),
+    autoSend:async()=>{sends++;return {status:200,body:{ok:true}};},
+    requestHandoff:async()=>{handoffs++;}
+  });
+  const r=await bridge.processProviderMessage('wamid.clinical');
+  assert.equal(r.outcome,'HANDOFF');assert.equal(sends,0);assert.equal(handoffs,1);assert.deepEqual(events,['HANDOFF']);
+});
+
+test('L4 BLOCK is terminal for this event and is not retried or handed off',async()=>{
+  let sends=0,handoffs=0;const events=[];
+  const bridge=createAutonomousBridge({
+    serviceRpc:async(name,p)=>{
+      if(name==='aos_wa_l10_bridge_claim_v1')return {data:claim(p.p_provider_message_id)};
+      if(name==='aos_wa_l10_bridge_event_v1'){events.push(p.p_event_type);return {data:{ok:true}};}
+      return {data:{ok:true}};
+    },
+    suggestInternal:async()=>safeSuggestion(),
+    autoSend:async()=>{sends++;return {status:403,body:{ok:false,decision:'BLOCK',reason:'WA_L4_COOLDOWN'}};},
+    requestHandoff:async()=>{handoffs++;}
+  });
+  const r=await bridge.processProviderMessage('wamid.cooldown');
+  assert.equal(r.outcome,'BLOCKED');assert.equal(sends,1);assert.equal(handoffs,0);assert.deepEqual(events,['SUGGESTED','BLOCKED']);
+});
+
+test('provider/runtime error fails closed into human handoff with no retry loop',async()=>{
+  let sends=0,handoffs=0;const events=[];
+  const bridge=createAutonomousBridge({
+    serviceRpc:async(name,p)=>{
+      if(name==='aos_wa_l10_bridge_claim_v1')return {data:claim(p.p_provider_message_id)};
+      if(name==='aos_wa_l10_bridge_event_v1'){events.push(p.p_event_type);return {data:{ok:true}};}
+      return {data:{ok:true}};
+    },
+    suggestInternal:async()=>safeSuggestion(),
+    autoSend:async()=>{sends++;throw new Error('META_SEND_TIMEOUT');},
+    requestHandoff:async()=>{handoffs++;}
+  });
+  const r=await bridge.processProviderMessage('wamid.error');
+  assert.equal(r.outcome,'ERROR');assert.equal(sends,1);assert.equal(handoffs,1);assert.deepEqual(events,['SUGGESTED','ERROR']);
+});

--- a/ci/wa-l10/autonomous_bridge_contract.test.js
+++ b/ci/wa-l10/autonomous_bridge_contract.test.js
@@ -1,0 +1,46 @@
+'use strict';
+const fs=require('fs');
+const assert=require('assert');
+
+const server=fs.readFileSync('app/server-wa4.js','utf8');
+const bridge=fs.readFileSync('app/wa-l10-autonomous-bridge.js','utf8');
+const migration=fs.readFileSync('supabase/migrations/20260904204500_wa_l10_autonomous_bridge_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260904204500_wa_l10_autonomous_bridge_v1.rollback.sql','utf8');
+const ddl=migration.slice(0,migration.indexOf('create or replace function'));
+
+for(const marker of [
+  'aos_wa_l10_bridge_jobs_v1','aos_wa_l10_bridge_attempts_v1','aos_wa_l10_bridge_events_v1',
+  'aos_wa_l10_bridge_enqueue_v1','aos_wa_l10_bridge_claim_v1','aos_wa_l10_bridge_pending_v1',
+  'aos_wa_l10_return_to_autonomous_canary_v1','aos_wa_l10_bridge_status_v1',
+  'WA_L10_EXACT_CONVERSATION_ALLOWLIST_REQUIRED','L10_AUTONOMOUS_RETURN','AI_ACTIVE'
+]) assert(migration.includes(marker),`missing bridge marker ${marker}`);
+
+assert(server.includes("require('./wa-l10-autonomous-bridge')"),'WA4 must mount L10 bridge');
+assert(server.includes("(p==='/webhook'||p==='/webhook/')&&req.method==='POST'"),'WA4 must intercept signed inbound POST only');
+assert(server.includes('bridge.enqueueWebhook(raw)'),'durable enqueue must happen after provider persistence');
+assert(server.includes("internalPost('/api/wa/auto-send'"),'autonomous output must reuse canonical L4 endpoint');
+assert(server.includes("'x-aos-wa-auto-token'"),'internal AI path must require server-only token');
+assert(server.includes('l4.internalTokenValid'),'internal token must be timing-safe validated');
+assert(server.includes('effectiveCanary()'),'enqueue failure must distinguish inert SAFE-OFF from active canary');
+assert(server.includes('setImmediate'),'AI processing must run after webhook ACK path, not block Meta on model latency');
+
+const claimAt=bridge.indexOf("serviceRpc('aos_wa_l10_bridge_claim_v1'");
+const suggestAt=bridge.indexOf('suggestInternal(claim.conversation_id)');
+const sendAt=bridge.indexOf('await autoSend({');
+assert(claimAt>=0&&suggestAt>claimAt&&sendAt>suggestAt,'claim -> governed suggestion -> L4 send ordering drifted');
+assert(bridge.includes('deterministicIdempotency(providerMessageId)'),'provider-message idempotency missing');
+assert(!/setInterval\s*\(|setTimeout\s*\(/.test(bridge),'bridge may not poll or schedule retry loops');
+assert(!/graph\.facebook\.com|graphSend\s*\(/i.test(bridge),'bridge may not become a second provider sender');
+assert(!/while\s*\(/.test(bridge),'bridge may not contain autonomous retry loops');
+
+assert(/subject_kind='CONVERSATION'/.test(migration),'CANARY must be exact-conversation scoped');
+assert(/v_conv\.owner_user_id is not null/.test(migration),'human ownership boundary missing');
+assert(/v_conv\.human_takeover_at is not null/.test(migration),'human takeover boundary missing');
+assert(/update public\.aos_wa_assignments_v1[\s\S]*state='RELEASED'/.test(migration),'return must preserve assignment history by release');
+assert(/insert into public\.aos_wa_routing_events_v1/.test(migration),'return transition must be audited');
+assert(/force row level security/i.test(migration),'bridge ledgers must FORCE RLS');
+assert(!/message_body|raw_webhook|access_token|recipient_address|contact_address/i.test(ddl),'bridge ledger DDL may not store raw content, recipient or secrets');
+assert(!/graph\.facebook\.com|graphSend\s*\(/i.test(migration),'SQL may not dispatch provider traffic');
+assert(rollback.includes('WA_L10_BRIDGE_RECOVERY_BLOCKED_AUDIT_HISTORY'),'rollback must fail closed after live evidence');
+
+console.log('WA_L10_AUTONOMOUS_BRIDGE_STATIC_CONTRACT=PASS');

--- a/ci/wa-l10/run-autonomous-bridge-db.sh
+++ b/ci/wa-l10/run-autonomous-bridge-db.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DB='postgresql://postgres:postgres@127.0.0.1:60202/postgres'
+cleanup(){ set +e; cd "$ROOT/ci/wa4c-full-local" && supabase stop --no-backup >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cd "$ROOT"
+test "${ASCENDA_FULL_LOCAL:-}" = '1'
+python3 scripts/ci/enforce-zero-cost-policy.py
+bash ci/wa4c-full-local/bootstrap.sh
+
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235500_wa_l4_autonomous_authority_v1.sql
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260902235600_wa_l4_authority_hardening_v1.sql
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260904014500_wa_l10_canary_observability_v1.sql
+
+# New bridge migration is reversible while dormant/no evidence.
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260904204500_wa_l10_autonomous_bridge_v1.sql
+test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_l10_bridge_jobs_v1")" = '0'
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260904204500_wa_l10_autonomous_bridge_v1.rollback.sql
+test "$(psql "$DB" -X -qAt -c "select to_regclass('public.aos_wa_l10_bridge_jobs_v1') is null")" = 't'
+
+# Reapply and exercise exact CANARY return/queue/idempotency/human-boundary behavior.
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260904204500_wa_l10_autonomous_bridge_v1.sql
+psql "$DB" -X -v ON_ERROR_STOP=1 -f ci/wa-l10/tests/002_autonomous_bridge.sql 2>&1 | tee /tmp/l10-bridge-db.txt
+grep -q 'WA_L10_AUTONOMOUS_BRIDGE_DB_CONTRACT_PASS' /tmp/l10-bridge-db.txt
+
+psql "$DB" -X -v ON_ERROR_STOP=1 -c "set statement_timeout='3000ms'; select public.aos_wa_l10_bridge_status_v1('CI-L10-BRIDGE-RUN-0001');" >/tmp/l10-bridge-status.txt
+
+test "$(psql "$DB" -X -qAt -c "select mode||':'||kill_switch_engaged from public.aos_wa_auto_authority_v1 where id=1")" = 'AUTO_OFF:true'
+test "$(psql "$DB" -X -qAt -c "select auto_reply_enabled::text||':'||ai_send_enabled::text||':'||auto_routing_enabled::text||':'||human_send_enabled::text from public.aos_wa_ai_control_v1 cross join public.aos_wa_routing_control_v1 where aos_wa_ai_control_v1.id=1 and aos_wa_routing_control_v1.id=1")" = 'false:false:false:true'
+test "$(psql "$DB" -X -qAt -c "select count(*) from public.aos_wa_auto_allowlist_v1 where active is true")" = '0'
+
+test "$(psql "$DB" -X -qAt -c "select count(*) from information_schema.columns where table_schema='public' and table_name in ('aos_wa_l10_bridge_jobs_v1','aos_wa_l10_bridge_attempts_v1','aos_wa_l10_bridge_events_v1') and column_name in ('message_body','raw_webhook','recipient_address','contact_address','access_token')")" = '0'
+
+# Immutable evidence prevents destructive recovery after live-shaped bridge use.
+set +e
+psql "$DB" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260904204500_wa_l10_autonomous_bridge_v1.rollback.sql >/tmp/l10-bridge-recovery.txt 2>&1
+rc=$?
+set -e
+test "$rc" -ne 0
+grep -q 'WA_L10_BRIDGE_RECOVERY_BLOCKED_AUDIT_HISTORY' /tmp/l10-bridge-recovery.txt
+
+test "$(psql "$DB" -X -qAt -c "select has_table_privilege('anon','public.aos_wa_l10_bridge_jobs_v1','SELECT')")" = 'f'
+test "$(psql "$DB" -X -qAt -c "select has_function_privilege('anon','public.aos_wa_l10_bridge_claim_v1(text)','EXECUTE')")" = 'f'
+
+(cd ci/wa4c-full-local && supabase db lint --local --schema public --level error 2>&1 | tee /tmp/l10-bridge-lint.txt)
+! grep -q '\[ERROR\]' /tmp/l10-bridge-lint.txt
+
+echo 'WA_L10_AUTONOMOUS_BRIDGE_FULL_LOCAL_PASS'

--- a/ci/wa-l10/tests/002_autonomous_bridge.sql
+++ b/ci/wa-l10/tests/002_autonomous_bridge.sql
@@ -63,11 +63,11 @@ do $$ begin
   if not exists(select 1 from public.aos_wa_routing_events_v1 where conversation_id='66666666-6666-4666-8666-666666666661' and event_type='conversation.autonomous_canary_return') then raise exception 'L10_RETURN_AUDIT_MISSING'; end if;
 end $$;
 
--- A real inbound-shaped ledger row binds to the exact conversation before enqueue.
+-- A real inbound-shaped ledger row is explicitly bound to the exact synthetic conversation before enqueue.
 insert into public.aos_wa_messages_v1(
-  provider_message_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
+  provider_message_id,conversation_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
 ) values (
-  'wamid.ci.l10.in.0001','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','hello canary','received',now(),now()
+  'wamid.ci.l10.in.0001','66666666-6666-4666-8666-666666666661','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','hello canary','received',now(),now()
 );
 
 do $$
@@ -102,9 +102,9 @@ update public.aos_wa_conversations_v1
 set state='HUMAN_ACTIVE',owner_user_id='44444444-4444-4444-8444-444444444444',human_takeover_at=now()
 where id='66666666-6666-4666-8666-666666666661';
 insert into public.aos_wa_messages_v1(
-  provider_message_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
+  provider_message_id,conversation_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
 ) values (
-  'wamid.ci.l10.in.0002','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','human now','received',now(),now()
+  'wamid.ci.l10.in.0002','66666666-6666-4666-8666-666666666661','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','human now','received',now(),now()
 );
 do $$ declare r jsonb; begin
   r:=public.aos_wa_l10_bridge_enqueue_v1('wamid.ci.l10.in.0002');

--- a/ci/wa-l10/tests/002_autonomous_bridge.sql
+++ b/ci/wa-l10/tests/002_autonomous_bridge.sql
@@ -1,0 +1,122 @@
+\set ON_ERROR_STOP on
+
+do $$
+declare
+  r jsonb;
+  v_hash text;
+begin
+  insert into public.aos_wa_conversations_v1(
+    id,conversation_key,contact_number,phone_number_id,state,opened_at,updated_at,
+    box_id,owner_user_id,human_takeover_at,handoff_requested_at,contact_address,contact_address_type
+  ) values (
+    '66666666-6666-4666-8666-666666666661','L10TEST:51911111111','51911111111','L10TEST','AI_COPILOT',now(),now(),
+    '77777777-7777-4777-8777-777777777777','44444444-4444-4444-8444-444444444444',now(),now(),'51911111111','PHONE'
+  ) on conflict(id) do nothing;
+
+  insert into public.aos_wa_assignments_v1(
+    id,conversation_id,box_id,owner_user_id,state,assigned_by,claimed_at
+  ) values (
+    '66666666-6666-4666-8666-666666666662','66666666-6666-4666-8666-666666666661',
+    '77777777-7777-4777-8777-777777777777','44444444-4444-4444-8444-444444444444','ACTIVE',
+    '11111111-1111-4111-8111-111111111111',now()
+  ) on conflict(id) do nothing;
+
+  r:=public.aos_wa_l10_prepare_run_v1(
+    '11111111-1111-4111-8111-111111111111','CI-L10-BRIDGE-RUN-0001',
+    '{"agenda":0,"llamadas":0,"leads":0,"ventas":0,"pacientes":0,"wa_events":0,"wa_messages":0,"wa_l6_journeys":0,"wa_l9_demo_runs":0,"active_allowlist":0,"wa_auto_outbound":0,"wa_auto_decisions":0,"wa_l5_booking_events":0,"wa_l7_ai_cost_events":0,"wa_outbound_requests":0,"wa_l7_meta_cost_events":0,"wa_l9_provider_dispatch":0}'::jsonb,
+    'VERIFIED_CURRENT','CI_POLICY_20260904','VERIFIED_CURRENT','CI_PROVIDER_20260904',
+    'UNKNOWN','CI_TEMPLATE_SERVICE_WINDOW','UNKNOWN','CI_BILLING_UNKNOWN',
+    'UNKNOWN','CI_SERVICE_WINDOW','EXACT_CONVERSATION'
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L10_PREP %',r; end if;
+  if coalesce((r->>'activation_authorized')::boolean,true) is not false then raise exception 'L10_PREP_MUST_NOT_ACTIVATE %',r; end if;
+
+  v_hash:=encode(extensions.digest(convert_to('PHONE:51911111111','UTF8'),'sha256'),'hex');
+  r:=public.aos_wa_l10_attach_scope_v1(
+    '11111111-1111-4111-8111-111111111111','CI-L10-BRIDGE-RUN-0001',
+    '66666666-6666-4666-8666-666666666661',v_hash,'CI_EXACT_CONVERSATION'
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L10_SCOPE %',r; end if;
+
+  r:=public.aos_wa_l4_allowlist_set_v1(
+    '11111111-1111-4111-8111-111111111111','CONVERSATION','66666666-6666-4666-8666-666666666661',true,now()+interval '2 hours','CI_L10_BRIDGE'
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L10_ALLOWLIST %',r; end if;
+
+  r:=public.aos_wa_l4_set_control_v1(
+    '11111111-1111-4111-8111-111111111111','CANARY',false,12,6,3,1,10,120,'CI-OWNER-AUTH-L10-BRIDGE-0001'
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'mode'<>'CANARY' then raise exception 'L10_CANARY %',r; end if;
+
+  r:=public.aos_wa_l10_return_to_autonomous_canary_v1(
+    '11111111-1111-4111-8111-111111111111','CI-L10-BRIDGE-RUN-0001',
+    '66666666-6666-4666-8666-666666666661','CI_OWNER_AUTH_CANARY'
+  );
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'state'<>'AI_ACTIVE' then raise exception 'L10_RETURN %',r; end if;
+end
+$$;
+
+-- Human ownership was released, never deleted, and the transition is audited.
+do $$ begin
+  if not exists(select 1 from public.aos_wa_assignments_v1 where id='66666666-6666-4666-8666-666666666662' and state='RELEASED' and terminal_reason='L10_AUTONOMOUS_RETURN') then raise exception 'L10_ASSIGNMENT_HISTORY_NOT_PRESERVED'; end if;
+  if not exists(select 1 from public.aos_wa_conversations_v1 where id='66666666-6666-4666-8666-666666666661' and state='AI_ACTIVE' and owner_user_id is null and human_takeover_at is null and handoff_requested_at is null) then raise exception 'L10_AI_ACTIVE_RETURN_FAILED'; end if;
+  if not exists(select 1 from public.aos_wa_routing_events_v1 where conversation_id='66666666-6666-4666-8666-666666666661' and event_type='conversation.autonomous_canary_return') then raise exception 'L10_RETURN_AUDIT_MISSING'; end if;
+end $$;
+
+-- A real inbound-shaped ledger row binds to the exact conversation before enqueue.
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
+) values (
+  'wamid.ci.l10.in.0001','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','hello canary','received',now(),now()
+);
+
+do $$
+declare r jsonb; a jsonb; begin
+  r:=public.aos_wa_l10_bridge_enqueue_v1('wamid.ci.l10.in.0001');
+  if coalesce((r->>'queued')::boolean,false) is not true or coalesce((r->>'replay')::boolean,true) is not false then raise exception 'L10_ENQUEUE %',r; end if;
+  a:=public.aos_wa_l10_bridge_enqueue_v1('wamid.ci.l10.in.0001');
+  if coalesce((a->>'queued')::boolean,false) is not true or coalesce((a->>'replay')::boolean,false) is not true then raise exception 'L10_ENQUEUE_REPLAY %',a; end if;
+
+  r:=public.aos_wa_l10_bridge_claim_v1('wamid.ci.l10.in.0001');
+  if coalesce((r->>'claimed')::boolean,false) is not true or r->>'recipient_kind'<>'PHONE' then raise exception 'L10_CLAIM %',r; end if;
+
+  a:=public.aos_wa_l10_bridge_claim_v1('wamid.ci.l10.in.0001');
+  if coalesce((a->>'claimed')::boolean,true) is not false or a->>'reason'<>'WA_L10_JOB_BUSY' then raise exception 'L10_CLAIM_EXACT_ONCE %',a; end if;
+
+  perform public.aos_wa_l10_bridge_event_v1('wamid.ci.l10.in.0001',(r->>'attempt_id')::uuid,'SUGGESTED','CI_GOVERNED_SUGGESTION',null,null,25);
+  perform public.aos_wa_l10_bridge_event_v1('wamid.ci.l10.in.0001',(r->>'attempt_id')::uuid,'SENT','CI_AUTO_SENT',null,'wamid.ci.l10.out.0001',50);
+
+  a:=public.aos_wa_l10_bridge_claim_v1('wamid.ci.l10.in.0001');
+  if coalesce((a->>'claimed')::boolean,true) is not false or a->>'reason'<>'WA_L10_JOB_TERMINAL' then raise exception 'L10_TERMINAL_REPLAY %',a; end if;
+end
+$$;
+
+do $$ declare s jsonb; begin
+  s:=public.aos_wa_l10_bridge_status_v1('CI-L10-BRIDGE-RUN-0001');
+  if (s->>'jobs')::integer<>1 or (s->>'sent')::integer<>1 or coalesce((s->>'effective_autonomous_send')::boolean,false) is not true then raise exception 'L10_STATUS %',s; end if;
+  if exists(select 1 from public.aos_wa_l10_bridge_pending_v1(5)) then raise exception 'L10_TERMINAL_JOB_MUST_NOT_BE_PENDING'; end if;
+end $$;
+
+-- Human boundary wins even while global CANARY remains on.
+update public.aos_wa_conversations_v1
+set state='HUMAN_ACTIVE',owner_user_id='44444444-4444-4444-8444-444444444444',human_takeover_at=now()
+where id='66666666-6666-4666-8666-666666666661';
+insert into public.aos_wa_messages_v1(
+  provider_message_id,direction,from_number,to_number,phone_number_id,contact_name,message_type,message_body,status,provider_timestamp,received_at
+) values (
+  'wamid.ci.l10.in.0002','INBOUND','51911111111','15550000000','L10TEST','CI Contact','text','human now','received',now(),now()
+);
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l10_bridge_enqueue_v1('wamid.ci.l10.in.0002');
+  if coalesce((r->>'queued')::boolean,true) is not false or r->>'reason'<>'WA_L10_HUMAN_BOUNDARY_ACTIVE' then raise exception 'L10_HUMAN_BOUNDARY %',r; end if;
+end $$;
+
+-- Return global authority to SAFE-OFF at test exit.
+do $$ declare r jsonb; begin
+  r:=public.aos_wa_l4_set_control_v1('11111111-1111-4111-8111-111111111111','AUTO_OFF',true,null,null,null,null,null,null,null);
+  if coalesce((r->>'ok')::boolean,false) is not true or r->>'mode'<>'AUTO_OFF' then raise exception 'L10_SAFE_OFF_EXIT %',r; end if;
+  r:=public.aos_wa_l4_allowlist_set_v1('11111111-1111-4111-8111-111111111111','CONVERSATION','66666666-6666-4666-8666-666666666661',false,null,'CI_L10_BRIDGE_EXIT');
+  if coalesce((r->>'ok')::boolean,false) is not true then raise exception 'L10_ALLOWLIST_EXIT %',r; end if;
+end $$;
+
+select 'WA_L10_AUTONOMOUS_BRIDGE_DB_CONTRACT_PASS' as result;

--- a/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
+++ b/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
@@ -34,5 +34,7 @@ assert(server.includes("const scope=read?'read':'write'"));
 assert(server.includes("const limit=read?600:120"));
 assert(!server.includes("const key=String(req.socket.remoteAddress||'unknown'),now=Date.now()"));
 assert(wa4.includes("['server-wa3-v2.js']"));
-assert(wa4.includes('Copilot only'));
+assert(wa4.includes('server-only L10 autonomous CANARY orchestration'));
+assert(wa4.includes('L4/L8 remain the sole autonomous send/preflight authority'));
+assert(wa4.includes('WA-3 remains human ownership authority'));
 console.log('WA-3 V2 boundary contract: PASS mode='+(finalMode?'FINAL':'V2'));

--- a/ci/wa3-boxes-routing-handoff/ui_contract_v2.py
+++ b/ci/wa3-boxes-routing-handoff/ui_contract_v2.py
@@ -31,5 +31,7 @@ assert "privacy:'NO_CUSTOMER_DATA'" in server
 assert 'contact_number' not in server
 assert 'message_body' not in server
 assert "['server-wa3-v2.js']" in wa4
-assert 'Copilot only' in wa4
+assert 'server-only L10 autonomous CANARY orchestration' in wa4
+assert 'L4/L8 remain the sole autonomous send/preflight authority' in wa4
+assert 'WA-3 remains human ownership authority' in wa4
 print('WA-3 V2 boundary contract: PASS mode='+('FINAL' if final_mode else 'V2'))

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,50 +1,51 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Captured:** 2026-09-03 America/Lima  
-**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — L10-A SAFE-OFF PREPARATION / CERTIFICATION ONLY`  
+**Captured:** 2026-09-04 America/Lima  
+**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — EVENT-DRIVEN AUTONOMOUS CANARY BRIDGE + TINY REAL CANARY`  
 **GitHub authority:** Issue `#456` = `OPEN / ACTIVE`  
 **Parent roadmap:** Issue `#410`  
-**Exact entry main:** `c3f2e9f8b28e05fae531451c9b9467ea292c91cf`  
-**Active branch:** `wa-l10-safe-off-revalidation-20260903`  
-**Last closed WA lane:** `WA-L9 — AUTONOMOUS DEMO READY`  
-**Effective WA production safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
-**CANARY ACTIVATION:** `NOT AUTHORIZED`
+**Exact entry main:** `4f4b3bef8073c04971418d8653e34695a9e89682`  
+**Active branch:** `wa-l10-live-canary-bridge-20260904`  
+**Last deployed L10 layer:** `L10-A SAFE-OFF observability · PR #463`  
+**Build/certification safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
+**L10 CANARY owner authorization:** `GRANTED · EXACT CURRENT TEST CONVERSATION ONLY`  
+**Authorization ref:** `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`  
+**L11/general PROD:** `NOT AUTHORIZED`
 
-## Lock acquisition
+## Fresh entry and owner gate
 
-PR #462 completed the P0 #457 governance closeout after 11/11 triggered workflows reached SUCCESS. Protected merge produced exact `main@c3f2e9f8b28e05fae531451c9b9467ea292c91cf`. Anti-drift confirmed that exact main before this branch was created.
+PR #463 merged the certified L10-A SAFE-OFF preparation to exact `main@4f4b3bef8073c04971418d8653e34695a9e89682`; Railway and Supabase production readbacks are healthy. Production WhatsApp inbound and human outbound were then proven live with the refreshed Meta token, and WA4 reported `copilotReady=true`.
 
-This branch is created exactly from that merge SHA. No pre-P0 WA-L10 branch, test result, PRE snapshot or activation evidence is valid as CANARY authority.
+On 2026-09-04 the owner separately authorized the previously frozen L10 CANARY sequence for only the current Zi Vital test conversation. The authorization is recorded on issue #456 and does not authorize broad customer traffic or L11.
 
-## Authorized mutable scope — L10-A only
+## Authorized mutable scope
 
-1. A0 — exact-main anti-drift, bounded LIVE safety readbacks and fresh PRE fingerprints.
-2. A1 — provider/policy/billing/template/consent readiness assessment without exposing secrets.
-3. A2 — discovery proving which observability/rollback gaps actually remain after L4-L9.
-4. A3 — minimum dormant SAFE-OFF implementation only where discovery proves a gap.
-5. A4 — exact-head cross-module certification, anti-drift, protected merge, Railway and Supabase readback.
+1. Build a durable event-driven bridge from a newly persisted inbound Meta `provider_message_id` to the existing governed WA4 conversation engine.
+2. Enforce effective-once delivery using a durable provider-message job, bounded crash lease and deterministic idempotency; no polling or provider retry loop.
+3. Keep L8 preflight + L4 as the only path permitted to authorize `/api/wa/auto-send`; the bridge may never call Meta directly.
+4. Add an explicit level-1 `return_to_autonomous_canary` transition that releases current human assignment state without deleting assignment/routing history, and only when exact L10 scope + exact L4 conversation allowlist + effective CANARY are all present.
+5. Certify code/DB/security/P0 regressions while production remains SAFE-OFF.
+6. After exact-head merge, Railway SUCCESS and merged-lineage Supabase migration, prepare one L10 run, attach only the current test conversation, activate only that exact `CONVERSATION` allowlist, transition L4 `AUTO_OFF → CANARY`, disengage kill switch, and return that conversation to `AI_ACTIVE`.
+7. Run a tiny real conversation canary with bounded turns; stop immediately on privacy, consent, duplicate, wrong fact/price, unsafe clinical, booking, provider/local divergence, runaway, budget or P0 regression.
 
-## Binding safety invariants
+## Binding invariants during implementation/certification
 
-- Production remains `AUTO_OFF`.
-- Kill switch remains engaged.
-- `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true`.
-- No live autonomous provider dispatch.
-- No active customer CANARY allowlist is created by L10-A.
-- No L10 function may become a second activation authority, sender, pricing authority, identity authority or booking authority.
-- Existing L4 remains the sole autonomous state machine and explicit authorization gate.
-- Existing L5/L6/L7/L8/L9 remain the canonical booking, attribution, cost, policy/security and shadow authorities.
-- No timeout inflation, browser polling, retry loop, materialized analytical hot path or synthetic PROD evidence.
-- Secrets, raw WhatsApp payloads and raw recipient identifiers are never written to GitHub/Notion/L10 evidence.
+- Production stays `AUTO_OFF` and kill switch engaged until exact-head code + DB gates pass and the merged runtime is deployed.
+- `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true` during build/certification.
+- No live autonomous provider dispatch before activation readback.
+- No active customer allowlist before the merged bridge/migration is certified.
+- L4 remains the sole `AUTO_OFF|CANARY|PROD` authority; L8 remains mandatory preflight.
+- L5/L6/L7 remain canonical booking, attribution and cost authorities.
+- Human handoff always overrides autonomy; an owned/taken-over conversation cannot enqueue autonomous work.
+- No browser-held provider/internal secrets, no raw webhook/message-body/recipient storage in L10 evidence.
+- No second sender, second AI authority, browser polling, autonomous retry loop, timeout inflation or materialized hot-path analytics.
 
-## Fresh A0 preliminary evidence
+## Activation boundary now authorized
 
-Current PROD bounded L8/L9 safety readbacks after P0 closeout show `AUTO_OFF`, kill switch engaged, autonomous reply/send/routing OFF, human-send ON, autonomous outbound `0`, provider-dispatch demo runs `0` and browser message/booking writes disabled. Active L4 CANARY allowlist entries were `0` at re-entry.
+The owner authorization permits the existing L4 state machine to enter **CANARY only after** this branch reaches exact-head PASS, protected merge, Railway SUCCESS and merged-lineage Supabase PASS. The cohort is fixed to the current Zi Vital test conversation; broader PHONE/CAMPAIGN allowlisting is outside this authorization.
 
-A fresh exact-entry PRE fingerprint must be frozen again on this branch before A3/A4; earlier values are informational only because normal clinic activity continues.
+Activation must use authorization ref `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`, a short-lived exact `CONVERSATION` allowlist, bounded daily/max-turn/rate/cooldown controls, and immediate SAFE-OFF rollback capability.
 
-## Activation boundary
+## Exit boundary
 
-`AUTO_OFF → CANARY` is **not authorized** by issue #456, this lock, L10-A implementation, CI success, merge, deploy or SAFE-OFF certification.
-
-After L10-A is fully certified, stop and present the owner with current provider/billing/template/consent readiness, exact PRE/POST evidence, remaining risks and a proposed minimal cohort. Only a separate explicit owner go/no-go can authorize the existing L4 `AUTO_OFF → CANARY` transition. L11 remains blocked until a real L10 CANARY PASS and separate owner authorization.
+WA-L10 can close only after real provider evidence shows one governed autonomous response path with no duplicate delivery and a bounded multi-turn test covering context, fact/price integrity, handoff and at least one booking-path interaction or a documented governed reason it was not exercised. L11/general production remains separately gated and is not authorized by this lock.

--- a/docs/control/WA_L10_CANARY_ACTIVATION_CURRENT.md
+++ b/docs/control/WA_L10_CANARY_ACTIVATION_CURRENT.md
@@ -1,0 +1,68 @@
+# WA-L10 — CURRENT CANARY ACTIVATION CONTRACT
+
+**Date:** 2026-09-04 America/Lima  
+**Issue:** #456  
+**Entry main:** `4f4b3bef8073c04971418d8653e34695a9e89682`  
+**Branch:** `wa-l10-live-canary-bridge-20260904`  
+**Authorization ref:** `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`
+
+## Production evidence before this branch
+
+- Meta inbound webhook reaches ASCENDA and persists the current test conversation.
+- Human-owned ASCENDA outbound reaches the real WhatsApp test number and Meta delivery callbacks return through the webhook.
+- `/api/wa3/provider-health` returned HTTP 200 after the refreshed credential was deployed.
+- WA4 startup reports `copilotReady=true`; production model secrets are loaded server-side.
+- L4 production remains `AUTO_OFF`, kill switch engaged, auto reply/send/routing OFF, human-send ON and active autonomous allowlist count zero.
+- Current test conversation is `9c48cc78-2ca0-48ee-8011-cb7fc2081996`; before activation it is human-owned / `AI_COPILOT`, so L4 correctly refuses autonomous send until an explicit governed ownership return occurs.
+
+## Why the bridge is required
+
+The signed F4 webhook currently persists inbound messages and acknowledges Meta but does not invoke WA4 AI or `/api/wa/auto-send`. Existing L4/L8 already provide the correct provider-send authority, so L10 adds orchestration only:
+
+`signed inbound -> durable provider_message job -> existing WA4 governed suggestion -> L8 -> L4 -> existing /api/wa/auto-send -> Meta`
+
+No second sender or second authority is created.
+
+## Effective-once contract
+
+- A provider message id is durably queued only when effective L4 CANARY is active, the conversation has exact L10 run scope, the L4 allowlist contains that exact conversation, and no human ownership/takeover/handoff boundary is active.
+- Work is claimed with at most two append-only attempts. A second attempt is possible only after a stale lease, for crash recovery; there is no timer/polling/retry loop.
+- The outbound idempotency key is a deterministic SHA-256 function of the inbound provider message id.
+- L4 authority and the existing outbound reservation remain the final duplicate guard.
+- Terminal SENT/BLOCKED/HANDOFF/ERROR outcomes are append-only, redacted evidence.
+
+## Governed return from human ownership
+
+`aos_wa_l10_return_to_autonomous_canary_v1` may run only for a level-1 WhatsApp administrator and only after:
+
+1. the L10 run and exact conversation scope exist;
+2. the scope recipient hash still matches the conversation canonical address;
+3. L4 is effective CANARY with kill switch disengaged;
+4. an active exact `CONVERSATION` allowlist entry exists.
+
+The function releases current ACTIVE/QUEUED assignment rows as historical `RELEASED`, writes a routing audit event, clears current owner/takeover/handoff projections and sets the conversation to `AI_ACTIVE`. It does not delete ownership history.
+
+## Deployment/activation order
+
+1. Exact-head CI PASS while production remains SAFE-OFF.
+2. Protected merge to main.
+3. Apply merged L10 bridge migration before the new Railway container begins serving CANARY traffic.
+4. Railway SUCCESS + WA4 bridge startup marker + provider health recheck.
+5. Freeze fresh PRE counts and create one L10 run while SAFE-OFF.
+6. Attach only conversation `9c48cc78-2ca0-48ee-8011-cb7fc2081996` using its recipient hash.
+7. Add a short-lived L4 `CONVERSATION` allowlist entry for that exact UUID.
+8. Call existing L4 control with `mode=CANARY`, kill switch false, bounded limits and authorization ref `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`.
+9. Call governed return-to-autonomous for that same run/conversation.
+10. Read back effective CANARY + exact scope + `AI_ACTIVE` ownerless state before asking for the first customer-side test message.
+
+## Initial limits
+
+Initial live canary target: one exact conversation, no broad routing, maximum 6 autonomous turns/conversation, daily cap 12, global rate 3/min, conversation rate 1/min, cooldown 10 seconds, duplicate window 120 seconds. Human sending remains globally available but requires human ownership; auto-routing remains OFF.
+
+## Immediate stop conditions
+
+Return to `AUTO_OFF + kill=true`, deactivate the exact allowlist and request human handoff on any privacy/identity or consent violation, duplicate delivery, wrong governed fact/price, unsafe clinical response, invalid booking mutation, provider/local divergence, repeated model/provider failure, runaway activity, budget breach or P0/cross-module regression.
+
+## L11 boundary
+
+This authorization and implementation are only for L10 CANARY. They do not authorize general-production `PROD`, broad allowlisting or L11 rollout.

--- a/supabase/migrations/20260904204500_wa_l10_autonomous_bridge_v1.sql
+++ b/supabase/migrations/20260904204500_wa_l10_autonomous_bridge_v1.sql
@@ -1,0 +1,442 @@
+-- WA-L10 C — durable event-driven autonomous bridge for a tiny governed CANARY.
+-- L4 remains the sole send/activation authority; L8 remains mandatory preflight.
+-- This layer only durably queues eligible inbound provider message ids, leases work,
+-- records redacted run-scoped evidence and provides an explicit human->AI_CANARY return.
+-- No raw message body, raw webhook, token or additional provider sender is stored here.
+
+begin;
+
+create table if not exists public.aos_wa_l10_bridge_jobs_v1 (
+  provider_message_id text primary key check (char_length(provider_message_id) between 8 and 256),
+  conversation_id uuid not null references public.aos_wa_conversations_v1(id) on delete restrict,
+  run_id uuid not null references public.aos_wa_l10_canary_runs_v1(id) on delete restrict,
+  queued_at timestamptz not null default now()
+);
+create index if not exists aos_wa_l10_bridge_jobs_run_idx
+  on public.aos_wa_l10_bridge_jobs_v1(run_id,queued_at,conversation_id);
+
+create table if not exists public.aos_wa_l10_bridge_attempts_v1 (
+  id uuid primary key default gen_random_uuid(),
+  provider_message_id text not null references public.aos_wa_l10_bridge_jobs_v1(provider_message_id) on delete restrict,
+  attempt_no smallint not null check (attempt_no between 1 and 2),
+  claimed_at timestamptz not null default now(),
+  unique(provider_message_id,attempt_no)
+);
+create index if not exists aos_wa_l10_bridge_attempts_claim_idx
+  on public.aos_wa_l10_bridge_attempts_v1(provider_message_id,claimed_at desc);
+
+create table if not exists public.aos_wa_l10_bridge_events_v1 (
+  id bigint generated always as identity primary key,
+  provider_message_id text not null references public.aos_wa_l10_bridge_jobs_v1(provider_message_id) on delete restrict,
+  attempt_id uuid references public.aos_wa_l10_bridge_attempts_v1(id) on delete restrict,
+  event_type text not null check (event_type in ('SUGGESTED','SENT','HANDOFF','BLOCKED','ERROR','SKIPPED')),
+  reason_code text not null check (char_length(reason_code) between 2 and 128),
+  authority_decision_id uuid references public.aos_wa_auto_decisions_v1(id) on delete restrict,
+  outbound_provider_message_id text check (outbound_provider_message_id is null or char_length(outbound_provider_message_id) between 8 and 256),
+  latency_ms integer check (latency_ms is null or latency_ms between 0 and 120000),
+  created_at timestamptz not null default now(),
+  unique(provider_message_id,attempt_id,event_type)
+);
+create index if not exists aos_wa_l10_bridge_events_job_idx
+  on public.aos_wa_l10_bridge_events_v1(provider_message_id,created_at,event_type);
+
+alter table public.aos_wa_l10_bridge_jobs_v1 enable row level security;
+alter table public.aos_wa_l10_bridge_jobs_v1 force row level security;
+alter table public.aos_wa_l10_bridge_attempts_v1 enable row level security;
+alter table public.aos_wa_l10_bridge_attempts_v1 force row level security;
+alter table public.aos_wa_l10_bridge_events_v1 enable row level security;
+alter table public.aos_wa_l10_bridge_events_v1 force row level security;
+
+revoke all on public.aos_wa_l10_bridge_jobs_v1 from public,anon,authenticated,service_role;
+revoke all on public.aos_wa_l10_bridge_attempts_v1 from public,anon,authenticated,service_role;
+revoke all on public.aos_wa_l10_bridge_events_v1 from public,anon,authenticated,service_role;
+grant select on public.aos_wa_l10_bridge_jobs_v1 to service_role;
+grant select on public.aos_wa_l10_bridge_attempts_v1 to service_role;
+grant select on public.aos_wa_l10_bridge_events_v1 to service_role;
+
+create or replace function public.aos_wa_l10_bridge_append_guard_v1()
+returns trigger language plpgsql set search_path='' as $$
+begin
+  raise exception 'WA_L10_BRIDGE_APPEND_ONLY' using errcode='55000';
+end
+$$;
+
+drop trigger if exists trg_aos_wa_l10_bridge_jobs_append_guard_v1 on public.aos_wa_l10_bridge_jobs_v1;
+create trigger trg_aos_wa_l10_bridge_jobs_append_guard_v1
+before update or delete on public.aos_wa_l10_bridge_jobs_v1
+for each row execute function public.aos_wa_l10_bridge_append_guard_v1();
+
+drop trigger if exists trg_aos_wa_l10_bridge_attempts_append_guard_v1 on public.aos_wa_l10_bridge_attempts_v1;
+create trigger trg_aos_wa_l10_bridge_attempts_append_guard_v1
+before update or delete on public.aos_wa_l10_bridge_attempts_v1
+for each row execute function public.aos_wa_l10_bridge_append_guard_v1();
+
+drop trigger if exists trg_aos_wa_l10_bridge_events_append_guard_v1 on public.aos_wa_l10_bridge_events_v1;
+create trigger trg_aos_wa_l10_bridge_events_append_guard_v1
+before update or delete on public.aos_wa_l10_bridge_events_v1
+for each row execute function public.aos_wa_l10_bridge_append_guard_v1();
+
+create or replace function public.aos_wa_l10_bridge_enqueue_v1(p_provider_message_id text)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_msg record;
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_scope public.aos_wa_l10_canary_scope_v1%rowtype;
+  v_run public.aos_wa_l10_canary_runs_v1%rowtype;
+  v_mode text; v_kill boolean; v_auto_reply boolean; v_ai_send boolean; v_auto_routing boolean; v_human_send boolean;
+  v_hash text;
+  v_inserted text;
+begin
+  select m.provider_message_id,m.conversation_id,m.direction,m.message_type,m.created_at
+    into v_msg
+  from public.aos_wa_messages_v1 m
+  where m.provider_message_id=p_provider_message_id
+  limit 1;
+  if v_msg.provider_message_id is null then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_MESSAGE_NOT_FOUND');
+  end if;
+  if v_msg.direction<>'INBOUND' or lower(coalesce(v_msg.message_type,''))<>'text' then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_MESSAGE_NOT_AUTONOMOUS_TEXT');
+  end if;
+  if v_msg.created_at<now()-interval '10 minutes' then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_MESSAGE_STALE');
+  end if;
+
+  select * into v_conv from public.aos_wa_conversations_v1 where id=v_msg.conversation_id;
+  if v_conv.id is null then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_CONVERSATION_NOT_FOUND');
+  end if;
+
+  select s.* into v_scope
+  from public.aos_wa_l10_canary_scope_v1 s
+  where s.conversation_id=v_conv.id
+  order by s.created_at desc
+  limit 1;
+  if v_scope.id is null then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_SCOPE_REQUIRED');
+  end if;
+  select * into v_run from public.aos_wa_l10_canary_runs_v1 where id=v_scope.run_id;
+  if v_run.id is null then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_RUN_REQUIRED');
+  end if;
+
+  v_hash:=encode(extensions.digest(convert_to(v_conv.contact_address_type||':'||v_conv.contact_address,'UTF8'),'sha256'),'hex');
+  if v_scope.recipient_hash<>v_hash then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_SCOPE_RECIPIENT_MISMATCH');
+  end if;
+
+  select a.mode,a.kill_switch_engaged,ai.auto_reply_enabled,r.ai_send_enabled,r.auto_routing_enabled,r.human_send_enabled
+    into v_mode,v_kill,v_auto_reply,v_ai_send,v_auto_routing,v_human_send
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1;
+
+  if v_mode is distinct from 'CANARY' or v_kill is distinct from false
+     or v_auto_reply is distinct from true or v_ai_send is distinct from true
+     or v_auto_routing is distinct from false or v_human_send is distinct from true then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_CANARY_NOT_EFFECTIVE');
+  end if;
+  if v_conv.state<>'AI_ACTIVE' or v_conv.owner_user_id is not null
+     or v_conv.human_takeover_at is not null or v_conv.handoff_requested_at is not null then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_HUMAN_BOUNDARY_ACTIVE');
+  end if;
+  if not exists(
+    select 1 from public.aos_wa_auto_allowlist_v1 a
+    where a.subject_kind='CONVERSATION' and a.subject_key=v_conv.id::text
+      and a.active is true and (a.expires_at is null or a.expires_at>now())
+  ) then
+    return jsonb_build_object('ok',true,'queued',false,'reason','WA_L10_EXACT_CONVERSATION_ALLOWLIST_REQUIRED');
+  end if;
+
+  insert into public.aos_wa_l10_bridge_jobs_v1(provider_message_id,conversation_id,run_id)
+  values(v_msg.provider_message_id,v_conv.id,v_run.id)
+  on conflict(provider_message_id) do nothing
+  returning provider_message_id into v_inserted;
+
+  return jsonb_build_object(
+    'ok',true,'queued',true,'replay',v_inserted is null,
+    'provider_message_id',v_msg.provider_message_id,'conversation_id',v_conv.id,'run_key',v_run.run_key
+  );
+end
+$$;
+
+create or replace function public.aos_wa_l10_bridge_claim_v1(p_provider_message_id text)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_job public.aos_wa_l10_bridge_jobs_v1%rowtype;
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_run public.aos_wa_l10_canary_runs_v1%rowtype;
+  v_attempts integer:=0;
+  v_latest timestamptz;
+  v_attempt public.aos_wa_l10_bridge_attempts_v1%rowtype;
+  v_mode text; v_kill boolean; v_auto_reply boolean; v_ai_send boolean; v_auto_routing boolean; v_human_send boolean;
+begin
+  perform pg_catalog.pg_advisory_xact_lock(744,10);
+  select * into v_job from public.aos_wa_l10_bridge_jobs_v1 where provider_message_id=p_provider_message_id;
+  if v_job.provider_message_id is null then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_JOB_NOT_FOUND');
+  end if;
+  if exists(
+    select 1 from public.aos_wa_l10_bridge_events_v1 e
+    where e.provider_message_id=p_provider_message_id and e.event_type in ('SENT','HANDOFF','BLOCKED','ERROR','SKIPPED')
+  ) then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_JOB_TERMINAL');
+  end if;
+  if v_job.queued_at<now()-interval '10 minutes' then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_JOB_STALE');
+  end if;
+
+  select count(*)::integer,max(claimed_at) into v_attempts,v_latest
+  from public.aos_wa_l10_bridge_attempts_v1 where provider_message_id=p_provider_message_id;
+  if v_attempts>=2 then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_MAX_ATTEMPTS');
+  end if;
+  if v_latest is not null and v_latest>now()-interval '90 seconds' then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_JOB_BUSY');
+  end if;
+
+  select * into v_conv from public.aos_wa_conversations_v1 where id=v_job.conversation_id;
+  select * into v_run from public.aos_wa_l10_canary_runs_v1 where id=v_job.run_id;
+  if v_conv.id is null or v_run.id is null then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_JOB_CONTEXT_MISSING');
+  end if;
+
+  select a.mode,a.kill_switch_engaged,ai.auto_reply_enabled,r.ai_send_enabled,r.auto_routing_enabled,r.human_send_enabled
+    into v_mode,v_kill,v_auto_reply,v_ai_send,v_auto_routing,v_human_send
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1;
+  if v_mode is distinct from 'CANARY' or v_kill is distinct from false
+     or v_auto_reply is distinct from true or v_ai_send is distinct from true
+     or v_auto_routing is distinct from false or v_human_send is distinct from true then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_CANARY_NOT_EFFECTIVE');
+  end if;
+  if v_conv.state<>'AI_ACTIVE' or v_conv.owner_user_id is not null
+     or v_conv.human_takeover_at is not null or v_conv.handoff_requested_at is not null then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_HUMAN_BOUNDARY_ACTIVE');
+  end if;
+  if not exists(
+    select 1 from public.aos_wa_auto_allowlist_v1 a
+    where a.subject_kind='CONVERSATION' and a.subject_key=v_conv.id::text
+      and a.active is true and (a.expires_at is null or a.expires_at>now())
+  ) then
+    return jsonb_build_object('ok',true,'claimed',false,'reason','WA_L10_EXACT_CONVERSATION_ALLOWLIST_REQUIRED');
+  end if;
+
+  insert into public.aos_wa_l10_bridge_attempts_v1(provider_message_id,attempt_no)
+  values(p_provider_message_id,(v_attempts+1)::smallint)
+  returning * into v_attempt;
+
+  return jsonb_build_object(
+    'ok',true,'claimed',true,'attempt_id',v_attempt.id,'attempt_no',v_attempt.attempt_no,
+    'conversation_id',v_conv.id,'run_key',v_run.run_key,
+    'recipient_kind',v_conv.contact_address_type,'recipient_address',v_conv.contact_address,
+    'campaign_key',nullif(v_conv.campaign_source,'')
+  );
+end
+$$;
+
+create or replace function public.aos_wa_l10_bridge_event_v1(
+  p_provider_message_id text,
+  p_attempt_id uuid,
+  p_event_type text,
+  p_reason_code text,
+  p_authority_decision_id uuid default null,
+  p_outbound_provider_message_id text default null,
+  p_latency_ms integer default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_type text:=upper(btrim(coalesce(p_event_type,'')));
+  v_reason text:=left(regexp_replace(upper(btrim(coalesce(p_reason_code,'WA_L10_UNKNOWN'))),'[^A-Z0-9_.:-]','_','g'),128);
+  v_id bigint;
+begin
+  if v_type not in ('SUGGESTED','SENT','HANDOFF','BLOCKED','ERROR','SKIPPED') then
+    return jsonb_build_object('ok',false,'error','WA_L10_EVENT_TYPE_INVALID');
+  end if;
+  if not exists(
+    select 1 from public.aos_wa_l10_bridge_attempts_v1 a
+    where a.id=p_attempt_id and a.provider_message_id=p_provider_message_id
+  ) then
+    return jsonb_build_object('ok',false,'error','WA_L10_ATTEMPT_REQUIRED');
+  end if;
+  if p_latency_ms is not null and p_latency_ms not between 0 and 120000 then
+    return jsonb_build_object('ok',false,'error','WA_L10_LATENCY_INVALID');
+  end if;
+
+  insert into public.aos_wa_l10_bridge_events_v1(
+    provider_message_id,attempt_id,event_type,reason_code,authority_decision_id,outbound_provider_message_id,latency_ms
+  ) values (
+    p_provider_message_id,p_attempt_id,v_type,v_reason,p_authority_decision_id,
+    nullif(btrim(coalesce(p_outbound_provider_message_id,'')),''),p_latency_ms
+  )
+  on conflict(provider_message_id,attempt_id,event_type) do nothing
+  returning id into v_id;
+
+  return jsonb_build_object('ok',true,'inserted',v_id is not null,'event_type',v_type);
+end
+$$;
+
+create or replace function public.aos_wa_l10_bridge_pending_v1(p_limit integer default 5)
+returns table(provider_message_id text)
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select j.provider_message_id
+  from public.aos_wa_l10_bridge_jobs_v1 j
+  where j.queued_at>=now()-interval '10 minutes'
+    and not exists(
+      select 1 from public.aos_wa_l10_bridge_events_v1 e
+      where e.provider_message_id=j.provider_message_id
+        and e.event_type in ('SENT','HANDOFF','BLOCKED','ERROR','SKIPPED')
+    )
+    and (select count(*) from public.aos_wa_l10_bridge_attempts_v1 a where a.provider_message_id=j.provider_message_id)<2
+    and not exists(
+      select 1 from public.aos_wa_l10_bridge_attempts_v1 a
+      where a.provider_message_id=j.provider_message_id and a.claimed_at>now()-interval '90 seconds'
+    )
+  order by j.queued_at asc
+  limit greatest(1,least(coalesce(p_limit,5),10))
+$$;
+
+create or replace function public.aos_wa_l10_return_to_autonomous_canary_v1(
+  p_actor_id uuid,
+  p_run_key text,
+  p_conversation_id uuid,
+  p_reason text default 'OWNER_AUTH_CANARY'
+) returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_run public.aos_wa_l10_canary_runs_v1%rowtype;
+  v_scope public.aos_wa_l10_canary_scope_v1%rowtype;
+  v_conv public.aos_wa_conversations_v1%rowtype;
+  v_mode text; v_kill boolean; v_auto_reply boolean; v_ai_send boolean; v_auto_routing boolean; v_human_send boolean;
+  v_hash text;
+  v_released integer:=0;
+  v_reason text:=left(regexp_replace(upper(btrim(coalesce(p_reason,'OWNER_AUTH_CANARY'))),'[^A-Z0-9_.:-]','_','g'),128);
+begin
+  if not public.aos_wa_l4_is_level1_admin_v1(p_actor_id) then
+    return jsonb_build_object('ok',false,'error','WA_L10_LEVEL1_ADMIN_REQUIRED');
+  end if;
+  select * into v_run from public.aos_wa_l10_canary_runs_v1 where run_key=p_run_key;
+  if v_run.id is null then return jsonb_build_object('ok',false,'error','WA_L10_RUN_NOT_FOUND'); end if;
+  select * into v_scope from public.aos_wa_l10_canary_scope_v1
+    where run_id=v_run.id and conversation_id=p_conversation_id;
+  if v_scope.id is null then return jsonb_build_object('ok',false,'error','WA_L10_SCOPE_REQUIRED'); end if;
+
+  select * into v_conv from public.aos_wa_conversations_v1 where id=p_conversation_id for update;
+  if v_conv.id is null then return jsonb_build_object('ok',false,'error','WA_L10_CONVERSATION_NOT_FOUND'); end if;
+  if v_conv.state in ('CLOSED','WON','LOST') then return jsonb_build_object('ok',false,'error','WA_L10_CONVERSATION_TERMINAL'); end if;
+
+  v_hash:=encode(extensions.digest(convert_to(v_conv.contact_address_type||':'||v_conv.contact_address,'UTF8'),'sha256'),'hex');
+  if v_scope.recipient_hash<>v_hash then return jsonb_build_object('ok',false,'error','WA_L10_SCOPE_RECIPIENT_MISMATCH'); end if;
+
+  select a.mode,a.kill_switch_engaged,ai.auto_reply_enabled,r.ai_send_enabled,r.auto_routing_enabled,r.human_send_enabled
+    into v_mode,v_kill,v_auto_reply,v_ai_send,v_auto_routing,v_human_send
+  from public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 r
+  where a.id=1 and ai.id=1 and r.id=1;
+  if v_mode is distinct from 'CANARY' or v_kill is distinct from false
+     or v_auto_reply is distinct from true or v_ai_send is distinct from true
+     or v_auto_routing is distinct from false or v_human_send is distinct from true then
+    return jsonb_build_object('ok',false,'error','WA_L10_EFFECTIVE_CANARY_REQUIRED');
+  end if;
+  if not exists(
+    select 1 from public.aos_wa_auto_allowlist_v1 a
+    where a.subject_kind='CONVERSATION' and a.subject_key=p_conversation_id::text
+      and a.active is true and (a.expires_at is null or a.expires_at>now())
+  ) then
+    return jsonb_build_object('ok',false,'error','WA_L10_EXACT_CONVERSATION_ALLOWLIST_REQUIRED');
+  end if;
+
+  if v_conv.state='AI_ACTIVE' and v_conv.owner_user_id is null
+     and v_conv.human_takeover_at is null and v_conv.handoff_requested_at is null then
+    return jsonb_build_object('ok',true,'idempotent',true,'state','AI_ACTIVE','released_assignments',0);
+  end if;
+
+  update public.aos_wa_assignments_v1
+  set state='RELEASED',released_at=coalesce(released_at,now()),terminal_reason='L10_AUTONOMOUS_RETURN',updated_at=now()
+  where conversation_id=p_conversation_id and state in ('ACTIVE','QUEUED');
+  get diagnostics v_released = row_count;
+
+  update public.aos_wa_conversations_v1
+  set owner_user_id=null,state='AI_ACTIVE',human_takeover_at=null,handoff_requested_at=null,
+      ownership_version=ownership_version+1,updated_at=now()
+  where id=p_conversation_id;
+
+  insert into public.aos_wa_routing_events_v1(conversation_id,box_id,event_type,actor_id,payload)
+  values(p_conversation_id,v_conv.box_id,'conversation.autonomous_canary_return',p_actor_id,
+    jsonb_build_object('run_id',v_run.id,'reason',v_reason,'from_state',v_conv.state,'released_assignments',v_released));
+
+  return jsonb_build_object('ok',true,'idempotent',false,'state','AI_ACTIVE','released_assignments',v_released,'run_id',v_run.id);
+end
+$$;
+
+create or replace function public.aos_wa_l10_bridge_status_v1(p_run_key text)
+returns jsonb
+language sql
+stable
+security definer
+set search_path=''
+as $$
+  select jsonb_build_object(
+    'ok',true,'version','WA-L10-BRIDGE-V1','run_key',r.run_key,
+    'jobs',(select count(*) from public.aos_wa_l10_bridge_jobs_v1 j where j.run_id=r.id),
+    'attempts',(select count(*) from public.aos_wa_l10_bridge_attempts_v1 a join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=a.provider_message_id where j.run_id=r.id),
+    'suggested',(select count(*) from public.aos_wa_l10_bridge_events_v1 e join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=e.provider_message_id where j.run_id=r.id and e.event_type='SUGGESTED'),
+    'sent',(select count(*) from public.aos_wa_l10_bridge_events_v1 e join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=e.provider_message_id where j.run_id=r.id and e.event_type='SENT'),
+    'handoff',(select count(*) from public.aos_wa_l10_bridge_events_v1 e join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=e.provider_message_id where j.run_id=r.id and e.event_type='HANDOFF'),
+    'blocked',(select count(*) from public.aos_wa_l10_bridge_events_v1 e join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=e.provider_message_id where j.run_id=r.id and e.event_type='BLOCKED'),
+    'errors',(select count(*) from public.aos_wa_l10_bridge_events_v1 e join public.aos_wa_l10_bridge_jobs_v1 j on j.provider_message_id=e.provider_message_id where j.run_id=r.id and e.event_type='ERROR'),
+    'authority_mode',a.mode,'kill_switch_engaged',a.kill_switch_engaged,
+    'effective_autonomous_send',(a.mode='CANARY' and a.kill_switch_engaged is false and ai.auto_reply_enabled and rc.ai_send_enabled),
+    'active_exact_scope',(select count(*) from public.aos_wa_auto_allowlist_v1 w join public.aos_wa_l10_canary_scope_v1 s on s.run_id=r.id and s.conversation_id::text=w.subject_key where w.subject_kind='CONVERSATION' and w.active is true and (w.expires_at is null or w.expires_at>now()))
+  )
+  from public.aos_wa_l10_canary_runs_v1 r
+  cross join public.aos_wa_auto_authority_v1 a
+  cross join public.aos_wa_ai_control_v1 ai
+  cross join public.aos_wa_routing_control_v1 rc
+  where r.run_key=p_run_key and a.id=1 and ai.id=1 and rc.id=1
+$$;
+
+revoke all on function public.aos_wa_l10_bridge_append_guard_v1() from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_bridge_enqueue_v1(text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_bridge_claim_v1(text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_bridge_event_v1(text,uuid,text,text,uuid,text,integer) from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_bridge_pending_v1(integer) from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_return_to_autonomous_canary_v1(uuid,text,uuid,text) from public,anon,authenticated;
+revoke all on function public.aos_wa_l10_bridge_status_v1(text) from public,anon,authenticated;
+
+grant execute on function public.aos_wa_l10_bridge_append_guard_v1() to service_role;
+grant execute on function public.aos_wa_l10_bridge_enqueue_v1(text) to service_role;
+grant execute on function public.aos_wa_l10_bridge_claim_v1(text) to service_role;
+grant execute on function public.aos_wa_l10_bridge_event_v1(text,uuid,text,text,uuid,text,integer) to service_role;
+grant execute on function public.aos_wa_l10_bridge_pending_v1(integer) to service_role;
+grant execute on function public.aos_wa_l10_return_to_autonomous_canary_v1(uuid,text,uuid,text) to service_role;
+grant execute on function public.aos_wa_l10_bridge_status_v1(text) to service_role;
+
+comment on table public.aos_wa_l10_bridge_jobs_v1 is 'L10 durable inbound provider-message jobs for exact conversation CANARY only; no raw content/recipient stored.';
+comment on table public.aos_wa_l10_bridge_attempts_v1 is 'L10 append-only bounded work leases; at most two attempts permits crash recovery without retry loops.';
+comment on table public.aos_wa_l10_bridge_events_v1 is 'L10 append-only redacted bridge outcomes. Final provider dispatch remains L4/L8 + Meta runtime authority.';
+comment on function public.aos_wa_l10_return_to_autonomous_canary_v1(uuid,text,uuid,text) is 'Explicit level-1 governed transition from human ownership to exact L10 CANARY AI_ACTIVE; preserves assignment/routing history.';
+
+commit;

--- a/supabase/rollbacks/20260904204500_wa_l10_autonomous_bridge_v1.rollback.sql
+++ b/supabase/rollbacks/20260904204500_wa_l10_autonomous_bridge_v1.rollback.sql
@@ -1,0 +1,27 @@
+-- WA-L10 autonomous bridge rollback.
+-- Never erase immutable live canary evidence.
+
+do $$
+begin
+  if to_regclass('public.aos_wa_l10_bridge_jobs_v1') is not null
+     and exists(select 1 from public.aos_wa_l10_bridge_jobs_v1 limit 1) then
+    raise exception 'WA_L10_BRIDGE_RECOVERY_BLOCKED_AUDIT_HISTORY' using errcode='55000';
+  end if;
+end
+$$;
+
+drop function if exists public.aos_wa_l10_bridge_status_v1(text);
+drop function if exists public.aos_wa_l10_return_to_autonomous_canary_v1(uuid,text,uuid,text);
+drop function if exists public.aos_wa_l10_bridge_pending_v1(integer);
+drop function if exists public.aos_wa_l10_bridge_event_v1(text,uuid,text,text,uuid,text,integer);
+drop function if exists public.aos_wa_l10_bridge_claim_v1(text);
+drop function if exists public.aos_wa_l10_bridge_enqueue_v1(text);
+
+drop trigger if exists trg_aos_wa_l10_bridge_events_append_guard_v1 on public.aos_wa_l10_bridge_events_v1;
+drop trigger if exists trg_aos_wa_l10_bridge_attempts_append_guard_v1 on public.aos_wa_l10_bridge_attempts_v1;
+drop trigger if exists trg_aos_wa_l10_bridge_jobs_append_guard_v1 on public.aos_wa_l10_bridge_jobs_v1;
+drop function if exists public.aos_wa_l10_bridge_append_guard_v1();
+
+drop table if exists public.aos_wa_l10_bridge_events_v1;
+drop table if exists public.aos_wa_l10_bridge_attempts_v1;
+drop table if exists public.aos_wa_l10_bridge_jobs_v1;


### PR DESCRIPTION
## Scope
Implements the owner-authorized L10 CANARY bridge while keeping production SAFE-OFF through code/DB certification.

- durable inbound provider-message queue + bounded crash lease;
- deterministic idempotency and append-only redacted outcomes;
- reuses existing WA4 governed suggestion engine;
- reuses existing `/api/wa/auto-send`; L8 + L4 remain the sole final authority;
- no polling, no direct Meta sender, no autonomous retry loop;
- explicit level-1 human→`AI_ACTIVE` CANARY return preserving assignment/routing history;
- exact `CONVERSATION` allowlist requirement;
- full-local DB contract + static/runtime tests;
- updates workstream lock and activation runbook.

## Owner authorization
Issue #456 contains the explicit L10 CANARY authorization. Ref: `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`.

This PR does **not** itself activate production CANARY. Activation happens only after exact-head PASS, protected merge, merged-lineage Supabase migration and Railway SUCCESS. L11/general PROD is not authorized.

Closes no issue until real provider canary evidence passes.