### PR TITLE
WA-L10: reduce unnecessary conversation dependencies and preserve burst clinical screening

### DIFF
--- a/app/wa4-copilot.js
+++ b/app/wa4-copilot.js
@@ -54,11 +54,12 @@ function composePatientReply(reply,messages,inbound){
   return (APPROVED_FIRST_CONTACT_PREFIX+(body?'\n\n'+body:'')).slice(0,900);
 }
 function deterministicOwnerApprovedIntroDraft(runtime,inbound,messages){
-  if(hasApprovedIntro(messages))return null;
   const intents=new Set(runtime&&Array.isArray(runtime.intents)?runtime.intents:[]);
   if(isGreetingOnly(inbound)){
+    if(hasApprovedIntro(messages))return {reply:'Aquí sigo 😊 ¿En qué puedo ayudarte?',intent:'INFO',next_action:'REPLY',confidence:1,cited_knowledge_ids:[],needs_human:false,reason:'Conversational acknowledgement; no business facts asserted.'};
     return {reply:conversationStyle.firstContactOrganic(),intent:'INFO',next_action:'REPLY',confidence:1,cited_knowledge_ids:[],needs_human:false,reason:'Owner-approved organic first-contact copy.'};
   }
+  if(hasApprovedIntro(messages))return null;
   const treatment=String(runtime&&runtime.state&&runtime.state.treatment||'');
   const transactional=['TREATMENT_PRICE','CONSULTATION_PRICE','PRICE_PER_SESSION','PROMOTION_REQUEST','BOOKING','SCHEDULE','RESCHEDULE_INTENT','CONFIRM_BOOKING','PAYMENT'];
   if(treatment==='TOXINA_BOTULINICA'&&!transactional.some(x=>intents.has(x))){
@@ -277,9 +278,17 @@ function createCopilot(deps){
       if(!conv||!messages.length)return writeJson(res,409,{ok:false,error:'WA4_CONVERSATION_CONTEXT_REQUIRED'});
 
       const runtime=runtimeV2.buildRuntimeContext({messages,conversation:conv});
-      const inbound=String(runtime.semantic_turn&&runtime.semantic_turn.text||lastInbound(messages));
+      const inbound=String(runtime.semantic_turn&&(runtime.semantic_turn.combined_text||runtime.semantic_turn.text)||lastInbound(messages));
       if(!inbound.trim())return writeJson(res,409,{ok:false,error:'WA4_INBOUND_MESSAGE_REQUIRED'});
       const clinicalRisk=ai.personalizedClinicalRisk(inbound);
+
+      // A clinical handoff needs no catalog, campaign, identity or model request.
+      // Keep authorization/context reads above and the same downstream L4/L8 boundary.
+      if(clinicalRisk){
+        const reply=conversationStyle.clinicalHandoff();
+        Promise.resolve(log({conversation_id:id,actor_id:auth.actor_id,task:'SALES_PLAYBOOK',provider:'deterministic',model:'DETERMINISTIC_GUARD',safety_model:null,outcome:'HUMAN_REQUIRED',input_messages:messages.length,input_chars:inbound.length,output_chars:reply.length,prompt_tokens:0,completion_tokens:0,total_tokens:0,estimated_cost_usd:0,latency_ms:Date.now()-started,safety_action:'HUMAN_CLINICAL',safety_category:'PERSONALIZED_CLINICAL'})).catch(()=>{});
+        return writeJson(res,200,{ok:true,runtime:runtimeSummary(runtime),contexts:{campaign:null,identity:null,booking:null},suggestion:{reply,intent:'OTHER',next_action:'HUMAN_CLINICAL',confidence:1,cited_knowledge_ids:[],needs_human:true,reason:'Consulta clínica personalizada.'},needs_human:true,next_action:'HUMAN_CLINICAL',model:'DETERMINISTIC_GUARD',estimated_cost_usd:0,latency_ms:Date.now()-started,auto_send:false});
+      }
 
       const introDraft=!clinicalRisk?deterministicOwnerApprovedIntroDraft(runtime,inbound,messages):null;
       if(introDraft){
@@ -322,11 +331,6 @@ function createCopilot(deps){
       const bookingCtx=clinicalRisk?{prompt_context:{status:'NOT_REQUESTED',confirmation_allowed:false}}:await bookingResolver.resolve({runtime,processContexts:governed.processContexts,preferred_site:identityCtx.preferred_site});
       const contexts=adapterSummary(campaignCtx,identityCtx,bookingCtx);
       const pb=governed.playbook;
-      if(clinicalRisk){
-        const reply=conversationStyle.clinicalHandoff();
-        await log({conversation_id:id,actor_id:auth.actor_id,task:'SALES_PLAYBOOK',provider:'deterministic',model:'DETERMINISTIC_GUARD',safety_model:null,outcome:'HUMAN_REQUIRED',input_messages:messages.length,input_chars:inbound.length,output_chars:reply.length,prompt_tokens:0,completion_tokens:0,total_tokens:0,estimated_cost_usd:0,latency_ms:Date.now()-started,safety_action:'HUMAN_CLINICAL',safety_category:'PERSONALIZED_CLINICAL'});
-        return writeJson(res,200,{ok:true,playbook:pb,runtime:runtimeSummary(runtime),contexts,suggestion:{reply,intent:'OTHER',next_action:'HUMAN_CLINICAL',confidence:1,cited_knowledge_ids:[],needs_human:true,reason:'Consulta clínica personalizada.'},model:'DETERMINISTIC_GUARD',estimated_cost_usd:0,auto_send:false});
-      }
       if(runtime.booking_readiness==='HIGH'&&identityCtx.requires_human===true){
         const suggestion={reply:'Para continuar con la reserva necesito validar tus datos antes de confirmar la cita. Mantengo tu preferencia mientras hacemos esa validación.',intent:'BOOKING',next_action:'HUMAN_COMMERCIAL',confidence:1,cited_knowledge_ids:[],needs_human:true,reason:'Conflicto o indisponibilidad de identidad canónica.'};
         const quality=qualityCheck(suggestion.reply,runtime,contexts,inbound,governed.publicBundle);

--- a/app/wa4-copilot.js
+++ b/app/wa4-copilot.js
@@ -278,9 +278,10 @@ function createCopilot(deps){
       if(!conv||!messages.length)return writeJson(res,409,{ok:false,error:'WA4_CONVERSATION_CONTEXT_REQUIRED'});
 
       const runtime=runtimeV2.buildRuntimeContext({messages,conversation:conv});
-      const inbound=String(runtime.semantic_turn&&(runtime.semantic_turn.combined_text||runtime.semantic_turn.text)||lastInbound(messages));
+      const inbound=String(runtime.semantic_turn&&runtime.semantic_turn.text||lastInbound(messages));
       if(!inbound.trim())return writeJson(res,409,{ok:false,error:'WA4_INBOUND_MESSAGE_REQUIRED'});
-      const clinicalRisk=ai.personalizedClinicalRisk(inbound);
+      const clinicalScreen=String(runtime.semantic_turn&&runtime.semantic_turn.combined_text||inbound);
+      const clinicalRisk=ai.personalizedClinicalRisk(clinicalScreen);
 
       // A clinical handoff needs no catalog, campaign, identity or model request.
       // Keep authorization/context reads above and the same downstream L4/L8 boundary.

--- a/ci/wa4-ai-sales-router/ai-router.test.js
+++ b/ci/wa4-ai-sales-router/ai-router.test.js
@@ -95,3 +95,4 @@ require('./retrieval-grounding-r3.test.js');
 require('./r4-continuity-presentation.test.js');
 require('./r6-conversation-ux-fastlane.test.js');
 require('./r7-conversation-product-contract.test.js');
+require('./r8-shortcuts.test.js');

--- a/ci/wa4-ai-sales-router/r8-shortcuts.test.js
+++ b/ci/wa4-ai-sales-router/r8-shortcuts.test.js
@@ -1,0 +1,39 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {createCopilot}=require('../../app/wa4-copilot');
+const style=require('../../app/wa4-conversation-style');
+
+function message(direction,message_body,seconds){return {direction,message_body,created_at:new Date(Date.UTC(2026,8,10)+seconds*1000).toISOString()};}
+async function run(messages,authorized=true){
+  const calls=[];let output;
+  const suggest=createCopilot({
+    authorize:async()=>({ok:authorized,actor_id:'synthetic-admin'}),
+    serviceGet:async path=>{calls.push(path);if(path.startsWith('/rest/v1/aos_wa_conversations_v1?'))return {data:[{id:'synthetic-conversation'}]};if(path.startsWith('/rest/v1/aos_wa_messages_v1?'))return {data:messages.slice().reverse()};throw new Error('DEPENDENCY_OFFLINE');},
+    serviceRpc:async()=>{calls.push('RPC');throw new Error('DEPENDENCY_OFFLINE');},
+    // A pending audit sink must not hold the patient response open.
+    servicePost:()=>{calls.push('AUDIT');return new Promise(()=>{});},
+    getGroqKey:async()=>{calls.push('MODEL');throw new Error('MODEL_OFFLINE');},
+    writeJson:(_res,status,body)=>{output={status,body};}
+  });
+  await suggest({}, {},'synthetic-conversation');return {calls,output};
+}
+test('R8 returning greeting works through the full handler without knowledge or models',async()=>{
+  const {calls,output}=await run([message('INBOUND','hola',0),message('OUTBOUND',style.firstContactOrganic(),10),message('INBOUND','hola',30)]);
+  assert.equal(output.status,200);assert.equal(output.body.needs_human,false);
+  assert.match(output.body.suggestion.reply,/Aquí sigo/);assert.equal(output.body.suggestion.reply.includes('Soy Sofía'),false);
+  assert.equal(calls.length,3);assert.equal(calls.includes('RPC'),false);assert.equal(calls.includes('MODEL'),false);
+});
+test('R8 clinical escalation survives unavailable enrichment and audit latency',async()=>{
+  const {calls,output}=await run([message('INBOUND','Estoy embarazada, puedo usar toxina?',0)]);
+  assert.equal(output.status,200);assert.equal(output.body.next_action,'HUMAN_CLINICAL');
+  assert.equal(output.body.auto_send,false);assert.equal(output.body.needs_human,true);assert.equal(calls.length,3);
+});
+test('R8 clinical risk in the first fragment cannot be hidden by a later greeting',async()=>{
+  const {output}=await run([message('INBOUND','Estoy embarazada',0),message('INBOUND','hola',2)]);
+  assert.equal(output.body.next_action,'HUMAN_CLINICAL');assert.equal(output.body.needs_human,true);
+});
+test('R8 unauthorized requests cannot reach even the deterministic shortcuts',async()=>{
+  const {calls,output}=await run([message('INBOUND','hola',0)],false);
+  assert.equal(output.status,403);assert.deepEqual(calls,[]);
+});

--- a/ci/wa4-ai-sales-router/ui_contract.py
+++ b/ci/wa4-ai-sales-router/ui_contract.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import re
 root = Path(__file__).resolve().parents[2]
 wa4 = (root/'app/server-wa4.js').read_text()
 wa3v2_path = root/'app/server-wa3-v2.js'
@@ -37,7 +38,7 @@ assert direct or f5_wrapped or phase_s_wrapped or s152_wrapped, 'Railway must st
 if normalized_start in (sentinel_phase_s, sentinel_phase_s_email, sentinel_s152, sentinel_s152_email):
     assert 'NODE_OPTIONS' not in str(rail.get('build',{}).get('buildCommand','')), 'Runtime preloads must not contaminate build'
 wa4_to_v1 = "['server-wa3.js']" in wa4 and 'proxy(req,res)' in wa4
-wa4_to_v2_to_v1 = "['server-wa3-v2.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa3.js']" in wa3v2 and 'proxy(req,res)' in wa3v2
+wa4_to_v2_to_v1 = "['server-wa3-v2.js']" in wa4 and 'proxy(req,res)' in wa4 and "['server-wa3.js']" in wa3v2 and re.search(r'proxy\(req,res(?:,(?:true|false))?\)', wa3v2)
 assert wa4_to_v1 or wa4_to_v2_to_v1, 'WA-4 must preserve the certified WA-3 authority directly or through explicit WA-3 V2 boundary'
 assert 'aos_wa4_authorize_copilot_v1' in wa4
 assert "auto_send:false" in wa4 or "auto_send: false" in wa4

--- a/docs/control/WA_L10_R8_SHORTCUTS_IMPACT_20260910.md
+++ b/docs/control/WA_L10_R8_SHORTCUTS_IMPACT_20260910.md
@@ -1,0 +1,27 @@
+# WA-L10 R8 — bounded conversation shortcuts
+
+## Impact Report
+**Project / phase:** WA-L10 #456; isolated candidate only.
+**Risk:** HIGH conversation orchestration. No production mutation or CANARY authorization.
+**Base:** 9592ee3a56e0ef26af2d455f80d5c191e2465bd6 (revalidated after concurrent PRs #484, #486 and #487).
+
+## Problem and change
+Returning greetings unnecessarily fell through to campaign/identity/knowledge/model processing. Clinical escalation also waited for enrichment, which could fail before the safe answer was returned. The runtime detected intents across inbound bursts but Copilot used only the final fragment for clinical screening and downstream evidence queries.
+
+The candidate keeps returning greetings deterministic, moves clinical handoff ahead of enrichment and evaluates the complete bounded semantic burst. Auth/context checks still precede every shortcut. Clinical output has explicit needs_human=true and auto_send=false. Existing L4/L8 and the single provider sender are unchanged. Audit submission is attempted without holding the clinical response open, matching the existing first-contact/price fast lanes; this is not a guarantee of audit persistence under a failed audit sink.
+
+## Comparison source
+Read-only ROO7 reference: web/app/api/os/ai/route.ts in CESARJAUREGUITORRES/roosiete. Its staff endpoint authenticates the session, accepts the last 12 messages and makes one Groq completion call. That shows a smaller orchestration path, not measured performance equivalence or a safe drop-in replacement for customer-facing clinical WhatsApp. No ROO7 code, data, prompts or credentials were copied or changed.
+
+## Tests
+Full handler tests inject offline enrichment/model services and a pending audit sink. They prove returning-greeting response, clinical handoff, first-fragment clinical screening and authorization denial. Canonical WA4, L10 bridge and conversation-runtime suites: 70/70 Node test entries PASS locally. No real provider or production-data fixtures. No E2E latency claim.
+
+## Historical notification evidence — superseded by PR #484
+On September 9, hola and HOLA PRUEBA 2 were persisted once each at 23:17:23Z and 23:19:12Z. L4 remained AUTO_OFF; no autonomous response was expected. S14 WA push failed with F17_RPC_UNAVAILABLE at 23:17:31Z and 23:19:13Z. Live target-resolution readback for the latter message returned HUMAN_OWNER_REQUIRED. The conversation was HUMAN_REQUESTED, unowned; client sound and server push eligibility both require HUMAN_ACTIVE + current owner. No WhatsApp push dispatch or notification row was created in the observed interval. An active admin push subscription exists, so missing registration is not established as the cause.
+
+PR #484 subsequently added the bounded V2 runtime VAPID path and one-recipient queue supervisor fallback while preserving the generic foreground shield. This candidate preserves that repair. PR #486 added Auth/WA availability classification and bounded coalescing/backoff; PR #487 records its production validation and restores the WA-L10 gate. The earlier notification diagnosis above describes the screenshot timestamp, not an assertion that current production still has that defect.
+
+## Remaining gates / rollback
+Current lock at 9592ee3 restores WA-L10 after P0 #485 closure. This remains an isolated SAFE-OFF conversation candidate, not a replacement for the R7 activation gate. Run relevant exact-head CI and protected merge before release. Inspect Railway staged changes before any deployment; do not apply unrelated pending variables. Verify production readback, full conversation replay and human takeover; obtain fresh exact-conversation CANARY authorization before activation. This candidate does not claim a full real conversation PASS; the deployed R7 flow still requires the explicitly authorized one-conversation canary. Notification remediation belongs to PR #484.
+
+Rollback: revert the candidate code commit, redeploy the previous certified source through the governed pipeline. No schema, price, patient, appointment, delivery authority or model configuration changes.

--- a/docs/control/WA_L10_R8_SHORTCUTS_IMPACT_20260910.md
+++ b/docs/control/WA_L10_R8_SHORTCUTS_IMPACT_20260910.md
@@ -25,3 +25,10 @@ PR #484 subsequently added the bounded V2 runtime VAPID path and one-recipient q
 Current lock at 9592ee3 restores WA-L10 after P0 #485 closure. This remains an isolated SAFE-OFF conversation candidate, not a replacement for the R7 activation gate. Run relevant exact-head CI and protected merge before release. Inspect Railway staged changes before any deployment; do not apply unrelated pending variables. Verify production readback, full conversation replay and human takeover; obtain fresh exact-conversation CANARY authorization before activation. This candidate does not claim a full real conversation PASS; the deployed R7 flow still requires the explicitly authorized one-conversation canary. Notification remediation belongs to PR #484.
 
 Rollback: revert the candidate code commit, redeploy the previous certified source through the governed pipeline. No schema, price, patient, appointment, delivery authority or model configuration changes.
+
+## Exact-head CI follow-up
+The first candidate CI exposed a cross-turn retrieval regression: using the entire burst for commercial retrieval could select an earlier PEN product when the latest request asked for a different USD product. Clinical screening now uses the combined burst while commercial retrieval retains the latest text and existing runtime-carried state. The full-local USD assertion is preserved and must pass on the revised head.
+
+The WA4 Python topology contract also still required the old two-argument WA3 V2 proxy call after P0 #485 introduced a third boolean. The assertion now accepts only the original call or the explicit true/false argument, while retaining the canonical child/wrapper checks.
+
+Owner authorized the one-conversation canary on 2026-09-10 in this chat. Activation is not yet executed: current Railway/main match at 9592ee3 and DB pressure is clear, but the remote browser provider-health request was blocked by the client (ERR_BLOCKED_BY_CLIENT). Fresh provider verification remains required. No authority flags or allowlist were changed.


### PR DESCRIPTION
Returning greetings and clinical handoffs could wait on campaign, identity, knowledge and model dependencies before replying. Clinical screening also inspected only the last fragment of a bounded inbound burst.

This change handles returning greetings and clinical escalation immediately after authorization/context reads, and screens the combined semantic turn. Clinical results explicitly require human handoff. No delivery authority, sender, schema, booking or model configuration changes.

Validation: 70/70 local Node test entries pass after rebasing onto main 9592ee3, including full-handler offline-dependency, pending-audit, clinical-first-fragment and authorization-denial tests. Diff hygiene passes. Exact-head CI remains required; no production or real conversation certification is claimed.

Preserves the notification repair in #484 and stability repairs in #486. Current production was rechecked at 9592ee3, Railway deployment 362b53e9 SUCCESS; live authority remains AUTO_OFF with kill switch engaged. This draft neither activates nor authorizes CANARY. The fresh one-conversation owner gate in #487 remains applicable.

Impact report and rollback: docs/control/WA_L10_R8_SHORTCUTS_IMPACT_20260910.md. Related to #456. No merge/deploy requested by this draft.