### PR TITLE
WA-L10: remediate first real turn DB hot path fail-closed

### DIFF
--- a/.github/workflows/wa-l10-safe-off.yml
+++ b/.github/workflows/wa-l10-safe-off.yml
@@ -34,7 +34,9 @@ jobs:
           node-version: '24'
       - name: L10 static contract
         shell: powershell
-        run: node ci/wa-l10/safe_off_contract.test.js
+        run: |
+          node ci/wa-l10/safe_off_contract.test.js
+          node ci/wa-l10/first_turn_hotpath_contract.test.js
       - name: L10 event-driven autonomous bridge contract
         shell: powershell
         run: |

--- a/ci/wa-l10/first_turn_hotpath_contract.test.js
+++ b/ci/wa-l10/first_turn_hotpath_contract.test.js
@@ -1,0 +1,22 @@
+'use strict';
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+const migration=fs.readFileSync('supabase/migrations/20260904225500_wa_l10_first_turn_hotpath_fix_v1.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260904225500_wa_l10_first_turn_hotpath_fix_v1.rollback.sql','utf8');
+const copilot=fs.readFileSync('app/wa4-copilot.js','utf8');
+
+assert.match(migration,/with\s+prepared\s+as\s+materialized/i,'search hot path must materialize the normalized eligible row set once');
+assert.match(migration,/public\.aos_wa4a_norm_v1\(k\.title\)\s+as\s+norm_title/i);
+assert.match(migration,/public\.aos_wa4a_norm_v1\(k\.search_text\)\s+as\s+norm_search/i);
+assert.equal((migration.match(/aos_wa4a_norm_v1\(k\.search_text\)/g)||[]).length,1,'derived search_text normalization must occur only once in the optimized function');
+assert.equal((migration.match(/aos_wa4a_norm_v1\(k\.title\)/g)||[]).length,1,'derived title normalization must occur only once in the optimized function');
+assert.match(migration,/p\.norm_search\s+like/i,'ranking/filtering must reuse the normalized row value');
+assert.doesNotMatch(migration,/set\s+(?:local\s+)?statement_timeout\s*=/i,'remediation must never inflate or alter statement_timeout');
+assert.doesNotMatch(migration,/create\s+materialized\s+view/i,'do not introduce a refresh-driven global materialized hot path');
+assert.match(copilot,/task\s*:\s*['"]SALES_PLAYBOOK['"]/,'WA4 fail-closed logger still emits SALES_PLAYBOOK');
+assert.match(migration,/['"]SALES_PLAYBOOK['"]::text/,'DB task CHECK must accept the existing fail-closed SALES_PLAYBOOK audit task');
+assert.match(rollback,/WA_L10_RECOVERY_BLOCKED_SALES_PLAYBOOK_AUDIT_HISTORY/,'rollback must preserve append-only audit evidence once SALES_PLAYBOOK rows exist');
+assert.doesNotMatch(migration,/aos_wa_l4_set_control_v1|aos_wa_l4_allowlist_set_v1|graph\.facebook\.com|\/messages/i,'DB hot-path repair must not activate CANARY or add a sender');
+
+console.log('WA-L10 first-turn hotpath contract: PASS');

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,51 +1,47 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
 **Captured:** 2026-09-04 America/Lima  
-**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — EVENT-DRIVEN AUTONOMOUS CANARY BRIDGE + TINY REAL CANARY`  
+**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — FIRST REAL TURN FAIL-CLOSED REMEDIATION`  
 **GitHub authority:** Issue `#456` = `OPEN / ACTIVE`  
 **Parent roadmap:** Issue `#410`  
-**Exact entry main:** `4f4b3bef8073c04971418d8653e34695a9e89682`  
-**Active branch:** `wa-l10-live-canary-bridge-20260904`  
-**Last deployed L10 layer:** `L10-A SAFE-OFF observability · PR #463`  
-**Build/certification safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
-**L10 CANARY owner authorization:** `GRANTED · EXACT CURRENT TEST CONVERSATION ONLY`  
+**Exact entry main:** `525975bb819ace54fe0af334bec584c208b98784`  
+**Active branch:** `wa-l10-first-turn-db-hotpath-fix-20260904`  
+**Deployed L10 layer:** `PR #464 · event-driven autonomous canary bridge`  
+**Current production safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
+**Active L4 allowlist:** `0`  
+**Prior L10 CANARY authorization:** `CONSUMED BY FIRST-TURN ATTEMPT; RE-ACTIVATION SUSPENDED PENDING FRESH EVIDENCE`  
 **Authorization ref:** `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`  
 **L11/general PROD:** `NOT AUTHORIZED`
 
-## Fresh entry and owner gate
+## First real turn result
 
-PR #463 merged the certified L10-A SAFE-OFF preparation to exact `main@4f4b3bef8073c04971418d8653e34695a9e89682`; Railway and Supabase production readbacks are healthy. Production WhatsApp inbound and human outbound were then proven live with the refreshed Meta token, and WA4 reported `copilotReady=true`.
+The exact Zi Vital test conversation produced a valid Meta inbound and entered the deployed L10 bridge. The provider message was durably queued and claimed exactly once. WA4 Copilot then failed before L4 autonomous authorization/provider dispatch. The bridge correctly requested human handoff and recorded `HANDOFF · WA4_COPILOT_UNAVAILABLE`; no AUTO decision or outbound autonomous message was created.
 
-On 2026-09-04 the owner separately authorized the previously frozen L10 CANARY sequence for only the current Zi Vital test conversation. The authorization is recorded on issue #456 and does not authorize broad customer traffic or L11.
+The corresponding `aos_wa_ai_runs_v1` row records `SALES_COPILOT · ERROR · FAIL_CLOSED · WA4_DB_UNAVAILABLE` with ~10.6 s latency. PostgreSQL logs at the same first-turn timestamp contain two `statement timeout` cancellations. A bounded read-only reproduction under a stricter 3 s limit identified the hot path in `aos_wa4a_knowledge_search_v1`, where the same derived `search_text` is repeatedly normalized inside phrase and per-token predicates. A second audit defect was exposed: WA4 intentionally logs a `SALES_PLAYBOOK` fail-closed event, but the current `aos_wa_ai_runs_v1_task_check` only accepts `SALES_COPILOT|MODEL_EVAL`.
 
-## Authorized mutable scope
+Per the predeclared canary rollback rule, production was immediately returned to `AUTO_OFF`, kill switch engaged, autonomous reply/send disabled, and the exact conversation allowlist disabled. The conversation remains `HUMAN_REQUESTED`. An authenticated `/api/wa3/provider-health` call subsequently returned HTTP 502, so provider readiness must also return to explicit READY before any retry.
 
-1. Build a durable event-driven bridge from a newly persisted inbound Meta `provider_message_id` to the existing governed WA4 conversation engine.
-2. Enforce effective-once delivery using a durable provider-message job, bounded crash lease and deterministic idempotency; no polling or provider retry loop.
-3. Keep L8 preflight + L4 as the only path permitted to authorize `/api/wa/auto-send`; the bridge may never call Meta directly.
-4. Add an explicit level-1 `return_to_autonomous_canary` transition that releases current human assignment state without deleting assignment/routing history, and only when exact L10 scope + exact L4 conversation allowlist + effective CANARY are all present.
-5. Certify code/DB/security/P0 regressions while production remains SAFE-OFF.
-6. After exact-head merge, Railway SUCCESS and merged-lineage Supabase migration, prepare one L10 run, attach only the current test conversation, activate only that exact `CONVERSATION` allowlist, transition L4 `AUTO_OFF → CANARY`, disengage kill switch, and return that conversation to `AI_ACTIVE`.
-7. Run a tiny real conversation canary with bounded turns; stop immediately on privacy, consent, duplicate, wrong fact/price, unsafe clinical, booking, provider/local divergence, runaway, budget or P0 regression.
+## Authorized mutable remediation scope
 
-## Binding invariants during implementation/certification
+1. Preserve the deployed event-driven L10 bridge and its fail-closed human boundary; do not add a second sender or authority.
+2. Replace repeated WA4A derived-row normalization with a bounded per-query materialized prepared set so each eligible title/search text is normalized once while preserving ranking/authority semantics.
+3. Align `aos_wa_ai_runs_v1_task_check` with the existing `SALES_PLAYBOOK` fail-closed logger so the audit path cannot fail while reporting a primary error.
+4. Add regression gates proving no timeout inflation, no global materialized-view refresh path, no CANARY activation side effect, and preservation of the L4/L8 authority boundary.
+5. Certify exact head, merge, deploy, apply merged-lineage migration, then run a strict bounded production read-only knowledge-search proof.
+6. Re-run authenticated Meta provider-health and require HTTP 200 / `diagnosis=READY`.
+7. Present the complete repaired evidence before any fresh `AUTO_OFF → CANARY` retry. Do not silently reuse the failed activation.
 
-- Production stays `AUTO_OFF` and kill switch engaged until exact-head code + DB gates pass and the merged runtime is deployed.
-- `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true` during build/certification.
-- No live autonomous provider dispatch before activation readback.
-- No active customer allowlist before the merged bridge/migration is certified.
+## Binding invariants
+
+- Production remains `AUTO_OFF`, kill switch engaged, `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true` throughout remediation/certification.
+- Active L4 allowlist remains zero until a separately reviewed retry gate.
+- No live autonomous provider dispatch during remediation.
+- No statement-timeout inflation or bypass of the 3 s bounded first-turn proof.
 - L4 remains the sole `AUTO_OFF|CANARY|PROD` authority; L8 remains mandatory preflight.
-- L5/L6/L7 remain canonical booking, attribution and cost authorities.
-- Human handoff always overrides autonomy; an owned/taken-over conversation cannot enqueue autonomous work.
-- No browser-held provider/internal secrets, no raw webhook/message-body/recipient storage in L10 evidence.
-- No second sender, second AI authority, browser polling, autonomous retry loop, timeout inflation or materialized hot-path analytics.
-
-## Activation boundary now authorized
-
-The owner authorization permits the existing L4 state machine to enter **CANARY only after** this branch reaches exact-head PASS, protected merge, Railway SUCCESS and merged-lineage Supabase PASS. The cohort is fixed to the current Zi Vital test conversation; broader PHONE/CAMPAIGN allowlisting is outside this authorization.
-
-Activation must use authorization ref `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`, a short-lived exact `CONVERSATION` allowlist, bounded daily/max-turn/rate/cooldown controls, and immediate SAFE-OFF rollback capability.
+- Human handoff always overrides autonomy.
+- No browser-held provider/internal secrets, no raw webhook/message-body/recipient storage in remediation evidence.
+- No second sender, browser polling, autonomous retry loop, or refresh-driven global materialized analytical hot path.
 
 ## Exit boundary
 
-WA-L10 can close only after real provider evidence shows one governed autonomous response path with no duplicate delivery and a bounded multi-turn test covering context, fact/price integrity, handoff and at least one booking-path interaction or a documented governed reason it was not exercised. L11/general production remains separately gated and is not authorized by this lock.
+This remediation can close only after exact-head CI, merged Railway/Supabase parity, strict bounded WA4A first-turn search PASS, authenticated provider-health READY, and a fresh safe readback showing `AUTO_OFF + kill=true + allowlist=0 + AUTO outbound=0`. A new real CANARY retry remains a separate go/no-go after that evidence. L11/general production stays blocked.

--- a/supabase/migrations/20260904225500_wa_l10_first_turn_hotpath_fix_v1.sql
+++ b/supabase/migrations/20260904225500_wa_l10_first_turn_hotpath_fix_v1.sql
@@ -1,0 +1,100 @@
+-- WA-L10 first-turn remediation — bounded governed knowledge search + complete fail-closed audit vocabulary.
+-- Root cause observed in PROD 2026-09-04: v1 repeatedly normalized the same derived search text
+-- inside phrase + per-token predicates, causing concurrent WA4 governed-knowledge calls to hit statement_timeout.
+-- This patch preserves ranking/authority semantics and computes normalization once per eligible row.
+-- No statement_timeout inflation, sender/authority change, allowlist mutation, or CANARY activation is introduced.
+
+begin;
+
+create or replace function public.aos_wa4a_knowledge_search_v1(
+  p_query text,
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text,
+  domain text,
+  subject_type text,
+  subject_id text,
+  title text,
+  facts jsonb,
+  authority_tier smallint,
+  source_relation text,
+  source_pk text,
+  source_updated_at timestamptz,
+  freshness_state text,
+  conflict_state text,
+  retrieval_state text,
+  evidence_ref jsonb,
+  score integer
+)
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_q text := public.aos_wa4a_norm_v1(p_query);
+  v_limit integer := greatest(1,least(coalesce(p_limit,12),24));
+  v_tokens text[];
+begin
+  if length(v_q)<2 then return; end if;
+
+  select coalesce(array_agg(distinct w),array[]::text[])
+    into v_tokens
+  from unnest(string_to_array(v_q,' ')) w
+  where length(w)>=3;
+
+  return query
+  with prepared as materialized (
+    select
+      k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.facts,k.authority_tier,
+      k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,
+      k.retrieval_state,k.evidence_ref,
+      public.aos_wa4a_norm_v1(k.title) as norm_title,
+      public.aos_wa4a_norm_v1(k.search_text) as norm_search
+    from public.aos_wa4a_knowledge_items_v1 k
+    where k.retrieval_state in ('READY','READY_WITH_WARNING')
+      and k.conflict_state='CLEAR'
+      and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
+  ), ranked as (
+    select
+      p.*,
+      (
+        case when p.norm_title=v_q then 100 else 0 end
+        + case when p.norm_title like '%'||v_q||'%' then 45 else 0 end
+        + case when p.norm_search like '%'||v_q||'%' then 25 else 0 end
+        + coalesce((select count(*)::integer*6 from unnest(v_tokens) w where p.norm_search like '%'||w||'%'),0)
+        + case when p.authority_tier=10 then 5 else 0 end
+      )::integer as rank_score
+    from prepared p
+    where p.norm_title like '%'||v_q||'%'
+       or p.norm_search like '%'||v_q||'%'
+       or exists(select 1 from unnest(v_tokens) w where p.norm_search like '%'||w||'%')
+  )
+  select
+    r.knowledge_id,r.domain,r.subject_type,r.subject_id,r.title,r.facts,r.authority_tier,
+    r.source_relation,r.source_pk,r.source_updated_at,r.freshness_state,r.conflict_state,
+    r.retrieval_state,r.evidence_ref,r.rank_score
+  from ranked r
+  order by r.rank_score desc,r.authority_tier asc,r.title asc
+  limit v_limit;
+end
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) to service_role;
+
+-- The WA4 Copilot intentionally records a SALES_PLAYBOOK fail-closed audit when governed
+-- knowledge cannot be loaded. PROD showed the logger itself was rejected by the old task CHECK.
+alter table public.aos_wa_ai_runs_v1
+  drop constraint if exists aos_wa_ai_runs_v1_task_check;
+alter table public.aos_wa_ai_runs_v1
+  add constraint aos_wa_ai_runs_v1_task_check
+  check (task = any(array['SALES_COPILOT'::text,'SALES_PLAYBOOK'::text,'MODEL_EVAL'::text]));
+
+comment on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) is
+'WA4A governed search hot-path v1: authority/ranking semantics preserved; eligible derived rows are normalized once via MATERIALIZED prepared set to prevent repeated regex normalization per token.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260904225500_wa_l10_first_turn_hotpath_fix_v1.rollback.sql
+++ b/supabase/rollbacks/20260904225500_wa_l10_first_turn_hotpath_fix_v1.rollback.sql
@@ -1,0 +1,65 @@
+-- Rollback for WA-L10 first-turn hot-path remediation.
+-- Refuses to narrow the audit task CHECK if SALES_PLAYBOOK evidence already exists.
+
+begin;
+
+do $$
+begin
+  if exists(select 1 from public.aos_wa_ai_runs_v1 where task='SALES_PLAYBOOK' limit 1) then
+    raise exception 'WA_L10_RECOVERY_BLOCKED_SALES_PLAYBOOK_AUDIT_HISTORY' using errcode='55000';
+  end if;
+end
+$$;
+
+create or replace function public.aos_wa4a_knowledge_search_v1(
+  p_query text,
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text, domain text, subject_type text, subject_id text, title text,
+  facts jsonb, authority_tier smallint, source_relation text, source_pk text,
+  source_updated_at timestamptz, freshness_state text, conflict_state text,
+  retrieval_state text, evidence_ref jsonb, score integer
+)
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_q text := public.aos_wa4a_norm_v1(p_query);
+  v_limit integer := greatest(1,least(coalesce(p_limit,12),24));
+begin
+  if length(v_q)<2 then return; end if;
+  return query
+  select k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.facts,k.authority_tier,
+    k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,k.retrieval_state,k.evidence_ref,
+    (case when public.aos_wa4a_norm_v1(k.title)=v_q then 100 else 0 end
+      + case when public.aos_wa4a_norm_v1(k.title) like '%'||v_q||'%' then 45 else 0 end
+      + case when public.aos_wa4a_norm_v1(k.search_text) like '%'||v_q||'%' then 25 else 0 end
+      + coalesce((select count(*)::integer*6 from unnest(string_to_array(v_q,' ')) w where length(w)>=3 and public.aos_wa4a_norm_v1(k.search_text) like '%'||w||'%'),0)
+      + case when k.authority_tier=10 then 5 else 0 end)::integer as score
+  from public.aos_wa4a_knowledge_items_v1 k
+  where k.retrieval_state in ('READY','READY_WITH_WARNING')
+    and k.conflict_state='CLEAR'
+    and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
+    and (public.aos_wa4a_norm_v1(k.title) like '%'||v_q||'%'
+      or public.aos_wa4a_norm_v1(k.search_text) like '%'||v_q||'%'
+      or exists(select 1 from unnest(string_to_array(v_q,' ')) w where length(w)>=3 and public.aos_wa4a_norm_v1(k.search_text) like '%'||w||'%'))
+  order by score desc,k.authority_tier asc,k.title asc
+  limit v_limit;
+end
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) to service_role;
+
+alter table public.aos_wa_ai_runs_v1
+  drop constraint if exists aos_wa_ai_runs_v1_task_check;
+alter table public.aos_wa_ai_runs_v1
+  add constraint aos_wa_ai_runs_v1_task_check
+  check (task = any(array['SALES_COPILOT'::text,'MODEL_EVAL'::text]));
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
## Incident
The first real Zi Vital L10 canary inbound was ingested by Meta, queued and claimed exactly once, then failed closed before L4/provider dispatch. Live evidence: `SALES_COPILOT / ERROR / FAIL_CLOSED / WA4_DB_UNAVAILABLE` (~10.6s), two PostgreSQL `statement timeout` cancellations at the same timestamp, bridge `HANDOFF / WA4_COPILOT_UNAVAILABLE`, zero AUTO decision/outbound.

Per the declared rollback rule, PROD is already back to `AUTO_OFF`, kill switch engaged, exact allowlist disabled, and the conversation is `HUMAN_REQUESTED`.

## Root cause
`aos_wa4a_knowledge_search_v1` repeatedly normalizes the same derived `title/search_text` in phrase and per-token predicates. A read-only reproduction with a stricter 3s statement boundary timed out in `aos_wa4a_norm_v1` via v1→v2→v3. A second defect rejected the intended `SALES_PLAYBOOK` fail-closed audit row because `aos_wa_ai_runs_v1_task_check` allowed only `SALES_COPILOT|MODEL_EVAL`.

## Fix
- materialize the eligible per-query prepared row set and normalize title/search text exactly once per row; preserve ranking, authority and v1 signature;
- align AI-run task CHECK with existing `SALES_PLAYBOOK` logger;
- rollback refuses to erase/narrow audit vocabulary after SALES_PLAYBOOK history exists;
- focused static contract forbids timeout inflation, global materialized-view hot paths, L4/allowlist activation or sender changes;
- current WA-L10 workflow runs the new regression contract on zero-cost/self-hosted runners.

## Safety
This PR does **not** reactivate CANARY. PROD must remain `AUTO_OFF + kill=true + allowlist=0`. After exact-head PASS/merge/deploy/migration, required gates are strict bounded production knowledge-search PASS and authenticated provider-health HTTP 200 / `diagnosis=READY` before any fresh canary go/no-go. L11/general PROD remains not authorized.