### PR TITLE
P0 #492: harden Agenda triggers under governed search_path

### DIFF
--- a/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
+++ b/.github/workflows/p0-callcenter-agenda-performance-hosted.yml
@@ -12,6 +12,8 @@ on:
       - 'app/public/f4-production-canary-hotfix.js'
       - 'supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql'
       - 'supabase/rollbacks/20260910212500_p0_agenda_postgrest_rpc_exposure_v1_recovery.sql'
+      - 'supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql'
+      - 'supabase/rollbacks/20260910213500_p0_agenda_trigger_searchpath_v1_recovery.sql'
       - 'app/public/panel-access-authority-v1.js'
       - 'supabase/migrations/20260901033000_p0_callcenter_io_booking_fastpath_v1.sql'
       - 'supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql'

--- a/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
+++ b/ci/wa4c-full-local/p0-callcenter-agenda-performance.test.js
@@ -14,6 +14,7 @@ const hotExec=hot.split(/\r?\n/).filter(line=>!line.trimStart().startsWith('--')
 const hotRollback=fs.readFileSync('supabase/rollbacks/20260902002500_mkt_loop6_p0_booking_hotpath_v3_recovery.sql','utf8');
 const agSql=fs.readFileSync('supabase/migrations/20260901034000_p0_agenda_status_governed_v1.sql','utf8');
 const agExposure=fs.readFileSync('supabase/migrations/20260910212500_p0_agenda_postgrest_rpc_exposure_v1.sql','utf8');
+const agTriggerFix=fs.readFileSync('supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql','utf8');
 const debt=fs.readFileSync('supabase/migrations/20260910200500_mkt_loop6_p0_contact_debt_timestamp_sanity_v1.sql','utf8');
 
 test('Call Center waits for Loop6 and coalesces duplicated panel reads',()=>{
@@ -110,6 +111,15 @@ test('P0 #492 keeps governed Agenda RPC exposed through PostgREST',()=>{
   assert.match(agenda,/d&&\(d\.error\|\|d\.code\)/);
   assert.match(agenda,/PGRST202/);
   assert.match(f4,/agenda-governed-status-v1\.js\?v=20260910-p0-492-v1/);
+});
+
+test('P0 #492 trigger functions survive governed empty search_path',()=>{
+  assert.match(agTriggerFix,/create or replace function public\.fn_asignar_hc\(\)[\s\S]*set search_path to ''/i);
+  assert.match(agTriggerFix,/from public\.aos_pacientes p/);
+  assert.match(agTriggerFix,/update public\.aos_pacientes p/);
+  assert.match(agTriggerFix,/create or replace function public\.fn_enriquecer_paciente_cita\(\)[\s\S]*set search_path to ''/i);
+  assert.doesNotMatch(agTriggerFix,/\bfrom\s+aos_pacientes\b/i);
+  assert.doesNotMatch(agTriggerFix,/\bupdate\s+aos_pacientes\b/i);
 });
 
 test('P0 runtimes reuse the already-certified F4 observer instead of creating new recurrent network owners',()=>{

--- a/supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql
+++ b/supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql
@@ -1,0 +1,108 @@
+-- P0 #492 · Agenda ASISTIO/EFECTIVA trigger search_path hardening.
+-- Root cause: the governed Agenda RPC executes with search_path='', while two
+-- legacy trigger functions referenced aos_pacientes without schema qualification.
+-- PostgreSQL therefore raised 42P01 before the governed transaction could finish.
+
+create or replace function public.fn_asignar_hc()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_hc text;
+  v_mes text;
+  v_seq int;
+  v_numero text;
+begin
+  if new.estado_cita = 'ASISTIO'
+     and (old.estado_cita is null or old.estado_cita <> 'ASISTIO') then
+    v_numero := coalesce(
+      new.numero_limpio,
+      pg_catalog.regexp_replace(coalesce(new.numero,''), '\\D', '', 'g')
+    );
+    if v_numero is null or v_numero = '' then
+      return new;
+    end if;
+
+    select p.codigo_hc
+      into v_hc
+      from public.aos_pacientes p
+     where p.numero_limpio = v_numero
+     limit 1;
+
+    if v_hc is not null then
+      return new;
+    end if;
+
+    v_mes := pg_catalog.to_char(current_date, 'YYYYMM');
+
+    select coalesce(max(
+      pg_catalog.regexp_replace(p.codigo_hc, 'HC-' || v_mes || '-', '')::int
+    ),0) + 1
+      into v_seq
+      from public.aos_pacientes p
+     where p.codigo_hc like 'HC-' || v_mes || '-%';
+
+    v_hc := 'HC-' || v_mes || '-' || pg_catalog.lpad(v_seq::text,4,'0');
+
+    update public.aos_pacientes p
+       set codigo_hc = v_hc
+     where p.numero_limpio = v_numero
+       and p.codigo_hc is null;
+  end if;
+
+  return new;
+end
+$function$;
+
+create or replace function public.fn_enriquecer_paciente_cita()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  if new.numero_limpio is not null
+     and new.numero_limpio <> ''
+     and pg_catalog.length(new.numero_limpio) >= 7 then
+
+    update public.aos_pacientes p
+       set "N° documento" = case
+             when coalesce(p."N° documento",'') = ''
+              and coalesce(new.dni,'') <> ''
+             then new.dni else p."N° documento" end,
+           "Email" = case
+             when coalesce(p."Email",'') = ''
+              and coalesce(new.correo,'') <> ''
+              and new.correo like '%@%'
+             then new.correo else p."Email" end,
+           "Nombres" = case
+             when coalesce(p."Nombres",'') = ''
+              and coalesce(new.nombre,'') <> ''
+             then new.nombre else p."Nombres" end,
+           "Apellidos" = case
+             when coalesce(p."Apellidos",'') = ''
+              and coalesce(new.apellido,'') <> ''
+             then new.apellido else p."Apellidos" end,
+           updated_at = pg_catalog.now()
+     where p.numero_limpio = new.numero_limpio
+       and (
+         (coalesce(p."N° documento",'') = '' and coalesce(new.dni,'') <> '')
+         or (coalesce(p."Email",'') = '' and coalesce(new.correo,'') <> '' and new.correo like '%@%')
+         or (coalesce(p."Nombres",'') = '' and coalesce(new.nombre,'') <> '')
+         or (coalesce(p."Apellidos",'') = '' and coalesce(new.apellido,'') <> '')
+       );
+  end if;
+
+  return new;
+end
+$function$;
+
+comment on function public.fn_asignar_hc()
+is 'Agenda HC trigger hardened for governed RPC search_path; P0 #492.';
+
+comment on function public.fn_enriquecer_paciente_cita()
+is 'Agenda patient enrichment trigger hardened for governed RPC search_path; P0 #492.';
+
+select pg_notify('pgrst','reload schema');

--- a/supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql
+++ b/supabase/migrations/20260910213500_p0_agenda_trigger_searchpath_v1.sql
@@ -19,7 +19,7 @@ begin
      and (old.estado_cita is null or old.estado_cita <> 'ASISTIO') then
     v_numero := coalesce(
       new.numero_limpio,
-      pg_catalog.regexp_replace(coalesce(new.numero,''), '\\D', '', 'g')
+      pg_catalog.regexp_replace(coalesce(new.numero,''), '[^0-9]', '', 'g')
     );
     if v_numero is null or v_numero = '' then
       return new;

--- a/supabase/rollbacks/20260910213500_p0_agenda_trigger_searchpath_v1_recovery.sql
+++ b/supabase/rollbacks/20260910213500_p0_agenda_trigger_searchpath_v1_recovery.sql
@@ -22,7 +22,7 @@ begin
      and (old.estado_cita is null or old.estado_cita <> 'ASISTIO') then
     v_numero := coalesce(
       new.numero_limpio,
-      pg_catalog.regexp_replace(coalesce(new.numero,''), '\\D', '', 'g')
+      pg_catalog.regexp_replace(coalesce(new.numero,''), '[^0-9]', '', 'g')
     );
     if v_numero is null or v_numero = '' then
       return new;

--- a/supabase/rollbacks/20260910213500_p0_agenda_trigger_searchpath_v1_recovery.sql
+++ b/supabase/rollbacks/20260910213500_p0_agenda_trigger_searchpath_v1_recovery.sql
@@ -1,0 +1,111 @@
+-- P0 #492 non-destructive recovery.
+-- Reassert the safe schema-qualified trigger implementations. Do not restore
+-- the legacy unqualified aos_pacientes references because they are the incident root cause.
+-- P0 #492 · Agenda ASISTIO/EFECTIVA trigger search_path hardening.
+-- Root cause: the governed Agenda RPC executes with search_path='', while two
+-- legacy trigger functions referenced aos_pacientes without schema qualification.
+-- PostgreSQL therefore raised 42P01 before the governed transaction could finish.
+
+create or replace function public.fn_asignar_hc()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_hc text;
+  v_mes text;
+  v_seq int;
+  v_numero text;
+begin
+  if new.estado_cita = 'ASISTIO'
+     and (old.estado_cita is null or old.estado_cita <> 'ASISTIO') then
+    v_numero := coalesce(
+      new.numero_limpio,
+      pg_catalog.regexp_replace(coalesce(new.numero,''), '\\D', '', 'g')
+    );
+    if v_numero is null or v_numero = '' then
+      return new;
+    end if;
+
+    select p.codigo_hc
+      into v_hc
+      from public.aos_pacientes p
+     where p.numero_limpio = v_numero
+     limit 1;
+
+    if v_hc is not null then
+      return new;
+    end if;
+
+    v_mes := pg_catalog.to_char(current_date, 'YYYYMM');
+
+    select coalesce(max(
+      pg_catalog.regexp_replace(p.codigo_hc, 'HC-' || v_mes || '-', '')::int
+    ),0) + 1
+      into v_seq
+      from public.aos_pacientes p
+     where p.codigo_hc like 'HC-' || v_mes || '-%';
+
+    v_hc := 'HC-' || v_mes || '-' || pg_catalog.lpad(v_seq::text,4,'0');
+
+    update public.aos_pacientes p
+       set codigo_hc = v_hc
+     where p.numero_limpio = v_numero
+       and p.codigo_hc is null;
+  end if;
+
+  return new;
+end
+$function$;
+
+create or replace function public.fn_enriquecer_paciente_cita()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  if new.numero_limpio is not null
+     and new.numero_limpio <> ''
+     and pg_catalog.length(new.numero_limpio) >= 7 then
+
+    update public.aos_pacientes p
+       set "N° documento" = case
+             when coalesce(p."N° documento",'') = ''
+              and coalesce(new.dni,'') <> ''
+             then new.dni else p."N° documento" end,
+           "Email" = case
+             when coalesce(p."Email",'') = ''
+              and coalesce(new.correo,'') <> ''
+              and new.correo like '%@%'
+             then new.correo else p."Email" end,
+           "Nombres" = case
+             when coalesce(p."Nombres",'') = ''
+              and coalesce(new.nombre,'') <> ''
+             then new.nombre else p."Nombres" end,
+           "Apellidos" = case
+             when coalesce(p."Apellidos",'') = ''
+              and coalesce(new.apellido,'') <> ''
+             then new.apellido else p."Apellidos" end,
+           updated_at = pg_catalog.now()
+     where p.numero_limpio = new.numero_limpio
+       and (
+         (coalesce(p."N° documento",'') = '' and coalesce(new.dni,'') <> '')
+         or (coalesce(p."Email",'') = '' and coalesce(new.correo,'') <> '' and new.correo like '%@%')
+         or (coalesce(p."Nombres",'') = '' and coalesce(new.nombre,'') <> '')
+         or (coalesce(p."Apellidos",'') = '' and coalesce(new.apellido,'') <> '')
+       );
+  end if;
+
+  return new;
+end
+$function$;
+
+comment on function public.fn_asignar_hc()
+is 'Agenda HC trigger hardened for governed RPC search_path; P0 #492.';
+
+comment on function public.fn_enriquecer_paciente_cita()
+is 'Agenda patient enrichment trigger hardened for governed RPC search_path; P0 #492.';
+
+select pg_notify('pgrst','reload schema');


### PR DESCRIPTION
## Root cause proven in PROD

The browser now reaches `aos_agenda_set_status_v1`, but the governed RPC runs with `search_path=''` by design. Two legacy Agenda triggers inherit that empty search path and referenced `aos_pacientes` without schema qualification.

A rollback-only transactional probe reproduced the advisor failure exactly:

- SQLSTATE `42P01`
- relation `aos_pacientes` does not exist
- context: `public.fn_asignar_hc()` line 14

No appointment change from the probe persisted.

### Fix
- `fn_asignar_hc()`: add `SET search_path TO ''` and schema-qualify `public.aos_pacientes`.
- `fn_enriquecer_paciente_cita()`: same hardening; it had the identical latent defect.
- Preserve all prior business semantics.
- Add non-destructive recovery and CI regression contract.

### Safety
No appointment/patient rows are rewritten by the migration itself. Strong-session/2FA, professional selection, governed atomic Agenda write, HC assignment, patient enrichment, notifications and audits remain active. WA-L10 remains SAFE-OFF; Marketing V4.3 remains read-only until this P0 closes.

Closes #492 only after exact-head CI, PROD migration/deploy and operational advisor verification.