### PR TITLE
WA-L10 R3: fix toxin retrieval relevance and deterministic grounding

### DIFF
--- a/.github/workflows/ascenda-ci.yml
+++ b/.github/workflows/ascenda-ci.yml
@@ -80,6 +80,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (Test-Path 'app/server-wa4.js') { node --check app/server-wa4.js }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (Test-Path 'app/wa4-knowledge.js') { node --check app/wa4-knowledge.js }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (Test-Path 'app/email-runtime-env-compat.cjs') { node --check app/email-runtime-env-compat.cjs }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (Test-Path 'app/supabase-runtime-auth.cjs') { node --check app/supabase-runtime-auth.cjs }
@@ -97,6 +99,12 @@ jobs:
           node ci/wa4c-runtime/supabase-auth-header.test.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node ci/wa4c-runtime/quota-target.test.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: WA-4 R3 focused retrieval and grounding regression
+        shell: powershell
+        run: |
+          node --test ci/wa4-ai-sales-router/retrieval-grounding-r3.test.js
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Check public JavaScript syntax

--- a/app/wa4-knowledge.js
+++ b/app/wa4-knowledge.js
@@ -11,6 +11,7 @@ const CATALOG_IDENTITY_ALLOWLIST = Object.freeze(new Set([
   'family_name','commercial_variant','clinical_sessions','brand','zones','unit_cap','syringes','volume_ml'
 ]));
 const FAQ_BOUNDS = Object.freeze({ maxItems: 6, questionChars: 220, answerChars: 650 });
+const CITATION_REPAIR_VISIBLE_ITEMS = 4;
 
 const FIELD_ALLOWLIST = Object.freeze({
   CATALOG: new Set(['tipo','nombre','nombre_corto','categoria','precio_base','precio_oferta','moneda','duracion_sesion','num_sesiones','frecuencia','descripcion_comercial','beneficios','faqs','requiere_doctora','requiere_enfermeria','included_benefit','included_benefit_source','catalog_identity','catalog_identity_source']),
@@ -187,21 +188,7 @@ function timeValues(bundle) {
   return out;
 }
 
-function validateGroundedSuggestion(obj, bundle) {
-  if (!obj || typeof obj !== 'object') return {ok:false,error:'WA4A_INVALID_MODEL_OBJECT'};
-  const reply = String(obj.reply || '').trim();
-  if (!reply || reply.length > 1600) return {ok:false,error:'WA4A_INVALID_REPLY'};
-  const items = Array.isArray(bundle && bundle.items) ? bundle.items : [];
-  const citations = Array.isArray(obj.cited_knowledge_ids) ? obj.cited_knowledge_ids.map(String) : [];
-  const allowedIds = new Set(items.map(x=>String(x.knowledge_id)));
-  if (citations.some(id=>!allowedIds.has(id))) return {ok:false,error:'WA4A_UNGROUNDED_CITATION'};
-
-  const nextAction = String(obj.next_action || 'REPLY').toUpperCase();
-  const humanOnly = nextAction === 'HUMAN_CLINICAL' || nextAction === 'HUMAN_COMMERCIAL';
-  if (!humanOnly && citations.length === 0) return {ok:false,error:'WA4A_EVIDENCE_REQUIRED'};
-  if (!humanOnly && items.length === 0) return {ok:false,error:'WA4A_KNOWLEDGE_REQUIRED'};
-
-  const allowedMoney = moneyValuesByCurrency(bundle || {items:[]});
+function moneyMentions(reply) {
   const mentions = [];
   const patterns = [
     {currency:'PEN',re:/(?:s\/\.?\s*|soles?\s*)(\d+(?:[.,]\d{1,2})?)/gi},
@@ -209,21 +196,97 @@ function validateGroundedSuggestion(obj, bundle) {
   ];
   for (const p of patterns) {
     let m;
-    while ((m = p.re.exec(reply))) mentions.push({currency:p.currency,value:Number(m[1].replace(',','.'))});
+    while ((m = p.re.exec(String(reply || '')))) {
+      const value = Number(m[1].replace(',','.'));
+      if (Number.isFinite(value)) mentions.push({currency:p.currency,value});
+    }
   }
-  if (mentions.some(x=>!allowedMoney[x.currency].has(x.value.toFixed(2)))) return {ok:false,error:'WA4A_UNGROUNDED_PRICE'};
+  return mentions;
+}
 
-  const allowedTimes = timeValues(bundle || {items:[]});
+function itemFamily(item) {
+  if (!item || String(item.domain || '').toUpperCase() !== 'CATALOG') return '';
+  const f = item.facts || {};
+  const identity = f.catalog_identity && typeof f.catalog_identity === 'object' ? f.catalog_identity : {};
+  return normalize(identity.family_name || f.categoria || f.nombre || item.title).trim();
+}
+
+function itemSupportsMoney(item,mention) {
+  if (!item || !mention) return false;
+  const values = moneyValuesByCurrency({items:[item]});
+  return Boolean(values[mention.currency] && values[mention.currency].has(Number(mention.value).toFixed(2)));
+}
+
+function deterministicCitationRepair(reply,bundle) {
+  const source = Array.isArray(bundle && bundle.items) ? bundle.items : [];
+  const visible = source.slice(0,CITATION_REPAIR_VISIBLE_ITEMS);
+  if (!visible.length) return [];
+  const mentions = moneyMentions(reply);
+
+  if (mentions.length) {
+    const ids = new Set();
+    for (const mention of mentions) {
+      const matches = visible.filter(item=>itemSupportsMoney(item,mention));
+      if (!matches.length) return [];
+      const catalogFamilies = new Set(matches.filter(x=>x.domain==='CATALOG').map(itemFamily).filter(Boolean));
+      const nonCatalog = matches.filter(x=>x.domain!=='CATALOG');
+      // Multiple unrelated items at the same amount are ambiguous and must not be auto-cited.
+      if (catalogFamilies.size > 1 || (nonCatalog.length > 1) || (catalogFamilies.size && nonCatalog.length)) return [];
+      for (const item of matches) ids.add(String(item.knowledge_id));
+    }
+    return [...ids].filter(Boolean).slice(0,CITATION_REPAIR_VISIBLE_ITEMS);
+  }
+
+  const catalogs = visible.filter(item=>String(item.domain||'').toUpperCase()==='CATALOG');
+  if (catalogs.length === 1) return [String(catalogs[0].knowledge_id)];
+  if (catalogs.length > 1) {
+    const families = new Set(catalogs.map(itemFamily).filter(Boolean));
+    if (families.size === 1) return catalogs.map(x=>String(x.knowledge_id)).filter(Boolean).slice(0,CITATION_REPAIR_VISIBLE_ITEMS);
+  }
+  return [];
+}
+
+function validateGroundedSuggestion(obj, bundle) {
+  if (!obj || typeof obj !== 'object') return {ok:false,error:'WA4A_INVALID_MODEL_OBJECT'};
+  const reply = String(obj.reply || '').trim();
+  if (!reply || reply.length > 1600) return {ok:false,error:'WA4A_INVALID_REPLY'};
+  const items = Array.isArray(bundle && bundle.items) ? bundle.items : [];
+  let citations = Array.isArray(obj.cited_knowledge_ids) ? obj.cited_knowledge_ids.map(String).filter(Boolean) : [];
+  const allowedIds = new Set(items.map(x=>String(x.knowledge_id)));
+  if (citations.some(id=>!allowedIds.has(id))) return {ok:false,error:'WA4A_UNGROUNDED_CITATION'};
+
+  const nextAction = String(obj.next_action || 'REPLY').toUpperCase();
+  const humanOnly = nextAction === 'HUMAN_CLINICAL' || nextAction === 'HUMAN_COMMERCIAL';
+  let citationRepaired = false;
+  if (!humanOnly && citations.length === 0) {
+    citations = deterministicCitationRepair(reply,bundle);
+    citationRepaired = citations.length > 0;
+  }
+  if (!humanOnly && citations.length === 0) return {ok:false,error:'WA4A_EVIDENCE_REQUIRED'};
+  if (!humanOnly && items.length === 0) return {ok:false,error:'WA4A_KNOWLEDGE_REQUIRED'};
+
+  // Commercial claims must be supported by the evidence actually cited. Human-only
+  // drafts without citations remain non-autonomous and retain the broader governed set.
+  const citedItems = citations.length ? items.filter(x=>citations.includes(String(x.knowledge_id))) : (humanOnly ? items : []);
+  const allowedMoney = moneyValuesByCurrency({items:citedItems});
+  const mentions = moneyMentions(reply);
+  if (mentions.some(x=>!allowedMoney[x.currency].has(Number(x.value).toFixed(2)))) return {ok:false,error:'WA4A_UNGROUNDED_PRICE'};
+
+  const allowedTimes = timeValues({items:citedItems});
   const mentionedTimes = [...reply.matchAll(/\b(?:[01]?\d|2[0-3]):[0-5]\d\b/g)].map(x=>x[0].padStart(5,'0'));
   if (mentionedTimes.some(t=>!allowedTimes.has(t))) return {ok:false,error:'WA4A_UNGROUNDED_HOURS'};
 
   const n = normalize(reply);
   if (/(direccion|dirección|ubicad|sede|como llegar|cómo llegar)/.test(n)) {
-    const citedDomains = new Set(items.filter(x=>citations.includes(String(x.knowledge_id))).map(x=>x.domain));
+    const citedDomains = new Set(citedItems.map(x=>x.domain));
     if (!citedDomains.has('BRANCH')) return {ok:false,error:'WA4A_BRANCH_EVIDENCE_REQUIRED'};
   }
 
-  return {ok:true,reply,citations,nextAction};
+  return {ok:true,reply,citations,nextAction,citationRepaired};
 }
 
-module.exports = {AUDIENCES,SEP26_CURRENT_SKU,CATALOG_IDENTITY_ALLOWLIST,FAQ_BOUNDS,FIELD_ALLOWLIST,normalize,normalizeAudience,boundedText,sanitizeFaqs,sanitizeCatalogIdentity,sanitizeFacts,buildKnowledgeBundle,validateGroundedSuggestion};
+module.exports = {
+  AUDIENCES,SEP26_CURRENT_SKU,CATALOG_IDENTITY_ALLOWLIST,FAQ_BOUNDS,FIELD_ALLOWLIST,CITATION_REPAIR_VISIBLE_ITEMS,
+  normalize,normalizeAudience,boundedText,sanitizeFaqs,sanitizeCatalogIdentity,sanitizeFacts,buildKnowledgeBundle,
+  moneyValuesByCurrency,moneyMentions,itemFamily,deterministicCitationRepair,validateGroundedSuggestion
+};

--- a/ci/wa4-ai-sales-router/ai-router.test.js
+++ b/ci/wa4-ai-sales-router/ai-router.test.js
@@ -91,3 +91,4 @@ require('./knowledge-bounds.test.js');
 require('./fastpath-r1.test.js');
 require('./fastpath-r1-resilience.test.js');
 require('./fastpath-r1-benchmark.test.js');
+require('./retrieval-grounding-r3.test.js');

--- a/ci/wa4-ai-sales-router/retrieval-grounding-r3.test.js
+++ b/ci/wa4-ai-sales-router/retrieval-grounding-r3.test.js
@@ -1,0 +1,98 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('fs');
+const path=require('path');
+const knowledge=require('../../app/wa4-knowledge');
+
+function catalog(id,name,price,family='TOXINA BOTULÍNICA',category='TOXINA'){
+  return {
+    knowledge_id:id,domain:'CATALOG',title:name,authority_tier:10,freshness_state:'FRESH',
+    facts:{nombre:name,categoria:category,moneda:'PEN',precio_base:price,precio_oferta:price,catalog_identity:{family_name:family,commercial_variant:name}}
+  };
+}
+function bundle(items){return {version:'TEST',audience:'PUBLIC_CLIENT',authority:'GOVERNED_SOURCE_ONLY',items};}
+
+const hutox=catalog('service:hutox-1','HUTOX 1 ZONA 15U',299);
+const nabota=catalog('service:nabota-1','NABOTA 1 ZONA 15U',399);
+const nabota3=catalog('service:nabota-3','NABOTA 3 ZONAS 50U',999);
+
+test('R3 missing citation is repaired only by an exact visible governed price',()=>{
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'Tenemos una opción de toxina a S/ 299.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([hutox,nabota,nabota3]));
+  assert.equal(r.ok,true);
+  assert.equal(r.citationRepaired,true);
+  assert.deepEqual(r.citations,['service:hutox-1']);
+});
+
+test('R3 price that exists only outside the four visible cards cannot repair a missing citation',()=>{
+  const hidden=catalog('service:hidden','TOXINA HIDDEN',777);
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'El precio es S/ 777.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([
+    catalog('service:a','A',100,'FAM A','A'),
+    catalog('service:b','B',200,'FAM B','B'),
+    catalog('service:c','C',300,'FAM C','C'),
+    catalog('service:d','D',400,'FAM D','D'),
+    hidden
+  ]));
+  assert.equal(r.ok,false);
+  assert.equal(r.error,'WA4A_EVIDENCE_REQUIRED');
+});
+
+test('R3 cited evidence cannot borrow a price from another bundle item',()=>{
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'La opción está en S/ 399.',next_action:'REPLY',cited_knowledge_ids:['service:hutox-1']
+  },bundle([hutox,nabota]));
+  assert.equal(r.ok,false);
+  assert.equal(r.error,'WA4A_UNGROUNDED_PRICE');
+});
+
+test('R3 no-money reply can repair citations when all visible catalog cards share one governed family',()=>{
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'Sí, tenemos opciones de toxina botulínica y puedo explicarte las alternativas.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([hutox,nabota,nabota3]));
+  assert.equal(r.ok,true);
+  assert.equal(r.citationRepaired,true);
+  assert.deepEqual(r.citations,['service:hutox-1','service:nabota-1','service:nabota-3']);
+});
+
+test('R3 mixed visible catalog families remain fail-closed without a citation',()=>{
+  const facial=catalog('service:facial','HIDROFACIAL',129,'FACIALES','FACIALES');
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'Tenemos varias opciones disponibles.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([hutox,facial]));
+  assert.equal(r.ok,false);
+  assert.equal(r.error,'WA4A_EVIDENCE_REQUIRED');
+});
+
+test('R3 invented price remains blocked even when a valid family is visible',()=>{
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'La toxina está en S/ 250.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([hutox,nabota,nabota3]));
+  assert.equal(r.ok,false);
+  assert.equal(r.error,'WA4A_EVIDENCE_REQUIRED');
+});
+
+test('R3 ambiguous equal prices across unrelated families are not auto-cited',()=>{
+  const a=catalog('service:a','A',299,'FAMILIA A','A');
+  const b=catalog('service:b','B',299,'FAMILIA B','B');
+  const r=knowledge.validateGroundedSuggestion({
+    reply:'El precio es S/ 299.',next_action:'REPLY',cited_knowledge_ids:[]
+  },bundle([a,b]));
+  assert.equal(r.ok,false);
+  assert.equal(r.error,'WA4A_EVIDENCE_REQUIRED');
+});
+
+test('R3 retrieval migration removes commercial filler and weights structured treatment evidence',()=>{
+  const sql=fs.readFileSync(path.join(__dirname,'../../supabase/migrations/20260905203000_wa4a_retrieval_relevance_v2.sql'),'utf8');
+  assert.ok(sql.includes("'informacion'"));
+  assert.ok(sql.includes("'precio'"));
+  assert.ok(sql.includes("select 'toxina'"));
+  assert.ok(sql.includes("w in ('botox','botulinica')"));
+  assert.ok(sql.includes('norm_structured'));
+  assert.ok(sql.includes("k.facts->>'categoria'"));
+  assert.ok(sql.includes('rank_score >= greatest(8,ceil(s.max_score*0.35)::integer)'));
+  assert.ok(!/statement_timeout\s*=|set\s+statement_timeout/i.test(sql));
+});

--- a/supabase/migrations/20260905203000_wa4a_retrieval_relevance_v2.sql
+++ b/supabase/migrations/20260905203000_wa4a_retrieval_relevance_v2.sql
@@ -1,0 +1,139 @@
+-- WA4A retrieval relevance V2
+-- Fixes R3 real-turn failure where generic commercial words ("informacion", "precio")
+-- outranked the actual treatment terms. Preserves function signature and callers.
+
+create or replace function public.aos_wa4a_knowledge_search_v1(
+  p_query text,
+  p_limit integer default 12,
+  p_domains text[] default null::text[]
+)
+returns table(
+  knowledge_id text,
+  domain text,
+  subject_type text,
+  subject_id text,
+  title text,
+  facts jsonb,
+  authority_tier smallint,
+  source_relation text,
+  source_pk text,
+  source_updated_at timestamptz,
+  freshness_state text,
+  conflict_state text,
+  retrieval_state text,
+  evidence_ref jsonb,
+  score integer
+)
+language plpgsql
+stable
+security definer
+set search_path to ''
+as $function$
+declare
+  v_q text := public.aos_wa4a_norm_v1(p_query);
+  v_limit integer := greatest(1,least(coalesce(p_limit,12),24));
+  v_raw_tokens text[];
+  v_tokens text[];
+begin
+  if length(v_q) < 2 then
+    return;
+  end if;
+
+  select coalesce(array_agg(distinct w),array[]::text[])
+    into v_raw_tokens
+  from unnest(string_to_array(v_q,' ')) w
+  where length(w) >= 3;
+
+  -- Remove conversational/commercial filler before candidate selection. These words
+  -- occur in nearly every catalog FAQ and previously swamped the treatment signal.
+  select coalesce(array_agg(distinct token),array[]::text[])
+    into v_tokens
+  from (
+    select w as token
+    from unnest(v_raw_tokens) w
+    where w <> all(array[
+      'hola','buenas','buenos','dias','tardes','noches',
+      'quiero','quisiera','necesito','informacion','sobre','saber',
+      'precio','precios','cuanto','cuesta','costo','costos',
+      'dame','favor','porfavor','para','como','puedo','puede','tener',
+      'mas','del','una','uno','unos','unas','que'
+    ]::text[])
+    union all
+    -- Commercial synonym only for retrieval. It does not alter the governed facts.
+    select 'toxina'
+    where exists (
+      select 1 from unnest(v_raw_tokens) w where w in ('botox','botulinica')
+    )
+  ) s;
+
+  -- For an unusually generic query, retain the old token behavior instead of
+  -- returning a fabricated match.
+  if coalesce(cardinality(v_tokens),0) = 0 then
+    v_tokens := v_raw_tokens;
+  end if;
+
+  return query
+  with prepared as materialized (
+    select
+      k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.search_text,k.facts,k.authority_tier,
+      k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,
+      k.retrieval_state,k.evidence_ref,
+      public.aos_wa4a_norm_v1(k.title) as norm_title,
+      public.aos_wa4a_norm_v1(concat_ws(' ',
+        k.title,
+        k.facts->>'nombre',
+        k.facts->>'nombre_corto',
+        k.facts->>'categoria'
+      )) as norm_structured,
+      public.aos_wa4a_norm_v1(k.search_text) as norm_search
+    from public.aos_wa4a_knowledge_items_v1 k
+    where k.retrieval_state in ('READY','READY_WITH_WARNING')
+      and k.conflict_state='CLEAR'
+      and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
+  ), candidates as materialized (
+    select p.*
+    from prepared p
+    where exists (
+      select 1
+      from unnest(v_tokens) w
+      where p.norm_structured like '%'||w||'%'
+         or p.norm_search like '%'||w||'%'
+    )
+  ), ranked as (
+    select
+      c.*,
+      (
+        case when c.norm_title=v_q then 140 else 0 end
+        + case when c.norm_title like '%'||v_q||'%' then 45 else 0 end
+        + case when c.norm_search like '%'||v_q||'%' then 25 else 0 end
+        + coalesce((select count(*)::integer*90 from unnest(v_tokens) w where c.norm_title like '%'||w||'%'),0)
+        + coalesce((select count(*)::integer*60 from unnest(v_tokens) w where c.norm_structured like '%'||w||'%'),0)
+        + coalesce((select count(*)::integer*8 from unnest(v_tokens) w where c.norm_search like '%'||w||'%'),0)
+        + case when c.authority_tier=10 then 5 else 0 end
+        -- Generic toxin inquiries should see the standard zone SKUs before
+        -- indication-specific variants such as hyperhidrosis/platisma.
+        + case
+            when 'toxina'=any(v_tokens)
+             and public.aos_wa4a_norm_v1(c.facts->>'categoria')='toxina'
+             and c.norm_title ~ '(^| )(1|2|3|[0-9]+) zona(s)?( |$)'
+            then 50 else 0
+          end
+      )::integer as rank_score
+    from candidates c
+  ), scored as (
+    select r.*,max(r.rank_score) over() as max_score
+    from ranked r
+  )
+  select
+    s.knowledge_id,s.domain,s.subject_type,s.subject_id,s.title,s.facts,s.authority_tier,
+    s.source_relation,s.source_pk,s.source_updated_at,s.freshness_state,s.conflict_state,
+    s.retrieval_state,s.evidence_ref,s.rank_score
+  from scored s
+  where s.rank_score >= greatest(8,ceil(s.max_score*0.35)::integer)
+  order by s.rank_score desc,s.authority_tier asc,s.title asc
+  limit v_limit;
+end
+$function$;
+
+comment on function public.aos_wa4a_knowledge_search_v1(text,integer,text[])
+is 'WA4A governed retrieval V2: stopword-resistant structured relevance + conservative toxin synonym routing.';

--- a/supabase/migrations/20260905203000_wa4a_retrieval_relevance_v2.sql
+++ b/supabase/migrations/20260905203000_wa4a_retrieval_relevance_v2.sql
@@ -1,6 +1,7 @@
 -- WA4A retrieval relevance V2
 -- Fixes R3 real-turn failure where generic commercial words ("informacion", "precio")
--- outranked the actual treatment terms. Preserves function signature and callers.
+-- outranked the actual treatment terms. Preserves function signature, candidate-prefilter
+-- architecture, authority/conflict gates and callers.
 
 create or replace function public.aos_wa4a_knowledge_search_v1(
   p_query text,
@@ -59,67 +60,79 @@ begin
       'mas','del','una','uno','unos','unas','que'
     ]::text[])
     union all
-    -- Commercial synonym only for retrieval. It does not alter the governed facts.
+    -- Commercial synonym only for retrieval. It does not alter governed facts.
     select 'toxina'
     where exists (
       select 1 from unnest(v_raw_tokens) w where w in ('botox','botulinica')
     )
   ) s;
 
-  -- For an unusually generic query, retain the old token behavior instead of
-  -- returning a fabricated match.
+  -- For an unusually generic query, retain the legacy token behavior rather than
+  -- manufacturing a treatment match.
   if coalesce(cardinality(v_tokens),0) = 0 then
     v_tokens := v_raw_tokens;
   end if;
 
   return query
-  with prepared as materialized (
+  with folded as materialized (
     select
       k.knowledge_id,k.domain,k.subject_type,k.subject_id,k.title,k.search_text,k.facts,k.authority_tier,
       k.source_relation,k.source_pk,k.source_updated_at,k.freshness_state,k.conflict_state,
       k.retrieval_state,k.evidence_ref,
-      public.aos_wa4a_norm_v1(k.title) as norm_title,
-      public.aos_wa4a_norm_v1(concat_ws(' ',
+      lower(translate(coalesce(k.title,''),'ÁÉÍÓÚÜÑáéíóúüñ','AEIOUUNaeiouun')) as fold_title,
+      lower(translate(concat_ws(' ',
         k.title,
         k.facts->>'nombre',
         k.facts->>'nombre_corto',
         k.facts->>'categoria'
-      )) as norm_structured,
-      public.aos_wa4a_norm_v1(k.search_text) as norm_search
+      ),'ÁÉÍÓÚÜÑáéíóúüñ','AEIOUUNaeiouun')) as fold_structured,
+      lower(translate(coalesce(k.search_text,''),'ÁÉÍÓÚÜÑáéíóúüñ','AEIOUUNaeiouun')) as fold_search
     from public.aos_wa4a_knowledge_items_v1 k
     where k.retrieval_state in ('READY','READY_WITH_WARNING')
       and k.conflict_state='CLEAR'
       and (p_domains is null or cardinality(p_domains)=0 or k.domain=any(p_domains))
   ), candidates as materialized (
-    select p.*
-    from prepared p
+    select f.*
+    from folded f
     where exists (
       select 1
       from unnest(v_tokens) w
-      where p.norm_structured like '%'||w||'%'
-         or p.norm_search like '%'||w||'%'
+      where f.fold_structured like '%'||w||'%'
+         or f.fold_search like '%'||w||'%'
     )
-  ), ranked as (
+  ), prepared as materialized (
     select
       c.*,
+      public.aos_wa4a_norm_v1(c.title) as norm_title,
+      public.aos_wa4a_norm_v1(concat_ws(' ',
+        c.title,
+        c.facts->>'nombre',
+        c.facts->>'nombre_corto',
+        c.facts->>'categoria'
+      )) as norm_structured,
+      public.aos_wa4a_norm_v1(c.search_text) as norm_search
+    from candidates c
+  ), ranked as (
+    select
+      p.*,
       (
-        case when c.norm_title=v_q then 140 else 0 end
-        + case when c.norm_title like '%'||v_q||'%' then 45 else 0 end
-        + case when c.norm_search like '%'||v_q||'%' then 25 else 0 end
-        + coalesce((select count(*)::integer*90 from unnest(v_tokens) w where c.norm_title like '%'||w||'%'),0)
-        + coalesce((select count(*)::integer*60 from unnest(v_tokens) w where c.norm_structured like '%'||w||'%'),0)
-        + coalesce((select count(*)::integer*8 from unnest(v_tokens) w where c.norm_search like '%'||w||'%'),0)
-        + case when c.authority_tier=10 then 5 else 0 end
+        case when p.norm_title=v_q then 140 else 0 end
+        + case when p.norm_title like '%'||v_q||'%' then 45 else 0 end
+        + case when p.norm_search like '%'||v_q||'%' then 25 else 0 end
+        + coalesce((select count(*)::integer*90 from unnest(v_tokens) w where p.norm_title like '%'||w||'%'),0)
+        + coalesce((select count(*)::integer*60 from unnest(v_tokens) w where p.norm_structured like '%'||w||'%'),0)
+        + coalesce((select count(*)::integer*8 from unnest(v_tokens) w where p.norm_search like '%'||w||'%'),0)
+        + case when p.authority_tier=10 then 5 else 0 end
         -- Generic toxin inquiries should see the standard zone SKUs before
         -- indication-specific variants such as hyperhidrosis/platisma.
         + case
             when 'toxina'=any(v_tokens)
-             and public.aos_wa4a_norm_v1(c.facts->>'categoria')='toxina'
-             and c.norm_title ~ '(^| )(1|2|3|[0-9]+) zona(s)?( |$)'
+             and public.aos_wa4a_norm_v1(p.facts->>'categoria')='toxina'
+             and p.norm_title ~ '(^| )(1|2|3|[0-9]+) zona(s)?( |$)'
             then 50 else 0
           end
       )::integer as rank_score
-    from candidates c
+    from prepared p
   ), scored as (
     select r.*,max(r.rank_score) over() as max_score
     from ranked r
@@ -136,4 +149,4 @@ end
 $function$;
 
 comment on function public.aos_wa4a_knowledge_search_v1(text,integer,text[])
-is 'WA4A governed retrieval V2: stopword-resistant structured relevance + conservative toxin synonym routing.';
+is 'WA4A governed retrieval V2: stopword-resistant structured relevance + conservative toxin synonym routing with cheap candidate prefilter.';


### PR DESCRIPTION
R3 real-turn remediation under SAFE-OFF. The failed turn reached Meta inbound -> L10 -> Groq but was blocked as WA4A_EVIDENCE_REQUIRED because governed retrieval ranked generic FAQ matches (vitamins/supplements) above the requested toxin treatment. This PR: (1) makes WA4A retrieval stopword-resistant, weights structured name/category evidence above long descriptive/FAQ text, maps botox/botulinica to the governed toxin retrieval term, and keeps a bounded relevance threshold; (2) repairs a missing model citation only when the first four visible governed cards prove the claim deterministically; (3) validates money against cited evidence rather than any unrelated bundle item; and (4) adds canonical regressions for exact-price repair, hidden evidence, cross-item prices, same-family repair, mixed-family fail-closed, invented prices, ambiguous equal prices, and the migration contract. Read-only PROD prototype of the exact failed phrase returned TOXINA + NABOTA/HUTOX instead of vitamins and completed in ~1.04s, below the existing 3s retrieval gate. No timeout increase, Auth/2FA change, Meta sender change, autonomous authority change, or CANARY authorization. PROD remains AUTO_OFF + kill switch ON.