### PR TITLE
MKT V4.3 UI: operational lineage and compact layout

### DIFF
--- a/.github/workflows/p0-marketing-read-pressure.yml
+++ b/.github/workflows/p0-marketing-read-pressure.yml
@@ -10,6 +10,8 @@ on:
       - 'src/admin-marketing.html'
       - 'supabase/migrations/20260910230000_marketing_value_map_v43.sql'
       - 'supabase/rollbacks/20260910230000_marketing_value_map_v43_recovery.sql'
+      - 'supabase/migrations/20260910233500_marketing_lineage_admin_v43.sql'
+      - 'supabase/rollbacks/20260910233500_marketing_lineage_admin_v43_recovery.sql'
       - 'docs/control/MARKETING_METRIC_DICTIONARY.md'
       - 'ci/performance/marketing-read-pressure.test.js'
       - '.github/workflows/p0-marketing-read-pressure.yml'
@@ -42,9 +44,13 @@ jobs:
           BOOT='app/public/admin-marketing-v2.js'
           CORE='app/public/admin-marketing-v2-core.js'
           MIG='supabase/migrations/20260910230000_marketing_value_map_v43.sql'
+          LINEAGE='supabase/migrations/20260910233500_marketing_lineage_admin_v43.sql'
           grep -q 'admin-marketing-v2-core.js' "$BOOT"
           grep -q 'aos_marketing_historico_public_v2' "$BOOT"
           grep -q 'aos_marketing_value_map_public_v43' "$BOOT"
-          grep -q '2026-09-10-v4.3-value-reconciliation' "$CORE"
+          grep -q '2026-09-10-v4.3.1-operational-lineage' "$CORE"
+          grep -q 'aos_marketing_lineage_admin_v43' "$BOOT"
+          grep -q "aos_app_actor_v3(p_token,'admin-marketing',true)" "$LINEAGE"
+          grep -q 'MARKETING_ADMIN_2FA_REQUIRED' "$LINEAGE"
           ! grep -Eq 'setInterval[[:space:]]*\(' "$BOOT"
           echo 'ASCENDA_P0_MARKETING_READ_PRESSURE_PASS'

--- a/app/public/admin-marketing-v2-core.js
+++ b/app/public/admin-marketing-v2-core.js
@@ -5,19 +5,53 @@
 (function(){
 'use strict';
 
-var RELEASE='2026-09-10-v4.3-value-reconciliation';
+var RELEASE='2026-09-10-v4.3.1-operational-lineage';
 if(window.__AOS_MKT4&&window.__AOS_MKT4.destroy){
   try{window.__AOS_MKT4.destroy();}catch(e){}
 }
 
 var alive=true, cycle=0, ctl=null, timers=[], wraps={};
-var S={kpi:null,summary:null,campaigns:[],history:[],ltv:[],valueMap:null,attr:null,intent:[],intentDetail:[]};
+var S={kpi:null,summary:null,campaigns:[],history:[],ltv:[],valueMap:null,secureLineage:null,attr:null,intent:[],intentDetail:[]};
 
 function $id(x){return document.getElementById(x);}
 function N(v){var x=Number(v);return Number.isFinite(x)?x:0;}
 function R2(v){return Math.round(N(v)*100)/100;}
 function M(v){return 'S/'+Math.round(N(v)).toLocaleString('es-PE');}
 function E(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c];});}
+function cacheToken(){
+  if(!('caches' in window))return Promise.resolve('');
+  return caches.open('aos-phase2-auth').then(function(x){return x.match('/__aos_app_token');}).then(function(r){return r?r.text():'';}).catch(function(){return '';});
+}
+function strongToken(){
+  var t='';try{t=String(sessionStorage.getItem('aos_app_token')||'').trim();}catch(_){}
+  if(t.length>=32)return Promise.resolve(t);
+  return cacheToken().then(function(x){
+    x=String(x||'').trim();
+    if(x.length>=32)try{sessionStorage.setItem('aos_app_token',x);}catch(_){}
+    return x;
+  });
+}
+function MY(v){
+  var s=String(v||''),m=s.match(/^(\d{4})-(\d{2})/);
+  if(!m)return '—';
+  var i=Number(m[2]);return (MF[i]||m[2]).slice(0,3).toUpperCase()+' '+m[1];
+}
+function friendlyMethod(v){
+  var s=String(v||'').toUpperCase();
+  if(s.indexOf('SAME_MONTH_UNIQUE_LEAD')>=0)return 'Lead único compatible del mes';
+  if(s.indexOf('LEAD_CALL_APPOINTMENT')>=0)return 'Lead → llamada → cita';
+  if(s.indexOf('LEAD_CALL')>=0)return 'Lead → llamada';
+  if(s.indexOf('LEAD_APPOINTMENT')>=0)return 'Lead → cita';
+  return s?s.replace(/_/g,' ').toLowerCase():'Sin método';
+}
+function friendlyTrace(v){
+  var s=String(v||'').toUpperCase();
+  if(s==='LEAD_CALL_APPOINTMENT')return 'Directa completa';
+  if(s==='LEAD_CALL')return 'Directa por llamada';
+  if(s==='LEAD_APPOINTMENT')return 'Directa por cita';
+  if(s==='STRONG_INFERRED')return 'Inferida fuerte';
+  return 'Inferida';
+}
 function A(v){
   if(Array.isArray(v))return v;
   if(v&&Array.isArray(v.ltv))return v.ltv;
@@ -124,19 +158,23 @@ function insights(){
   var a=$id('mk4-insights')||$id('mk-v3-insights');
   if(a){
     a.id='mk4-insights';
+    a.style.cssText='display:flex;gap:10px;flex-wrap:wrap;align-items:flex-start';
     [['mk-v3-attr-card','mk4-attr-card'],['mk-v3-attr','mk4-attr'],['mk-v3-intent-card','mk4-intent-card'],['mk-v3-intent','mk4-intent']].forEach(function(x){
       var e=$id(x[0]);if(e)e.id=x[1];
     });
+    var ac=$id('mk4-attr-card'),ic=$id('mk4-intent-card');
+    if(ac)ac.style.cssText='flex:1 1 470px;align-self:flex-start';
+    if(ic)ic.style.cssText='flex:1 1 520px;align-self:flex-start';
+    var old=ac&&ac.querySelector('.tag');if(old)old.style.display='none';
     return a;
   }
   var l=$id('mk-ltv');if(!l)return null;
   var card=l.closest('.crd');if(!card)return null;
-  a=document.createElement('div');a.id='mk4-insights';a.style.cssText='display:flex;gap:10px;flex-wrap:wrap';
-  a.innerHTML='<div class="crd" id="mk4-attr-card" style="flex:1 1 420px"><div class="ct">🧠 Atribución y reingresos <span class="tag tag-b">V4.2</span></div><div id="mk4-attr"><div class="ld">Cargando…</div></div></div><div class="crd" id="mk4-intent-card" style="flex:1 1 420px"><div class="ct">🧩 Intención → Compra <span class="tag tag-c">auditable</span></div><div id="mk4-intent"><div class="ld">Cargando…</div></div></div>';
+  a=document.createElement('div');a.id='mk4-insights';a.style.cssText='display:flex;gap:10px;flex-wrap:wrap;align-items:flex-start';
+  a.innerHTML='<div class="crd" id="mk4-attr-card" style="flex:1 1 470px;align-self:flex-start"><div class="ct">🧠 Atribución y reingresos</div><div id="mk4-attr"><div class="ld">Cargando…</div></div></div><div class="crd" id="mk4-intent-card" style="flex:1 1 520px;align-self:flex-start"><div class="ct">🧩 Intención → Compra <span class="tag tag-c">auditable</span></div><div id="mk4-intent"><div class="ld">Cargando…</div></div></div>';
   card.insertAdjacentElement('afterend',a);
   return a;
 }
-
 function loading(){
   traceBox();insights();
   var g=$id('mk4-trace-grid');if(g)g.innerHTML='<div class="ld">Cargando trazabilidad…</div>';
@@ -235,11 +273,13 @@ function renderLtv(raw){
   var vm=O(raw),rows=A(vm.acquisitionLtv).sort(function(a,b){return N(a.mes)-N(b.mes);});
   var react=A(vm.reactivationLtv).sort(function(a,b){return N(a.mes)-N(b.mes);});
   var recon=A(vm.reconciliation).sort(function(a,b){return N(a.mes)-N(b.mes);});
-  var lineage=A(vm.lineage);
+  var secure=O(S.secureLineage||{}),secureRows=A(secure.rows);
+  var lineage=secure&&secure.ok===true&&secureRows.length?secureRows:A(vm.lineage);
   S.valueMap=vm;S.ltv=rows;
 
-  var b=$id('mk-ltv'),tag=$id('mk-ltv-tag');if(!b||!tag)return;
-  if(!rows.length&&!recon.length){b.innerHTML='<div class="ld">Sin mapa de valor</div>';tag.textContent='sin datos';return;}
+  var b=$id('mk-ltv'),tag=$id('mk-ltv-tag');if(!b)return;
+  if(tag){tag.textContent='';tag.style.display='none';}
+  if(!rows.length&&!recon.length){b.innerHTML='<div class="ld">Sin mapa de valor</div>';return;}
 
   var selected=month()?C().m:null;
   var rec=selected?recon.find(function(x){return N(x.mes)===selected;}):null;
@@ -261,19 +301,11 @@ function renderLtv(raw){
   }
 
   var reconciled=Math.abs(N(rec.reconciliation_delta))<0.01;
-  tag.textContent='V4.3 · '+(reconciled?'RECONCILIADO':'REVISAR')+' · '+M(rec.revenue_attributed);
-
-  var h='<div style="border:1px solid #DCE7F7;background:#F8FBFF;border-radius:10px;padding:11px;margin-bottom:12px">'+
-    '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;margin-bottom:8px">'+
-      '<div><b style="font-size:10px;color:#163A70">🧾 RECONCILIACIÓN DEL REVENUE ATRIBUIDO</b><div style="font-size:8px;color:#6B7BA8;margin-top:2px">Todo el revenue pagado del período debe vivir en una sola categoría, sin mezclarlo con LTV.</div></div>'+
-      '<div style="text-align:right"><div style="font-size:8px;color:#6B7BA8">REVENUE ATRIBUIDO PAGADO</div><div style="font-size:24px;font-weight:900;color:#0A4FBF">'+M(rec.revenue_attributed)+'</div><div style="font-size:7px;color:'+(reconciled?'#059669':'#DC2626')+'">'+(reconciled?'✓ Adquisición + reactivación + seguimiento = total':'⚠ Diferencia '+M(rec.reconciliation_delta))+'</div></div>'+
-    '</div>'+
-    '<div style="display:flex;gap:8px;flex-wrap:wrap">'+
-      '<div style="flex:1;min-width:160px;background:#EEF6FF;border-radius:8px;padding:9px"><div style="font-size:8px;color:#0A4FBF;font-weight:800">ADQUISICIÓN</div><div style="font-size:19px;font-weight:900;color:#0A4FBF">'+M(rec.acquisition)+'</div><div style="font-size:7px;color:#6B7BA8">'+N(rec.acquisition_clients)+' cliente(s) nuevo(s)</div></div>'+
-      '<div style="flex:1;min-width:160px;background:#ECFDF5;border-radius:8px;padding:9px"><div style="font-size:8px;color:#059669;font-weight:800">REACTIVACIÓN</div><div style="font-size:19px;font-weight:900;color:#059669">'+M(rec.reactivation)+'</div><div style="font-size:7px;color:#6B7BA8">'+N(rec.reactivation_clients)+' cliente(s) recuperado(s)</div></div>'+
-      '<div style="flex:1;min-width:160px;background:#FFF7ED;border-radius:8px;padding:9px"><div style="font-size:8px;color:#D97706;font-weight:800">SEGUIMIENTO HISTÓRICO</div><div style="font-size:19px;font-weight:900;color:#D97706">'+M(rec.historical_followup)+'</div><div style="font-size:7px;color:#6B7BA8">'+N(rec.historical_clients)+' cliente(s) de continuidad</div></div>'+
-    '</div>'+
-    '<div style="font-size:8px;color:#6B7BA8;margin-top:7px">'+N(rec.clients)+' clientes atribuidos · '+N(rec.operations)+' operaciones'+(N(rec.organic_revenue)>0?' · Orgánico fuera del KPI pagado: <b>'+M(rec.organic_revenue)+'</b>':'')+'</div>'+
+  var h='<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:9px;margin-bottom:14px">'+
+    '<div style="background:#EFF6FF;border:1px solid #DBEAFE;border-radius:10px;padding:12px"><div style="font-size:8px;color:#64748B;font-weight:800">REVENUE ATRIBUIDO</div><div style="font-size:25px;font-weight:900;color:#0A4FBF;margin-top:2px">'+M(rec.revenue_attributed)+'</div><div style="font-size:7px;color:#64748B;margin-top:3px">'+N(rec.clients)+' clientes · '+N(rec.operations)+' operaciones'+(reconciled?'':' · revisar diferencia')+'</div></div>'+
+    '<div style="background:#F8FAFF;border:1px solid #E2E8F0;border-radius:10px;padding:12px"><div style="font-size:8px;color:#0A4FBF;font-weight:800">ADQUISICIÓN</div><div style="font-size:22px;font-weight:900;color:#0A4FBF;margin-top:2px">'+M(rec.acquisition)+'</div><div style="font-size:7px;color:#64748B;margin-top:3px">'+N(rec.acquisition_clients)+' cliente(s) nuevo(s)</div></div>'+
+    '<div style="background:#ECFDF5;border:1px solid #D1FAE5;border-radius:10px;padding:12px"><div style="font-size:8px;color:#047857;font-weight:800">REACTIVACIÓN</div><div style="font-size:22px;font-weight:900;color:#059669;margin-top:2px">'+M(rec.reactivation)+'</div><div style="font-size:7px;color:#64748B;margin-top:3px">'+N(rec.reactivation_clients)+' cliente(s) recuperado(s)</div></div>'+
+    '<div style="background:#FFF7ED;border:1px solid #FFEDD5;border-radius:10px;padding:12px"><div style="font-size:8px;color:#B45309;font-weight:800">SEGUIMIENTO HISTÓRICO</div><div style="font-size:22px;font-weight:900;color:#D97706;margin-top:2px">'+M(rec.historical_followup)+'</div><div style="font-size:7px;color:#64748B;margin-top:3px">'+N(rec.historical_clients)+' cliente(s) de continuidad</div></div>'+
   '</div>';
 
   var f=selected?rows.find(function(x){return N(x.mes)===selected;}):null;
@@ -284,7 +316,7 @@ function renderLtv(raw){
   }
   var mult=N(f.m0)?N(f.ltv_total)/N(f.m0):0;
 
-  h+='<div style="margin:4px 0 7px"><b style="font-size:10px;color:#5B21B6">📈 LTV DE ADQUISICIÓN</b><div style="font-size:8px;color:#6B7BA8">Solo clientes nuevos adquiridos por la cohorte. Sus compras posteriores acumulan M+1, M+2, M+3 y M+4+.</div></div>';
+  h+='<div style="margin:4px 0 7px"><b style="font-size:10px;color:#5B21B6">📈 LTV DE ADQUISICIÓN</b><div style="font-size:8px;color:#6B7BA8">Clientes nuevos adquiridos por cada cohorte; sus compras posteriores acumulan M+1, M+2, M+3 y M+4+.</div></div>';
   h+='<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px"><div style="flex:1;background:#F5F3FF;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#7C3AED">LTV / M0</div><div style="font-size:24px;font-weight:800;color:#7C3AED">'+(mult?mult.toFixed(1)+'x':'—')+'</div></div><div style="flex:1;background:#F0FDF4;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#059669">ROAS LTV ADQUISICIÓN</div><div style="font-size:24px;font-weight:800;color:#059669">'+N(f.roas_ltv).toFixed(2)+'x</div></div><div style="flex:1;background:#FFF7ED;border-radius:8px;padding:10px;text-align:center"><div style="font-size:8px;color:#D97706">CAC ADQUISICIÓN</div><div style="font-size:24px;font-weight:800;color:#D97706">'+M(f.cac_adquisicion)+'</div></div></div>';
 
   if(rows.length){
@@ -294,7 +326,7 @@ function renderLtv(raw){
   }
 
   var reactShow=react.filter(function(x){return N(x.reactivated_clients)>0||(selected===N(x.mes));});
-  h+='<div style="margin:14px 0 7px;padding-top:10px;border-top:1px solid #EEF2F8"><b style="font-size:10px;color:#047857">♻️ VALOR POST-REACTIVACIÓN</b><div style="font-size:8px;color:#6B7BA8">Cliente existente recuperado por un nuevo touchpoint. R0 es el mes de reactivación; luego se acumula R+1, R+2, R+3 y R+4+ sin mezclarlo con adquisición.</div></div>';
+  h+='<div style="margin:14px 0 7px;padding-top:10px;border-top:1px solid #EEF2F8"><b style="font-size:10px;color:#047857">♻️ VALOR POST-REACTIVACIÓN</b><div style="font-size:8px;color:#6B7BA8">R0 es el mes en que una campaña recupera a un cliente existente; luego se acumulan R+1, R+2, R+3 y R+4+.</div></div>';
   if(!reactShow.length){
     h+='<div class="ld">Aún no hay cohortes de reactivación en este período.</div>';
   }else{
@@ -304,43 +336,63 @@ function renderLtv(raw){
   }
 
   if(month()){
-    h+='<div style="margin:14px 0 7px;padding-top:10px;border-top:1px solid #EEF2F8"><b style="font-size:10px;color:#163A70">🔎 AUDITORÍA DE ATRIBUCIÓN DEL MES</b><div style="font-size:8px;color:#6B7BA8">Mapea cada cliente a lead/campaña/anuncio. Teléfono enmascarado; método y confianza quedan visibles cuando la cadena directa no existe.</div></div>';
+    h+='<div style="margin:14px 0 7px;padding-top:10px;border-top:1px solid #EEF2F8"><b style="font-size:10px;color:#163A70">🔎 TRAZABILIDAD COMERCIAL DEL MES</b><div style="font-size:8px;color:#6B7BA8">Muestra por qué una venta se considera adquisición o reactivación y de qué historial venía el cliente.</div></div>';
     if(!lineage.length){
       h+='<div class="ld">Sin ventas atribuibles para auditar.</div>';
     }else{
-      h+='<div style="overflow:auto"><table class="vt"><thead><tr><th>CLIENTE</th><th>TIPO</th><th>LEAD / CAMPAÑA</th><th>ANUNCIO</th><th>TRAZA</th><th>CONFIANZA</th><th>OPS.</th><th>FACT.</th></tr></thead><tbody>'+lineage.map(function(x){
+      h+='<div style="overflow:auto"><table class="vt"><thead><tr><th>CLIENTE</th><th>TIPO</th><th>HISTORIAL PREVIO</th><th>INGRESO / REACTIVACIÓN ACTUAL</th><th>TRAZA</th><th>CONFIANZA</th><th>OPS.</th><th>FACT.</th></tr></thead><tbody>'+lineage.map(function(x){
         var typ=String(x.tipo_atribucion||'').toUpperCase(),tc=typ==='ADQUISICION'?'#0A4FBF':typ==='REACTIVACION'?'#059669':'#D97706';
-        var trace='📞 '+N(x.llamadas_vinculadas)+' · 📅 '+N(x.citas_vinculadas);
-        return '<tr><td><b>•••• '+E(x.telefono_ult4||'—')+'</b></td><td><span style="font-size:7px;font-weight:800;color:'+tc+'">'+E(typ)+'</span></td><td><b>#'+E(x.lead_id)+'</b> · '+E(x.lead_fecha)+'<div style="font-size:7px;color:#6B7BA8">'+E(x.campana)+'</div></td><td>'+E(x.anuncio||'—')+'</td><td>'+trace+'<div style="font-size:7px;color:#6B7BA8">'+E(x.lineage_strength)+' · '+E(x.metodo_match)+'</div></td><td><b style="color:'+(N(x.confidence)>=80?'#059669':'#D97706')+'">'+N(x.confidence)+'%</b></td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td></tr>';
+        var full=String(x.telefono||'').trim();
+        var phone=full||('•••• '+String(x.telefono_ult4||'—'));
+        var name=String(x.cliente||'').trim()||('Cliente '+String(x.telefono_ult4||'—'));
+        var previous='';
+        if(typ==='REACTIVACION'){
+          if(x.prior_lead_date){
+            previous='<b>Lead previo: '+MY(x.prior_lead_date)+'</b><div style="font-size:7px;color:#6B7BA8">'+E(x.prior_campaign||'Campaña no registrada')+(x.prior_ad?' · '+E(x.prior_ad):'')+'</div>';
+          }else if(x.first_sale_date){
+            previous='<b>Cliente desde '+MY(x.first_sale_date)+'</b><div style="font-size:7px;color:#6B7BA8">Sin lead previo histórico registrado</div>';
+          }else{
+            previous='<span style="color:#9AAAC8">Historial previo confirmado</span>';
+          }
+        }else{
+          previous='<b>Nuevo en '+MY(x.first_sale_date||x.lead_fecha)+'</b><div style="font-size:7px;color:#6B7BA8">Sin compra anterior</div>';
+        }
+        var current='<b>'+MY(x.lead_fecha)+' · Lead #'+E(x.lead_id)+'</b><div style="font-size:7px;color:#6B7BA8">'+E(x.campana||'—')+(x.anuncio?' · '+E(x.anuncio):'')+'</div>';
+        var direct=N(x.llamadas_vinculadas)||N(x.citas_vinculadas);
+        var trace='<b>'+friendlyTrace(x.lineage_strength)+'</b><div style="font-size:7px;color:#6B7BA8;margin-top:2px">'+(direct?('Llamadas vinculadas: '+N(x.llamadas_vinculadas)+' · Citas: '+N(x.citas_vinculadas)):'Sin llamada/cita enlazada por ID')+'</div><div style="font-size:7px;color:#6B7BA8">'+E(friendlyMethod(x.metodo_match))+'</div>';
+        return '<tr><td style="min-width:150px"><b>'+E(name)+'</b><div style="font-size:8px;color:#64748B;margin-top:2px">'+E(phone)+'</div></td><td><span style="font-size:7px;font-weight:800;color:'+tc+'">'+E(typ)+'</span></td><td style="min-width:160px">'+previous+'</td><td style="min-width:210px">'+current+'</td><td style="min-width:180px">'+trace+'</td><td><b style="color:'+(N(x.confidence)>=80?'#059669':'#D97706')+'">'+N(x.confidence)+'%</b></td><td>'+N(x.operaciones)+'</td><td class="hi hi-g">'+M(x.facturacion)+'</td></tr>';
       }).join('')+'</tbody></table></div>';
     }
   }
 
-  h+='<div style="font-size:8px;color:#6B7BA8;margin-top:8px"><b>Lectura:</b> revenue atribuido explica el resultado del período; LTV de adquisición y valor post-reactivación siguen cohortes distintas y no deben sumarse entre sí para reconstruir el M0.</div>';
   b.innerHTML=h;
 }
-
 function renderAttr(raw){
   var s=O(raw);S.attr=s;insights();
   var b=$id('mk4-attr');if(!b)return;
   var ac=N(s.clientesAdquiridosM0||s.clientesAdquiridos||s.clientesAdquiridosAtribuidos);
-  var v=[
+  var primary=[
     [s.personasUnicas,'PERSONAS ÚNICAS','#0A4FBF'],
-    [s.touchpointsEfectivos,'TOUCHPOINTS EFECTIVOS','#0D9488'],
-    [s.duplicadosTecnicosProbables,'DUPLICADOS TÉCNICOS','#DC2626'],
     [s.reingresosProspectoHistorico,'REINGRESOS HISTÓRICOS','#7C3AED'],
-    [s.reingresosProspectoMismoMes,'REINGRESOS MISMO MES','#7C3AED'],
     [s.reingresosClienteExistente,'CLIENTES QUE REINGRESAN','#D97706'],
-    [ac,month()?'CLIENTES M0':'CLIENTES ADQUIRIDOS','#059669'],
+    [ac,month()?'CLIENTES M0':'CLIENTES ADQUIRIDOS','#059669']
+  ];
+  var secondary=[
+    [s.touchpointsEfectivos,'TOUCHPOINTS EFECTIVOS','#0D9488'],
     [s.reactivacionesConfirmadas,'REACTIVACIONES CONF.','#00C9A7'],
+    [s.reingresosProspectoMismoMes,'REINGRESOS MISMO MES','#7C3AED'],
+    [s.duplicadosTecnicosProbables,'DUPLICADOS TÉCNICOS','#DC2626'],
     [s.anomaliasHigh,'REVISIÓN ALTA','#DC2626'],
     [s.anomaliasMedium,'REVISIÓN MEDIA','#D97706']
   ];
-  b.innerHTML='<div class="g-row">'+v.map(function(x){
-    return '<div class="g-c" style="background:#F8FAFF;border:1px solid #EEF2F8"><div class="g-v" style="color:'+x[2]+'">'+N(x[0])+'</div><div class="g-l">'+x[1]+'</div></div>';
-  }).join('')+'</div><div style="font-size:8px;color:#6B7BA8;margin-top:6px">Reingreso ≠ reactivación. Los duplicados técnicos son candidatos de revisión; no se eliminan automáticamente.</div>';
+  var p='<div style="display:grid;grid-template-columns:repeat(2,minmax(130px,1fr));gap:8px">'+primary.map(function(x){
+    return '<div style="background:#F8FAFF;border:1px solid #E7EDF7;border-radius:10px;padding:13px 10px;min-height:72px;display:flex;flex-direction:column;justify-content:center;text-align:center"><div style="font-size:22px;font-weight:900;color:'+x[2]+'">'+N(x[0])+'</div><div style="font-size:7px;font-weight:800;color:#64748B;margin-top:3px;letter-spacing:.25px">'+x[1]+'</div></div>';
+  }).join('')+'</div>';
+  var q='<div style="display:grid;grid-template-columns:repeat(3,minmax(95px,1fr));gap:6px;margin-top:8px">'+secondary.map(function(x){
+    return '<div style="background:#FFF;border:1px solid #EEF2F8;border-radius:8px;padding:8px;text-align:center"><div style="font-size:15px;font-weight:900;color:'+x[2]+'">'+N(x[0])+'</div><div style="font-size:6px;font-weight:800;color:#64748B;margin-top:2px">'+x[1]+'</div></div>';
+  }).join('')+'</div>';
+  b.innerHTML=p+q+'<div style="font-size:8px;color:#6B7BA8;margin-top:7px">Reingreso ≠ reactivación. Los duplicados técnicos quedan para revisión y no se eliminan automáticamente.</div>';
 }
-
 function renderIntent(r,d){
   insights();
   var card=$id('mk4-intent-card'),b=$id('mk4-intent');if(!card||!b)return;
@@ -401,6 +453,19 @@ function loadAll(){
     });
   }
 
+  S.secureLineage=null;
+  if(month()&&window.AOS&&AOS.role==='ADMIN'){
+    chain=chain.then(function(){
+      return strongToken().then(function(token){
+        if(stale(my)||String(token||'').length<32)return;
+        return rpc('aos_marketing_lineage_admin_v43',{p_token:token,p_anio:c.a,p_mes:c.m},s)
+          .then(function(x){if(!stale(my))S.secureLineage=O(x);});
+      }).catch(function(e){
+        if(e&&e.name!=='AbortError')console.warn('[MKT4.3] secure lineage fallback',e&&e.message);
+      });
+    });
+  }
+
   chain=chain.then(function(){
     return rpc('aos_marketing_historico_public_v2',{p_anio:c.a},s)
       .then(function(x){if(!stale(my))renderHistory(x);})
@@ -437,5 +502,5 @@ window.__AOS_MKT4={release:RELEASE,reload:loadAll,destroy:destroy,state:S};
 window.__AOS_MARKETING_V3_ACTIVE=false;
 window.__AOS_MARKETING_V3_CONSISTENCY_PATCH=false;
 traceBox();insights();L(loadAll,1200);L(styleOrganicRow,1400);
-console.log('[ASCENDA] Marketing V4.3 mounted — revenue reconciliation + acquisition/reactivation cohorts');
+console.log('[ASCENDA] Marketing V4.3.1 mounted — operational lineage + compact revenue/value UI');
 })();

--- a/app/public/admin-marketing-v2.js
+++ b/app/public/admin-marketing-v2.js
@@ -6,7 +6,7 @@
 (function(){
 'use strict';
 
-var RELEASE='2026-09-10-mkt-v4.3-read-pressure-v1';
+var RELEASE='2026-09-10-mkt-v4.3.1-ui-lineage';
 var G=window.__AOS_MKT_PERF_V1;
 
 // SPA remounts can keep an older fetch wrapper alive. Upgrade deterministically by
@@ -39,6 +39,7 @@ if(!G){
     aos_marketing_attribution_public_v2_anio:10000,
     aos_marketing_intent_public_v2:10000,
     aos_marketing_intent_detail_public_v3:10000,
+    aos_marketing_lineage_admin_v43:10000,
     aos_marketing_historico_public_v2:60000,
     aos_marketing_ltv_public_v2:60000,
     aos_marketing_value_map_public_v43:60000
@@ -46,13 +47,15 @@ if(!G){
   var lazy={
     aos_marketing_historico_public_v2:'#mk-hist',
     aos_marketing_ltv_public_v2:'#mk-ltv',
-    aos_marketing_value_map_public_v43:'#mk-ltv'
+    aos_marketing_value_map_public_v43:'#mk-ltv',
+    aos_marketing_lineage_admin_v43:'#mk-ltv'
   };
   var monthlySerial={
     aos_marketing_period_summary_v2:true,
     aos_marketing_attribution_public_v3:true,
     aos_marketing_intent_public_v2:true,
-    aos_marketing_intent_detail_public_v3:true
+    aos_marketing_intent_detail_public_v3:true,
+    aos_marketing_lineage_admin_v43:true
   };
   var annualReads={
     aos_marketing_historico_public_v2:true,

--- a/app/public/admin-marketing.html
+++ b/app/public/admin-marketing.html
@@ -73,7 +73,7 @@
     <div class="crd"><div class="ct">▼ Embudo de Conversión <span class="tag tag-c">leads nuevos del mes</span></div><div id="mk-emb"></div></div>
     <div class="crd"><div class="ct">📅 Histórico mensual</div><div id="mk-hist"></div></div>
   </div>
-  <div class="crd"><div class="ct">📊 Valor atribuido, LTV y Reactivación <span style="margin-left:auto;font-size:8px;font-weight:700;color:#7C3AED;background:#F5F3FF;padding:2px 8px;border-radius:5px;" id="mk-ltv-tag">cargando...</span></div><div id="mk-ltv"></div></div>
+  <div class="crd"><div class="ct">📊 Valor atribuido, LTV y Reactivación </div><div id="mk-ltv"></div></div>
   <div class="mk-2t">
     <div class="crd"><div class="ct">📢 Top Anuncios <span class="tag tag-c">leads del mes</span><span style="margin-left:auto;font-size:8px;font-weight:600;color:#9AAAC8;">clic en una fila para ver detalle</span></div><div style="overflow-x:auto;max-height:420px;overflow-y:auto;"><table class="vt"><thead><tr><th>Anuncio</th><th>Leads</th><th>Citas</th><th>%</th><th>Asist.</th><th>Clientes</th><th>Ventas</th><th style="color:#0A4FBF;">Fact.Mes</th><th style="color:#7C3AED;">Cli.Fuera</th><th style="color:#D97706;">Vtas.Fuera</th><th style="color:#00C9A7;">Fact.Acum.</th></tr></thead><tbody id="mk-an"></tbody></table></div></div>
     <div class="crd"><div class="ct">🎯 Campañas <span class="tag tag-c">leads del mes</span></div><div style="overflow-x:auto;max-height:420px;overflow-y:auto;"><table class="vt"><thead><tr><th>Trat.</th><th>Leads</th><th>Citas</th><th>%</th><th>Asist.</th><th>Clientes</th><th>Ventas</th><th style="color:#0A4FBF;">Fact.Mes</th><th style="color:#00C9A7;">Fact.Acum.</th><th>Inv.</th><th>ROAS</th></tr></thead><tbody id="mk-camp"></tbody></table></div></div>

--- a/ci/performance/marketing-read-pressure.test.js
+++ b/ci/performance/marketing-read-pressure.test.js
@@ -8,10 +8,12 @@ const indexMigration=fs.readFileSync('supabase/migrations/20260902022000_p0_mark
 const callLeadMigration=fs.readFileSync('supabase/migrations/20260902024000_p0_marketing_call_lead_single_pass_v4.sql','utf8');
 const summaryMigration=fs.readFileSync('supabase/migrations/20260902164000_p0_marketing_period_summary_fast_v5.sql','utf8');
 const valueMapMigration=fs.readFileSync('supabase/migrations/20260910230000_marketing_value_map_v43.sql','utf8');
+const lineageMigration=fs.readFileSync('supabase/migrations/20260910233500_marketing_lineage_admin_v43.sql','utf8');
+const marketingHtml=fs.readFileSync('app/public/admin-marketing.html','utf8');
 
 test('preserves certified Marketing V4.3 core',()=>{
   assert.match(boot,/admin-marketing-v2-core\.js/);
-  assert.match(core,/2026-09-10-v4\.3-value-reconciliation/);
+  assert.match(core,/2026-09-10-v4\.3\.1-operational-lineage/);
   assert.match(core,/Facturación, ROAS y CAC excluyen ORGANICO/);
 });
 
@@ -23,6 +25,7 @@ test('single-flight and cache are scoped to Marketing reads',()=>{
   assert.match(boot,/aos_marketing_historico_public_v2:60000/);
   assert.match(boot,/aos_marketing_ltv_public_v2:60000/);
   assert.match(boot,/aos_marketing_value_map_public_v43:60000/);
+  assert.match(boot,/aos_marketing_lineage_admin_v43:10000/);
   assert.match(boot,/inflight\.has\(key\)/);
   assert.match(boot,/cache\.get\(key\)/);
 });
@@ -41,6 +44,7 @@ test('expensive annual analytics are viewport gated and wait for monthly quiesce
   assert.match(boot,/aos_marketing_historico_public_v2:'#mk-hist'/);
   assert.match(boot,/aos_marketing_ltv_public_v2:'#mk-ltv'/);
   assert.match(boot,/aos_marketing_value_map_public_v43:'#mk-ltv'/);
+  assert.match(boot,/aos_marketing_lineage_admin_v43:'#mk-ltv'/);
   assert.match(boot,/IntersectionObserver/);
   assert.match(boot,/rootMargin:'500px 0px'/);
   assert.match(boot,/setTimeout\(finish,12000\)/);
@@ -62,7 +66,7 @@ test('legacy LTV cohort read is suppressed from bootstrap start',()=>{
 });
 
 test('new bootstrap release replaces older SPA fetch wrapper',()=>{
-  assert.match(boot,/2026-09-10-mkt-v4\.3-read-pressure-v1/);
+  assert.match(boot,/2026-09-10-mkt-v4\.3\.1-ui-lineage/);
   assert.match(boot,/G&&G\.release!==RELEASE&&typeof G\.baseFetch==='function'/);
   assert.match(boot,/window\.fetch=G\.baseFetch/);
   assert.match(boot,/delete window\.__AOS_MKT_PERF_V1/);
@@ -75,6 +79,7 @@ test('period summary attribution and intent share one serialized monthly lane',(
   assert.match(boot,/aos_marketing_attribution_public_v3:true/);
   assert.match(boot,/aos_marketing_intent_public_v2:true/);
   assert.match(boot,/aos_marketing_intent_detail_public_v3:true/);
+  assert.match(boot,/aos_marketing_lineage_admin_v43:true/);
   assert.match(boot,/function runMonthly\(/);
   assert.match(boot,/function withoutSignal\(/);
   assert.match(boot,/monthlyTail=queued\.then/);
@@ -97,11 +102,32 @@ test('V4.3 value map reconciles revenue and keeps cohorts separate',()=>{
   assert.doesNotMatch(valueMapMigration,/update\s+public\./i);
   assert.doesNotMatch(valueMapMigration,/delete\s+from\s+public\./i);
   assert.doesNotMatch(valueMapMigration,/insert\s+into\s+public\./i);
-  assert.match(core,/RECONCILIACIÓN DEL REVENUE ATRIBUIDO/);
+  assert.doesNotMatch(core,/RECONCILIACIÓN DEL REVENUE ATRIBUIDO/);
   assert.match(core,/LTV DE ADQUISICIÓN/);
   assert.match(core,/VALOR POST-REACTIVACIÓN/);
-  assert.match(core,/AUDITORÍA DE ATRIBUCIÓN DEL MES/);
+  assert.match(core,/TRAZABILIDAD COMERCIAL DEL MES/);
   assert.match(core,/aos_marketing_value_map_public_v43/);
+});
+
+test('V4.3.1 secure lineage exposes PII only behind admin 2FA',()=>{
+  assert.match(lineageMigration,/create or replace function public\.aos_marketing_lineage_admin_v43/);
+  assert.match(lineageMigration,/aos_app_actor_v3\(p_token,'admin-marketing',true\)/);
+  assert.match(lineageMigration,/coalesce\(u\.nivel_jerarquia,99\)<=2/);
+  assert.match(lineageMigration,/g\.numero_limpio as telefono/);
+  assert.match(lineageMigration,/coalesce\(nullif\(ci\.cliente,''\),'SIN NOMBRE'\)/);
+  assert.match(lineageMigration,/prior_lead_date/);
+  assert.match(lineageMigration,/first_sale_date/);
+  assert.match(lineageMigration,/MARKETING_ADMIN_2FA_REQUIRED/);
+  assert.doesNotMatch(lineageMigration,/update\s+public\./i);
+  assert.doesNotMatch(lineageMigration,/delete\s+from\s+public\./i);
+  assert.doesNotMatch(lineageMigration,/insert\s+into\s+public\./i);
+  assert.match(core,/function strongToken\(/);
+  assert.match(core,/AOS\.role==='ADMIN'/);
+  assert.match(core,/Cliente desde/);
+  assert.match(core,/Lead previo:/);
+  assert.match(core,/Lead único compatible del mes/);
+  assert.match(core,/align-items:flex-start/);
+  assert.doesNotMatch(marketingHtml,/id="mk-ltv-tag"/);
 });
 
 test('confirmed-call lookup index is partial and formula-neutral',()=>{

--- a/src/admin-marketing.html
+++ b/src/admin-marketing.html
@@ -62,7 +62,7 @@
     <div class="crd"><div class="ct">▼ Embudo de Conversión <span class="tag tag-c">leads nuevos del mes</span></div><div id="mk-emb"></div></div>
     <div class="crd"><div class="ct">📅 Histórico mensual</div><div id="mk-hist"></div></div>
   </div>
-  <div class="crd"><div class="ct">📊 Valor atribuido, LTV y Reactivación <span style="margin-left:auto;font-size:8px;font-weight:700;color:#7C3AED;background:#F5F3FF;padding:2px 8px;border-radius:5px;" id="mk-ltv-tag">cargando...</span></div><div id="mk-ltv"></div></div>
+  <div class="crd"><div class="ct">📊 Valor atribuido, LTV y Reactivación </div><div id="mk-ltv"></div></div>
   <div class="mk-2t">
     <div class="crd"><div class="ct">📢 Top Anuncios <span class="tag tag-c">leads del mes</span></div><div style="overflow-x:auto;max-height:420px;overflow-y:auto;"><table class="vt"><thead><tr><th>Anuncio</th><th>Leads</th><th>Citas</th><th>%</th><th>Asist.</th><th>Clientes</th><th>Ventas</th><th style="color:#0A4FBF;">Fact.Mes</th><th style="color:#00C9A7;">Fact.Acum.</th></tr></thead><tbody id="mk-an"></tbody></table></div></div>
     <div class="crd"><div class="ct">🎯 Campañas <span class="tag tag-c">leads del mes</span></div><div style="overflow-x:auto;max-height:420px;overflow-y:auto;"><table class="vt"><thead><tr><th>Trat.</th><th>Leads</th><th>Citas</th><th>%</th><th>Asist.</th><th>Clientes</th><th>Ventas</th><th style="color:#0A4FBF;">Fact.Mes</th><th style="color:#00C9A7;">Fact.Acum.</th><th>Inv.</th><th>ROAS</th></tr></thead><tbody id="mk-camp"></tbody></table></div></div>

--- a/supabase/migrations/20260910233500_marketing_lineage_admin_v43.sql
+++ b/supabase/migrations/20260910233500_marketing_lineage_admin_v43.sql
@@ -1,0 +1,161 @@
+-- Marketing V4.3 UI polish · secure operational lineage
+-- Adds an admin/2FA-only monthly lineage reader so the internal Marketing panel
+-- can show client identity and prior commercial history without expanding the
+-- public/masked V4.3 value-map surface.
+
+create or replace function public.aos_marketing_lineage_admin_v43(
+  p_token text,
+  p_anio integer,
+  p_mes integer
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path to ''
+set statement_timeout to '4s'
+as $function$
+with actor as (
+  select public.aos_app_actor_v3(p_token,'admin-marketing',true) as id
+),
+authorized as (
+  select u.id
+  from actor a
+  join public.aos_usuarios u on u.id=a.id
+  where coalesce(u.nivel_jerarquia,99)<=2
+),
+bounds as (
+  select
+    pg_catalog.make_date(p_anio,p_mes,1) as d0,
+    (pg_catalog.make_date(p_anio,p_mes,1)+interval '1 month')::date as d1
+  where p_anio between 2020 and extract(year from current_date)::int+1
+    and p_mes between 1 and 12
+),
+attrs as materialized (
+  select a.*
+  from bounds b,
+       lateral public.aos_marketing_attribution_v2_preview(b.d0,b.d1-1) a
+  where a.lead_fecha>=b.d0
+    and a.lead_fecha<b.d1
+    and a.venta_fecha>=b.d0
+    and a.venta_fecha<b.d1
+    and upper(coalesce(trim(a.lead_tratamiento),'')) not in ('ORGANICO','ORGÁNICO')
+),
+grp as (
+  select
+    a.numero_limpio,
+    a.tipo_atribucion,
+    a.lead_id,
+    a.lead_fecha,
+    a.lead_tratamiento,
+    a.lead_anuncio,
+    count(*)::bigint as operaciones,
+    sum(a.monto)::numeric as facturacion,
+    count(distinct a.llamada_id) filter(where a.llamada_id is not null)::bigint as llamadas_vinculadas,
+    count(distinct a.cita_id) filter(where a.cita_id is not null)::bigint as citas_vinculadas,
+    max(a.confidence)::int as confidence,
+    string_agg(
+      distinct case
+        when a.metodo_match='SAME_MONTH_UNIQUE_NEW_CUSTOMER' then 'SAME_MONTH_UNIQUE_LEAD'
+        else a.metodo_match
+      end,
+      ', ' order by case
+        when a.metodo_match='SAME_MONTH_UNIQUE_NEW_CUSTOMER' then 'SAME_MONTH_UNIQUE_LEAD'
+        else a.metodo_match
+      end
+    ) as metodo_match
+  from attrs a
+  group by 1,2,3,4,5,6
+),
+rows as (
+  select
+    g.numero_limpio as telefono,
+    right(g.numero_limpio,4) as telefono_ult4,
+    coalesce(nullif(ci.cliente,''),'SIN NOMBRE') as cliente,
+    g.tipo_atribucion,
+    g.lead_id,
+    g.lead_fecha,
+    g.lead_tratamiento as campana,
+    g.lead_anuncio as anuncio,
+    ph.prior_lead_date,
+    ph.prior_campaign,
+    ph.prior_ad,
+    fs.first_sale_date,
+    fl.first_lead_date,
+    g.llamadas_vinculadas,
+    g.citas_vinculadas,
+    g.confidence,
+    g.metodo_match,
+    g.operaciones,
+    g.facturacion,
+    case
+      when g.llamadas_vinculadas>0 and g.citas_vinculadas>0 then 'LEAD_CALL_APPOINTMENT'
+      when g.llamadas_vinculadas>0 then 'LEAD_CALL'
+      when g.citas_vinculadas>0 then 'LEAD_APPOINTMENT'
+      when g.confidence>=80 then 'STRONG_INFERRED'
+      else 'INFERRED'
+    end as lineage_strength,
+    case
+      when ph.prior_lead_date is not null then 'PRIOR_LEAD'
+      when fs.first_sale_date is not null and fs.first_sale_date<g.lead_fecha then 'PRIOR_CLIENT'
+      when fl.first_lead_date is not null and fl.first_lead_date<g.lead_fecha then 'PRIOR_LEAD'
+      else 'NEW'
+    end as prior_origin_type
+  from grp g
+  left join lateral (
+    select
+      trim(concat_ws(' ',
+        nullif(trim(v.nombres),''),
+        nullif(trim(v.apellidos),'')
+      )) as cliente
+    from public.aos_ventas v
+    where v.numero_limpio=g.numero_limpio
+    order by
+      case when coalesce(trim(v.nombres),'')<>'' or coalesce(trim(v.apellidos),'')<>'' then 0 else 1 end,
+      v.fecha desc,
+      v.created_at desc nulls last
+    limit 1
+  ) ci on true
+  left join lateral (
+    select
+      l.fecha as prior_lead_date,
+      l.tratamiento as prior_campaign,
+      l.anuncio as prior_ad
+    from public.aos_leads l
+    where l.numero_limpio=g.numero_limpio
+      and l.fecha<g.lead_fecha
+    order by l.fecha desc,l.created_at desc nulls last,l.id desc
+    limit 1
+  ) ph on true
+  left join lateral (
+    select min(v.fecha) as first_sale_date
+    from public.aos_ventas v
+    where v.numero_limpio=g.numero_limpio
+  ) fs on true
+  left join lateral (
+    select min(l.fecha) as first_lead_date
+    from public.aos_leads l
+    where l.numero_limpio=g.numero_limpio
+  ) fl on true
+)
+select case
+  when not exists(select 1 from bounds) then
+    jsonb_build_object('ok',false,'error','INVALID_PERIOD','rows','[]'::jsonb)
+  when not exists(select 1 from authorized) then
+    jsonb_build_object('ok',false,'error','MARKETING_ADMIN_2FA_REQUIRED','rows','[]'::jsonb)
+  else jsonb_build_object(
+    'ok',true,
+    'version','MKT-V4.3-UI',
+    'rows',coalesce((select jsonb_agg(to_jsonb(r) order by r.facturacion desc,r.lead_id) from rows r),'[]'::jsonb)
+  )
+end
+$function$;
+
+revoke all on function public.aos_marketing_lineage_admin_v43(text,integer,integer) from public;
+grant execute on function public.aos_marketing_lineage_admin_v43(text,integer,integer)
+  to anon,authenticated,service_role;
+
+comment on function public.aos_marketing_lineage_admin_v43(text,integer,integer)
+is 'Admin+2FA monthly Marketing lineage. Full phone/name plus prior lead/client history; read-only. Public V4.3 map remains masked.';
+
+select pg_notify('pgrst','reload schema');

--- a/supabase/rollbacks/20260910233500_marketing_lineage_admin_v43_recovery.sql
+++ b/supabase/rollbacks/20260910233500_marketing_lineage_admin_v43_recovery.sql
@@ -1,0 +1,3 @@
+-- Marketing V4.3 UI lineage recovery
+drop function if exists public.aos_marketing_lineage_admin_v43(text,integer,integer);
+select pg_notify('pgrst','reload schema');


### PR DESCRIPTION
## Owner-requested UI polish before returning to WA-L10

Tracks #497.

### Visual cleanup
- removes the redundant V4.3/reconciled badge and the long reconciliation heading/copy;
- keeps one clean four-card summary: Revenue attributed / Acquisition / Reactivation / Historical follow-up;
- makes Atribución y reingresos use larger hierarchical cards;
- prevents the left card from stretching to the height of the long Intención audit, eliminating wasted whitespace.

### Operational lineage
- replaces icon-only 📞0 / 📅0 trace with a readable narrative:
  - client identity;
  - acquisition/reactivation type;
  - prior lead month/campaign when available;
  - otherwise client-since month from first historical sale;
  - current lead month/campaign/ad;
  - direct vs inferred trace;
  - linked calls/citas;
  - friendly match method;
  - confidence / ops / revenue.
- admin users with a valid 2FA panel session receive full name + full phone through new `aos_marketing_lineage_admin_v43`;
- non-admin / unavailable strong-session fallback stays on the existing masked public lineage.

### Security
The new PII-bearing reader:
- requires `aos_app_actor_v3(p_token,'admin-marketing',true)`;
- additionally requires hierarchy level <=2;
- is read-only;
- does not expand the public V4.3 value-map PII surface.

No attribution formula or historical business rows are changed. WA-L10 remains SAFE-OFF.