### PR TITLE
P0 #490: stop repeated Call Center phones and restore backlog priority

### DIFF
--- a/.github/workflows/callcenter-governed-runtime-guard.yml
+++ b/.github/workflows/callcenter-governed-runtime-guard.yml
@@ -7,9 +7,13 @@ on:
       - 'app/public/app.html'
       - 'app/public/calls.html'
       - 'app/public/calls.js'
+      - 'app/public/calls-performance-v1.js'
+      - 'app/public/calls-performance-v1.js'
       - 'app/public/calls-loop6.js'
       - 'app/public/f4-production-canary-hotfix.js'
       - 'supabase/migrations/*loop6*'
+      - 'supabase/rollbacks/*loop6*'
+      - 'supabase/rollbacks/*loop6*'
       - '.github/workflows/callcenter-governed-runtime-guard.yml'
   push:
     branches: [main, 'fix/**']

--- a/.github/workflows/callcenter-governed-runtime-guard.yml
+++ b/.github/workflows/callcenter-governed-runtime-guard.yml
@@ -8,11 +8,9 @@ on:
       - 'app/public/calls.html'
       - 'app/public/calls.js'
       - 'app/public/calls-performance-v1.js'
-      - 'app/public/calls-performance-v1.js'
       - 'app/public/calls-loop6.js'
       - 'app/public/f4-production-canary-hotfix.js'
       - 'supabase/migrations/*loop6*'
-      - 'supabase/rollbacks/*loop6*'
       - 'supabase/rollbacks/*loop6*'
       - '.github/workflows/callcenter-governed-runtime-guard.yml'
   push:
@@ -21,9 +19,11 @@ on:
       - 'app/public/app.html'
       - 'app/public/calls.html'
       - 'app/public/calls.js'
+      - 'app/public/calls-performance-v1.js'
       - 'app/public/calls-loop6.js'
       - 'app/public/f4-production-canary-hotfix.js'
       - 'supabase/migrations/*loop6*'
+      - 'supabase/rollbacks/*loop6*'
       - '.github/workflows/callcenter-governed-runtime-guard.yml'
   workflow_dispatch:
 

--- a/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
+++ b/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'app/public/calls-performance-v1.js'
+      - 'app/public/calls.js'
+      - 'supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql'
+      - 'supabase/rollbacks/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1_recovery.sql'
       - 'app/public/agenda-governed-status-v1.js'
       - 'app/public/panel-access-authority-v1.js'
       - 'supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql'

--- a/app/public/calls.js
+++ b/app/public/calls.js
@@ -135,7 +135,7 @@ function loadLead(_retried){
     document.getElementById('cc-num').textContent='Error: sin sesión';document.getElementById('cc-no-lead').style.display='block';document.getElementById('cc-no-txt').textContent='Sesión no detectada. Recarga la página.';console.error('[CC] _ctx vacío después de 5 reintentos:',JSON.stringify(x));return;
   }
   CC._retries=0;
-  _rpc('aos_siguiente_lead_v2',{p_asesor:x.a,p_id_asesor:x.id,p_hoy:x.hoy},function(res){
+  _rpc('aos_siguiente_lead',{p_asesor:x.a,p_id_asesor:x.id,p_hoy:x.hoy},function(res){
     if(!res||!res.ok||!res.lead){
       document.getElementById('cc-no-lead').style.display='block';
       document.getElementById('cc-no-txt').textContent=res?(res.msg||'Sin leads pendientes.'):'Sin leads pendientes.';

--- a/ci/sentinel/phase6_business_health_contract.js
+++ b/ci/sentinel/phase6_business_health_contract.js
@@ -43,7 +43,7 @@ ok(c.live_preflight?.email_historical_records_live_state==='IGNORED_OUTSIDE_HORI
 
 ok(calls.includes("_rpc('aos_panel_asesor'"),'F6_CALLCENTER_PANEL_SOURCE_MISSING');
 ok(calls.includes("_rpc('aos_monitoreo_equipo'"),'F6_CALLCENTER_TEAM_SOURCE_MISSING');
-ok(calls.includes("_rpc('aos_siguiente_lead_v2'"),'F6_CALLCENTER_BACKLOG_SOURCE_MISSING');
+ok(calls.includes("_rpc('aos_siguiente_lead'"),'F6_CALLCENTER_BACKLOG_SOURCE_MISSING');
 ok(f4.includes("rpcName='aos_sales_intelligence_gateway'"),'F6_SALES_GATEWAY_SOURCE_MISSING');
 ok(wa2.includes('aos_wa_conversations_v1'),'F6_WA_CONVERSATION_SOURCE_MISSING');
 ok(wa3.includes('aos_wa_outbound_requests_v1'),'F6_WA_OUTBOUND_SOURCE_MISSING');

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -4,6 +4,7 @@ const test=require('node:test');
 const assert=require('node:assert/strict');
 
 const cc=fs.readFileSync('app/public/calls-performance-v1.js','utf8');
+const calls=fs.readFileSync('app/public/calls.js','utf8');
 const agenda=fs.readFileSync('app/public/agenda-governed-status-v1.js','utf8');
 const f4=fs.readFileSync('app/public/f4-production-canary-hotfix.js','utf8');
 const panel=fs.readFileSync('app/public/panel-access-authority-v1.js','utf8');
@@ -12,12 +13,24 @@ const hot=fs.readFileSync('supabase/migrations/20260902002500_mkt_loop6_p0_booki
 const hotExec=hot.split(/\r?\n/).filter(line=>!line.trimStart().startsWith('--')).join('\n');
 const hotRollback=fs.readFileSync('supabase/rollbacks/20260902002500_mkt_loop6_p0_booking_hotpath_v3_recovery.sql','utf8');
 const agSql=fs.readFileSync('supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql','utf8');
+const debt=fs.readFileSync('supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql','utf8');
 
 test('Call Center waits for Loop6 and coalesces duplicated panel reads',()=>{
   assert.match(cc,/__AOS_CC_LOOP6_POSTLOAD_READY__!=='v2\.3-postload'/);
   assert.match(cc,/aos_siguiente_lead_v2'\?'aos_siguiente_lead'/);
   assert.match(cc,/aos_panel_asesor:2500/);
   assert.match(cc,/aos_horarios_semana:30000/);
+});
+
+test('P0 #490 keeps Contact Debt event time sane and initial selector canonical',()=>{
+  assert.match(calls,/_rpc\('aos_siguiente_lead',\{p_asesor:x\.a,p_id_asesor:x\.id,p_hoy:x\.hoy\}/);
+  assert.doesNotMatch(calls,/_rpc\('aos_siguiente_lead_v2',\{p_asesor:x\.a,p_id_asesor:x\.id,p_hoy:x\.hoy\}/);
+  assert.match(debt,/aos_callcenter_effective_lead_ts_v1/);
+  assert.match(debt,/p_hora_ingreso <= now\(\)\+interval '5 minutes'/);
+  assert.match(debt,/abs\(\(\(p_hora_ingreso at time zone 'America\/Lima'\)::date - p_fecha\)\) <= 1/);
+  assert.match(debt,/>= public\.aos_callcenter_effective_lead_ts_v1/);
+  assert.match(debt,/order by bucket,lead_ts,id/);
+  assert.match(debt,/return public\.aos_siguiente_lead_v2\(p_asesor,p_id_asesor,p_hoy\)/);
 });
 
 test('Call Center governed writes prefer canonical strong-session token and fail closed',()=>{

--- a/supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql
+++ b/supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql
@@ -1,0 +1,259 @@
+-- P0 #490 · Call Center Contact Debt timestamp sanity
+-- Raw lead data is immutable. Some legacy hora_ingreso values contain day/month
+-- inversion and can point months into the future. Those timestamps must never
+-- keep a phone permanently pending after a real call.
+create or replace function public.aos_callcenter_effective_lead_ts_v1(
+  p_fecha date,
+  p_hora_ingreso timestamptz,
+  p_created_at timestamptz
+)
+returns timestamptz
+language sql
+stable
+set search_path = pg_catalog, public
+as $function$
+  select case
+    when p_fecha is null then coalesce(p_hora_ingreso,p_created_at,now())
+    when p_hora_ingreso is not null
+      and p_hora_ingreso <= now()+interval '5 minutes'
+      and abs(((p_hora_ingreso at time zone 'America/Lima')::date - p_fecha)) <= 1
+      then p_hora_ingreso
+    when p_created_at is not null
+      and p_created_at <= now()+interval '5 minutes'
+      and abs(((p_created_at at time zone 'America/Lima')::date - p_fecha)) <= 1
+      then p_created_at
+    else (p_fecha::timestamp at time zone 'America/Lima')
+  end
+$function$;
+
+revoke all on function public.aos_callcenter_effective_lead_ts_v1(date,timestamptz,timestamptz) from public,anon,authenticated;
+
+-- CC-Q1 / Call Center Contact-Debt Priority V1 · P0 #490 sanity hardening
+-- Goal: every NEW lead touchpoint must be worked before legacy call-center tiers.
+-- Order: TODAY -> CURRENT MONTH -> CURRENT YEAR -> HISTORICAL -> existing TIER engine.
+-- Important: a phone having an OLD call does not satisfy a NEW lead touchpoint.
+-- Raw leads/calls are never rewritten. Existing aos_siguiente_lead_v2 remains the fallback engine.
+
+create or replace function public.aos_siguiente_lead(
+  p_asesor text,
+  p_id_asesor text,
+  p_hoy date
+)
+returns json
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $function$
+declare
+  v_lead_id bigint := null;
+  v_num text := null;
+  v_trat text := '';
+  v_anuncio text := '';
+  v_fecha date := null;
+  v_hora_ingreso timestamptz := null;
+  v_lead_ts timestamptz := null;
+  v_bucket integer := null;
+  v_bucket_code text := null;
+  v_tier text := null;
+  v_cola_tipo text := 'global';
+  v_contexto json := null;
+  v_intento integer := 1;
+  v_wait_minutes integer := 0;
+  v_lead json := null;
+begin
+  -- Preserve historical cleanup behavior.
+  delete from public.aos_leads_en_curso where fecha < p_hoy;
+
+  select coalesce(tipo_cola,'global')
+    into v_cola_tipo
+  from public.aos_cola_config
+  where upper(asesor)=upper(p_asesor)
+  limit 1;
+  v_cola_tipo := coalesce(v_cola_tipo,'global');
+
+  -- CONTACT DEBT:
+  -- A lead touchpoint is pending when there is no call tied to that lead_id
+  -- and no same-phone call recorded at/after that lead arrived.
+  -- Multiple pending touchpoints for one phone collapse to the latest touchpoint.
+  -- Active assignments from another advisor are leased for 20 minutes; abandoned
+  -- assignments can then re-enter the pool instead of being frozen all day.
+  with debt as (
+    select
+      ld.id,
+      ld.numero_limpio,
+      ld.fecha,
+      coalesce(ld.tratamiento,'') as tratamiento,
+      coalesce(ld.anuncio,'') as anuncio,
+      ld.hora_ingreso,
+      public.aos_callcenter_effective_lead_ts_v1(
+        ld.fecha,
+        ld.hora_ingreso,
+        ld.created_at
+      ) as lead_ts,
+      case
+        when ld.fecha=p_hoy then 0
+        when date_trunc('month',ld.fecha)=date_trunc('month',p_hoy) then 1
+        when date_trunc('year',ld.fecha)=date_trunc('year',p_hoy) then 2
+        else 3
+      end as bucket,
+      row_number() over (
+        partition by ld.numero_limpio
+        order by public.aos_callcenter_effective_lead_ts_v1(
+          ld.fecha,
+          ld.hora_ingreso,
+          ld.created_at
+        ) desc, ld.id desc
+      ) as rn
+    from public.aos_leads ld
+    where ld.numero_limpio is not null
+      and ld.numero_limpio<>''
+      and not exists (
+        select 1
+        from public.aos_llamadas ll
+        where ll.numero_limpio=ld.numero_limpio
+          and (
+            ll.lead_id_origen=ld.id
+            or coalesce(
+              ll.created_at,
+              ll.ult_ts,
+              ll.ts_log,
+              (ll.fecha::timestamp at time zone 'America/Lima')
+            ) >= public.aos_callcenter_effective_lead_ts_v1(
+              ld.fecha,
+              ld.hora_ingreso,
+              ld.created_at
+            )
+          )
+      )
+      and not exists (
+        select 1
+        from public.v_numeros_con_cita_pendiente cp
+        where cp.numero_limpio=ld.numero_limpio
+      )
+      and not exists (
+        select 1
+        from public.aos_leads_en_curso lc
+        where lc.numero_limpio=ld.numero_limpio
+          and lc.fecha=p_hoy
+          and upper(lc.asesor)<>upper(p_asesor)
+          and coalesce(lc.asignado_at,now()) >= now()-interval '20 minutes'
+      )
+  ), ranked as (
+    select *
+    from debt
+    where rn=1
+    order by bucket,lead_ts,id
+    limit 32
+  )
+  select
+    ld.id,
+    ld.numero_limpio,
+    r.tratamiento,
+    r.anuncio,
+    r.fecha,
+    r.hora_ingreso,
+    r.lead_ts,
+    r.bucket
+  into
+    v_lead_id,
+    v_num,
+    v_trat,
+    v_anuncio,
+    v_fecha,
+    v_hora_ingreso,
+    v_lead_ts,
+    v_bucket
+  from ranked r
+  join public.aos_leads ld on ld.id=r.id
+  order by r.bucket,r.lead_ts,r.id
+  for update of ld skip locked
+  limit 1;
+
+  if v_num is not null then
+    v_bucket_code := case v_bucket
+      when 0 then 'TODAY'
+      when 1 then 'MONTH'
+      when 2 then 'YEAR'
+      else 'HISTORICAL'
+    end;
+
+    v_tier := case v_bucket
+      when 0 then 'PRIORIDAD 0 · NUEVO SIN CONTACTO HOY'
+      when 1 then 'PRIORIDAD 0 · PENDIENTE DEL MES'
+      when 2 then 'PRIORIDAD 0 · PENDIENTE DEL AÑO'
+      else 'PRIORIDAD 0 · PENDIENTE HISTÓRICO'
+    end;
+
+    select coalesce(count(*),0)+1
+      into v_intento
+    from public.aos_llamadas
+    where numero_limpio=v_num;
+
+    v_wait_minutes := greatest(
+      0,
+      floor(extract(epoch from (now()-v_lead_ts))/60)::integer
+    );
+
+    v_lead := json_build_object(
+      'id',v_lead_id,
+      'num',v_num,
+      'trat',v_trat,
+      'anuncio',v_anuncio,
+      'fecha',v_fecha,
+      'hora_ingreso',v_hora_ingreso,
+      'intento',v_intento,
+      'rowNum',0,
+      'attributionSource','CONTACT_DEBT_EXACT',
+      'contactDebtBucket',v_bucket_code,
+      'waitMinutes',v_wait_minutes
+    );
+
+    insert into public.aos_leads_en_curso(
+      asesor,numero_limpio,fecha,lead_id_origen,asignado_at
+    )
+    values(
+      upper(p_asesor),v_num,p_hoy,v_lead_id,now()
+    )
+    on conflict(asesor,numero_limpio,fecha)
+    do update set
+      lead_id_origen=excluded.lead_id_origen,
+      asignado_at=excluded.asignado_at;
+
+    select json_build_object(
+      'ultimaLlamada',json_build_object(
+        'fecha',ll.fecha,
+        'estado',ll.estado,
+        'asesor',ll.asesor,
+        'obs',coalesce(ll.observacion,''),
+        'intento',ll.intento
+      )
+    )
+    into v_contexto
+    from public.aos_llamadas ll
+    where ll.numero_limpio=v_num
+    order by coalesce(ll.created_at,ll.ult_ts,ll.ts_log) desc nulls last,ll.id desc
+    limit 1;
+
+    return json_build_object(
+      'ok',true,
+      'lead',v_lead,
+      'tier',v_tier,
+      'tierNum',0,
+      'fromSupabase',true,
+      'colaConfig',v_cola_tipo,
+      'contexto',v_contexto,
+      'contactDebt',true,
+      'contactDebtBucket',v_bucket_code,
+      'waitMinutes',v_wait_minutes,
+      'leaseMinutes',20
+    );
+  end if;
+
+  -- No new/uncontacted touchpoints remain: preserve the certified existing
+  -- campaign/tipification/no-show/patient/province + TIER 1-8 engine exactly.
+  return public.aos_siguiente_lead_v2(p_asesor,p_id_asesor,p_hoy);
+end;
+$function$;
+
+-- Keep the same browser execution surface used by the current Call Center.
+grant execute on function public.aos_siguiente_lead(text,text,date) to anon,authenticated,service_role;

--- a/supabase/rollbacks/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1_recovery.sql
+++ b/supabase/rollbacks/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1_recovery.sql
@@ -1,0 +1,232 @@
+-- P0 #490 recovery: restore the prior certified CONTACT_DEBT selector exactly.
+-- CC-Q1 / Call Center Contact-Debt Priority V1
+-- Goal: every NEW lead touchpoint must be worked before legacy call-center tiers.
+-- Order: TODAY -> CURRENT MONTH -> CURRENT YEAR -> HISTORICAL -> existing TIER engine.
+-- Important: a phone having an OLD call does not satisfy a NEW lead touchpoint.
+-- Raw leads/calls are never rewritten. Existing aos_siguiente_lead_v2 remains the fallback engine.
+
+create or replace function public.aos_siguiente_lead(
+  p_asesor text,
+  p_id_asesor text,
+  p_hoy date
+)
+returns json
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $function$
+declare
+  v_lead_id bigint := null;
+  v_num text := null;
+  v_trat text := '';
+  v_anuncio text := '';
+  v_fecha date := null;
+  v_hora_ingreso timestamptz := null;
+  v_lead_ts timestamptz := null;
+  v_bucket integer := null;
+  v_bucket_code text := null;
+  v_tier text := null;
+  v_cola_tipo text := 'global';
+  v_contexto json := null;
+  v_intento integer := 1;
+  v_wait_minutes integer := 0;
+  v_lead json := null;
+begin
+  -- Preserve historical cleanup behavior.
+  delete from public.aos_leads_en_curso where fecha < p_hoy;
+
+  select coalesce(tipo_cola,'global')
+    into v_cola_tipo
+  from public.aos_cola_config
+  where upper(asesor)=upper(p_asesor)
+  limit 1;
+  v_cola_tipo := coalesce(v_cola_tipo,'global');
+
+  -- CONTACT DEBT:
+  -- A lead touchpoint is pending when there is no call tied to that lead_id
+  -- and no same-phone call recorded at/after that lead arrived.
+  -- Multiple pending touchpoints for one phone collapse to the latest touchpoint.
+  -- Active assignments from another advisor are leased for 20 minutes; abandoned
+  -- assignments can then re-enter the pool instead of being frozen all day.
+  with debt as (
+    select
+      ld.id,
+      ld.numero_limpio,
+      ld.fecha,
+      coalesce(ld.tratamiento,'') as tratamiento,
+      coalesce(ld.anuncio,'') as anuncio,
+      ld.hora_ingreso,
+      coalesce(
+        ld.hora_ingreso,
+        ld.created_at,
+        (ld.fecha::timestamp at time zone 'America/Lima')
+      ) as lead_ts,
+      case
+        when ld.fecha=p_hoy then 0
+        when date_trunc('month',ld.fecha)=date_trunc('month',p_hoy) then 1
+        when date_trunc('year',ld.fecha)=date_trunc('year',p_hoy) then 2
+        else 3
+      end as bucket,
+      row_number() over (
+        partition by ld.numero_limpio
+        order by coalesce(
+          ld.hora_ingreso,
+          ld.created_at,
+          (ld.fecha::timestamp at time zone 'America/Lima')
+        ) desc, ld.id desc
+      ) as rn
+    from public.aos_leads ld
+    where ld.numero_limpio is not null
+      and ld.numero_limpio<>''
+      and not exists (
+        select 1
+        from public.aos_llamadas ll
+        where ll.numero_limpio=ld.numero_limpio
+          and (
+            ll.lead_id_origen=ld.id
+            or coalesce(
+              ll.created_at,
+              ll.ult_ts,
+              ll.ts_log,
+              (ll.fecha::timestamp at time zone 'America/Lima')
+            ) >= coalesce(
+              ld.hora_ingreso,
+              ld.created_at,
+              (ld.fecha::timestamp at time zone 'America/Lima')
+            )
+          )
+      )
+      and not exists (
+        select 1
+        from public.v_numeros_con_cita_pendiente cp
+        where cp.numero_limpio=ld.numero_limpio
+      )
+      and not exists (
+        select 1
+        from public.aos_leads_en_curso lc
+        where lc.numero_limpio=ld.numero_limpio
+          and lc.fecha=p_hoy
+          and upper(lc.asesor)<>upper(p_asesor)
+          and coalesce(lc.asignado_at,now()) >= now()-interval '20 minutes'
+      )
+  ), ranked as (
+    select *
+    from debt
+    where rn=1
+    order by bucket,lead_ts,id
+    limit 32
+  )
+  select
+    ld.id,
+    ld.numero_limpio,
+    r.tratamiento,
+    r.anuncio,
+    r.fecha,
+    r.hora_ingreso,
+    r.lead_ts,
+    r.bucket
+  into
+    v_lead_id,
+    v_num,
+    v_trat,
+    v_anuncio,
+    v_fecha,
+    v_hora_ingreso,
+    v_lead_ts,
+    v_bucket
+  from ranked r
+  join public.aos_leads ld on ld.id=r.id
+  order by r.bucket,r.lead_ts,r.id
+  for update of ld skip locked
+  limit 1;
+
+  if v_num is not null then
+    v_bucket_code := case v_bucket
+      when 0 then 'TODAY'
+      when 1 then 'MONTH'
+      when 2 then 'YEAR'
+      else 'HISTORICAL'
+    end;
+
+    v_tier := case v_bucket
+      when 0 then 'PRIORIDAD 0 · NUEVO SIN CONTACTO HOY'
+      when 1 then 'PRIORIDAD 0 · PENDIENTE DEL MES'
+      when 2 then 'PRIORIDAD 0 · PENDIENTE DEL AÑO'
+      else 'PRIORIDAD 0 · PENDIENTE HISTÓRICO'
+    end;
+
+    select coalesce(count(*),0)+1
+      into v_intento
+    from public.aos_llamadas
+    where numero_limpio=v_num;
+
+    v_wait_minutes := greatest(
+      0,
+      floor(extract(epoch from (now()-v_lead_ts))/60)::integer
+    );
+
+    v_lead := json_build_object(
+      'id',v_lead_id,
+      'num',v_num,
+      'trat',v_trat,
+      'anuncio',v_anuncio,
+      'fecha',v_fecha,
+      'hora_ingreso',v_hora_ingreso,
+      'intento',v_intento,
+      'rowNum',0,
+      'attributionSource','CONTACT_DEBT_EXACT',
+      'contactDebtBucket',v_bucket_code,
+      'waitMinutes',v_wait_minutes
+    );
+
+    insert into public.aos_leads_en_curso(
+      asesor,numero_limpio,fecha,lead_id_origen,asignado_at
+    )
+    values(
+      upper(p_asesor),v_num,p_hoy,v_lead_id,now()
+    )
+    on conflict(asesor,numero_limpio,fecha)
+    do update set
+      lead_id_origen=excluded.lead_id_origen,
+      asignado_at=excluded.asignado_at;
+
+    select json_build_object(
+      'ultimaLlamada',json_build_object(
+        'fecha',ll.fecha,
+        'estado',ll.estado,
+        'asesor',ll.asesor,
+        'obs',coalesce(ll.observacion,''),
+        'intento',ll.intento
+      )
+    )
+    into v_contexto
+    from public.aos_llamadas ll
+    where ll.numero_limpio=v_num
+    order by coalesce(ll.created_at,ll.ult_ts,ll.ts_log) desc nulls last,ll.id desc
+    limit 1;
+
+    return json_build_object(
+      'ok',true,
+      'lead',v_lead,
+      'tier',v_tier,
+      'tierNum',0,
+      'fromSupabase',true,
+      'colaConfig',v_cola_tipo,
+      'contexto',v_contexto,
+      'contactDebt',true,
+      'contactDebtBucket',v_bucket_code,
+      'waitMinutes',v_wait_minutes,
+      'leaseMinutes',20
+    );
+  end if;
+
+  -- No new/uncontacted touchpoints remain: preserve the certified existing
+  -- campaign/tipification/no-show/patient/province + TIER 1-8 engine exactly.
+  return public.aos_siguiente_lead_v2(p_asesor,p_id_asesor,p_hoy);
+end;
+$function$;
+
+-- Keep the same browser execution surface used by the current Call Center.
+grant execute on function public.aos_siguiente_lead(text,text,date) to anon,authenticated,service_role;
+
+drop function if exists public.aos_callcenter_effective_lead_ts_v1(date,timestamptz,timestamptz);


### PR DESCRIPTION
## Production incident

Call Center advisors are receiving the same phone repeatedly and the normal backlog/rebarrido is being starved.

### Root cause proven on live data
- `aos_siguiente_lead` uses `hora_ingreso` as authoritative lead event time.
- 89 legacy leads currently have `hora_ingreso` in the future; 85/89 are false CONTACT_DEBT after sanity correction.
- Real September calls can never satisfy a malformed November/December lead timestamp, so those phones remain permanently pending and can be reissued after every attempt.
- CONTACT_DEBT runs before the legacy Tier engine, so it prevents access to the ordinary backlog. Current live aggregate has ~2,936 eligible rebarrido phones, including 792 whose latest lead is from August.
- Raw leads/calls remain immutable.

### Fix
1. Add `aos_callcenter_effective_lead_ts_v1`.
   - trust `hora_ingreso` only when it is not future and its Lima date is coherent with business `fecha`;
   - otherwise trust coherent `created_at`;
   - otherwise fall back to business `fecha` at Lima midnight.
2. Use the same sane timestamp for CONTACT_DEBT ranking and for call-after-lead satisfaction.
3. Align canonical `calls.js` with the already-live `calls.html` selector: initial load uses `aos_siguiente_lead`, not the stale V2 source.
4. Preserve TODAY → MONTH → YEAR → HISTORICAL → existing Tier 1–8 fallback, exact lead lineage, Loop6 governance, leases, and raw data.
5. Add recovery SQL and regression contracts.

### Safety
- No historical rows are rewritten or deleted.
- No WhatsApp authority changes.
- WA-L10 #456 remains SAFE-OFF and paused.
- This P0 is the only mutable HIGH/CRITICAL workstream until production verification completes.

Closes #490 after production verification only.