### PR TITLE
WA-L10 FASTPATH R1: fast model routing and compact safety context

### DIFF
--- a/app/ai-router.js
+++ b/app/ai-router.js
@@ -15,6 +15,9 @@ const COSTS = Object.freeze({
   'qwen/qwen3.6-27b': { input: 0.60, output: 3.00 }
 });
 
+const SAFETY_MAX_COMPLETION_TOKENS = 180;
+const SAFETY_MAX_KNOWLEDGE_ITEMS = 8;
+
 function requestJson(opts, payload, timeoutMs) {
   return new Promise((resolve, reject) => {
     const data = payload == null ? '' : JSON.stringify(payload);
@@ -44,6 +47,91 @@ function requestJson(opts, payload, timeoutMs) {
   });
 }
 
+function boundedText(value, max) {
+  const text = String(value == null ? '' : value).trim();
+  return text ? text.slice(0, max) : '';
+}
+
+function compactList(value, maxItems, maxChars) {
+  return Array.isArray(value) ? value.slice(0, maxItems).map(x => boundedText(x, maxChars)).filter(Boolean) : [];
+}
+
+function compactSafetyFacts(domain, facts) {
+  const f = facts && typeof facts === 'object' && !Array.isArray(facts) ? facts : {};
+  const d = String(domain || '').toUpperCase();
+  const out = {};
+  const copyText = (key, max = 320) => { const v = boundedText(f[key], max); if (v) out[key] = v; };
+  const copyNumber = key => { const n = Number(f[key]); if (Number.isFinite(n)) out[key] = n; };
+  const copyBool = key => { if (typeof f[key] === 'boolean') out[key] = f[key]; };
+
+  if (d === 'CATALOG') {
+    ['tipo','nombre','nombre_corto','categoria','moneda','duracion_sesion','frecuencia'].forEach(k => copyText(k, 180));
+    ['precio_base','precio_oferta','num_sesiones'].forEach(copyNumber);
+    copyText('descripcion_comercial', 360);
+    const beneficios = compactList(f.beneficios, 5, 180); if (beneficios.length) out.beneficios = beneficios;
+    copyBool('requiere_doctora'); copyBool('requiere_enfermeria');
+    copyText('included_benefit', 240);
+    if (f.catalog_identity && typeof f.catalog_identity === 'object' && !Array.isArray(f.catalog_identity)) {
+      const identity = {};
+      for (const key of ['family_name','commercial_variant','brand','zones','unit_cap','syringes','volume_ml']) {
+        const value = f.catalog_identity[key];
+        if (typeof value === 'number' && Number.isFinite(value)) identity[key] = value;
+        else { const text = boundedText(value, 120); if (text) identity[key] = text; }
+      }
+      if (Object.keys(identity).length) out.catalog_identity = identity;
+    }
+  } else if (d === 'PROMOTION') {
+    ['nombre','descripcion','tipo_descuento','codigo','vigencia_inicio','vigencia_fin'].forEach(k => copyText(k, k === 'descripcion' ? 360 : 180));
+    copyNumber('valor_descuento');
+    const tratamientos = compactList(f.tratamientos, 8, 160); if (tratamientos.length) out.tratamientos = tratamientos;
+    const segmentos = compactList(f.segmentos, 8, 120); if (segmentos.length) out.segmentos = segmentos;
+  } else if (d === 'BRANCH') {
+    ['nombre','direccion','telefono','maps_link'].forEach(k => copyText(k, k === 'direccion' || k === 'maps_link' ? 300 : 160));
+  } else if (d === 'HOURS') {
+    ['sede','dia_semana','hora_apertura','hora_cierre'].forEach(k => copyText(k, 80)); copyBool('activo');
+  } else if (d === 'CATEGORY') {
+    ['nombre','descripcion_comercial'].forEach(k => copyText(k, k === 'descripcion_comercial' ? 360 : 180));
+    const beneficios = compactList(f.beneficios, 5, 180); if (beneficios.length) out.beneficios = beneficios;
+  } else if (d === 'CLINIC_KNOWLEDGE') {
+    ['code','node_type','parent_code','title','risk_level','audience'].forEach(k => copyText(k, 160));
+    copyText('answer', 650);
+  }
+  return out;
+}
+
+function compactSafetyKnowledge(bundle) {
+  const b = bundle && typeof bundle === 'object' ? bundle : {};
+  const items = Array.isArray(b.items) ? b.items : [];
+  return {
+    version: boundedText(b.version, 80) || 'WA4A1-KNOWLEDGE-V2',
+    audience: boundedText(b.audience, 80) || 'PUBLIC_CLIENT',
+    authority: boundedText(b.authority, 80) || 'GOVERNED_SOURCE_ONLY',
+    generic_llm_authority: false,
+    price_authority: boundedText(b.price_authority, 80) || null,
+    price_stage: b.price_stage === true,
+    items: items.slice(0, SAFETY_MAX_KNOWLEDGE_ITEMS).map(item => ({
+      knowledge_id: boundedText(item && item.knowledge_id, 160),
+      domain: boundedText(item && item.domain, 80),
+      title: boundedText(item && item.title, 180),
+      authority_tier: Number(item && item.authority_tier || 99),
+      freshness_state: boundedText(item && item.freshness_state, 80),
+      facts: compactSafetyFacts(item && item.domain, item && item.facts)
+    })).filter(item => item.knowledge_id)
+  };
+}
+
+function compactSafetyMessages(messages) {
+  const source = Array.isArray(messages) ? messages : [];
+  return source.map(m => {
+    if (!m || m.role !== 'user' || typeof m.content !== 'string') return m;
+    let obj;
+    try { obj = JSON.parse(m.content); } catch (_) { return m; }
+    if (!obj || typeof obj !== 'object' || !obj.approved_public_knowledge) return m;
+    const copy = Object.assign({}, obj, { approved_public_knowledge: compactSafetyKnowledge(obj.approved_public_knowledge) });
+    return Object.assign({}, m, { content: JSON.stringify(copy) });
+  });
+}
+
 async function listModels(apiKey) {
   if (!apiKey) throw Object.assign(new Error('GROQ_KEY_REQUIRED'), { status: 503 });
   const out = await requestJson({
@@ -67,10 +155,13 @@ async function listModels(apiKey) {
 async function chat(apiKey, model, messages, options) {
   if (!apiKey) throw Object.assign(new Error('GROQ_KEY_REQUIRED'), { status: 503 });
   options = options || {};
+  const isSafety = model === MODELS.safety;
+  const requestedTokens = Number(options.maxTokens || (isSafety ? SAFETY_MAX_COMPLETION_TOKENS : 700));
+  const maxTokens = isSafety ? Math.min(requestedTokens, SAFETY_MAX_COMPLETION_TOKENS) : Math.min(requestedTokens, 3000);
   const body = {
     model,
-    messages,
-    max_completion_tokens: Math.max(64, Math.min(Number(options.maxTokens || 700), 3000)),
+    messages: isSafety ? compactSafetyMessages(messages) : messages,
+    max_completion_tokens: Math.max(64, maxTokens),
     response_format: { type: 'json_object' }
   };
   if (model === MODELS.fast || model === MODELS.reasoning || model === MODELS.safety) {
@@ -119,9 +210,9 @@ function normalize(value) {
 
 function chooseModel(lastInbound, context) {
   const text = normalize(lastInbound);
-  const complex = String(lastInbound || '').length > 550 ||
-    /(compar|diferencia|mejor opcion|cuantas sesiones|plan|paquete|presupuesto|objec|resultado|duracion|combinar|alternativa|recomiend)/.test(text) ||
-    (context && Number(context.catalogMatches || 0) > 2);
+  const complex = Boolean(context && context.forceReasoning === true) ||
+    String(lastInbound || '').length > 700 ||
+    /(compar|diferencia|mejor opcion|cuantas sesiones|plan|paquete|presupuesto|objec|resultado|duracion|combinar|alternativa|recomiend)/.test(text);
   return complex ? MODELS.reasoning : MODELS.fast;
 }
 
@@ -151,6 +242,8 @@ function validateSuggestion(obj, allowedCatalogIds, allowedSoles) {
 }
 
 module.exports = {
-  MODELS, COSTS, listModels, chat, estimateCost, redactPII, normalize,
-  chooseModel, personalizedClinicalRisk, validateSuggestion
+  MODELS, COSTS, SAFETY_MAX_COMPLETION_TOKENS, SAFETY_MAX_KNOWLEDGE_ITEMS,
+  listModels, chat, estimateCost, redactPII, normalize, chooseModel,
+  personalizedClinicalRisk, validateSuggestion, compactSafetyFacts,
+  compactSafetyKnowledge, compactSafetyMessages
 };

--- a/app/ai-router.js
+++ b/app/ai-router.js
@@ -16,7 +16,7 @@ const COSTS = Object.freeze({
 });
 
 const SAFETY_MAX_COMPLETION_TOKENS = 180;
-const SAFETY_MAX_KNOWLEDGE_ITEMS = 8;
+const SAFETY_MAX_KNOWLEDGE_ITEMS = 12;
 
 function requestJson(opts, payload, timeoutMs) {
   return new Promise((resolve, reject) => {

--- a/ci/wa4-ai-sales-router/ai-router.test.js
+++ b/ci/wa4-ai-sales-router/ai-router.test.js
@@ -86,5 +86,6 @@ test('cost estimator uses current Groq prices', () => {
   assert.equal(ai.estimateCost('openai/gpt-oss-120b', { prompt_tokens: 1000000, completion_tokens: 1000000 }), 0.75);
 });
 
-// Keep the production-scale knowledge-payload regression in the canonical WA4 test entrypoint.
+// Keep production-scale payload and FASTPATH regressions in the canonical WA4 test entrypoint.
 require('./knowledge-bounds.test.js');
+require('./fastpath-r1.test.js');

--- a/ci/wa4-ai-sales-router/fastpath-r1.test.js
+++ b/ci/wa4-ai-sales-router/fastpath-r1.test.js
@@ -1,0 +1,69 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const ai = require('../../app/ai-router');
+const booking = require('../../app/wa4-booking-resolver');
+
+test('FASTPATH simple commercial turn stays on 20B even with many catalog matches', () => {
+  assert.equal(
+    ai.chooseModel('Hola, quiero más información sobre toxina', { catalogMatches: 12 }),
+    ai.MODELS.fast
+  );
+});
+
+test('FASTPATH explicit comparison still escalates to reasoning model', () => {
+  assert.equal(
+    ai.chooseModel('¿Cuál es la diferencia entre HIFU y bioestimulador y cuál me conviene más?', { catalogMatches: 2 }),
+    ai.MODELS.reasoning
+  );
+});
+
+test('FASTPATH non-booking turn performs zero booking authority calls', async () => {
+  let getCalls = 0;
+  let rpcCalls = 0;
+  const resolver = booking.createBookingResolver({
+    serviceGet: async () => { getCalls += 1; throw new Error('UNEXPECTED_BOOKING_GET'); },
+    serviceRpc: async () => { rpcCalls += 1; throw new Error('UNEXPECTED_BOOKING_RPC'); }
+  });
+  const out = await resolver.resolve({
+    runtime: { booking_readiness: 'LOW', intents: ['INFO'], state: {} },
+    processContexts: []
+  });
+  assert.equal(out.status, 'NOT_REQUESTED');
+  assert.equal(out.prompt_context.status, 'NOT_REQUESTED');
+  assert.equal(out.prompt_context.confirmation_allowed, false);
+  assert.equal(getCalls, 0);
+  assert.equal(rpcCalls, 0);
+});
+
+test('FASTPATH safety knowledge removes FAQ bulk while preserving governed commercial facts', () => {
+  const items = Array.from({ length: 12 }, (_, i) => ({
+    knowledge_id: `catalog-${i}`,
+    domain: 'CATALOG',
+    title: `Toxina ${i}`,
+    authority_tier: 1,
+    freshness_state: 'CURRENT',
+    facts: {
+      nombre: `Toxina ${i}`,
+      categoria: 'Toxina',
+      precio_base: 500 + i,
+      precio_oferta: 450 + i,
+      moneda: 'PEN',
+      descripcion_comercial: 'Descripción aprobada '.repeat(30),
+      beneficios: Array.from({ length: 20 }, (_, n) => `Beneficio ${n} `.repeat(10)),
+      faqs: Array.from({ length: 80 }, (_, n) => ({ q: `Pregunta ${n} `.repeat(20), a: `Respuesta ${n} `.repeat(80) }))
+    }
+  }));
+  const original = { version: 'WA4A1-KNOWLEDGE-V2', audience: 'PUBLIC_CLIENT', authority: 'GOVERNED_SOURCE_ONLY', generic_llm_authority: false, items };
+  const compact = ai.compactSafetyKnowledge(original);
+  assert.equal(compact.items.length, ai.SAFETY_MAX_KNOWLEDGE_ITEMS);
+  assert.equal(compact.items[0].facts.precio_oferta, 450);
+  assert.equal(compact.items[0].facts.moneda, 'PEN');
+  assert.equal(Object.hasOwn(compact.items[0].facts, 'faqs'), false);
+  assert.ok(JSON.stringify(compact).length < 30000);
+  assert.ok(JSON.stringify(compact).length < JSON.stringify(original).length / 10);
+});
+
+test('FASTPATH safety pass has a hard small completion budget', () => {
+  assert.equal(ai.SAFETY_MAX_COMPLETION_TOKENS, 180);
+});


### PR DESCRIPTION
## Scope
R1-core only; PROD remains `AUTO_OFF` and kill switch engaged.

## Findings
- Booking was audited rather than blindly changed: `wa4-booking-resolver.resolve()` already exits `NOT_REQUESTED` before any booking DB/RPC call when `booking_readiness` is not HIGH. Added a regression to freeze this behavior.
- Real defect: `chooseModel()` escalated a simple commercial turn to `openai/gpt-oss-120b` solely when catalog matches >2.
- Safety pass reused an oversized governed-knowledge payload and a 350-token output budget.

## Changes
- Simple commercial turns stay on `openai/gpt-oss-20b` regardless of catalog result count; explicit complex/comparison language still escalates to 120B.
- Safety model transport compacts governed facts: strips FAQ bulk, bounds lists/text, preserves all up-to-12 retrieved evidence IDs/domains/authority/freshness, prices/currency, branch/hours, promotion and clinically relevant public facts.
- Safety completion hard-capped at 180 tokens.
- Added regressions for simple 12-match routing, explicit comparison routing, zero booking calls on INFO, >10x safety-payload reduction, and safety token cap.
- Isolated exact-logic certification: syntax PASS; 12-item synthetic safety payload reduced 1,273,808 → 14,943 chars (~1.17%) while preserving price facts; simple toxina turn routes to 20B and explicit comparison routes to 120B.

No DB/schema changes, no timeout inflation, no Meta changes, no L4/L8 authority changes, no CANARY activation. Follow-up R1-resilience will address provider fallback and Answer Cards after this core is certified.