### PR TITLE
P0 #467 v2: hard-shield VAPID bootstrap and F5 recovery scan

### DIFF
--- a/app/business-priority-preload.js
+++ b/app/business-priority-preload.js
@@ -54,6 +54,9 @@ if (!https.__AOS_BUSINESS_PRIORITY_PRELOAD_V1__) {
     const p = t.path
     if (p.indexOf('/rest/v1/aos_agentes?') === 0 && p.indexOf('tipo_ejecucion=eq.cron') >= 0) return 'agent-cron-scan'
     if (p.indexOf('/rest/v1/rpc/aos_notification_push_claim_v1') === 0) return 'notification-push-claim'
+    if (p.indexOf('/rest/v1/rpc/aos_push_vapid_config_v1') === 0) return 'notification-vapid-config'
+    if (p.indexOf('/rest/v1/rpc/aos_push_vapid_store_v1') === 0) return 'notification-vapid-store'
+    if (p.indexOf('/rest/v1/aos_f5_private_file_transport_tmp?') === 0 && p.indexOf('status=in.(READY,PROCESSING)') >= 0) return 'f5-recovery-scan'
     if (p.indexOf('/rest/v1/aos_email_plantillas?') === 0 && p.indexOf('activo=eq.true') >= 0) return 'email-template-cache'
     if (p.indexOf('/rest/v1/aos_usuarios?') === 0 && p.indexOf('select=nombre,apellidos,cmp') >= 0 && p.indexOf('cmp=neq.') >= 0) return 'medical-cmp-cache'
     if (p.indexOf('/rest/v1/rpc/aos_generar_snapshot') === 0) return 'global-snapshot'
@@ -180,7 +183,7 @@ if (!https.__AOS_BUSINESS_PRIORITY_PRELOAD_V1__) {
   }
 
   global.__AOS_BUSINESS_PRIORITY_V1__ = {
-    version: 'p0-a-v1.4',
+    version: 'p0-a-v1.5',
     states: states,
     shieldKey: SHIELD_KEY,
     classify: classify,

--- a/ci/performance/foreground-priority-incident-mode.test.js
+++ b/ci/performance/foreground-priority-incident-mode.test.js
@@ -38,6 +38,9 @@ test('foreground-priority mode suppresses only classified background traffic bef
   const background=[
     {hostname:host,path:'/rest/v1/aos_agentes?activo=eq.true&tipo_ejecucion=eq.cron'},
     {hostname:host,path:'/rest/v1/rpc/aos_notification_push_claim_v1'},
+    {hostname:host,path:'/rest/v1/rpc/aos_push_vapid_config_v1'},
+    {hostname:host,path:'/rest/v1/rpc/aos_push_vapid_store_v1'},
+    {hostname:host,path:'/rest/v1/aos_f5_private_file_transport_tmp?status=in.(READY,PROCESSING)&select=source_filename,source_sha256,content_base64&order=source_filename.asc'},
     {hostname:host,path:'/rest/v1/aos_email_plantillas?select=tipo,html_body&activo=eq.true'},
     {hostname:host,path:'/rest/v1/aos_usuarios?select=nombre,apellidos,cmp&area=eq.médica&cmp=neq.'},
     {hostname:host,path:'/rest/v1/rpc/aos_generar_snapshot'},


### PR DESCRIPTION
Follow-up to #468 after production readback showed foregroundPriorityMode=true but S14/S15 still reached Supabase through VAPID bootstrap and F5 recovery still incurred a 30s DB timeout. This narrows incident mode further: it locally suppresses only VAPID config/store initialization and the temporary F5 recovery READY/PROCESSING scan, in addition to the already-classified background paths. Auth V3, Call Center, Agenda, Sales, governed WhatsApp and AI bootstrap remain on the normal transport. No DB/schema changes, no auth/2FA relaxation, no timeout increase. Focused node --check + incident-mode regression: 2/2 PASS before push. Production remains WA SAFE-OFF.