### PR TITLE
P0 #492: restore governed Agenda status save

### DIFF
--- a/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
+++ b/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
@@ -9,6 +9,9 @@ on:
       - 'supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql'
       - 'supabase/rollbacks/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1_recovery.sql'
       - 'app/public/agenda-governed-status-v1.js'
+      - 'app/public/f4-production-canary-hotfix.js'
+      - 'supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql'
+      - 'supabase/rollbacks/20260910212500_p0_agenda_postgrest_rpc_exposure_v1_recovery.sql'
       - 'app/public/panel-access-authority-v1.js'
       - 'supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql'
       - 'supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql'
@@ -54,5 +57,6 @@ jobs:
           ! grep -Ev '^[[:space:]]*--' "$HOT" | grep -q 'aos_rev_customer_lifecycle_v1('
           ! grep -Ev '^[[:space:]]*--' "$HOT" | grep -qi 'statement_timeout'
           grep -q "aos_agenda_set_status_v1" supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql
+          grep -q "pg_notify('pgrst','reload schema')" supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql
           ! grep -Eq '(auto_reply_enabled|ai_send_enabled|auto_routing_enabled)[[:space:]]*=[[:space:]]*true' supabase/migrations/2026090103*.sql "$HOT"
           echo 'ASCENDA_P0_CALLCENTER_AGENDA_PERFORMANCE_CONTRACT_PASS'

--- a/app/public/agenda-governed-status-v1.js
+++ b/app/public/agenda-governed-status-v1.js
@@ -26,7 +26,9 @@ function apiError(code){
     APPOINTMENT_NOT_FOUND:'La cita ya no existe o cambió. Recarga Agenda.',
     DOCTOR_AUTHORITY_REQUIRED:'La cita no tiene una doctora válida asignada.',
     ATTENDING_NURSE_REQUIRED:'Selecciona quién realizará la atención.',
-    INVALID_APPOINTMENT_STATUS:'Estado de cita no válido.'
+    INVALID_APPOINTMENT_STATUS:'Estado de cita no válido.',
+    PGRST202:'Agenda está actualizando su conexión segura. Recarga el panel y vuelve a guardar.',
+    HTTP_404:'Agenda no encontró el RPC gobernado. Recarga el panel; si persiste, reporta el código PGRST.'
   };
   return map[code]||code||'No se pudo actualizar la cita.';
 }
@@ -67,7 +69,10 @@ function install(){
         body:JSON.stringify({p_token:token,p_cita_id:String(AG.sel.id),p_estado:est,p_asistente:asistente,p_nota:nota})
       }).then(function(r){
         return r.json().catch(function(){return null;}).then(function(d){
-          if(!r.ok||!d||d.ok!==true){var code=d&&d.error?d.error:('HTTP_'+r.status);throw new Error(code);}
+          if(!r.ok||!d||d.ok!==true){
+            var code=d&&(d.error||d.code)?String(d.error||d.code):('HTTP_'+r.status);
+            throw new Error(code);
+          }
           return d;
         });
       });
@@ -88,7 +93,7 @@ function install(){
   governedSave.__agendaGovernedV1=true;
   governedSave.__legacy=window.agGuardarEstado;
   window.agGuardarEstado=governedSave;
-  window.__AOS_AGENDA_GOVERNED_STATUS_V1__='v1';
+  window.__AOS_AGENDA_GOVERNED_STATUS_V1__='v1.1-p0-492';
   console.log('[ASCENDA][AGENDA] governed status runtime active');
   return true;
 }

--- a/app/public/f4-production-canary-hotfix.js
+++ b/app/public/f4-production-canary-hotfix.js
@@ -221,7 +221,7 @@ function ensureAgendaGovernedPostload(){
     var old=document.getElementById('aos-agenda-governed-status-v1');if(old)old.remove();
     var s=document.createElement('script');
     s.id='aos-agenda-governed-status-v1';
-    s.src='/agenda-governed-status-v1.js?v=20260901-p0-v1';
+    s.src='/agenda-governed-status-v1.js?v=20260910-p0-492-v1';
     s.async=false;
     s.onerror=function(){console.error('[ASCENDA][AGENDA] governed status runtime failed');};
     (document.head||document.documentElement).appendChild(s);

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -13,6 +13,7 @@ const hot=fs.readFileSync('supabase/migrations/20260902002500_mkt_loop6_p0_booki
 const hotExec=hot.split(/\r?\n/).filter(line=>!line.trimStart().startsWith('--')).join('\n');
 const hotRollback=fs.readFileSync('supabase/rollbacks/20260902002500_mkt_loop6_p0_booking_hotpath_v3_recovery.sql','utf8');
 const agSql=fs.readFileSync('supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql','utf8');
+const agExposure=fs.readFileSync('supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql','utf8');
 const debt=fs.readFileSync('supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql','utf8');
 
 test('Call Center waits for Loop6 and coalesces duplicated panel reads',()=>{
@@ -100,6 +101,15 @@ test('Agenda status is an atomic strong-session RPC and preserves WhatsApp direc
   assert.doesNotMatch(agenda,/method:'PATCH'/);
   assert.doesNotMatch(agenda,/setInterval\(/);
   assert.doesNotMatch(agenda,/setTimeout\(/);
+});
+
+test('P0 #492 keeps governed Agenda RPC exposed through PostgREST',()=>{
+  assert.match(agExposure,/to_regprocedure\('public\.aos_agenda_set_status_v1\(text,text,text,text,text\)'\)/);
+  assert.match(agExposure,/grant execute on function public\.aos_agenda_set_status_v1\(text,text,text,text,text\)/);
+  assert.match(agExposure,/pg_notify\('pgrst','reload schema'\)/);
+  assert.match(agenda,/d&&\(d\.error\|\|d\.code\)/);
+  assert.match(agenda,/PGRST202/);
+  assert.match(f4,/agenda-governed-status-v1\.js\?v=20260910-p0-492-v1/);
 });
 
 test('P0 runtimes reuse the already-certified F4 observer instead of creating new recurrent network owners',()=>{

--- a/supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql
+++ b/supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql
@@ -1,0 +1,19 @@
+-- P0 #492 · Agenda governed RPC PostgREST exposure recovery.
+-- No business data mutation. Reassert API privileges and force PostgREST to
+-- rebuild its schema cache so the already-certified strong-session RPC is routable.
+do $$
+begin
+  if to_regprocedure('public.aos_agenda_set_status_v1(text,text,text,text,text)') is null then
+    raise exception 'AGENDA_STATUS_RPC_MISSING';
+  end if;
+end
+$$;
+
+grant usage on schema public to anon, authenticated, service_role;
+grant execute on function public.aos_agenda_set_status_v1(text,text,text,text,text)
+  to anon, authenticated, service_role;
+
+comment on function public.aos_agenda_set_status_v1(text,text,text,text,text)
+is 'Agenda governed status V1. P0 #492 reasserted PostgREST exposure; strong-session/2FA authority and atomic attention sync remain unchanged.';
+
+select pg_notify('pgrst','reload schema');

--- a/supabase/rollbacks/20260910212500_p0_agenda_postgrest_rpc_exposure_v1_recovery.sql
+++ b/supabase/rollbacks/20260910212500_p0_agenda_postgrest_rpc_exposure_v1_recovery.sql
@@ -1,0 +1,6 @@
+-- P0 #492 recovery is intentionally non-destructive.
+-- The underlying Agenda RPC predates this exposure repair and must remain present.
+grant usage on schema public to anon, authenticated, service_role;
+grant execute on function public.aos_agenda_set_status_v1(text,text,text,text,text)
+  to anon, authenticated, service_role;
+select pg_notify('pgrst','reload schema');


### PR DESCRIPTION
## Incident
Advisor cannot mark appointments ASISTIO/EFECTIVA; browser reports `No se guardó la cita · HTTP_404`.

### Evidence
- PROD function `aos_agenda_set_status_v1(text,text,text,text,text)` exists.
- Exact EXECUTE privilege exists for anon/authenticated/service_role.
- No governed audit event was written near the reported failure, confirming the request did not enter the function.
- This isolates the failure to PostgREST RPC exposure/schema cache rather than business validation.

### Fix
- reassert schema usage + function EXECUTE grants;
- explicitly `pg_notify('pgrst','reload schema')`;
- keep recovery non-destructive;
- improve frontend diagnostics so a future PostgREST miss surfaces `PGRST202` rather than opaque `HTTP_404`;
- cache-bust the governed Agenda runtime;
- extend P0 Agenda CI coverage.

### Safety
No appointment rows are rewritten by the migration. Strong-session/2FA, professional selection, atomic attention sync, audit and no-direct-PATCH constraints remain intact. WhatsApp remains SAFE-OFF. Marketing V4.3 remains read-only until this P0 closes.

Closes #492 only after production operational verification.