### PR TITLE
WA-L10: candidate prefilter v2 for strict first-turn 3s gate

### DIFF
--- a/.github/workflows/wa-l10-safe-off.yml
+++ b/.github/workflows/wa-l10-safe-off.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           node ci/wa-l10/safe_off_contract.test.js
           node ci/wa-l10/first_turn_hotpath_contract.test.js
+          node ci/wa-l10/first_turn_candidate_prefilter_v2_contract.test.js
       - name: L10 event-driven autonomous bridge contract
         shell: powershell
         run: |

--- a/.github/workflows/wa4a-knowledge-fabric.yml
+++ b/.github/workflows/wa4a-knowledge-fabric.yml
@@ -7,7 +7,12 @@ on:
       - 'app/wa4-knowledge.js'
       - 'supabase/migrations/*wa4a_knowledge_fabric*'
       - 'supabase/rollbacks/*wa4a_knowledge_fabric*'
+      - 'supabase/migrations/*wa_l10_first_turn*'
+      - 'supabase/rollbacks/*wa_l10_first_turn*'
       - 'ci/wa4a-knowledge-fabric/**'
+      - 'ci/wa-l10/*hotpath*'
+      - 'ci/wa-l10/*candidate_prefilter*'
+      - 'ci/wa-l10/tests/*first_turn*'
       - 'docs/control/WHATSAPP_REVENUE_HUB_WA4A_*'
       - '.github/workflows/wa4a-knowledge-fabric.yml'
   push:
@@ -51,6 +56,8 @@ jobs:
           node --check app/wa4-copilot.js
           node --check app/ai-router.js
           node --test ci/wa4-ai-sales-router/ai-router.test.js
+          node ci/wa-l10/first_turn_hotpath_contract.test.js
+          node ci/wa-l10/first_turn_candidate_prefilter_v2_contract.test.js
           ! grep -q "wa4-knowledge" app/server-wa4.js app/wa4-copilot.js
           ! grep -Eq "auto_send:[[:space:]]*true" app/wa4-knowledge.js
           ! grep -q "graph.facebook.com" app/wa4-knowledge.js
@@ -59,6 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           M=supabase/migrations/20260827185000_wa4a_knowledge_fabric_v1.sql
+          V2=supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql
           grep -q 'aos_wa4a_knowledge_authority_v1' "$M"
           grep -q 'aos_wa4a_knowledge_items_v1' "$M"
           grep -q 'aos_wa4a_knowledge_issues_v1' "$M"
@@ -68,7 +76,10 @@ jobs:
           grep -q 'public.aos_config_horarios' "$M"
           grep -q 'public.aos_sedes_geo.horario_\*' "$M"
           grep -q 'security_invoker=true' "$M"
-          ! grep -Eiq '(insert into|update|delete from|alter table)[[:space:]]+public\.(aos_catalogo_servicios|aos_promociones|aos_sedes_geo|aos_config_horarios|aos_catalogo_categorias)' "$M"
+          grep -q 'candidates as materialized' "$V2"
+          ! grep -Eiq '(insert into|update|delete from|alter table)[[:space:]]+public\.(aos_catalogo_servicios|aos_promociones|aos_sedes_geo|aos_config_horarios|aos_catalogo_categorias)' "$M" "$V2"
+          ! grep -Eiq '(set[[:space:]]+(local[[:space:]]+)?statement_timeout|create[[:space:]]+materialized[[:space:]]+view)' "$V2"
+          ! grep -Eiq 'aos_wa_l4_set_control_v1|aos_wa_l4_allowlist_set_v1|graph\.facebook\.com|/messages' "$V2"
           ! grep -Eiq 'public\.(aos_pacientes|aos_ventas|aos_leads|aos_rev_)' "$M"
           ! grep -Eiq '(descripcion_clinica|indicaciones|contraindicaciones|perfil_paciente|mecanismo_accion|composicion)' "$M"
           ! grep -Eiq '(auto_routing|ai_send|auto_reply|copilot)[[:space:]]*=[[:space:]]*true' "$M"
@@ -97,7 +108,7 @@ jobs:
           echo 'WA-4A isolated Postgres did not become ready' >&2
           exit 1
 
-      - name: Build certified WA prerequisites through WA-7A.4
+      - name: Build certified WA prerequisites through WA-7A.4 and current L10 hotpath
         run: |
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa3-boxes-routing-handoff/schema_contract.sql
@@ -117,6 +128,8 @@ jobs:
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827141500_wa7a4_marketing_eligibility_v1.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a-knowledge-fabric/source_contract.sql
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260827185000_wa4a_knowledge_fabric_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260904225500_wa_l10_first_turn_hotpath_fix_v1.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql
 
       - name: Database lint
         working-directory: ci/zero-cost-staging
@@ -127,6 +140,20 @@ jobs:
           set -euo pipefail
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa4a-knowledge-fabric/tests/001_knowledge_fabric.sql | tee /tmp/wa4a-db.txt
           grep -q 'WA4A_KNOWLEDGE_FABRIC_PASS' /tmp/wa4a-db.txt
+
+      - name: Exact real first-turn production-scale strict 3s gate
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/wa-l10/tests/003_first_turn_candidate_prefilter_v2.sql 2>&1 | tee /tmp/wa-l10-first-turn-v2.txt
+          grep -q 'WA_L10_FIRST_TURN_V2_STRICT_3S_PASS' /tmp/wa-l10-first-turn-v2.txt
+
+      - name: Candidate prefilter rollback and reapply
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollbacks/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select position('eligible derived rows are normalized once' in coalesce(obj_description('public.aos_wa4a_knowledge_search_v1(text,integer,text[])'::regprocedure,'pg_proc'),''))>0")" = 't'
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select position('candidate prefilter' in lower(coalesce(obj_description('public.aos_wa4a_knowledge_search_v1(text,integer,text[])'::regprocedure,'pg_proc'),'')))>0")" = 't'
 
       - name: Existing WA-4 ownership budget safety regression
         run: |
@@ -160,7 +187,7 @@ jobs:
           set -euo pipefail
           test "$(psql "$DB_URL" -X -qAt -c 'select copilot_enabled from public.aos_wa_ai_control_v1 where id=1')" = "f"
           test "$(psql "$DB_URL" -X -qAt -c 'select auto_reply_enabled from public.aos_wa_ai_control_v1 where id=1')" = "f"
-          echo 'WA-4A TEST CERTIFICATION ONLY: Knowledge Fabric is PROD-ready but unapplied to production.'
+          echo 'WA-4A TEST CERTIFICATION ONLY: governed knowledge remains SAFE-OFF.'
           echo 'Governed source facts + evidence refs > approved derived knowledge > generic LLM knowledge.'
           echo 'Conflicting/stale/missing facts fail closed; no Copilot activation, AI send, auto-reply, auto-routing, campaigns or Ads Sync.'
 

--- a/ci/wa-l10/first_turn_candidate_prefilter_v2_contract.test.js
+++ b/ci/wa-l10/first_turn_candidate_prefilter_v2_contract.test.js
@@ -1,0 +1,23 @@
+'use strict';
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+const migration=fs.readFileSync('supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql','utf8');
+const rollback=fs.readFileSync('supabase/rollbacks/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.rollback.sql','utf8');
+
+assert.match(migration,/with\s+folded\s+as\s+materialized/i,'v2 must materialize the cheap folded eligible set');
+assert.match(migration,/candidates\s+as\s+materialized/i,'v2 must materialize the candidate subset');
+assert.match(migration,/prepared\s+as\s+materialized/i,'v2 must materialize canonical normalized candidates once');
+assert.match(migration,/lower\s*\(\s*translate\s*\(\s*coalesce\s*\(\s*k\.search_text\s*,\s*''\s*\)/i,'v2 must use cheap accent/case folding before regex normalization');
+assert.match(migration,/exists\s*\(\s*select\s+1\s+from\s+unnest\s*\(v_tokens\)\s+w\s+where\s+f\.fold_search\s+like/i,'candidate filtering must use bounded query tokens against folded text');
+assert.equal((migration.match(/aos_wa4a_norm_v1\(c\.search_text\)/g)||[]).length,1,'expensive canonical candidate search_text normalization must occur once');
+assert.equal((migration.match(/aos_wa4a_norm_v1\(k\.search_text\)/g)||[]).length,0,'v2 must not canonically regex-normalize every eligible source row');
+assert.match(migration,/p\.norm_search\s+like/i,'final ranking/filter must reuse canonical candidate normalization');
+assert.doesNotMatch(migration,/set\s+(?:local\s+)?statement_timeout\s*=/i,'v2 must never alter statement_timeout');
+assert.doesNotMatch(migration,/create\s+materialized\s+view/i,'v2 must not create a refresh-driven persistent materialized view');
+assert.doesNotMatch(migration,/aos_wa_l4_set_control_v1|aos_wa_l4_allowlist_set_v1|graph\.facebook\.com|\/messages/i,'v2 must not activate CANARY, mutate allowlist, or add a sender');
+assert.match(rollback,/with\s+prepared\s+as\s+materialized/i,'rollback must restore v1 prepared-set behavior');
+assert.match(rollback,/aos_wa4a_norm_v1\(k\.search_text\)\s+as\s+norm_search/i,'rollback must restore v1 per-eligible-row normalization');
+assert.doesNotMatch(rollback,/aos_wa_l4_set_control_v1|aos_wa_l4_allowlist_set_v1|graph\.facebook\.com|\/messages/i,'rollback must preserve authority boundary');
+
+console.log('WA-L10 first-turn candidate prefilter v2 contract: PASS');

--- a/ci/wa-l10/tests/003_first_turn_candidate_prefilter_v2.sql
+++ b/ci/wa-l10/tests/003_first_turn_candidate_prefilter_v2.sql
@@ -1,0 +1,84 @@
+\set ON_ERROR_STOP on
+
+-- Approximate current PROD text volume without PII/PHI: ~234 active services with ~12.7k-char
+-- derived commercial search_text and ~27 categories with ~8k-char search_text.
+insert into public.aos_catalogo_servicios(
+  nombre,nombre_corto,tipo,categoria,descripcion_comercial,beneficios,duracion_sesion,
+  num_sesiones,frecuencia,precio_base,precio_oferta,faqs,tags,estado,updated_at
+)
+select
+  'Synthetic Service '||g,
+  'Synthetic '||g,
+  'SERVICIO',
+  'Synthetic',
+  'Commercial fixture '||g,
+  'Approved synthetic benefit',
+  '30 min','1','Según evaluación',100,null,
+  jsonb_build_array(jsonb_build_object('q','FAQ '||g,'a',repeat('contenido comercial aprobado ',450))),
+  'synthetic service fixture '||g,
+  'ACTIVO',now()
+from generate_series(1,230) g;
+
+insert into public.aos_catalogo_categorias(
+  id,nombre,descripcion_comercial,beneficios,faqs,estado,updated_at
+)
+select
+  'synthetic-cat-'||g,
+  'Synthetic Category '||g,
+  'Synthetic category fixture '||g,
+  'Approved category benefit',
+  jsonb_build_array(jsonb_build_object('q','FAQ category '||g,'a',repeat('categoria comercial aprobada ',300))),
+  'ACTIVO',now()
+from generate_series(1,26) g;
+
+DO $$
+DECLARE
+  v_services integer;
+  v_categories integer;
+BEGIN
+  select count(*) into v_services from public.aos_catalogo_servicios where coalesce(estado,'ACTIVO')='ACTIVO';
+  select count(*) into v_categories from public.aos_catalogo_categorias where coalesce(estado,'ACTIVO')='ACTIVO';
+  if v_services < 234 then raise exception 'WA_L10_V2_SERVICE_SCALE_INCOMPLETE:%',v_services; end if;
+  if v_categories < 27 then raise exception 'WA_L10_V2_CATEGORY_SCALE_INCOMPLETE:%',v_categories; end if;
+END $$;
+
+set statement_timeout='3000ms';
+
+DO $$
+BEGIN
+  if not exists(
+    select 1
+    from public.aos_wa4a_knowledge_search_v1(
+      'Hola, quisiera información sobre Botox y cómo puedo agendar una evaluación.',
+      12,
+      null
+    )
+    where knowledge_id='service:10000000-0000-4000-8000-000000000001'
+      and score>0
+      and (evidence_ref->>'relation')='public.aos_catalogo_servicios'
+  ) then
+    raise exception 'WA_L10_EXACT_FIRST_TURN_RETRIEVAL_FAILED';
+  end if;
+END $$;
+
+DO $$
+BEGIN
+  if not exists(
+    select 1 from public.aos_wa4a_knowledge_search_v1('botox precio',12,array['CATALOG'])
+    where knowledge_id='service:10000000-0000-4000-8000-000000000001' and score>0
+  ) then raise exception 'WA_L10_V2_BOTOX_REGRESSION'; end if;
+
+  if not exists(
+    select 1 from public.aos_wa4a_knowledge_search_v1('miraflores',12,array['HOURS'])
+    where domain='HOURS'
+  ) then raise exception 'WA_L10_V2_HOURS_REGRESSION'; end if;
+
+  if exists(
+    select 1 from public.aos_wa4a_knowledge_search_v1('laser conflict',12,array['CATALOG'])
+    where subject_id in ('10000000-0000-4000-8000-000000000003','10000000-0000-4000-8000-000000000004')
+  ) then raise exception 'WA_L10_V2_CONFLICT_FAIL_CLOSED_REGRESSION'; end if;
+END $$;
+
+reset statement_timeout;
+
+select 'WA_L10_FIRST_TURN_V2_STRICT_3S_PASS' as result;

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,47 +1,51 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
 **Captured:** 2026-09-04 America/Lima  
-**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — FIRST REAL TURN FAIL-CLOSED REMEDIATION`  
+**ACTIVE HIGH/CRITICAL LOCK:** `WA-L10 #456 — FIRST REAL TURN FAIL-CLOSED REMEDIATION V2`  
 **GitHub authority:** Issue `#456` = `OPEN / ACTIVE`  
 **Parent roadmap:** Issue `#410`  
-**Exact entry main:** `525975bb819ace54fe0af334bec584c208b98784`  
-**Active branch:** `wa-l10-first-turn-db-hotpath-fix-20260904`  
+**Exact entry main:** `abb6444766cb45116f42c450c1174d339c2b86fc`  
+**Active branch:** `wa-l10-first-turn-candidate-prefilter-20260904`  
 **Deployed L10 layer:** `PR #464 · event-driven autonomous canary bridge`  
+**Deployed first remediation:** `PR #465 · first-turn DB hotpath v1`  
 **Current production safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
 **Active L4 allowlist:** `0`  
 **Prior L10 CANARY authorization:** `CONSUMED BY FIRST-TURN ATTEMPT; RE-ACTIVATION SUSPENDED PENDING FRESH EVIDENCE`  
 **Authorization ref:** `OWNER-CHAT-20260904-L10-ZIVITAL-CANARY`  
 **L11/general PROD:** `NOT AUTHORIZED`
 
-## First real turn result
+## First real turn and v1 remediation result
 
 The exact Zi Vital test conversation produced a valid Meta inbound and entered the deployed L10 bridge. The provider message was durably queued and claimed exactly once. WA4 Copilot then failed before L4 autonomous authorization/provider dispatch. The bridge correctly requested human handoff and recorded `HANDOFF · WA4_COPILOT_UNAVAILABLE`; no AUTO decision or outbound autonomous message was created.
 
-The corresponding `aos_wa_ai_runs_v1` row records `SALES_COPILOT · ERROR · FAIL_CLOSED · WA4_DB_UNAVAILABLE` with ~10.6 s latency. PostgreSQL logs at the same first-turn timestamp contain two `statement timeout` cancellations. A bounded read-only reproduction under a stricter 3 s limit identified the hot path in `aos_wa4a_knowledge_search_v1`, where the same derived `search_text` is repeatedly normalized inside phrase and per-token predicates. A second audit defect was exposed: WA4 intentionally logs a `SALES_PLAYBOOK` fail-closed event, but the current `aos_wa_ai_runs_v1_task_check` only accepts `SALES_COPILOT|MODEL_EVAL`.
+PR #465 fixed the first discovered defects without timeout inflation: it normalized each eligible derived row once via a per-query MATERIALIZED prepared set and aligned the append-only audit CHECK with the existing `SALES_PLAYBOOK` fail-closed logger. It merged and deployed on exact main `abb6444766cb45116f42c450c1174d339c2b86fc`.
 
-Per the predeclared canary rollback rule, production was immediately returned to `AUTO_OFF`, kill switch engaged, autonomous reply/send disabled, and the exact conversation allowlist disabled. The conversation remains `HUMAN_REQUESTED`. An authenticated `/api/wa3/provider-health` call subsequently returned HTTP 502, so provider readiness must also return to explicit READY before any retry.
+Fresh production certification then used the exact real first-turn phrase under the binding `statement_timeout=3000ms` boundary. That exact proof still returned SQLSTATE `57014` (`canceling statement due to statement timeout`). Therefore v1 is insufficient and the CANARY retry remains blocked. Production source profiling explains the residual cost: about 234 active service rows average ~12.7k characters of derived commercial search text, with additional category rows averaging ~8k characters. Canonical regexp normalization of the entire eligible multi-megabyte corpus once per request remains too expensive under foreground load.
 
-## Authorized mutable remediation scope
+The same observation window also contained transient foreground Call Center/Historial/Panel timeouts near the 3 s boundary. Those are treated as systemic pressure signals, not as evidence that L10 may bypass its own strict first-turn gate.
 
-1. Preserve the deployed event-driven L10 bridge and its fail-closed human boundary; do not add a second sender or authority.
-2. Replace repeated WA4A derived-row normalization with a bounded per-query materialized prepared set so each eligible title/search text is normalized once while preserving ranking/authority semantics.
-3. Align `aos_wa_ai_runs_v1_task_check` with the existing `SALES_PLAYBOOK` fail-closed logger so the audit path cannot fail while reporting a primary error.
-4. Add regression gates proving no timeout inflation, no global materialized-view refresh path, no CANARY activation side effect, and preservation of the L4/L8 authority boundary.
-5. Certify exact head, merge, deploy, apply merged-lineage migration, then run a strict bounded production read-only knowledge-search proof.
-6. Re-run authenticated Meta provider-health and require HTTP 200 / `diagnosis=READY`.
-7. Present the complete repaired evidence before any fresh `AUTO_OFF → CANARY` retry. Do not silently reuse the failed activation.
+## Authorized mutable remediation v2 scope
+
+1. Preserve the deployed event-driven L10 bridge, L4 authority and L8 mandatory preflight; no second sender or authority.
+2. Add a **cheap per-query candidate prefilter** using case/accent folding without regexp normalization.
+3. Perform the existing canonical `aos_wa4a_norm_v1(search_text)` and the original ranking semantics only on the candidate subset.
+4. Keep the solution request-scoped: no persistent/global materialized view, no refresh trigger, no polling and no retry loop.
+5. Add a production-scale synthetic regression approximating the current service/category text volume and require the exact real first-turn phrase to pass under 3 s.
+6. Re-run the original WA4A retrieval/provenance/conflict/ACL suite plus L4-L10 authority/safety regressions.
+7. Certify exact head, merge, deploy, apply merged-lineage migration, then repeat the exact strict 3 s proof in PROD.
+8. Require a fresh authenticated Meta provider-health `200 / READY` after DB remediation before any new `AUTO_OFF → CANARY` transition.
 
 ## Binding invariants
 
 - Production remains `AUTO_OFF`, kill switch engaged, `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true` throughout remediation/certification.
-- Active L4 allowlist remains zero until a separately reviewed retry gate.
+- Active L4 allowlist remains zero until the retry gate is explicitly re-armed after all evidence is green.
 - No live autonomous provider dispatch during remediation.
-- No statement-timeout inflation or bypass of the 3 s bounded first-turn proof.
+- No statement-timeout inflation or bypass of the 3 s exact first-turn proof.
 - L4 remains the sole `AUTO_OFF|CANARY|PROD` authority; L8 remains mandatory preflight.
 - Human handoff always overrides autonomy.
-- No browser-held provider/internal secrets, no raw webhook/message-body/recipient storage in remediation evidence.
-- No second sender, browser polling, autonomous retry loop, or refresh-driven global materialized analytical hot path.
+- No browser-held provider/internal secrets and no raw webhook/message-body/recipient storage in remediation evidence.
+- No second sender, browser polling, autonomous retry loop or refresh-driven global materialized analytical hot path.
 
 ## Exit boundary
 
-This remediation can close only after exact-head CI, merged Railway/Supabase parity, strict bounded WA4A first-turn search PASS, authenticated provider-health READY, and a fresh safe readback showing `AUTO_OFF + kill=true + allowlist=0 + AUTO outbound=0`. A new real CANARY retry remains a separate go/no-go after that evidence. L11/general production stays blocked.
+This remediation can close only after exact-head CI, merged Railway/Supabase parity, strict production-scale + exact-PROD first-turn search PASS, authenticated provider-health READY, and a fresh safe readback showing `AUTO_OFF + kill=true + allowlist=0 + AUTO outbound=0`. Only then may the tiny exact-conversation L10 CANARY be re-armed for one fresh real turn. L11/general production stays blocked.

--- a/supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql
+++ b/supabase/migrations/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.sql
@@ -1,0 +1,107 @@
+-- WA-L10 first-turn remediation v2 — cheap candidate prefilter before exact normalization.
+-- PROD evidence after v1 showed the exact real first-turn phrase can still exceed the 3 s boundary
+-- because v1 normalizes every eligible multi-kilobyte knowledge search_text once per request.
+-- v2 preserves the final v1 ranking/authority calculation, but first folds the source text with a
+-- cheap accent/case transform, narrows to plausible candidates, and performs the expensive canonical
+-- regexp normalization only on that candidate set.
+-- No statement_timeout change, sender/authority mutation, allowlist mutation, polling, or CANARY activation.
+
+begin;
+
+create or replace function public.aos_wa4a_knowledge_search_v1(
+  p_query text,
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text,
+  domain text,
+  subject_type text,
+  subject_id text,
+  title text,
+  facts jsonb,
+  authority_tier smallint,
+  source_relation text,
+  source_pk text,
+  source_updated_at timestamptz,
+  freshness_state text,
+  conflict_state text,
+  retrieval_state text,
+  evidence_ref jsonb,
+  score integer
+)
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_q text := public.aos_wa4a_norm_v1(p_query);
+  v_limit integer := greatest(1,least(coalesce(p_limit,12),24));
+  v_tokens text[];
+begin
+  if length(v_q)<2 then return; end if;
+
+  select coalesce(array_agg(distinct w),array[]::text[])
+    into v_tokens
+  from unnest(string_to_array(v_q,' ')) w
+  where length(w)>=3;
+
+  return query
+  with folded as materialized (
+    select
+      k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.search_text,k.facts,k.authority_tier,
+      k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,
+      k.retrieval_state,k.evidence_ref,
+      public.aos_wa4a_norm_v1(k.title) as norm_title,
+      lower(translate(coalesce(k.search_text,''),'ÁÉÍÓÚÜÑáéíóúüñ','AEIOUUNaeiouun')) as fold_search
+    from public.aos_wa4a_knowledge_items_v1 k
+    where k.retrieval_state in ('READY','READY_WITH_WARNING')
+      and k.conflict_state='CLEAR'
+      and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
+  ), candidates as materialized (
+    select f.*
+    from folded f
+    where f.norm_title like '%'||v_q||'%'
+       or f.fold_search like '%'||v_q||'%'
+       or exists(select 1 from unnest(v_tokens) w where f.fold_search like '%'||w||'%')
+  ), prepared as materialized (
+    select
+      c.knowledge_id,c.domain,c.subject_type,c.subject_id,c.title,c.facts,c.authority_tier,
+      c.source_relation,c.source_pk,c.source_updated_at,c.freshness_state,c.conflict_state,
+      c.retrieval_state,c.evidence_ref,c.norm_title,
+      public.aos_wa4a_norm_v1(c.search_text) as norm_search
+    from candidates c
+  ), ranked as (
+    select
+      p.*,
+      (
+        case when p.norm_title=v_q then 100 else 0 end
+        + case when p.norm_title like '%'||v_q||'%' then 45 else 0 end
+        + case when p.norm_search like '%'||v_q||'%' then 25 else 0 end
+        + coalesce((select count(*)::integer*6 from unnest(v_tokens) w where p.norm_search like '%'||w||'%'),0)
+        + case when p.authority_tier=10 then 5 else 0 end
+      )::integer as rank_score
+    from prepared p
+    where p.norm_title like '%'||v_q||'%'
+       or p.norm_search like '%'||v_q||'%'
+       or exists(select 1 from unnest(v_tokens) w where p.norm_search like '%'||w||'%')
+  )
+  select
+    r.knowledge_id,r.domain,r.subject_type,r.subject_id,r.title,r.facts,r.authority_tier,
+    r.source_relation,r.source_pk,r.source_updated_at,r.freshness_state,r.conflict_state,
+    r.retrieval_state,r.evidence_ref,r.rank_score
+  from ranked r
+  order by r.rank_score desc,r.authority_tier asc,r.title asc
+  limit v_limit;
+end
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) to service_role;
+
+comment on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) is
+'WA4A governed search hot-path v2: cheap accent/case folded candidate prefilter first; canonical regex normalization and original ranking are applied only to candidates. No timeout inflation.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;

--- a/supabase/rollbacks/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.rollback.sql
+++ b/supabase/rollbacks/20260905001000_wa_l10_first_turn_candidate_prefilter_v2.rollback.sql
@@ -1,0 +1,90 @@
+-- Rollback for WA-L10 first-turn candidate prefilter v2.
+-- Restores the deployed v1 behavior: canonical search_text normalization once per eligible row.
+-- Audit vocabulary is intentionally left unchanged because v2 does not modify it.
+
+begin;
+
+create or replace function public.aos_wa4a_knowledge_search_v1(
+  p_query text,
+  p_limit integer default 12,
+  p_domains text[] default null
+)
+returns table(
+  knowledge_id text,
+  domain text,
+  subject_type text,
+  subject_id text,
+  title text,
+  facts jsonb,
+  authority_tier smallint,
+  source_relation text,
+  source_pk text,
+  source_updated_at timestamptz,
+  freshness_state text,
+  conflict_state text,
+  retrieval_state text,
+  evidence_ref jsonb,
+  score integer
+)
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_q text := public.aos_wa4a_norm_v1(p_query);
+  v_limit integer := greatest(1,least(coalesce(p_limit,12),24));
+  v_tokens text[];
+begin
+  if length(v_q)<2 then return; end if;
+
+  select coalesce(array_agg(distinct w),array[]::text[])
+    into v_tokens
+  from unnest(string_to_array(v_q,' ')) w
+  where length(w)>=3;
+
+  return query
+  with prepared as materialized (
+    select
+      k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.facts,k.authority_tier,
+      k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,
+      k.retrieval_state,k.evidence_ref,
+      public.aos_wa4a_norm_v1(k.title) as norm_title,
+      public.aos_wa4a_norm_v1(k.search_text) as norm_search
+    from public.aos_wa4a_knowledge_items_v1 k
+    where k.retrieval_state in ('READY','READY_WITH_WARNING')
+      and k.conflict_state='CLEAR'
+      and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
+  ), ranked as (
+    select
+      p.*,
+      (
+        case when p.norm_title=v_q then 100 else 0 end
+        + case when p.norm_title like '%'||v_q||'%' then 45 else 0 end
+        + case when p.norm_search like '%'||v_q||'%' then 25 else 0 end
+        + coalesce((select count(*)::integer*6 from unnest(v_tokens) w where p.norm_search like '%'||w||'%'),0)
+        + case when p.authority_tier=10 then 5 else 0 end
+      )::integer as rank_score
+    from prepared p
+    where p.norm_title like '%'||v_q||'%'
+       or p.norm_search like '%'||v_q||'%'
+       or exists(select 1 from unnest(v_tokens) w where p.norm_search like '%'||w||'%')
+  )
+  select
+    r.knowledge_id,r.domain,r.subject_type,r.subject_id,r.title,r.facts,r.authority_tier,
+    r.source_relation,r.source_pk,r.source_updated_at,r.freshness_state,r.conflict_state,
+    r.retrieval_state,r.evidence_ref,r.rank_score
+  from ranked r
+  order by r.rank_score desc,r.authority_tier asc,r.title asc
+  limit v_limit;
+end
+$$;
+
+revoke all on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) from public,anon,authenticated;
+grant execute on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) to service_role;
+
+comment on function public.aos_wa4a_knowledge_search_v1(text,integer,text[]) is
+'WA4A governed search hot-path v1: authority/ranking semantics preserved; eligible derived rows are normalized once via MATERIALIZED prepared set to prevent repeated regex normalization per token.';
+
+select pg_catalog.pg_notify('pgrst','reload schema');
+commit;


### PR DESCRIPTION
## Scope
Second-stage fail-closed remediation for WA-L10 first real turn. PR #465 reduced repeated normalization but the exact original user phrase still reproduces SQLSTATE 57014 in PROD under the binding 3 s statement timeout.

## Root cause v2
The governed knowledge view currently exposes ~234 active service rows averaging ~12.7k chars of derived commercial search text, plus category content. Even one canonical regexp normalization per eligible row/request is still too costly under foreground pressure.

## Change
- Cheap accent/case folded candidate prefilter first.
- Canonical `aos_wa4a_norm_v1(search_text)` only on candidate rows.
- Preserve the exact v1 final ranking, authority, freshness/conflict and ACL semantics.
- Production-scale synthetic fixture approximating current source text volume.
- Exact original first-turn phrase must complete under `statement_timeout=3000ms`.
- Re-run original WA4A retrieval/provenance/conflict/ACL suite.
- Re-run WA-L10 SAFE-OFF, L5-L9 current authority and bridge regressions.

## Explicit non-changes
No timeout inflation. No persistent/global materialized view. No sender. No L4 control transition. No allowlist mutation. No polling/retry loop. No CANARY activation.

## Entry lock
Exact base main: `abb6444766cb45116f42c450c1174d339c2b86fc`.

PROD remains SAFE-OFF: `AUTO_OFF`, kill=true, auto_reply=false, ai_send=false, auto_routing=false, human_send=true, allowlist=0, autonomous outbound=0. L11/general PROD remains NOT AUTHORIZED.