### PR TITLE
WA-L10 R2: bound Groq knowledge context after real-turn rejection

### DIFF
--- a/app/wa4-knowledge.js
+++ b/app/wa4-knowledge.js
@@ -10,6 +10,7 @@ const SEP26_CURRENT_SKU = 'CATALOG_SEP2026_CURRENT_SKU';
 const CATALOG_IDENTITY_ALLOWLIST = Object.freeze(new Set([
   'family_name','commercial_variant','clinical_sessions','brand','zones','unit_cap','syringes','volume_ml'
 ]));
+const FAQ_BOUNDS = Object.freeze({ maxItems: 6, questionChars: 220, answerChars: 650 });
 
 const FIELD_ALLOWLIST = Object.freeze({
   CATALOG: new Set(['tipo','nombre','nombre_corto','categoria','precio_base','precio_oferta','moneda','duracion_sesion','num_sesiones','frecuencia','descripcion_comercial','beneficios','faqs','requiere_doctora','requiere_enfermeria','included_benefit','included_benefit_source','catalog_identity','catalog_identity_source']),
@@ -29,6 +30,28 @@ function normalizeAudience(value) {
   return AUDIENCES.has(audience) ? audience : 'PUBLIC_CLIENT';
 }
 
+function boundedText(value,maxChars) {
+  const text = String(value == null ? '' : value).trim();
+  return text ? text.slice(0,maxChars) : '';
+}
+
+function sanitizeFaqs(value) {
+  if (!Array.isArray(value)) return [];
+  const out = [];
+  for (const item of value) {
+    if (out.length >= FAQ_BOUNDS.maxItems) break;
+    if (item && typeof item === 'object' && !Array.isArray(item)) {
+      const q = boundedText(item.q,FAQ_BOUNDS.questionChars);
+      const a = boundedText(item.a,FAQ_BOUNDS.answerChars);
+      if (q || a) out.push({q,a});
+      continue;
+    }
+    const text = boundedText(item,FAQ_BOUNDS.answerChars);
+    if (text) out.push({q:'',a:text});
+  }
+  return out;
+}
+
 function sanitizeCatalogIdentity(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const out = {};
@@ -46,28 +69,34 @@ function sanitizeCatalogIdentity(value) {
 }
 
 function sanitizeFacts(domain, facts) {
-  const allowed = FIELD_ALLOWLIST[String(domain || '').toUpperCase()];
+  const normalizedDomain = String(domain || '').toUpperCase();
+  const allowed = FIELD_ALLOWLIST[normalizedDomain];
   if (!allowed || !facts || typeof facts !== 'object' || Array.isArray(facts)) return {};
   const out = {};
   for (const key of allowed) {
     if (!Object.prototype.hasOwnProperty.call(facts,key)) continue;
-    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'included_benefit') {
+    if (key === 'faqs') {
+      const faqs = sanitizeFaqs(facts[key]);
+      if (faqs.length) out[key] = faqs;
+      continue;
+    }
+    if (normalizedDomain === 'CATALOG' && key === 'included_benefit') {
       if (facts.included_benefit_source !== SEP26_CURRENT_SKU) continue;
       const text = String(facts[key] == null ? '' : facts[key]).trim();
       if (text) out[key] = text.slice(0,500);
       continue;
     }
-    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'included_benefit_source') {
+    if (normalizedDomain === 'CATALOG' && key === 'included_benefit_source') {
       if (facts[key] === SEP26_CURRENT_SKU) out[key] = SEP26_CURRENT_SKU;
       continue;
     }
-    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'catalog_identity') {
+    if (normalizedDomain === 'CATALOG' && key === 'catalog_identity') {
       if (facts.catalog_identity_source !== SEP26_CURRENT_SKU) continue;
       const identity = sanitizeCatalogIdentity(facts[key]);
       if (identity) out[key] = identity;
       continue;
     }
-    if (String(domain || '').toUpperCase() === 'CATALOG' && key === 'catalog_identity_source') {
+    if (normalizedDomain === 'CATALOG' && key === 'catalog_identity_source') {
       if (facts[key] === SEP26_CURRENT_SKU) out[key] = SEP26_CURRENT_SKU;
       continue;
     }
@@ -197,4 +226,4 @@ function validateGroundedSuggestion(obj, bundle) {
   return {ok:true,reply,citations,nextAction};
 }
 
-module.exports = {AUDIENCES,SEP26_CURRENT_SKU,CATALOG_IDENTITY_ALLOWLIST,FIELD_ALLOWLIST,normalize,normalizeAudience,sanitizeCatalogIdentity,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};
+module.exports = {AUDIENCES,SEP26_CURRENT_SKU,CATALOG_IDENTITY_ALLOWLIST,FAQ_BOUNDS,FIELD_ALLOWLIST,normalize,normalizeAudience,boundedText,sanitizeFaqs,sanitizeCatalogIdentity,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};

--- a/ci/wa4-ai-sales-router/ai-router.test.js
+++ b/ci/wa4-ai-sales-router/ai-router.test.js
@@ -85,3 +85,6 @@ test('cost estimator uses current Groq prices', () => {
   assert.equal(ai.estimateCost('openai/gpt-oss-20b', { prompt_tokens: 1000000, completion_tokens: 1000000 }), 0.375);
   assert.equal(ai.estimateCost('openai/gpt-oss-120b', { prompt_tokens: 1000000, completion_tokens: 1000000 }), 0.75);
 });
+
+// Keep the production-scale knowledge-payload regression in the canonical WA4 test entrypoint.
+require('./knowledge-bounds.test.js');

--- a/ci/wa4-ai-sales-router/knowledge-bounds.test.js
+++ b/ci/wa4-ai-sales-router/knowledge-bounds.test.js
@@ -1,0 +1,72 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const knowledge=require('../../app/wa4-knowledge');
+
+function faq(i){
+  return {q:('Pregunta '+i+' '+ 'q'.repeat(260)),a:('Respuesta '+i+' '+ 'a'.repeat(900))};
+}
+function row(i){
+  return {
+    knowledge_id:'catalog-'+String(i).padStart(2,'0'),
+    domain:'CATALOG',
+    subject_type:'service',
+    subject_id:String(i),
+    title:'Toxina '+i,
+    facts:{
+      tipo:'SERVICIO',nombre:'Toxina '+i,nombre_corto:'Toxina '+i,categoria:'Toxina',
+      precio_base:500+i,precio_oferta:450+i,moneda:'PEN',
+      descripcion_comercial:'Descripción gobernada '+i,
+      beneficios:['Beneficio A','Beneficio B'],
+      faqs:Array.from({length:80},(_,n)=>faq(n)),
+      requiere_doctora:true,
+      catalog_identity:{family_name:'Toxina',commercial_variant:'Variante '+i,unit_cap:50},
+      catalog_identity_source:knowledge.SEP26_CURRENT_SKU
+    },
+    authority_tier:1,
+    freshness_state:'CURRENT',
+    conflict_state:'CLEAR',
+    retrieval_state:'READY',
+    evidence_ref:{relation:'aos_catalogo',pk:String(i),version:'v1'}
+  };
+}
+
+test('production-scale catalog FAQ payload stays bounded without weakening authority',()=>{
+  const rows=Array.from({length:12},(_,i)=>row(i+1));
+  const bundle=knowledge.buildKnowledgeBundle(rows,12,'PUBLIC_CLIENT');
+  assert.equal(bundle.items.length,12);
+  assert.equal(bundle.authority,'GOVERNED_SOURCE_ONLY');
+  assert.equal(bundle.generic_llm_authority,false);
+
+  for(const item of bundle.items){
+    assert.equal(item.domain,'CATALOG');
+    assert.equal(item.authority_tier,1);
+    assert.ok(Array.isArray(item.facts.faqs));
+    assert.ok(item.facts.faqs.length<=knowledge.FAQ_BOUNDS.maxItems);
+    for(const f of item.facts.faqs){
+      assert.ok(f.q.length<=knowledge.FAQ_BOUNDS.questionChars);
+      assert.ok(f.a.length<=knowledge.FAQ_BOUNDS.answerChars);
+    }
+    assert.ok(Number.isFinite(Number(item.facts.precio_base)));
+    assert.ok(Number.isFinite(Number(item.facts.precio_oferta)));
+    assert.equal(item.facts.moneda,'PEN');
+    assert.match(item.facts.descripcion_comercial,/Descripción gobernada/);
+  }
+
+  const chars=JSON.stringify(bundle).length;
+  assert.ok(chars<100000,`bounded bundle too large: ${chars}`);
+
+  const cited=bundle.items[0];
+  const valid=knowledge.validateGroundedSuggestion({
+    reply:`El precio aprobado es S/ ${cited.facts.precio_oferta}.`,
+    next_action:'REPLY',
+    cited_knowledge_ids:[cited.knowledge_id]
+  },bundle);
+  assert.equal(valid.ok,true);
+});
+
+test('non-array FAQ values fail closed to no FAQ prompt payload',()=>{
+  const facts=knowledge.sanitizeFacts('CATALOG',{nombre:'X',faqs:'unbounded text'});
+  assert.equal(facts.nombre,'X');
+  assert.equal(Object.hasOwn(facts,'faqs'),false);
+});


### PR DESCRIPTION
## Incident reproduced
Real L10 R2 inbound at 2026-09-05T17:21:47Z queued correctly, then WA4 failed closed with `SALES_COPILOT / GROQ_REJECTED` and L10 emitted `HANDOFF / WA4_COPILOT_UNAVAILABLE`. No L4 AUTO decision and no autonomous outbound request were created. PROD has already been returned to `AUTO_OFF + kill=true`; exact allowlist disabled.

## Root cause evidence
The exact production query for `HOLA QUIERO MAS INFORMACION sobre toxina` returns 12 CATALOG rows whose currently allowed `faqs` payload totals ~519,082 characters; current WA4 passes the full arrays into `GOVERNED_KNOWLEDGE`. Each SKU contains 50–80 `{q,a}` FAQ objects. This creates a >0.5 MB public knowledge prompt before runtime/playbook/history and is incompatible with a bounded model context.

## Fix
- Bound CATALOG/CATEGORY FAQ prompt material to max 6 items per knowledge row.
- Bound each FAQ question to 220 chars and answer to 650 chars.
- Preserve governed item identity, evidence, authority tier, price fields, benefits, ranking and existing safety/price validation.
- Add production-scale regression: 12 CATALOG rows × 80 long FAQs must serialize to <100k chars while preserving grounded price/citation validation.
- Wire the regression into the canonical WA4 test entrypoint.

No DB/schema change, no timeout inflation, no Meta sender change, no L4/L8 authority change, and no CANARY activation in this PR. Issue #456.