### PR TITLE
P0 #485: stabilize Auth/WhatsApp and eliminate false 2FA under upstream pressure

### DIFF
--- a/.github/workflows/p0-485-stability.yml
+++ b/.github/workflows/p0-485-stability.yml
@@ -26,13 +26,13 @@ permissions:
 
 jobs:
   stability:
-    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    runs-on: [self-hosted, Windows, X64, ascenda-fast]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Syntax gates
         run: |
           node --check app/wa3-stability.js

--- a/.github/workflows/p0-485-stability.yml
+++ b/.github/workflows/p0-485-stability.yml
@@ -40,6 +40,8 @@ jobs:
           node --check app/public/wa-performance-hardening.js
       - name: P0 485 deterministic contract
         run: node ci/p0-485/stability_contract.js
+      - name: P0 485 browser runtime contract
+        run: node ci/p0-485/browser_runtime_contract.js
       - name: Existing WA performance behavior contract
         run: node ci/phase-s/wa_performance_hardening_behavior_contract.js
       - name: Existing WA3 UI contract

--- a/.github/workflows/p0-485-stability.yml
+++ b/.github/workflows/p0-485-stability.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   stability:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/p0-485-stability.yml
+++ b/.github/workflows/p0-485-stability.yml
@@ -1,0 +1,46 @@
+name: P0-485 Stability
+
+on:
+  pull_request:
+    paths:
+      - 'app/server-wa3-v2.js'
+      - 'app/wa3-stability.js'
+      - 'app/public/wa-performance-hardening.js'
+      - 'ci/p0-485/**'
+      - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
+      - '.github/workflows/p0-485-stability.yml'
+  push:
+    branches:
+      - 'p0-485-auth-wa-stability-20260909'
+    paths:
+      - 'app/server-wa3-v2.js'
+      - 'app/wa3-stability.js'
+      - 'app/public/wa-performance-hardening.js'
+      - 'ci/p0-485/**'
+      - 'docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md'
+      - '.github/workflows/p0-485-stability.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Syntax gates
+        run: |
+          node --check app/wa3-stability.js
+          node --check app/server-wa3-v2.js
+          node --check app/public/wa-performance-hardening.js
+      - name: P0 485 deterministic contract
+        run: node ci/p0-485/stability_contract.js
+      - name: Existing WA performance behavior contract
+        run: node ci/phase-s/wa_performance_hardening_behavior_contract.js
+      - name: Existing WA3 UI contract
+        run: node ci/wa3-boxes-routing-handoff/ui_contract_v2.js

--- a/app/public/wa-performance-hardening.js
+++ b/app/public/wa-performance-hardening.js
@@ -35,8 +35,9 @@ function backoffOpen(key){var x=failures.get(key);return !!(x&&Date.now()<x.unti
 function parseBody(body){try{return body?JSON.parse(body):{};}catch(_){return {};}}
 function trueAuthDenial(status,data){if(status!==401&&status!==403)return false;var e=String(data&&data.error||'');return e==='WA3_2FA_PANEL_REQUIRED'||e==='AOS_2FA_SESSION_MISSING'||e==='PUSH_APP_SESSION_REQUIRED';}
 function recentlyVerified(){return lastVerifiedAt&&Date.now()-lastVerifiedAt<RECENT_VERIFY_MS;}
-function serviceCode(code){var c=String(code||'');return c==='WA3_AUTH_UPSTREAM_UNAVAILABLE'||c==='WA3_INBOX_UNAVAILABLE'||c==='WA3_BOOTSTRAP_UNAVAILABLE'||c==='WA3_MESSAGES_UNAVAILABLE'||c==='WA3_TEAM_SUMMARY_UNAVAILABLE'||c==='WA3_QUEUE_SUMMARY_UNAVAILABLE'||c==='WA3V2_INNER_UNAVAILABLE'||/^HTTP_5\d\d$/.test(c);}
+function serviceCode(code){var c=String(code||'');return c==='WA3_AUTH_UPSTREAM_UNAVAILABLE'||c==='WA3_INBOX_UNAVAILABLE'||c==='WA3_BOOTSTRAP_UNAVAILABLE'||c==='WA3_MESSAGES_UNAVAILABLE'||c==='WA3_TEAM_SUMMARY_UNAVAILABLE'||c==='WA3_QUEUE_SUMMARY_UNAVAILABLE'||c==='WA3_SERVICE_BACKOFF'||c==='WA3V2_INNER_UNAVAILABLE'||/^HTTP_5\d\d$/.test(c);}
 function repairServiceCard(){
+  if(!document||typeof document.querySelector!=='function')return;
   var box=document.querySelector('.wa8-authbox');if(!box)return;
   var bold=box.querySelector('b'),code=String(bold&&bold.textContent||'').trim();if(!serviceCode(code))return;
   var h=box.querySelector('h3'),p=box.querySelector('p'),b=box.querySelector('button');
@@ -46,6 +47,7 @@ function repairServiceCard(){
   if(!box.dataset.aosP0485){box.dataset.aosP0485='1';metrics.service_card_patches++;}
 }
 function installServiceGuard(tries){
+  if(!document||typeof document.getElementById!=='function'||typeof MutationObserver!=='function')return;
   var ws=document.getElementById('workspace');if(!ws){if((tries||0)<80)setTimeout(function(){installServiceGuard((tries||0)+1);},250);return;}
   if(serviceObserver)serviceObserver.disconnect();serviceObserver=new MutationObserver(repairServiceCard);serviceObserver.observe(ws,{childList:true,subtree:true});repairServiceCard();
 }

--- a/app/public/wa-performance-hardening.js
+++ b/app/public/wa-performance-hardening.js
@@ -1,27 +1,54 @@
 // ASCENDA Conversations — WA-3 read coalescing / adaptive in-memory cache.
+// P0 #485: foreground stability, stale-client backoff and service-vs-auth UI separation.
 (function(){
 'use strict';
 if(window.AOS_WA_PERF&&window.AOS_WA_PERF.installed)return;
 var baseFetch=window.fetch.bind(window);
-var cache=new Map(),inflight=new Map(),epoch=0;
-var metrics={requests:0,network:0,cache_hits:0,coalesced:0,invalidations:0,stale_retries:0};
+var cache=new Map(),inflight=new Map(),failures=new Map(),epoch=0;
+var lastVerifiedAt=0,authDeniedUntil=0,authDeniedToken='',serviceObserver=null;
+var AUTH_BACKOFF_MS=120000,RECENT_VERIFY_MS=15000,STALE_MAX_MS=120000;
+var metrics={requests:0,network:0,cache_hits:0,coalesced:0,invalidations:0,stale_retries:0,backoff_hits:0,auth_backoff_hits:0,service_card_patches:0,transient_auth_remaps:0};
 var rules=[
-  {test:function(u){return u.pathname==='/api/wa3/inbox';},visible:4000,hidden:20000},
-  {test:function(u){return u.pathname==='/api/wa3/queue-summary';},visible:4000,hidden:15000},
-  {test:function(u){return u.pathname==='/api/wa3/team-summary';},visible:4000,hidden:15000},
-  {test:function(u){return /^\/api\/wa3\/conversations\/[0-9a-f-]{36}\/messages$/i.test(u.pathname);},visible:3500,hidden:20000}
+  {test:function(u){return u.pathname==='/api/wa3/inbox';},visible:8000,hidden:60000},
+  {test:function(u){return u.pathname==='/api/wa3/queue-summary';},visible:12000,hidden:60000},
+  {test:function(u){return u.pathname==='/api/wa3/team-summary';},visible:20000,hidden:60000},
+  {test:function(u){return /^\/api\/wa3\/conversations\/[0-9a-f-]{36}\/messages$/i.test(u.pathname);},visible:5000,hidden:60000}
 ];
 function methodOf(input,init){return String(init&&init.method||(input&&input.method)||'GET').toUpperCase();}
 function urlOf(input){try{return new URL(typeof input==='string'?input:(input&&input.url)||'',location.href);}catch(_){return null;}}
+function token(){try{return String(sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'').trim();}catch(_){return '';}}
 function ruleFor(u){if(!u||u.origin!==location.origin)return null;for(var i=0;i<rules.length;i++)if(rules[i].test(u))return rules[i];return null;}
 function ttlFor(rule){return document.hidden?rule.hidden:rule.visible;}
 function keyFor(u){return u.pathname+u.search;}
 function snapshot(resp,body){var hs=[];try{resp.headers.forEach(function(v,k){hs.push([k,v]);});}catch(_){}return {status:resp.status,statusText:resp.statusText,headers:hs,body:body};}
-function materialize(s,kind){var h=new Headers(s.headers||[]);h.set('X-AOS-WA-Perf',kind||'HIT');return new Response(s.body,{status:s.status,statusText:s.statusText,headers:h});}
-function invalidate(reason){epoch++;cache.clear();inflight.clear();metrics.invalidations++;try{window.dispatchEvent(new CustomEvent('aos-wa-perf-invalidated',{detail:{reason:reason||'unknown'}}));}catch(_){} }
+function materialize(s,kind,statusOverride){var h=new Headers(s.headers||[]);h.set('X-AOS-WA-Perf',kind||'HIT');var status=statusOverride||s.status;return new Response(s.body,{status:status,statusText:status===503?'Service Unavailable':s.statusText,headers:h});}
+function synthetic(status,error,kind){return new Response(JSON.stringify({ok:false,error:error,retryable:status>=500}),{status:status,headers:{'Content-Type':'application/json','Cache-Control':'no-store','X-AOS-WA-Perf':kind||'SYNTHETIC'}});}
+function invalidate(reason){epoch++;cache.clear();inflight.clear();failures.clear();metrics.invalidations++;try{window.dispatchEvent(new CustomEvent('aos-wa-perf-invalidated',{detail:{reason:reason||'unknown'}}));}catch(_){} }
 function cacheableResponse(resp){return !!resp&&resp.ok===true&&resp.status>=200&&resp.status<300;}
-function readCached(key,rule){var x=cache.get(key);if(!x)return null;if(Date.now()-x.at>=ttlFor(rule)){cache.delete(key);return null;}return x.snapshot;}
+function readCached(key,rule){var x=cache.get(key);if(!x)return null;if(Date.now()-x.at>=ttlFor(rule))return null;return x.snapshot;}
+function readStale(key){var x=cache.get(key);if(!x)return null;if(Date.now()-x.at>STALE_MAX_MS){cache.delete(key);return null;}return x.snapshot;}
 function store(key,s){cache.set(key,{at:Date.now(),snapshot:s});}
+function failure(key){var x=failures.get(key);if(!x){x={count:0,until:0};failures.set(key,x);}return x;}
+function markFailure(key){var x=failure(key);x.count=Math.min(6,x.count+1);var wait=Math.min(60000,15000*Math.pow(2,x.count-1));x.until=Date.now()+wait;return wait;}
+function clearFailure(key){failures.delete(key);}
+function backoffOpen(key){var x=failures.get(key);return !!(x&&Date.now()<x.until);}
+function parseBody(body){try{return body?JSON.parse(body):{};}catch(_){return {};}}
+function trueAuthDenial(status,data){if(status!==401&&status!==403)return false;var e=String(data&&data.error||'');return e==='WA3_2FA_PANEL_REQUIRED'||e==='AOS_2FA_SESSION_MISSING'||e==='PUSH_APP_SESSION_REQUIRED';}
+function recentlyVerified(){return lastVerifiedAt&&Date.now()-lastVerifiedAt<RECENT_VERIFY_MS;}
+function serviceCode(code){var c=String(code||'');return c==='WA3_AUTH_UPSTREAM_UNAVAILABLE'||c==='WA3_INBOX_UNAVAILABLE'||c==='WA3_BOOTSTRAP_UNAVAILABLE'||c==='WA3_MESSAGES_UNAVAILABLE'||c==='WA3_TEAM_SUMMARY_UNAVAILABLE'||c==='WA3_QUEUE_SUMMARY_UNAVAILABLE'||c==='WA3V2_INNER_UNAVAILABLE'||/^HTTP_5\d\d$/.test(c);}
+function repairServiceCard(){
+  var box=document.querySelector('.wa8-authbox');if(!box)return;
+  var bold=box.querySelector('b'),code=String(bold&&bold.textContent||'').trim();if(!serviceCode(code))return;
+  var h=box.querySelector('h3'),p=box.querySelector('p'),b=box.querySelector('button');
+  if(h)h.textContent='WhatsApp Hub temporalmente no disponible';
+  if(p)p.innerHTML='Tu sesión de ASCENDA sigue activa. El servicio de WhatsApp no respondió a tiempo y se reintentará sin cerrar tu sesión.<br><b>'+String(code).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];})+'</b>';
+  if(b){b.textContent='Reintentar WhatsApp';b.onclick=function(){var v=window.AOS&&AOS.activeView||'admin-whatsapp';if(typeof window.navigateTo==='function')window.navigateTo(v);else location.reload();};}
+  if(!box.dataset.aosP0485){box.dataset.aosP0485='1';metrics.service_card_patches++;}
+}
+function installServiceGuard(tries){
+  var ws=document.getElementById('workspace');if(!ws){if((tries||0)<80)setTimeout(function(){installServiceGuard((tries||0)+1);},250);return;}
+  if(serviceObserver)serviceObserver.disconnect();serviceObserver=new MutationObserver(repairServiceCard);serviceObserver.observe(ws,{childList:true,subtree:true});repairServiceCard();
+}
 window.fetch=function(input,init){
   metrics.requests++;
   var method=methodOf(input,init),u=urlOf(input);
@@ -32,8 +59,16 @@ window.fetch=function(input,init){
   }
   var rule=ruleFor(u);
   if(!rule){metrics.network++;return baseFetch(input,init);}
+  var currentToken=token();
+  if(authDeniedToken&&currentToken&&currentToken!==authDeniedToken){authDeniedToken='';authDeniedUntil=0;}
+  if(currentToken&&authDeniedToken===currentToken&&Date.now()<authDeniedUntil){metrics.auth_backoff_hits++;return Promise.resolve(synthetic(403,'WA3_2FA_PANEL_REQUIRED','AUTH-BACKOFF'));}
   var key=keyFor(u),hit=readCached(key,rule);
   if(hit){metrics.cache_hits++;return Promise.resolve(materialize(hit,'HIT'));}
+  if(backoffOpen(key)){
+    metrics.backoff_hits++;
+    var stale=readStale(key);if(stale)return Promise.resolve(materialize(stale,'STALE-BACKOFF'));
+    return Promise.resolve(synthetic(503,'WA3_SERVICE_BACKOFF','BACKOFF'));
+  }
   if(inflight.has(key)){
     metrics.coalesced++;
     return inflight.get(key).then(function(s){if(s)return materialize(s,'COALESCED');metrics.stale_retries++;return window.fetch(input,init);});
@@ -41,21 +76,31 @@ window.fetch=function(input,init){
   metrics.network++;
   var requestEpoch=epoch;
   var pipeline=baseFetch(input,init).then(function(resp){
-    if(!cacheableResponse(resp))return {cache:null,response:resp,stale:false};
     return resp.text().then(function(body){
-      var s=snapshot(resp,body),fresh=requestEpoch===epoch;
-      if(fresh)store(key,s);
-      return {cache:fresh?s:null,response:fresh?materialize(s,'MISS'):null,stale:!fresh};
+      var data=parseBody(body),status=Number(resp.status||0),s=snapshot(resp,body);
+      if(status===403&&String(data&&data.error||'')==='WA3_2FA_PANEL_REQUIRED'&&recentlyVerified()){
+        metrics.transient_auth_remaps++;markFailure(key);
+        s.status=503;s.statusText='Service Unavailable';s.body=JSON.stringify({ok:false,error:'WA3_AUTH_UPSTREAM_UNAVAILABLE',retryable:true});
+        return {cache:null,response:materialize(s,'AUTH-UPSTREAM-REMAP',503),stale:false};
+      }
+      if(cacheableResponse(resp)){
+        lastVerifiedAt=Date.now();authDeniedUntil=0;authDeniedToken='';clearFailure(key);
+        var fresh=requestEpoch===epoch;if(fresh)store(key,s);
+        return {cache:fresh?s:null,response:fresh?materialize(s,'MISS'):null,stale:!fresh};
+      }
+      if(trueAuthDenial(status,data)&&currentToken){authDeniedToken=currentToken;authDeniedUntil=Date.now()+AUTH_BACKOFF_MS;}
+      if(status===408||status===429||status>=500)markFailure(key);
+      return {cache:null,response:materialize(s,'ERROR'),stale:false};
     }).catch(function(){return {cache:null,response:resp,stale:false};});
-  });
+  }).catch(function(e){markFailure(key);throw e;});
   var shared=pipeline.then(function(x){return x.cache;}).catch(function(){return null;});
   inflight.set(key,shared);
   shared.finally(function(){if(inflight.get(key)===shared)inflight.delete(key);});
   return pipeline.then(function(x){if(x.stale){metrics.stale_retries++;return window.fetch(input,init);}return x.response;});
 };
 function fresh(){invalidate('foreground');}
-window.addEventListener('focus',fresh);
 window.addEventListener('online',fresh);
 document.addEventListener('visibilitychange',function(){if(!document.hidden)fresh();});
-window.AOS_WA_PERF={installed:true,invalidate:invalidate,stats:function(){return Object.assign({cache_entries:cache.size,inflight:inflight.size,epoch:epoch,hidden:document.hidden},metrics);}};
+installServiceGuard(0);
+window.AOS_WA_PERF={installed:true,invalidate:invalidate,repairServiceCard:repairServiceCard,stats:function(){return Object.assign({cache_entries:cache.size,inflight:inflight.size,backoff_keys:failures.size,epoch:epoch,hidden:document.hidden,last_verified_at:lastVerifiedAt||null,auth_backoff_until:authDeniedUntil||null},metrics);}};
 })();

--- a/app/public/wa-performance-hardening.js
+++ b/app/public/wa-performance-hardening.js
@@ -5,7 +5,7 @@
 if(window.AOS_WA_PERF&&window.AOS_WA_PERF.installed)return;
 var baseFetch=window.fetch.bind(window);
 var cache=new Map(),inflight=new Map(),failures=new Map(),epoch=0;
-var lastVerifiedAt=0,authDeniedUntil=0,authDeniedToken='',serviceObserver=null;
+var lastVerifiedAt=0,authDeniedUntil=0,serviceObserver=null;
 var AUTH_BACKOFF_MS=120000,RECENT_VERIFY_MS=15000,STALE_MAX_MS=120000;
 var metrics={requests:0,network:0,cache_hits:0,coalesced:0,invalidations:0,stale_retries:0,backoff_hits:0,auth_backoff_hits:0,service_card_patches:0,transient_auth_remaps:0};
 var rules=[
@@ -16,7 +16,6 @@ var rules=[
 ];
 function methodOf(input,init){return String(init&&init.method||(input&&input.method)||'GET').toUpperCase();}
 function urlOf(input){try{return new URL(typeof input==='string'?input:(input&&input.url)||'',location.href);}catch(_){return null;}}
-function token(){try{return String(sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'').trim();}catch(_){return '';}}
 function ruleFor(u){if(!u||u.origin!==location.origin)return null;for(var i=0;i<rules.length;i++)if(rules[i].test(u))return rules[i];return null;}
 function ttlFor(rule){return document.hidden?rule.hidden:rule.visible;}
 function keyFor(u){return u.pathname+u.search;}
@@ -61,9 +60,7 @@ window.fetch=function(input,init){
   }
   var rule=ruleFor(u);
   if(!rule){metrics.network++;return baseFetch(input,init);}
-  var currentToken=token();
-  if(authDeniedToken&&currentToken&&currentToken!==authDeniedToken){authDeniedToken='';authDeniedUntil=0;}
-  if(currentToken&&authDeniedToken===currentToken&&Date.now()<authDeniedUntil){metrics.auth_backoff_hits++;return Promise.resolve(synthetic(403,'WA3_2FA_PANEL_REQUIRED','AUTH-BACKOFF'));}
+  if(Date.now()<authDeniedUntil){metrics.auth_backoff_hits++;return Promise.resolve(synthetic(403,'WA3_2FA_PANEL_REQUIRED','AUTH-BACKOFF'));}
   var key=keyFor(u),hit=readCached(key,rule);
   if(hit){metrics.cache_hits++;return Promise.resolve(materialize(hit,'HIT'));}
   if(backoffOpen(key)){
@@ -86,11 +83,11 @@ window.fetch=function(input,init){
         return {cache:null,response:materialize(s,'AUTH-UPSTREAM-REMAP',503),stale:false};
       }
       if(cacheableResponse(resp)){
-        lastVerifiedAt=Date.now();authDeniedUntil=0;authDeniedToken='';clearFailure(key);
+        lastVerifiedAt=Date.now();authDeniedUntil=0;clearFailure(key);
         var fresh=requestEpoch===epoch;if(fresh)store(key,s);
         return {cache:fresh?s:null,response:fresh?materialize(s,'MISS'):null,stale:!fresh};
       }
-      if(trueAuthDenial(status,data)&&currentToken){authDeniedToken=currentToken;authDeniedUntil=Date.now()+AUTH_BACKOFF_MS;}
+      if(trueAuthDenial(status,data))authDeniedUntil=Date.now()+AUTH_BACKOFF_MS;
       if(status===408||status===429||status>=500)markFailure(key);
       return {cache:null,response:materialize(s,'ERROR'),stale:false};
     }).catch(function(){return {cache:null,response:resp,stale:false};});

--- a/app/server-wa3-v2.js
+++ b/app/server-wa3-v2.js
@@ -1,10 +1,12 @@
 'use strict';
 // WA-3 V2 additive multiagent boundary.
-// Handles only readiness/queue/claim/team summary. Existing server-wa3.js remains ownership, routing and human-send authority.
+// Handles readiness/queue/claim/team summary and the P0 #485 outer auth availability guard.
+// Existing server-wa3.js remains ownership, routing and human-send authority.
 const http=require('http');
 const https=require('https');
 const crypto=require('crypto');
 const {spawn}=require('child_process');
+const {createActorResolver,createSuccessCache,shouldRemapInnerAuth}=require('./wa3-stability');
 
 const EXTERNAL_PORT=parseInt(process.env.PORT||'4173',10);
 const INNER_PORT=EXTERNAL_PORT===4200?4201:4200;
@@ -57,17 +59,17 @@ function sbRequest(method,endpoint,body,useService){
       apikey:key,
       Authorization:'Bearer '+key,
       'Content-Type':'application/json',
-      'User-Agent':'AscendaOS-WA3V2/1.0'
+      'User-Agent':'AscendaOS-WA3V2/1.1'
     };
     if(data)headers['Content-Length']=Buffer.byteLength(data);
     const q=https.request({hostname:sb.hostname,port:sb.port||443,path:endpoint,method,headers,timeout:12000},r=>{
       let raw='';r.on('data',c=>raw+=c);r.on('end',()=>{
         const out={status:r.statusCode||502,data:parseData(raw),raw};
         if(out.status>=200&&out.status<300)resolve(out);
-        else reject(Object.assign(new Error('WA3V2_DB_UNAVAILABLE'),{status:502,upstreamStatus:out.status,data:out.data}));
+        else reject(Object.assign(new Error('WA3V2_DB_UNAVAILABLE'),{status:503,upstreamStatus:out.status,data:out.data}));
       });
     });
-    q.on('timeout',()=>q.destroy(new Error('WA3V2_DB_TIMEOUT')));
+    q.on('timeout',()=>q.destroy(Object.assign(new Error('WA3V2_DB_TIMEOUT'),{status:503})));
     q.on('error',reject);
     if(data)q.write(data);
     q.end();
@@ -77,74 +79,95 @@ const sbRpc=(name,payload)=>sbRequest('POST','/rest/v1/rpc/'+name,payload,false)
 const serviceRpc=(name,payload)=>sbRequest('POST','/rest/v1/rpc/'+name,payload,true);
 const serviceGet=(endpoint)=>sbRequest('GET',endpoint,null,true);
 
-async function actor(req){
-  const token=strongToken(req);if(!token)return null;
-  try{
+// P0 #485: a transport/PostgREST outage is not an authentication denial.
+// Positive verification is short-lived; definitive denials are cached longer so stale clients
+// cannot hammer Supabase. Upstream failures are never negative-cached.
+const actorResolver=createActorResolver({
+  okTtlMs:5000,
+  denyTtlMs:30000,
+  maxEntries:1500,
+  verify:async function(token){
     const out=await sbRpc('aos_wa3_actor_v1',{p_token:token});
     const a=out.data;
     return a&&a.ok===true&&UUID_RE.test(String(a.actor_id||''))?a:null;
-  }catch(_){return null;}
+  }
+});
+const queueCache=createSuccessCache({ttlMs:10000,maxEntries:500});
+const teamCache=createSuccessCache({ttlMs:20000,maxEntries:100});
+
+async function actor(req){
+  return actorResolver.resolve(strongToken(req));
 }
 async function requireActor(req,res,adminOnly){
-  const a=await actor(req);
+  let a;
+  try{a=await actor(req);}catch(e){
+    writeJson(res,503,{ok:false,error:'WA3_AUTH_UPSTREAM_UNAVAILABLE',retryable:true});
+    return null;
+  }
   if(!a){writeJson(res,403,{ok:false,error:'WA3_2FA_PANEL_REQUIRED'});return null;}
   if(adminOnly&&a.is_admin!==true){writeJson(res,403,{ok:false,error:'WA3_ADMIN_REQUIRED'});return null;}
   return a;
 }
 async function queueSummary(a){
-  const out=await serviceRpc('aos_wa3_queue_summary_v1',{p_actor_id:a.actor_id});
-  return out.data||{ok:false,error:'WA3_QUEUE_SUMMARY_EMPTY'};
+  return queueCache.get('queue:'+String(a.actor_id),async function(){
+    const out=await serviceRpc('aos_wa3_queue_summary_v1',{p_actor_id:a.actor_id});
+    return out.data||{ok:false,error:'WA3_QUEUE_SUMMARY_EMPTY'};
+  });
 }
 async function getQueue(req,res){
   const a=await requireActor(req,res,false);if(!a)return;
   try{
     const d=await queueSummary(a);
     writeJson(res,d.ok===false?409:200,d);
-  }catch(e){writeJson(res,503,{ok:false,error:'WA3_QUEUE_SUMMARY_UNAVAILABLE'});}
+  }catch(e){writeJson(res,503,{ok:false,error:'WA3_QUEUE_SUMMARY_UNAVAILABLE',retryable:true});}
+}
+async function buildTeamSummary(){
+  const [members,users,assignments]=await Promise.all([
+    serviceGet('/rest/v1/aos_wa_box_members_v1?active=eq.true&select=box_id,user_id,max_active,priority,last_assigned_at'),
+    serviceGet('/rest/v1/aos_usuarios?activo=eq.true&select=id,nombre,rol,cargo,sede,nivel_jerarquia,paneles_acceso'),
+    serviceGet('/rest/v1/aos_wa_assignments_v1?state=eq.ACTIVE&select=owner_user_id,box_id')
+  ]);
+  const memberRows=Array.isArray(members.data)?members.data:[];
+  const userRows=Array.isArray(users.data)?users.data:[];
+  const assignmentRows=Array.isArray(assignments.data)?assignments.data:[];
+  const ids=new Set(memberRows.map(x=>String(x.user_id||'')));
+  const candidateUsers=userRows.filter(u=>ids.has(String(u.id)));
+  const agents=await Promise.all(candidateUsers.map(async u=>{
+    const effectiveOut=await serviceRpc('aos_wa3_effective_presence_v2',{p_actor_id:u.id});
+    const p=effectiveOut.data||{};
+    if(p.ok===false)throw new Error('WA3_EFFECTIVE_PRESENCE_UNAVAILABLE');
+    const boxes=memberRows.filter(m=>m.user_id===u.id).map(m=>({box_id:m.box_id,max_active:m.max_active,priority:m.priority}));
+    const activeLoad=assignmentRows.filter(x=>x.owner_user_id===u.id).length;
+    return {
+      id:u.id,
+      name:u.nombre||null,
+      role:u.rol||null,
+      cargo:u.cargo||null,
+      sede:u.sede||null,
+      effective_status:p.status||'OFFLINE',
+      labor_state:p.labor_state||null,
+      last_seen_at:p.last_seen_at||null,
+      available_since:p.available_since||null,
+      presence_source:p.presence_source||null,
+      active_load:activeLoad,
+      boxes:boxes
+    };
+  }));
+  agents.sort((x,y)=>String(x.name||'').localeCompare(String(y.name||''),'es'));
+  return {
+    ok:true,
+    agents:agents,
+    generated_at:new Date().toISOString(),
+    snapshot_source:'aos_wa3_effective_presence_v2',
+    privacy:'NO_CUSTOMER_DATA'
+  };
 }
 async function teamSummary(req,res){
   const a=await requireActor(req,res,true);if(!a)return;
   try{
-    const [members,users,assignments]=await Promise.all([
-      serviceGet('/rest/v1/aos_wa_box_members_v1?active=eq.true&select=box_id,user_id,max_active,priority,last_assigned_at'),
-      serviceGet('/rest/v1/aos_usuarios?activo=eq.true&select=id,nombre,rol,cargo,sede,nivel_jerarquia,paneles_acceso'),
-      serviceGet('/rest/v1/aos_wa_assignments_v1?state=eq.ACTIVE&select=owner_user_id,box_id')
-    ]);
-    const memberRows=Array.isArray(members.data)?members.data:[];
-    const userRows=Array.isArray(users.data)?users.data:[];
-    const assignmentRows=Array.isArray(assignments.data)?assignments.data:[];
-    const ids=new Set(memberRows.map(x=>String(x.user_id||'')));
-    const candidateUsers=userRows.filter(u=>ids.has(String(u.id)));
-    const agents=await Promise.all(candidateUsers.map(async u=>{
-      const effectiveOut=await serviceRpc('aos_wa3_effective_presence_v2',{p_actor_id:u.id});
-      const p=effectiveOut.data||{};
-      if(p.ok===false)throw new Error('WA3_EFFECTIVE_PRESENCE_UNAVAILABLE');
-      const boxes=memberRows.filter(m=>m.user_id===u.id).map(m=>({box_id:m.box_id,max_active:m.max_active,priority:m.priority}));
-      const activeLoad=assignmentRows.filter(x=>x.owner_user_id===u.id).length;
-      return {
-        id:u.id,
-        name:u.nombre||null,
-        role:u.rol||null,
-        cargo:u.cargo||null,
-        sede:u.sede||null,
-        effective_status:p.status||'OFFLINE',
-        labor_state:p.labor_state||null,
-        last_seen_at:p.last_seen_at||null,
-        available_since:p.available_since||null,
-        presence_source:p.presence_source||null,
-        active_load:activeLoad,
-        boxes:boxes
-      };
-    }));
-    agents.sort((x,y)=>String(x.name||'').localeCompare(String(y.name||''),'es'));
-    writeJson(res,200,{
-      ok:true,
-      agents:agents,
-      generated_at:new Date().toISOString(),
-      snapshot_source:'aos_wa3_effective_presence_v2',
-      privacy:'NO_CUSTOMER_DATA'
-    });
-  }catch(e){writeJson(res,503,{ok:false,error:'WA3_TEAM_SUMMARY_UNAVAILABLE'});}
+    const d=await teamCache.get('team:admin',buildTeamSummary);
+    writeJson(res,200,d);
+  }catch(e){writeJson(res,503,{ok:false,error:'WA3_TEAM_SUMMARY_UNAVAILABLE',retryable:true});}
 }
 async function presence(req,res){
   const a=await requireActor(req,res,false);if(!a)return;
@@ -178,7 +201,7 @@ async function presence(req,res){
     if(heartbeat){const prior=presenceHeartbeats.get(key);if(prior&&prior.promise)presenceHeartbeats.delete(key);}
     const p=e&&e.presence;
     if(p&&p.ok===false)return writeJson(res,409,p);
-    writeJson(res,503,{ok:false,error:'WA3_PRESENCE_UNAVAILABLE'});
+    writeJson(res,503,{ok:false,error:'WA3_PRESENCE_UNAVAILABLE',retryable:true});
   }
 }
 async function claimNext(req,res){
@@ -189,13 +212,14 @@ async function claimNext(req,res){
   try{
     const out=await serviceRpc('aos_wa3_claim_next_v2',{p_box_id:boxId,p_actor_id:a.actor_id});
     const d=out.data||{};
+    queueCache.clear('queue:'+String(a.actor_id));
+    teamCache.clear('team:admin');
     writeJson(res,d.ok===false?409:200,d);
-  }catch(e){writeJson(res,503,{ok:false,error:'WA3_CLAIM_UNAVAILABLE'});}
+  }catch(e){writeJson(res,503,{ok:false,error:'WA3_CLAIM_UNAVAILABLE',retryable:true});}
 }
 
-// Per-session limiter. The WA3V2 boundary sits behind multiple internal wrappers,
-// so socket.remoteAddress is normally loopback and MUST NOT be the primary key.
-// Reads and writes use independent buckets so UI polling can never block a human action.
+// Per-session limiter. Reads and writes use independent buckets so polling cannot block
+// a human mutation, while stale clients cannot create an unbounded request storm.
 const buckets=new Map();
 function rateIdentity(req){
   const token=strongToken(req);
@@ -206,7 +230,7 @@ function rateAllowed(req){
   const now=Date.now();
   const read=req.method==='GET'||req.method==='HEAD';
   const scope=read?'read':'write';
-  const limit=read?600:120;
+  const limit=read?240:120;
   const key=rateIdentity(req)+'|'+scope;
   let b=buckets.get(key);
   if(!b||now-b.start>60000){b={start:now,n:0};buckets.set(key,b);}
@@ -214,14 +238,26 @@ function rateAllowed(req){
   if(buckets.size>2000){for(const [k,v] of buckets)if(now-v.start>120000)buckets.delete(k);}
   return b.n<=limit;
 }
-function proxy(req,res){
+function proxy(req,res,prevalidated){
   const headers=Object.assign({},req.headers,{host:'127.0.0.1:'+INNER_PORT});
   const q=http.request({hostname:'127.0.0.1',port:INNER_PORT,path:req.url,method:req.method,headers},r=>{
+    if(prevalidated&&r.statusCode===403){
+      const chunks=[];let total=0,overflow=false;
+      r.on('data',c=>{total+=c.length;if(total<=65536)chunks.push(Buffer.from(c));else overflow=true;});
+      r.on('end',()=>{
+        const body=Buffer.concat(chunks);
+        if(!overflow&&shouldRemapInnerAuth(r.statusCode,body,true)){
+          return writeJson(res,503,{ok:false,error:'WA3_AUTH_UPSTREAM_UNAVAILABLE',retryable:true});
+        }
+        res.writeHead(r.statusCode||502,r.headers);res.end(body);
+      });
+      return;
+    }
     res.writeHead(r.statusCode||502,r.headers);r.pipe(res);
   });
   q.on('error',e=>{
     console.error('[WA3V2] proxy',e.message);
-    if(!res.headersSent)writeJson(res,502,{ok:false,error:'WA3V2_INNER_UNAVAILABLE'});else res.end();
+    if(!res.headersSent)writeJson(res,502,{ok:false,error:'WA3V2_INNER_UNAVAILABLE',retryable:true});else res.end();
   });
   req.pipe(q);
 }
@@ -234,10 +270,17 @@ const server=http.createServer(async(req,res)=>{
   if(req.method==='GET'&&p==='/api/wa3/team-summary')return teamSummary(req,res);
   if(req.method==='POST'&&p==='/api/wa3/presence')return presence(req,res);
   if(req.method==='POST'&&p==='/api/wa3/claim-next')return claimNext(req,res);
-  return proxy(req,res);
+  if(p.startsWith('/api/wa3/')){
+    // Prevalidate once at the outer boundary. A genuine denial stays 403. If the inner
+    // legacy authority independently loses PostgREST after this successful check, its
+    // generic 403 is remapped to retryable 503; access remains fail-closed.
+    const a=await requireActor(req,res,false);if(!a)return;
+    return proxy(req,res,true);
+  }
+  return proxy(req,res,false);
 });
 server.on('clientError',(_,socket)=>socket.end('HTTP/1.1 400 Bad Request\r\n\r\n'));
-server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[WA3V2] multiagent boundary listening',{external:EXTERNAL_PORT,inner:INNER_PORT}));
+server.listen(EXTERNAL_PORT,'0.0.0.0',()=>console.log('[WA3V2] multiagent boundary listening',{external:EXTERNAL_PORT,inner:INNER_PORT,p0_485:true}));
 function shutdown(sig){
   console.log('[WA3V2] shutdown',sig);
   try{child.kill(sig);}catch(_){}

--- a/app/wa3-stability.js
+++ b/app/wa3-stability.js
@@ -1,0 +1,110 @@
+'use strict'
+
+const crypto = require('crypto')
+
+function tokenKey(token) {
+  return crypto.createHash('sha256').update(String(token || '')).digest('hex').slice(0, 32)
+}
+
+function createActorResolver(opts) {
+  opts = opts || {}
+  const verify = opts.verify
+  if (typeof verify !== 'function') throw new Error('WA3_VERIFY_REQUIRED')
+  const okTtlMs = Math.max(1000, Number(opts.okTtlMs || 5000))
+  const denyTtlMs = Math.max(1000, Number(opts.denyTtlMs || 30000))
+  const maxEntries = Math.max(10, Number(opts.maxEntries || 1000))
+  const cache = new Map()
+  const inflight = new Map()
+
+  function prune(now) {
+    if (cache.size <= maxEntries) return
+    for (const [k, v] of cache) {
+      if (!v || now >= v.expiresAt) cache.delete(k)
+      if (cache.size <= maxEntries) break
+    }
+    while (cache.size > maxEntries) cache.delete(cache.keys().next().value)
+  }
+
+  async function resolve(token) {
+    const t = String(token || '').trim()
+    if (t.length < 32) return null
+    const key = tokenKey(t)
+    const now = Date.now()
+    const hit = cache.get(key)
+    if (hit && now < hit.expiresAt) return hit.actor
+    if (hit) cache.delete(key)
+    if (inflight.has(key)) return inflight.get(key)
+
+    const p = Promise.resolve()
+      .then(function() { return verify(t) })
+      .then(function(actor) {
+        const good = actor && actor.ok === true && typeof actor.actor_id === 'string'
+        cache.set(key, { actor: good ? actor : null, expiresAt: Date.now() + (good ? okTtlMs : denyTtlMs) })
+        prune(Date.now())
+        return good ? actor : null
+      })
+      .catch(function(err) {
+        const e = new Error('WA3_AUTH_UPSTREAM_UNAVAILABLE')
+        e.status = 503
+        e.cause = err
+        throw e
+      })
+      .finally(function() { inflight.delete(key) })
+    inflight.set(key, p)
+    return p
+  }
+
+  function invalidate(token) {
+    const t = String(token || '').trim()
+    if (t) cache.delete(tokenKey(t))
+    else cache.clear()
+  }
+
+  return { resolve, invalidate, cache, inflight, okTtlMs, denyTtlMs }
+}
+
+function createSuccessCache(opts) {
+  opts = opts || {}
+  const ttlMs = Math.max(250, Number(opts.ttlMs || 5000))
+  const maxEntries = Math.max(10, Number(opts.maxEntries || 1000))
+  const cache = new Map()
+  const inflight = new Map()
+
+  async function get(key, loader) {
+    const k = String(key || '')
+    const now = Date.now()
+    const hit = cache.get(k)
+    if (hit && now - hit.at < ttlMs) return hit.value
+    if (hit) cache.delete(k)
+    if (inflight.has(k)) return inflight.get(k)
+    const p = Promise.resolve()
+      .then(loader)
+      .then(function(value) {
+        cache.set(k, { at: Date.now(), value: value })
+        while (cache.size > maxEntries) cache.delete(cache.keys().next().value)
+        return value
+      })
+      .finally(function() { inflight.delete(k) })
+    inflight.set(k, p)
+    return p
+  }
+
+  function clear(key) {
+    if (key == null) cache.clear()
+    else cache.delete(String(key))
+  }
+
+  return { get, clear, cache, inflight, ttlMs }
+}
+
+function shouldRemapInnerAuth(status, body, prevalidated) {
+  if (!prevalidated || Number(status) !== 403) return false
+  let data = body
+  if (Buffer.isBuffer(data)) data = data.toString('utf8')
+  if (typeof data === 'string') {
+    try { data = JSON.parse(data) } catch (_) { return false }
+  }
+  return !!(data && data.error === 'WA3_2FA_PANEL_REQUIRED')
+}
+
+module.exports = { tokenKey, createActorResolver, createSuccessCache, shouldRemapInnerAuth }

--- a/ci/p0-485/browser_runtime_contract.js
+++ b/ci/p0-485/browser_runtime_contract.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const fs = require('fs')
+const vm = require('vm')
+const assert = require('assert')
+
+function boot(sequence) {
+  const source = fs.readFileSync('app/public/wa-performance-hardening.js', 'utf8')
+  let network = 0
+  const listeners = {}
+  const tokenValue = 't'.repeat(64)
+  const baseFetch = async function(input) {
+    network++
+    const url = String(input)
+    const next = sequence.shift() || { status: 200, body: { ok: true, url: url } }
+    return new Response(JSON.stringify(next.body || {}), {
+      status: next.status,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+  const window = {
+    fetch: baseFetch,
+    addEventListener: function(name, fn) { listeners['w:' + name] = fn },
+    dispatchEvent: function() {}
+  }
+  const document = {
+    hidden: false,
+    addEventListener: function(name, fn) { listeners['d:' + name] = fn }
+  }
+  const sessionStorage = {
+    getItem: function(k) { return k === 'aos_app_token' ? tokenValue : null }
+  }
+  const context = {
+    window, document, sessionStorage,
+    location: new URL('https://ascenda.test/app.html'),
+    URL, Headers, Response, Map, Date, Promise, console,
+    CustomEvent: class { constructor(type, opts) { this.type = type; this.detail = opts && opts.detail } }
+  }
+  vm.createContext(context)
+  vm.runInContext(source, context)
+  return { window, getNetwork: function() { return network } }
+}
+
+async function transientAuthIsServiceOutage() {
+  const h = boot([
+    { status: 200, body: { ok: true, rows: [] } },
+    { status: 403, body: { ok: false, error: 'WA3_2FA_PANEL_REQUIRED' } }
+  ])
+  const ok = await h.window.fetch('/api/wa3/inbox?limit=120')
+  assert.strictEqual(ok.status, 200)
+  const before = h.getNetwork()
+  const remapped = await h.window.fetch('/api/wa3/team-summary')
+  assert.strictEqual(remapped.status, 503, '403 after a fresh verified WA call must be treated as upstream availability, not forced logout')
+  const body = await remapped.json()
+  assert.strictEqual(body.error, 'WA3_AUTH_UPSTREAM_UNAVAILABLE')
+  assert.strictEqual(h.getNetwork(), before + 1)
+  const backedOff = await h.window.fetch('/api/wa3/team-summary')
+  assert.strictEqual(backedOff.status, 503)
+  assert.strictEqual(h.getNetwork(), before + 1, 'retry during service backoff must not hit network')
+  const stats = h.window.AOS_WA_PERF.stats()
+  assert.strictEqual(stats.transient_auth_remaps, 1)
+  assert(stats.backoff_hits >= 1)
+}
+
+async function definitiveAuthStopsZombieReads() {
+  const h = boot([
+    { status: 403, body: { ok: false, error: 'WA3_2FA_PANEL_REQUIRED' } }
+  ])
+  const first = await h.window.fetch('/api/wa3/inbox?limit=120')
+  assert.strictEqual(first.status, 403)
+  const before = h.getNetwork()
+  for (let i = 0; i < 100; i++) {
+    const r = await h.window.fetch('/api/wa3/team-summary')
+    assert.strictEqual(r.status, 403)
+  }
+  assert.strictEqual(h.getNetwork(), before, 'definitive auth denial must locally back off stale/zombie GET traffic')
+  assert(h.window.AOS_WA_PERF.stats().auth_backoff_hits >= 100)
+}
+
+async function main() {
+  await transientAuthIsServiceOutage()
+  await definitiveAuthStopsZombieReads()
+  console.log('P0_485_BROWSER_RUNTIME_CONTRACT_PASS')
+}
+
+main().catch(function(err) { console.error(err); process.exit(1) })

--- a/ci/p0-485/stability_contract.js
+++ b/ci/p0-485/stability_contract.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const { createActorResolver, createSuccessCache, shouldRemapInnerAuth } = require('../../app/wa3-stability')
+
+const TOKEN_A = 'a'.repeat(64)
+const TOKEN_B = 'b'.repeat(64)
+const TOKEN_C = 'c'.repeat(64)
+const ACTOR = { ok: true, actor_id: '11111111-1111-4111-8111-111111111111', is_admin: true }
+
+async function actorContracts() {
+  let okCalls = 0
+  const ok = createActorResolver({ okTtlMs: 5000, denyTtlMs: 30000, verify: async function() {
+    okCalls++
+    await new Promise(function(resolve) { setTimeout(resolve, 3) })
+    return ACTOR
+  } })
+  const many = await Promise.all(Array.from({ length: 100 }, function() { return ok.resolve(TOKEN_A) }))
+  assert.strictEqual(okCalls, 1, '100 concurrent actor reads must coalesce to one upstream verification')
+  many.forEach(function(a) { assert.strictEqual(a.actor_id, ACTOR.actor_id) })
+  await ok.resolve(TOKEN_A)
+  assert.strictEqual(okCalls, 1, 'positive actor verification must use the short cache')
+
+  let denyCalls = 0
+  const deny = createActorResolver({ okTtlMs: 5000, denyTtlMs: 30000, verify: async function() { denyCalls++; return null } })
+  for (let i = 0; i < 50; i++) assert.strictEqual(await deny.resolve(TOKEN_B), null)
+  assert.strictEqual(denyCalls, 1, 'definitive stale/invalid session must be negative-cached')
+
+  let failCalls = 0
+  const fail = createActorResolver({ verify: async function() { failCalls++; throw new Error('upstream unavailable') } })
+  const firstWave = await Promise.allSettled(Array.from({ length: 50 }, function() { return fail.resolve(TOKEN_C) }))
+  assert.strictEqual(failCalls, 1, 'concurrent upstream failure must still coalesce')
+  firstWave.forEach(function(r) {
+    assert.strictEqual(r.status, 'rejected')
+    assert.strictEqual(r.reason.message, 'WA3_AUTH_UPSTREAM_UNAVAILABLE')
+    assert.strictEqual(r.reason.status, 503)
+  })
+  await assert.rejects(fail.resolve(TOKEN_C), /WA3_AUTH_UPSTREAM_UNAVAILABLE/)
+  assert.strictEqual(failCalls, 2, 'upstream failure must never be cached as an auth denial')
+}
+
+async function summaryCacheContracts() {
+  let loads = 0
+  const cache = createSuccessCache({ ttlMs: 10000 })
+  const values = await Promise.all(Array.from({ length: 200 }, function() {
+    return cache.get('team:admin', async function() { loads++; await new Promise(function(resolve) { setTimeout(resolve, 2) }); return { ok: true, agents: [] } })
+  }))
+  assert.strictEqual(loads, 1, '200 supervisor summary reads must coalesce to one loader')
+  values.forEach(function(v) { assert.strictEqual(v.ok, true) })
+  await cache.get('team:admin', async function() { loads++; return { ok: true } })
+  assert.strictEqual(loads, 1, 'supervisor summary success cache must prevent immediate refetch')
+}
+
+function sourceContracts() {
+  const server = fs.readFileSync('app/server-wa3-v2.js', 'utf8')
+  const perf = fs.readFileSync('app/public/wa-performance-hardening.js', 'utf8')
+  const lock = fs.readFileSync('docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md', 'utf8')
+
+  for (const token of [
+    "error:'WA3_AUTH_UPSTREAM_UNAVAILABLE'",
+    'createActorResolver',
+    "queueCache=createSuccessCache({ttlMs:10000",
+    "teamCache=createSuccessCache({ttlMs:20000",
+    'shouldRemapInnerAuth',
+    "const limit=read?240:120",
+    "if(p.startsWith('/api/wa3/'))"
+  ]) assert(server.includes(token), 'server stability token missing: ' + token)
+
+  for (const token of [
+    'visible:8000,hidden:60000',
+    'visible:12000,hidden:60000',
+    'visible:20000,hidden:60000',
+    'AUTH_BACKOFF_MS=120000',
+    'Math.min(60000,15000*Math.pow(2,x.count-1))',
+    'WhatsApp Hub temporalmente no disponible',
+    "WA3_AUTH_UPSTREAM_UNAVAILABLE",
+    'transient_auth_remaps'
+  ]) assert(perf.includes(token), 'browser stability token missing: ' + token)
+
+  assert(lock.includes('P0 #485'), 'workstream lock must point to P0 #485')
+  assert(lock.includes('AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF'), 'SAFE-OFF lock missing')
+  assert(lock.includes('L10 CANARY:** `NOT AUTHORIZED DURING P0`'), 'CANARY prohibition missing')
+
+  assert.strictEqual(shouldRemapInnerAuth(403, JSON.stringify({ error: 'WA3_2FA_PANEL_REQUIRED' }), true), true)
+  assert.strictEqual(shouldRemapInnerAuth(403, JSON.stringify({ error: 'WA3_ADMIN_REQUIRED' }), true), false)
+  assert.strictEqual(shouldRemapInnerAuth(503, JSON.stringify({ error: 'WA3_2FA_PANEL_REQUIRED' }), true), false)
+  assert.strictEqual(shouldRemapInnerAuth(403, JSON.stringify({ error: 'WA3_2FA_PANEL_REQUIRED' }), false), false)
+}
+
+async function main() {
+  await actorContracts()
+  await summaryCacheContracts()
+  sourceContracts()
+  console.log('P0_485_STABILITY_CONTRACT_PASS')
+}
+
+main().catch(function(err) { console.error(err); process.exit(1) })

--- a/ci/phase4-revenue/ui_contract.js
+++ b/ci/phase4-revenue/ui_contract.js
@@ -60,7 +60,7 @@ ok(prc1Sql.includes("resolution_status='RESOLVED'") && prc1Sql.includes("resolut
 // WA-3 V2 is allowed only as the explicit additive wrapper between WA-4 and WA-3 V1.
 const wa4ToWa3 = (
   (wa4.includes("['server-wa3.js']") && wa4.includes('proxy(req,res)')) ||
-  (wa4.includes("['server-wa3-v2.js']") && wa4.includes('proxy(req,res)') && wa3v2.includes("['server-wa3.js']") && wa3v2.includes('proxy(req,res)'))
+  (wa4.includes("['server-wa3-v2.js']") && wa4.includes('proxy(req,res)') && wa3v2.includes("['server-wa3.js']") && wa3v2.includes('proxy(req,res'))
 );
 const directF4 = railway.includes('node server-f4.js');
 const wa2WrappedF4 = railway.includes('node server-wa2.js') && wa2.includes("['server-f4.js']") && wa2.includes('proxy(req,res)');

--- a/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
+++ b/ci/wa3-boxes-routing-handoff/ui_contract_v2.js
@@ -31,7 +31,8 @@ assert(!server.includes('message_body'));
 assert(server.includes("const crypto=require('crypto')"));
 assert(server.includes("crypto.createHash('sha256').update(token)"));
 assert(server.includes("const scope=read?'read':'write'"));
-assert(server.includes("const limit=read?600:120"));
+// P0 #485 lowers the read bucket from 600/min to 240/min; writes remain independently bounded.
+assert(server.includes("const limit=read?240:120"));
 assert(!server.includes("const key=String(req.socket.remoteAddress||'unknown'),now=Date.now()"));
 assert(wa4.includes("['server-wa3-v2.js']"));
 assert(wa4.includes('server-only L10 autonomous CANARY orchestration'));

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,43 +1,46 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Captured:** 2026-09-05 America/Lima  
-**ACTIVE HIGH/CRITICAL LOCK:** `P0 #467 — AUTH AVAILABILITY / SUPABASE-POSTGREST PRESSURE`  
-**GitHub authority:** Issue `#467` = `OPEN / ACTIVE`  
-**Exact entry main:** `6c34f833762e370dd709e5789f2ac3f40847349d`  
-**Active branch:** `p0-467-foreground-priority-20260905`  
-**WA-L10 #456:** `PAUSED — NO MUTABLE WORK WHILE P0 #467 IS ACTIVE`  
+**Captured:** 2026-09-09 America/Lima  
+**ACTIVE HIGH/CRITICAL LOCK:** `P0 #485 — AUTH/WHATSAPP FALSE-2FA + POLLING-PRESSURE RECURRENCE`  
+**GitHub authority:** Issue `#485` = `OPEN / ACTIVE`  
+**Exact entry main:** `07e5ac06ae82ea586d7239fa69a75532384460a1`  
+**Active branch:** `p0-485-auth-wa-stability-20260909`  
+**WA-L10 #456:** `PAUSED — RESUME ONLY AFTER P0 #485 PROD LOAD/RECURRENCE PASS`  
 **Current production safety:** `AUTO_OFF · KILL SWITCH ENGAGED · SAFE-OFF`  
 **Active L4 allowlist:** `0`  
-**L10 CANARY:** `NOT AUTHORIZED`  
+**L10 CANARY:** `NOT AUTHORIZED DURING P0`  
 **L11/general PROD:** `NOT AUTHORIZED`
 
 ## Incident evidence
 
-Wilmer's login requests reach Railway, but `/api/auth/v3/login` terminates with `502` after the fixed 12 s Auth V3 upstream boundary. Railway logs identify `AUTH_UPSTREAM_TIMEOUT` against `aos_login_v3`; the app container itself remains healthy and lightly loaded.
+At approximately 19:13–19:17 Lima on 2026-09-09, immediately after the real R7 notification gate, production again developed cross-module Supabase/PostgREST latency. The owner observed intermittent login failure, global slowness and a WhatsApp Hub screen titled `Sesión 2FA requerida` while the underlying failure code was `WA3_INBOX_UNAVAILABLE`. The system later recovered and fresh `/api/wa3/provider-health` returned HTTP 200 / READY on the same deployment.
 
-Supabase is degraded beyond Auth: unrelated REST resources and RPCs return `503/504/522`, and direct management SQL currently cannot establish a usable connection. This is therefore a database/PostgREST availability incident, not a credential rejection and not a reason to weaken Auth V3/2FA.
+The failure exposed two distinct correctness problems plus a load amplifier: WA3 actor verification collapsed upstream database failure into the same null result used for an invalid session; the native UI rendered any mount failure as a 2FA error; and overlapping native/supervisor refresh loops repeatedly requested inbox, queue and team summaries. `team-summary` itself performs multiple aggregate reads plus per-agent effective-presence RPCs.
 
-The first sustained degradation begins immediately after a synchronized recurring background window around 09:38 UTC: snapshot, configuration/branding cache, medical CMP cache, template cache, agent cron scan and notification-push claim all align within seconds. The existing business-priority circuit suppresses several known background sources after failure, but the snapshot/config paths were not classified and there was no reversible incident-mode hard suppression before network I/O.
+This is an availability/classification incident, not authority to weaken authentication and not authority to activate the autonomous WhatsApp agent.
 
 ## Authorized P0 remediation scope
 
-1. Preserve Auth V3/2FA fail-closed and the existing 12 s transport boundary; **no timeout inflation and no bypass**.
-2. Add a reversible `AOS_FOREGROUND_PRIORITY_MODE=true` incident mode in the existing composed HTTPS preload.
-3. In that mode, reject only classified non-critical background calls locally before Supabase network I/O, including snapshot/config cache paths that were previously uncovered.
-4. Keep Auth, Call Center, Agenda, Sales, WhatsApp routing/authority and AI-key bootstrap on the normal transport path.
-5. Enable the incident mode in Railway only after exact-head CI and protected merge/deploy.
-6. Prove Supabase/PostgREST recovery with cheap reads/SQL and observe the timeout window before asking Wilmer to retry login.
-7. After recovery, implement the durable scheduling fix: de-synchronize/serialize recurring background jobs and remove false-success recovery semantics rather than leaving emergency mode as the permanent architecture.
+1. Preserve Auth V3/2FA fail-closed and existing transport timeout boundaries; **no timeout inflation and no bypass**.
+2. Distinguish definitive authentication denial from upstream Auth/PostgREST unavailability. Upstream failure must be retryable 503-class state, not false 403/2FA.
+3. Keep a short positive actor-verification cache, longer definitive-negative cache and in-flight coalescing; never negative-cache upstream outages.
+4. Coalesce/cache bounded supervisor queue/team summaries and cap request-rate exposure without blocking human mutations.
+5. Increase browser read-cache intervals, add exponential backoff/stale-safe reads, stop zombie-session network churn after definitive auth denial, and preserve the valid ASCENDA shell during WA 5xx.
+6. Replace the misleading 2FA recovery card with a retryable WhatsApp-service-unavailable state when the error is operational rather than authentication-related.
+7. Add deterministic P0 regression and bounded recurrence/load gates before production merge.
+8. Deploy only while L4/L8 remain SAFE-OFF, then verify production Auth/WA availability, DB pressure and no request storm before releasing this lock.
 
 ## Binding invariants
 
 - Production WhatsApp remains `AUTO_OFF`, kill switch engaged, `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true`.
 - Active L4 allowlist remains zero and autonomous outbound remains zero.
-- No live autonomous provider dispatch and no CANARY transition during P0 #467.
+- No live autonomous provider dispatch and no CANARY transition during P0 #485.
 - No auth timeout inflation, credential bypass, 2FA bypass, DB restart, project pause, or destructive recovery without separate evidence/authorization.
-- No new polling/retry loop, persistent materialized analytical hot path or duplicate authority.
-- `main` drift invalidates the candidate and requires revalidation.
+- No new hot polling loop, persistent materialized analytical hot path, second sender, second identity authority or duplicate routing authority.
+- `main` drift invalidates the candidate and requires exact-current revalidation.
 
 ## Exit boundary
 
-P0 #467 can close only after exact-head CI, Railway deployment, foreground-priority recovery evidence, Supabase/PostgREST readiness, successful Auth V3 smoke, and a post-recovery observation window without renewed systemic 503/504/522 pressure. WA-L10 may resume only from the then-current exact main and with fresh SAFE-OFF evidence.
+P0 #485 can close only after exact-head CI, protected merge, Railway SAFE-OFF deployment, production readback and a bounded recurrence/load test proving: Auth/WA errors are classified correctly; no false 2FA/logout is produced by WA 5xx; stale clients back off; supervisor reads are coalesced; login/critical WA endpoints stay inside existing boundaries; and Postgres has no sustained waiting or >2 s / >5 s active-query buildup during the test.
+
+Only after that PASS may WA-L10 #456 resume **exactly** at the prepared one-conversation R7 CANARY gate. `AUTO_OFF -> CANARY` still requires a new explicit owner activation authorization after this P0 is closed.


### PR DESCRIPTION
Closes #485 after exact-head CI + SAFE-OFF production deployment + recurrence/load validation.

## Scope
- Preserve Auth V3/2FA fail-closed; no timeout inflation or bypass.
- Separate definitive 2FA denial from Supabase/PostgREST unavailability at the WA3 outer boundary.
- Add short positive / bounded negative actor verification caching with in-flight coalescing; upstream outages are never cached as denials.
- Coalesce queue/team supervisor summaries and cap WA3 request exposure.
- Increase browser read-cache windows, add bounded exponential backoff/stale-safe reads, and stop stale-session network churn after definitive auth denial.
- Convert operational WA 5xx mount failures from the misleading “Sesión 2FA requerida” card into a retryable service-unavailable state without clearing the ASCENDA session.
- Add dedicated deterministic P0 regression/load-coalescing gates and update the HIGH/CRITICAL workstream lock.

## Binding safety
Throughout this PR and deployment: `AUTO_OFF`, kill switch engaged, `auto_reply=false`, `ai_send=false`, `auto_routing=false`, `human_send=true`, active autonomous allowlist=0. No autonomous Meta/provider dispatch and no R7 CANARY activation.

## Production exit
Do not treat merge as closure by itself. After deploy, run bounded recurrence/load validation and DB/PostgREST pressure readback. WA-L10 #456 resumes only after PASS and only at the prior one-conversation R7 CANARY gate, which still requires fresh explicit owner activation authorization.