### PR TITLE
APP-PWA-V2 #517 — base aislada de dispositivos, presencia y notificaciones

### DIFF
--- a/app/device-api-v2.js
+++ b/app/device-api-v2.js
@@ -1,0 +1,103 @@
+'use strict'
+
+// APP-PWA-V2 #517 — actor-bound device/presence API.
+// This module is inert until wired by server-f17 in a dedicated integration gate.
+
+function createDeviceApi(deps) {
+  deps = deps || {}
+  const verifyApp = deps.verifyApp
+  const serviceRpc = deps.serviceRpc
+  const writeJson = deps.writeJson
+  const readRaw = deps.readRaw
+  const parseJson = deps.parseJson
+
+  if (![verifyApp, serviceRpc, writeJson, readRaw, parseJson].every(function(x){ return typeof x === 'function' })) {
+    throw new Error('DEVICE_API_DEPENDENCIES_REQUIRED')
+  }
+
+  async function actor(req, res) {
+    const a = await verifyApp(req.headers['x-aos-app-token'], false)
+    if (!a || !a.ok) {
+      writeJson(res, a && a.status || 403, { ok: false, error: 'DEVICE_APP_SESSION_REQUIRED' })
+      return null
+    }
+    return a
+  }
+
+  async function body(req, res, maxBytes) {
+    let raw
+    try { raw = await readRaw(req, maxBytes || 64 * 1024) }
+    catch (e) { writeJson(res, e.status || 400, { ok:false, error:e.message || 'INVALID_BODY' }); return null }
+    const parsed = parseJson(raw.toString('utf8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      writeJson(res, 400, { ok:false, error:'INVALID_JSON' }); return null
+    }
+    return parsed
+  }
+
+  async function register(req, res) {
+    const a = await actor(req, res); if (!a) return
+    const b = await body(req, res, 64 * 1024); if (!b) return
+    b.user_id = a.actor_id
+    try {
+      const out = await serviceRpc('aos_device_upsert_v1', { p_payload:b })
+      if (!out || out.ok !== true) return writeJson(res, 400, out || { ok:false, error:'DEVICE_REGISTER_REJECTED' })
+      return writeJson(res, 200, out)
+    } catch (e) {
+      return writeJson(res, 503, { ok:false, error:'DEVICE_REGISTER_UNAVAILABLE' })
+    }
+  }
+
+  async function list(req, res) {
+    const a = await actor(req, res); if (!a) return
+    try {
+      const out = await serviceRpc('aos_devices_actor_v1', { p_payload:{ actor_id:a.actor_id } })
+      if (!out || out.ok !== true) return writeJson(res, 403, out || { ok:false, error:'DEVICE_LIST_REJECTED' })
+      return writeJson(res, 200, out)
+    } catch (e) {
+      return writeJson(res, 503, { ok:false, error:'DEVICE_LIST_UNAVAILABLE' })
+    }
+  }
+
+  async function presence(req, res) {
+    const a = await actor(req, res); if (!a) return
+    const b = await body(req, res, 32 * 1024); if (!b) return
+    b.user_id = a.actor_id
+    try {
+      const out = await serviceRpc('aos_app_presence_touch_v1', { p_payload:b })
+      if (!out || out.ok !== true) return writeJson(res, 400, out || { ok:false, error:'PRESENCE_REJECTED' })
+      return writeJson(res, 200, out)
+    } catch (e) {
+      return writeJson(res, 503, { ok:false, error:'PRESENCE_UNAVAILABLE' })
+    }
+  }
+
+  async function mutate(req, res, rpcName) {
+    const a = await actor(req, res); if (!a) return
+    const b = await body(req, res, 32 * 1024); if (!b) return
+    b.actor_id = a.actor_id
+    try {
+      const out = await serviceRpc(rpcName, { p_payload:b })
+      if (!out || out.ok !== true) return writeJson(res, 400, out || { ok:false, error:'DEVICE_MUTATION_REJECTED' })
+      return writeJson(res, 200, out)
+    } catch (e) {
+      return writeJson(res, 503, { ok:false, error:'DEVICE_MUTATION_UNAVAILABLE' })
+    }
+  }
+
+  async function handle(req, res, url) {
+    const p = url.pathname
+    if (p === '/api/devices/health' && req.method === 'GET') return writeJson(res, 200, {ok:true,version:'APP-PWA-V2-517',auth:'actor-bound'})
+    if (p === '/api/devices' && req.method === 'GET') return list(req,res)
+    if (p === '/api/devices/register' && req.method === 'POST') return register(req,res)
+    if (p === '/api/devices/presence' && req.method === 'POST') return presence(req,res)
+    if (p === '/api/devices/preferences' && req.method === 'POST') return mutate(req,res,'aos_device_preferences_actor_v1')
+    if (p === '/api/devices/rename' && req.method === 'POST') return mutate(req,res,'aos_device_rename_actor_v1')
+    if (p === '/api/devices/disable' && req.method === 'POST') return mutate(req,res,'aos_device_disable_actor_v1')
+    return false
+  }
+
+  return { handle, register, list, presence }
+}
+
+module.exports = { createDeviceApi }

--- a/app/public/admin-device-center-v2.html
+++ b/app/public/admin-device-center-v2.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>ASCENDA · Dispositivos y Notificaciones</title>
+<style>
+:root{--navy:#071D4A;--blue:#0A4FBF;--green:#00C9A7;--bg:#F5F7FB;--muted:#6B7BA8;--line:#DDE4F5;--danger:#DC2626;--warn:#D97706}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;color:#0D1B3E}
+.wrap{max-width:1080px;margin:auto;padding:22px 18px 70px}.top{display:flex;gap:14px;align-items:flex-start;justify-content:space-between;margin-bottom:18px}
+h1{font-size:24px;margin:0;color:var(--navy)}.sub{font-size:12px;color:var(--muted);margin-top:5px;line-height:1.45}.pill{font-size:10px;font-weight:800;padding:7px 10px;border-radius:99px;background:#E8FFF9;color:#087A68;white-space:nowrap}
+.grid{display:grid;grid-template-columns:1.1fr .9fr;gap:14px}.card{background:white;border:1px solid var(--line);border-radius:18px;padding:16px;box-shadow:0 7px 24px rgba(7,29,74,.05);margin-bottom:14px}
+.card h2{font-size:14px;margin:0 0 12px}.hero{display:flex;gap:14px;align-items:center}.ico{width:52px;height:52px;border-radius:16px;background:#EEF4FF;display:grid;place-items:center;font-size:25px}.grow{flex:1}.title{font-size:14px;font-weight:850}.meta{font-size:10px;color:var(--muted);margin-top:4px}.health{font-size:10px;font-weight:850;padding:5px 8px;border-radius:99px;background:#E8FFF9;color:#087A68}
+.kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:14px}.k{border:1px solid var(--line);border-radius:12px;padding:10px}.k b{display:block;font-size:11px}.k span{font-size:9px;color:var(--muted)}
+.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:13px}.btn{border:0;border-radius:10px;padding:9px 12px;font-weight:800;font-size:10px;cursor:pointer;background:var(--navy);color:white}.btn.sec{background:#EEF3FC;color:var(--navy)}.btn.red{background:#FEECEC;color:var(--danger)}.btn:disabled{opacity:.45;cursor:not-allowed}
+.row{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:11px 0;border-bottom:1px solid #EEF1F7}.row:last-child{border-bottom:0}.rtitle{font-size:11px;font-weight:800}.rsub{font-size:9px;color:var(--muted);margin-top:3px}.toggle{width:38px;height:22px;border-radius:20px;background:#CDD5E6;position:relative;cursor:pointer;flex:none}.toggle:after{content:"";position:absolute;width:16px;height:16px;border-radius:50%;background:white;left:3px;top:3px;transition:.15s}.toggle.on{background:var(--green)}.toggle.on:after{left:19px}
+.device{border:1px solid var(--line);border-radius:13px;padding:12px;margin-bottom:8px}.device:last-child{margin-bottom:0}.dhead{display:flex;align-items:center;gap:10px}.dicon{font-size:22px}.dname{font-size:11px;font-weight:850}.dmeta{font-size:9px;color:var(--muted);margin-top:2px}.tag{margin-left:auto;font-size:8px;font-weight:850;padding:4px 7px;border-radius:99px;background:#F1F5F9;color:#475569}.tag.me{background:#E8FFF9;color:#087A68}
+.notice{font-size:10px;line-height:1.5;padding:10px 12px;border-radius:12px;background:#FFF8E8;color:#8A5B00;margin-bottom:12px}.err{background:#FEECEC;color:#991B1B}.ok{background:#E8FFF9;color:#087A68}
+.empty{font-size:10px;color:var(--muted);text-align:center;padding:20px}.foot{font-size:9px;color:#8A98B6;text-align:center;margin-top:20px}
+@media(max-width:760px){.grid{grid-template-columns:1fr}.top{flex-direction:column}.kpis{grid-template-columns:1fr 1fr 1fr}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="top">
+    <div><h1>Dispositivos y Notificaciones</h1><div class="sub">Controla esta instalación de ASCENDA, los canales de alerta y la salud del push.</div></div>
+    <div class="pill">ASCENDA PWA V2</div>
+  </div>
+  <div id="notice" class="notice" style="display:none"></div>
+  <div class="grid">
+    <div>
+      <div class="card">
+        <h2>Este dispositivo</h2>
+        <div class="hero">
+          <div class="ico" id="currentIcon">💻</div>
+          <div class="grow"><div class="title" id="currentName">Detectando…</div><div class="meta" id="currentMeta">—</div></div>
+          <div class="health" id="currentHealth">REVISANDO</div>
+        </div>
+        <div class="kpis">
+          <div class="k"><b id="pushState">—</b><span>Push</span></div>
+          <div class="k"><b id="permState">—</b><span>Permiso</span></div>
+          <div class="k"><b id="installState">—</b><span>Instalación</span></div>
+        </div>
+        <div class="actions">
+          <button class="btn" id="registerBtn">Registrar / actualizar</button>
+          <button class="btn sec" id="localTestBtn">Probar notificación local</button>
+          <button class="btn sec" id="reloadBtn">Actualizar estado</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>Mis dispositivos</h2>
+        <div id="devices"><div class="empty">Aún no se cargaron dispositivos.</div></div>
+      </div>
+    </div>
+
+    <div>
+      <div class="card">
+        <h2>Canales y alertas</h2>
+        <div class="sub" style="margin-bottom:8px">Preferencias para este dispositivo. Las políticas críticas de la organización pueden prevalecer.</div>
+        <div id="channels"></div>
+        <div class="actions"><button class="btn" id="savePrefsBtn">Guardar preferencias</button></div>
+      </div>
+      <div class="card">
+        <h2>Capacidades</h2>
+        <div id="caps"></div>
+      </div>
+    </div>
+  </div>
+  <div class="foot">La notificación es un canal de aviso. Ventas, citas, chats, tareas y llamadas continúan funcionando aunque el push falle.</div>
+</div>
+<script src="/aos-device-runtime-v2.js"></script>
+<script>
+(function(){
+'use strict';
+var CHANNELS=[
+ ['WHATSAPP','WhatsApp','Conversaciones asignadas y mensajes nuevos'],
+ ['SALES','Ventas','Ventas registradas y eventos comerciales'],
+ ['COMMISSION','Comisiones','Cambios de comisión y metas'],
+ ['AGENDA','Agenda','Citas nuevas, cambios y alertas'],
+ ['CHAT','Coordinación / Chat','Mensajes internos y coordinaciones'],
+ ['TASKS','Tareas','Asignaciones, vencimientos y confirmaciones'],
+ ['AGENTS','Agentes','Alertas relevantes de agentes ASCENDA'],
+ ['SENTINEL','Sentinel','Alertas operativas y de seguridad'],
+ ['SYSTEM','Sistema','Actualizaciones y avisos de ASCENDA']
+];
+var state={snap:null,devices:[],current:null,prefs:{}};
+function e(id){return document.getElementById(id)}
+function esc(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
+function msg(text,kind){var n=e('notice');n.className='notice '+(kind||'');n.textContent=text;n.style.display='block';clearTimeout(n._t);n._t=setTimeout(function(){n.style.display='none'},5000)}
+function token(){
+ try{var t=sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'';if(t)return Promise.resolve(t)}catch(_){}
+ if(!('caches'in window))return Promise.resolve('');
+ return caches.open('aos-phase2-auth').then(function(c){return c.match('/__aos_app_token')}).then(function(r){return r?r.text():''}).catch(function(){return ''})
+}
+function api(path,opt){
+ opt=opt||{};return token().then(function(t){if(!t||t.length<32)throw new Error('SESSION_REQUIRED');
+  var h=new Headers(opt.headers||{});h.set('X-AOS-App-Token',t);h.set('Accept','application/json');if(opt.body!=null)h.set('Content-Type','application/json');
+  return fetch(path,{method:opt.method||'GET',headers:h,body:opt.body==null?undefined:JSON.stringify(opt.body),cache:'no-store',credentials:'same-origin'});
+ }).then(function(r){return r.json().catch(function(){return {ok:false,error:'INVALID_JSON'}}).then(function(d){if(!r.ok||d.ok===false){var x=new Error(d.error||('HTTP_'+r.status));x.status=r.status;throw x}return d})})
+}
+function icon(s){return s.form_factor==='MOBILE'?'📱':s.form_factor==='TABLET'?'📟':'💻'}
+function label(s){return [s.os_family||'DISPOSITIVO',s.runtime_surface||'WEB'].join(' · ')}
+function capRow(name,value){return '<div class="row"><div><div class="rtitle">'+esc(name)+'</div></div><div class="tag">'+esc(value)+'</div></div>'}
+function renderSnapshot(){
+ var s=state.snap=AOS_DEVICE_RUNTIME_V2.snapshot();
+ e('currentIcon').textContent=icon(s);e('currentName').textContent=(s.os_family||'Dispositivo')+' '+(s.form_factor==='MOBILE'?'móvil':s.form_factor==='TABLET'?'tablet':'escritorio');
+ e('currentMeta').textContent=label(s)+' · '+s.installation_id.slice(0,8);
+ e('pushState').textContent=s.push_supported?'COMPATIBLE':'NO';e('permState').textContent=String(s.notification_permission||'—').toUpperCase();e('installState').textContent=s.standalone?'INSTALADA':'NAVEGADOR';
+ var healthy=s.push_supported&&s.notification_permission==='granted';e('currentHealth').textContent=healthy?'ÓPTIMO':s.push_supported?'PENDIENTE':'LIMITADO';e('currentHealth').style.background=healthy?'#E8FFF9':'#FFF8E8';e('currentHealth').style.color=healthy?'#087A68':'#8A5B00';
+ e('caps').innerHTML=[
+  capRow('Service Worker',s.service_worker_supported?'Sí':'No'),
+  capRow('Web Push',s.push_supported?'Sí':'No'),
+  capRow('Badge de app',s.badge_supported?'Sí':'No'),
+  capRow('Marcador telefónico',s.tel_supported?'Sí':'No'),
+  capRow('Modo instalado',s.standalone?'Sí':'No'),
+  capRow('Superficie',s.runtime_surface),
+  capRow('Ventana visible',s.visible===null?'—':s.visible?'Sí':'No'),
+  capRow('Ventana enfocada',s.focused===null?'—':s.focused?'Sí':'No')
+ ].join('');
+}
+function defaultName(){var s=state.snap;return 'ASCENDA '+(s.form_factor==='MOBILE'?'Móvil':'Equipo')+' · '+s.os_family}
+function register(){
+ renderSnapshot();var s=state.snap;var payload=Object.assign({},s,{device_name:defaultName(),app_version:'PWA-V2-517'});
+ return api('/api/devices/register',{method:'POST',body:payload}).then(function(d){msg('Dispositivo registrado correctamente.','ok');return load()}).catch(function(x){msg('No se pudo registrar: '+x.message,'err')})
+}
+function renderDevices(){
+ var root=e('devices');if(!state.devices.length){root.innerHTML='<div class="empty">No hay dispositivos registrados todavía.</div>';return}
+ root.innerHTML=state.devices.map(function(d){
+  var me=state.snap&&d.installation_id===state.snap.installation_id;
+  var last=d.last_seen_at?new Date(d.last_seen_at).toLocaleString('es-PE'):'Sin actividad';
+  return '<div class="device"><div class="dhead"><div class="dicon">'+(d.form_factor==='MOBILE'?'📱':'💻')+'</div><div><div class="dname">'+esc(d.device_name||d.os_family||'Dispositivo')+'</div><div class="dmeta">'+esc((d.os_family||'')+' · '+(d.runtime_surface||''))+' · '+esc(last)+'</div></div><div class="tag '+(me?'me':'')+'">'+(me?'ESTE':'REGISTRADO')+'</div></div></div>'
+ }).join('')
+}
+function renderChannels(){
+ var p=state.prefs||{};e('channels').innerHTML=CHANNELS.map(function(x){var on=p[x[0]]!==false;return '<div class="row"><div><div class="rtitle">'+esc(x[1])+'</div><div class="rsub">'+esc(x[2])+'</div></div><div class="toggle '+(on?'on':'')+'" data-channel="'+x[0]+'"></div></div>'}).join('');
+ e('channels').querySelectorAll('.toggle').forEach(function(t){t.onclick=function(){this.classList.toggle('on');state.prefs[this.getAttribute('data-channel')]=this.classList.contains('on')}})
+}
+function load(){
+ renderSnapshot();return api('/api/devices').then(function(d){
+  state.devices=d.rows||[];state.current=state.devices.find(function(x){return x.installation_id===state.snap.installation_id})||null;
+  state.prefs=Object.assign({},state.current&&state.current.channel_preferences||{});renderDevices();renderChannels();
+ }).catch(function(x){renderDevices();renderChannels();msg('El centro todavía no está activado en este entorno: '+x.message,'')})
+}
+function savePrefs(){
+ if(!state.current){msg('Primero registra este dispositivo.','');return}
+ api('/api/devices/preferences',{method:'POST',body:{device_id:state.current.id,channel_preferences:state.prefs,quiet_hours:{}}}).then(function(){msg('Preferencias guardadas.','ok');load()}).catch(function(x){msg('No se pudieron guardar: '+x.message,'err')})
+}
+function localTest(){
+ if(!('Notification'in window)){msg('Este dispositivo no soporta Notification API.','err');return}
+ function show(){try{new Notification('ASCENDA · Prueba local',{body:'Las notificaciones del dispositivo están disponibles.',icon:'/icons/icon-192x192.png'})}catch(_){msg('No se pudo abrir la prueba local.','err')}}
+ if(Notification.permission==='granted')return show();
+ if(Notification.permission==='default')Notification.requestPermission().then(function(p){renderSnapshot();if(p==='granted')show();else msg('Permiso de notificaciones no concedido.','')});
+ else msg('Las notificaciones están bloqueadas en el navegador/sistema.','err')
+}
+e('registerBtn').onclick=register;e('reloadBtn').onclick=load;e('savePrefsBtn').onclick=savePrefs;e('localTestBtn').onclick=localTest;
+renderSnapshot();renderChannels();load();
+})();
+</script>
+</body>
+</html>

--- a/app/public/admin-device-center-v2.html
+++ b/app/public/admin-device-center-v2.html
@@ -87,7 +87,7 @@ var CHANNELS=[
 var state={snap:null,devices:[],current:null,prefs:{}};
 function e(id){return document.getElementById(id)}
 function esc(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
-function msg(text,kind){var n=e('notice');n.className='notice '+(kind||'');n.textContent=text;n.style.display='block';clearTimeout(n._t);n._t=setTimeout(function(){n.style.display='none'},5000)}
+function msg(text,kind){var n=e('notice');n.className='notice '+(kind||'');n.textContent=text;n.style.display='block';if(n._anim)try{n._anim.cancel()}catch(_){};if(typeof n.animate==='function'){n._anim=n.animate([{opacity:1},{opacity:1,offset:.82},{opacity:0}],{duration:5000,easing:'linear'});n._anim.finished.then(function(){n.style.display='none';n.style.opacity=''}).catch(function(){})}}
 function token(){
  try{var t=sessionStorage.getItem('aos_app_token')||sessionStorage.getItem('aos_si_token')||'';if(t)return Promise.resolve(t)}catch(_){}
  if(!('caches'in window))return Promise.resolve('');

--- a/app/public/aos-device-runtime-v2.js
+++ b/app/public/aos-device-runtime-v2.js
@@ -1,0 +1,92 @@
+// ASCENDA APP PWA V2 #517 — capability + installation identity runtime.
+// Inactive until explicitly imported by the app shell.
+(function(root){
+  'use strict';
+
+  var KEY='aos_installation_id_v1';
+
+  function uuid(){
+    try{if(root.crypto&&typeof root.crypto.randomUUID==='function')return root.crypto.randomUUID();}catch(_){}
+    var s='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+    return s.replace(/[xy]/g,function(c){
+      var r=Math.random()*16|0,v=c==='x'?r:(r&3|8);return v.toString(16);
+    });
+  }
+
+  function installationId(){
+    try{
+      var v=root.localStorage&&root.localStorage.getItem(KEY);
+      if(v&&/^[0-9a-f-]{36}$/i.test(v))return v;
+      v=uuid();
+      if(root.localStorage)root.localStorage.setItem(KEY,v);
+      return v;
+    }catch(_){return uuid();}
+  }
+
+  function standalone(){
+    try{
+      return !!((root.matchMedia&&root.matchMedia('(display-mode: standalone)').matches)||
+        (root.navigator&&root.navigator.standalone===true));
+    }catch(_){return false;}
+  }
+
+  function coarsePointer(){
+    try{return !!(root.matchMedia&&root.matchMedia('(pointer: coarse)').matches);}catch(_){return false;}
+  }
+
+  function formFactor(){
+    var w=0;try{w=Math.min(root.screen&&root.screen.width||0,root.innerWidth||0)||root.innerWidth||0;}catch(_){}
+    if(coarsePointer()&&w>0&&w<=820)return 'MOBILE';
+    if(coarsePointer()&&w>820&&w<=1366)return 'TABLET';
+    return 'DESKTOP';
+  }
+
+  function osHint(){
+    try{
+      var p=String(root.navigator&&root.navigator.userAgentData&&root.navigator.userAgentData.platform||root.navigator&&root.navigator.platform||'').toLowerCase();
+      var ua=String(root.navigator&&root.navigator.userAgent||'').toLowerCase();
+      if(p.indexOf('win')>=0)return 'WINDOWS';
+      if(p.indexOf('mac')>=0&&ua.indexOf('iphone')<0&&ua.indexOf('ipad')<0)return 'MACOS';
+      if(ua.indexOf('android')>=0)return 'ANDROID';
+      if(/iphone|ipad|ipod/.test(ua))return 'IOS';
+      if(p.indexOf('linux')>=0)return 'LINUX';
+    }catch(_){}
+    return 'UNKNOWN';
+  }
+
+  function notificationPermission(){
+    try{return typeof root.Notification!=='undefined'?String(root.Notification.permission||'default'):'unsupported';}
+    catch(_){return 'unsupported';}
+  }
+
+  function supportsTel(){
+    // tel: support cannot be proven from browser APIs. This is a conservative capability hint.
+    var f=formFactor(),os=osHint();
+    return f==='MOBILE'&&(os==='ANDROID'||os==='IOS');
+  }
+
+  function snapshot(){
+    var n=root.navigator||{};
+    return {
+      installation_id:installationId(),
+      os_family:osHint(),
+      form_factor:formFactor(),
+      runtime_surface:standalone()?'PWA':'WEB',
+      standalone:standalone(),
+      service_worker_supported:!!n.serviceWorker,
+      push_supported:!!(n.serviceWorker&&root.PushManager),
+      badge_supported:typeof n.setAppBadge==='function',
+      notification_permission:notificationPermission(),
+      tel_supported:supportsTel(),
+      native_bridge:!!root.kroniaDesktop,
+      focused:(function(){try{return root.document?root.document.hasFocus():null;}catch(_){return null;}})(),
+      visible:(function(){try{return root.document?root.document.visibilityState==='visible':null;}catch(_){return null;}})()
+    };
+  }
+
+  root.AOS_DEVICE_RUNTIME_V2={
+    version:'APP-PWA-V2-517',
+    installationId:installationId,
+    snapshot:snapshot
+  };
+})(typeof window!=='undefined'?window:self);

--- a/ci/app-pwa-v2/contract.js
+++ b/ci/app-pwa-v2/contract.js
@@ -1,0 +1,53 @@
+'use strict'
+const fs=require('fs')
+const path=require('path')
+const root=path.resolve(__dirname,'../..')
+function read(p){return fs.readFileSync(path.join(root,p),'utf8')}
+function ok(v,m){if(!v)throw new Error(m)}
+
+const migration=read('supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql')
+const rollback=read('supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql')
+const runtime=read('app/public/aos-device-runtime-v2.js')
+const panel=read('app/public/admin-device-center-v2.html')
+const api=read('app/device-api-v2.js')
+const contract=read('docs/control/ASCENDA_APP_PWA_V2_CONTRACT_517.md')
+
+ok(migration.includes('create table if not exists public.aos_devices_v1'),'device registry missing')
+ok(migration.includes('unique(user_id, installation_id)'),'stable user+installation identity missing')
+ok(migration.includes('add column if not exists device_id uuid'),'push->device bridge missing')
+ok(migration.includes('create table if not exists public.aos_app_presence_v1'),'app presence table missing')
+ok(migration.includes('aos_effective_presence_v1'),'effective presence RPC missing')
+ok(migration.includes('HEARTBEAT_STALE'),'stale presence cutoff missing')
+ok(migration.includes('revoke all on public.aos_devices_v1 from anon, authenticated'),'device table must not be browser-readable')
+ok(migration.includes('grant execute on function public.aos_device_upsert_v1(jsonb) to service_role'),'device upsert must remain service-role only')
+ok(migration.includes('aos_devices_actor_v1'),'actor-bound device listing missing')
+ok(migration.includes('aos_device_preferences_actor_v1'),'actor-bound preferences missing')
+
+ok(api.includes("b.user_id = a.actor_id"),'registration must overwrite browser user identity')
+ok(api.includes("b.actor_id = a.actor_id"),'device mutations must be actor-bound')
+ok(api.includes("verifyApp(req.headers['x-aos-app-token'], false)"),'device API must verify ASCENDA app token')
+ok(!api.includes('graph.facebook.com'),'device API must not depend on Meta')
+ok(!api.includes('/api/wa/send'),'device API must not alter WhatsApp send path')
+
+ok(runtime.includes("localStorage.getItem(KEY)"),'installation identity must persist locally')
+ok(runtime.includes("matchMedia('(display-mode: standalone)')"),'PWA installed surface detection missing')
+ok(runtime.includes("badge_supported:typeof n.setAppBadge==='function'"),'Badge capability detection missing')
+ok(runtime.includes("document.visibilityState==='visible'"),'visibility capability missing')
+ok(!runtime.includes('supabase.co'),'browser device runtime must not call Supabase directly')
+ok(!runtime.includes('apikey'),'browser device runtime must not embed an API key')
+
+ok(panel.includes('Dispositivos y Notificaciones'),'Spanish panel name missing')
+ok(panel.includes("'X-AOS-App-Token'"),'panel must use actor-bound same-origin API')
+ok(panel.includes('/api/devices/register'),'device registration UI missing')
+ok(panel.includes('/api/devices/preferences'),'device preference UI missing')
+ok(!panel.includes('supabase.co'),'device center must not call Supabase directly')
+ok(!panel.includes('graph.facebook.com'),'device center must not call Meta')
+
+ok(contract.includes('Notifications are side effects'),'side-effect isolation contract missing')
+ok(contract.includes('No mass replay.'),'backlog anti-replay gate missing')
+ok(contract.includes('time_outside_app_sec'),'call duration semantics gate missing')
+
+ok(rollback.includes('drop table if exists public.aos_devices_v1'),'device rollback missing')
+ok(rollback.includes('drop function if exists public.aos_devices_actor_v1(jsonb)'),'actor RPC rollback missing')
+
+console.log('APP-PWA-V2 #517 contract: PASS')

--- a/docs/control/ASCENDA_APP_PWA_V2_CONTRACT_517.md
+++ b/docs/control/ASCENDA_APP_PWA_V2_CONTRACT_517.md
@@ -1,0 +1,177 @@
+# ASCENDA APP PWA V2 — Contract Freeze
+
+Issue: #517  
+Branch: `app-pwa-v2-517`  
+Base SHA: `aa00b7bc75340cc956311ff1fcc6b5bd0f0e2186`
+
+## 1. Scope
+
+This workstream evolves ASCENDA OS as the primary installed PWA for Windows, Android and iOS Home Screen.
+
+It MUST NOT change:
+- Meta permissions;
+- WhatsApp provider gateway;
+- Conversation routing;
+- AI send authority;
+- AUTO routing;
+- kill switch / SAFE-OFF;
+- business authority for sales, appointments, commissions or call-center lead selection.
+
+Notifications are side effects. Failure to notify MUST NOT fail the business transaction.
+
+## 2. Device identity
+
+Web Push endpoint is transport identity, not device identity.
+
+Canonical installation identity:
+- `installation_id`: random UUID generated once per installed/browser surface and persisted locally;
+- `device_id`: server-side UUID mapped to authenticated user + installation_id;
+- endpoint may rotate without creating a new device.
+
+Capabilities are detected, not guessed solely from user agent:
+- service_worker_supported;
+- push_supported;
+- notification_permission;
+- badge_supported;
+- tel_supported;
+- standalone;
+- focused/visible where available;
+- os_family/form_factor are descriptive hints only.
+
+## 3. Presence truth
+
+Presence is effective only when state and liveness agree.
+
+Inputs:
+1. declared labor state: ACTIVO, EN LLAMADA, BREAK, BAÑO, ATENCIÓN, LIMPIEZA, CAPACITACIÓN, CIERRE_TURNO;
+2. authenticated heartbeat;
+3. device/session last_seen.
+
+Rules:
+- current heartbeat + declared state => state is effective;
+- stale heartbeat => OFFLINE/STALE regardless of stale `aos_estado_equipo` value;
+- no sensor/location/camera inference for private states;
+- admin sees explicit state + elapsed time + liveness quality.
+
+## 4. Notification lifecycle
+
+Canonical lifecycle:
+`CREATED -> ELIGIBLE -> QUEUED -> PROVIDER_ACCEPTED -> DEVICE_HANDLED -> OPENED -> ACTIONED|ACKNOWLEDGED`.
+
+Never label PROVIDER_ACCEPTED or Web Push HTTP acceptance as read/seen.
+
+## 5. Channels
+
+Allowed channel vocabulary:
+- WHATSAPP
+- SALES
+- COMMISSION
+- AGENDA
+- CHAT
+- TASKS
+- AGENTS
+- SENTINEL
+- SYSTEM
+
+## 6. Priority
+
+Canonical priority:
+- LOW
+- NORMAL
+- HIGH
+- CRITICAL
+
+Priority belongs to the business event, not to the transport.
+
+## 7. Privacy
+
+Lock-screen payloads default to low-information summaries.
+Sensitive patient/treatment content is revealed only after authenticated open inside ASCENDA.
+
+## 8. TTL
+
+Every push-eligible event must carry or derive an expiry.
+
+Old events remain auditable in-app but expired push deliveries are not replayed.
+
+Initial policy:
+- human WhatsApp: short TTL;
+- agent/sentinel critical: short TTL + escalation policy;
+- sales/commission: hours;
+- agenda: contextual to appointment timing;
+- chat: short push TTL, persistent message;
+- tasks: until due/ack policy;
+- manual notifications: explicit TTL.
+
+## 9. Foreground policy
+
+Do not suppress OS notification merely because any ASCENDA client exists.
+
+Policy inputs:
+- client focused;
+- client visibility;
+- event priority;
+- user/device preferences.
+
+Default:
+- focused + visible + non-critical => in-app toast/inbox;
+- hidden/unfocused => OS notification;
+- CRITICAL => OS + in-app, subject to dedupe and policy.
+
+## 10. Backlog safety
+
+Before enabling generic S15 delivery:
+- snapshot pending rows;
+- assign expiry;
+- collapse obsolete digests;
+- mark expired rows without sending;
+- establish a cutover timestamp;
+- enable delivery for post-cutover events only.
+
+No mass replay.
+
+## 11. Communication
+
+Internal coordination uses existing `aos_mensajes` plus unified notification events.
+
+Delivery targets:
+- user;
+- group;
+- role;
+- sede;
+- all authorized users.
+
+Urgent communication may require explicit acknowledgement.
+
+## 12. Call-center semantics
+
+PWA `tel:` handoff remains supported.
+
+Current `visibilitychange` timing MUST be treated as:
+- `time_outside_app_sec`, not confirmed call duration.
+
+Confirmed call duration requires a trusted native or CTI provider source.
+
+## 13. Rollout
+
+Order:
+1. schema/contracts;
+2. actor-bound APIs;
+3. inactive UI;
+4. device canary;
+5. push canary;
+6. one advisor;
+7. one sede;
+8. both sedes;
+9. full rollout.
+
+Every phase requires rollback and negative-auth checks.
+
+## 14. Non-interference gate
+
+Files and migrations may be prepared on this branch while CONV-L1 #505 is active.
+
+No production deployment or shared service-worker/app-shell cutover from this branch until:
+- exact diff review confirms no WhatsApp/Meta runtime regression;
+- current production SHA is revalidated;
+- canary scope is explicitly selected.

--- a/supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
+++ b/supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
@@ -1,0 +1,261 @@
+-- APP-PWA-V2 #517 — additive Device Registry + ASCENDA app presence.
+-- PREPARED ONLY. Do not apply to production until APP-G2 gate.
+-- This migration does not modify Meta/WhatsApp routing or AI authorities.
+
+create table if not exists public.aos_devices_v1 (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.aos_usuarios(id) on delete cascade,
+  installation_id uuid not null,
+  device_name text,
+  os_family text,
+  form_factor text,
+  runtime_surface text not null default 'WEB',
+  app_version text,
+  service_worker_version text,
+  notification_permission text,
+  push_supported boolean not null default false,
+  badge_supported boolean not null default false,
+  tel_supported boolean not null default false,
+  standalone boolean not null default false,
+  native_bridge boolean not null default false,
+  channel_preferences jsonb not null default '{}'::jsonb,
+  quiet_hours jsonb not null default '{}'::jsonb,
+  last_seen_at timestamptz,
+  last_push_handled_at timestamptz,
+  last_notification_opened_at timestamptz,
+  last_failure_code text,
+  last_failure_at timestamptz,
+  active boolean not null default true,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(user_id, installation_id)
+);
+
+create index if not exists aos_devices_v1_user_active_idx
+  on public.aos_devices_v1(user_id, active, last_seen_at desc);
+
+alter table public.aos_devices_v1 enable row level security;
+revoke all on public.aos_devices_v1 from anon, authenticated;
+grant select, insert, update, delete on public.aos_devices_v1 to service_role;
+
+alter table public.aos_push_subscriptions_v1
+  add column if not exists device_id uuid references public.aos_devices_v1(id) on delete set null;
+
+create index if not exists aos_push_subscriptions_v1_device_active_idx
+  on public.aos_push_subscriptions_v1(device_id, active);
+
+create table if not exists public.aos_app_presence_v1 (
+  user_id uuid not null references public.aos_usuarios(id) on delete cascade,
+  device_id uuid not null references public.aos_devices_v1(id) on delete cascade,
+  labor_state text,
+  heartbeat_at timestamptz not null default now(),
+  focused boolean,
+  visible boolean,
+  runtime_surface text,
+  session_started_at timestamptz,
+  state_started_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now(),
+  primary key(user_id, device_id)
+);
+
+create index if not exists aos_app_presence_v1_heartbeat_idx
+  on public.aos_app_presence_v1(heartbeat_at desc);
+
+alter table public.aos_app_presence_v1 enable row level security;
+revoke all on public.aos_app_presence_v1 from anon, authenticated;
+grant select, insert, update, delete on public.aos_app_presence_v1 to service_role;
+
+create or replace function public.aos_device_upsert_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_user uuid;
+  v_installation uuid;
+  v_id uuid;
+begin
+  begin
+    v_user := nullif(p_payload->>'user_id','')::uuid;
+    v_installation := nullif(p_payload->>'installation_id','')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_DEVICE_IDENTITY');
+  end;
+
+  if v_user is null or v_installation is null then
+    return jsonb_build_object('ok',false,'error','DEVICE_IDENTITY_REQUIRED');
+  end if;
+
+  if not exists(select 1 from public.aos_usuarios u where u.id=v_user and u.activo=true) then
+    return jsonb_build_object('ok',false,'error','ACTIVE_USER_REQUIRED');
+  end if;
+
+  insert into public.aos_devices_v1(
+    user_id,installation_id,device_name,os_family,form_factor,runtime_surface,
+    app_version,service_worker_version,notification_permission,push_supported,
+    badge_supported,tel_supported,standalone,native_bridge,last_seen_at,metadata,active,updated_at
+  )
+  values(
+    v_user,v_installation,
+    left(nullif(trim(coalesce(p_payload->>'device_name','')),''),160),
+    left(nullif(trim(coalesce(p_payload->>'os_family','')),''),80),
+    left(nullif(trim(coalesce(p_payload->>'form_factor','')),''),40),
+    left(coalesce(nullif(trim(p_payload->>'runtime_surface'),''),'WEB'),40),
+    left(nullif(trim(coalesce(p_payload->>'app_version','')),''),80),
+    left(nullif(trim(coalesce(p_payload->>'service_worker_version','')),''),80),
+    left(nullif(trim(coalesce(p_payload->>'notification_permission','')),''),32),
+    coalesce((p_payload->>'push_supported')::boolean,false),
+    coalesce((p_payload->>'badge_supported')::boolean,false),
+    coalesce((p_payload->>'tel_supported')::boolean,false),
+    coalesce((p_payload->>'standalone')::boolean,false),
+    coalesce((p_payload->>'native_bridge')::boolean,false),
+    now(),
+    coalesce(p_payload->'metadata','{}'::jsonb),
+    true,
+    now()
+  )
+  on conflict(user_id,installation_id) do update set
+    device_name=coalesce(excluded.device_name,aos_devices_v1.device_name),
+    os_family=coalesce(excluded.os_family,aos_devices_v1.os_family),
+    form_factor=coalesce(excluded.form_factor,aos_devices_v1.form_factor),
+    runtime_surface=excluded.runtime_surface,
+    app_version=coalesce(excluded.app_version,aos_devices_v1.app_version),
+    service_worker_version=coalesce(excluded.service_worker_version,aos_devices_v1.service_worker_version),
+    notification_permission=coalesce(excluded.notification_permission,aos_devices_v1.notification_permission),
+    push_supported=excluded.push_supported,
+    badge_supported=excluded.badge_supported,
+    tel_supported=excluded.tel_supported,
+    standalone=excluded.standalone,
+    native_bridge=excluded.native_bridge,
+    last_seen_at=now(),
+    metadata=aos_devices_v1.metadata || excluded.metadata,
+    active=true,
+    updated_at=now()
+  returning id into v_id;
+
+  return jsonb_build_object('ok',true,'device_id',v_id);
+end
+$$;
+
+create or replace function public.aos_app_presence_touch_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_user uuid;
+  v_device uuid;
+  v_state text := upper(trim(coalesce(p_payload->>'labor_state','')));
+  v_now timestamptz := now();
+begin
+  begin
+    v_user := nullif(p_payload->>'user_id','')::uuid;
+    v_device := nullif(p_payload->>'device_id','')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_PRESENCE_IDENTITY');
+  end;
+
+  if not exists(
+    select 1 from public.aos_devices_v1 d
+    where d.id=v_device and d.user_id=v_user and d.active=true
+  ) then
+    return jsonb_build_object('ok',false,'error','ACTIVE_DEVICE_REQUIRED');
+  end if;
+
+  update public.aos_devices_v1
+     set last_seen_at=v_now,
+         app_version=coalesce(nullif(trim(p_payload->>'app_version'),''),app_version),
+         service_worker_version=coalesce(nullif(trim(p_payload->>'service_worker_version'),''),service_worker_version),
+         updated_at=v_now
+   where id=v_device and user_id=v_user;
+
+  insert into public.aos_app_presence_v1(
+    user_id,device_id,labor_state,heartbeat_at,focused,visible,runtime_surface,
+    session_started_at,state_started_at,metadata,updated_at
+  )
+  values(
+    v_user,v_device,nullif(v_state,''),v_now,
+    case when p_payload ? 'focused' then (p_payload->>'focused')::boolean else null end,
+    case when p_payload ? 'visible' then (p_payload->>'visible')::boolean else null end,
+    nullif(trim(p_payload->>'runtime_surface'),''),
+    coalesce(nullif(p_payload->>'session_started_at','')::timestamptz,v_now),
+    coalesce(nullif(p_payload->>'state_started_at','')::timestamptz,v_now),
+    coalesce(p_payload->'metadata','{}'::jsonb),
+    v_now
+  )
+  on conflict(user_id,device_id) do update set
+    labor_state=coalesce(nullif(excluded.labor_state,''),aos_app_presence_v1.labor_state),
+    heartbeat_at=v_now,
+    focused=excluded.focused,
+    visible=excluded.visible,
+    runtime_surface=coalesce(excluded.runtime_surface,aos_app_presence_v1.runtime_surface),
+    session_started_at=coalesce(aos_app_presence_v1.session_started_at,excluded.session_started_at),
+    state_started_at=case
+      when excluded.labor_state is distinct from aos_app_presence_v1.labor_state then v_now
+      else aos_app_presence_v1.state_started_at
+    end,
+    metadata=aos_app_presence_v1.metadata || excluded.metadata,
+    updated_at=v_now;
+
+  return jsonb_build_object('ok',true,'heartbeat_at',v_now);
+end
+$$;
+
+create or replace function public.aos_effective_presence_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_user uuid;
+  v_stale_seconds integer := greatest(30, least(coalesce(nullif(p_payload->>'stale_seconds','')::integer,120),900));
+  v_last public.aos_app_presence_v1%rowtype;
+  v_age numeric;
+begin
+  begin v_user := nullif(p_payload->>'user_id','')::uuid;
+  exception when others then return jsonb_build_object('ok',false,'error','INVALID_USER_ID'); end;
+
+  select p.* into v_last
+  from public.aos_app_presence_v1 p
+  join public.aos_devices_v1 d on d.id=p.device_id and d.active=true
+  where p.user_id=v_user
+  order by p.heartbeat_at desc
+  limit 1;
+
+  if not found then
+    return jsonb_build_object('ok',true,'status','OFFLINE','stale',true,'reason','NO_HEARTBEAT');
+  end if;
+
+  v_age := extract(epoch from (now()-v_last.heartbeat_at));
+  if v_age > v_stale_seconds then
+    return jsonb_build_object(
+      'ok',true,'status','OFFLINE','stale',true,'reason','HEARTBEAT_STALE',
+      'last_seen_at',v_last.heartbeat_at,'age_seconds',round(v_age)
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,
+    'status',coalesce(nullif(v_last.labor_state,''),'ACTIVO'),
+    'stale',false,
+    'last_seen_at',v_last.heartbeat_at,
+    'age_seconds',round(v_age),
+    'focused',v_last.focused,
+    'visible',v_last.visible,
+    'device_id',v_last.device_id,
+    'state_started_at',v_last.state_started_at
+  );
+end
+$$;
+
+revoke all on function public.aos_device_upsert_v1(jsonb) from public, anon, authenticated;
+revoke all on function public.aos_app_presence_touch_v1(jsonb) from public, anon, authenticated;
+revoke all on function public.aos_effective_presence_v1(jsonb) from public, anon, authenticated;
+grant execute on function public.aos_device_upsert_v1(jsonb) to service_role;
+grant execute on function public.aos_app_presence_touch_v1(jsonb) to service_role;
+grant execute on function public.aos_effective_presence_v1(jsonb) to service_role;

--- a/supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
+++ b/supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
@@ -259,3 +259,167 @@ revoke all on function public.aos_effective_presence_v1(jsonb) from public, anon
 grant execute on function public.aos_device_upsert_v1(jsonb) to service_role;
 grant execute on function public.aos_app_presence_touch_v1(jsonb) to service_role;
 grant execute on function public.aos_effective_presence_v1(jsonb) to service_role;
+
+
+create or replace function public.aos_devices_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid;
+  v_rows jsonb;
+begin
+  begin v_actor := nullif(p_payload->>'actor_id','')::uuid;
+  exception when others then return jsonb_build_object('ok',false,'error','INVALID_ACTOR_ID'); end;
+
+  if not exists(select 1 from public.aos_usuarios u where u.id=v_actor and u.activo=true) then
+    return jsonb_build_object('ok',false,'error','ACTIVE_USER_REQUIRED');
+  end if;
+
+  select coalesce(jsonb_agg(jsonb_build_object(
+    'id',d.id,
+    'installation_id',d.installation_id,
+    'device_name',d.device_name,
+    'os_family',d.os_family,
+    'form_factor',d.form_factor,
+    'runtime_surface',d.runtime_surface,
+    'app_version',d.app_version,
+    'service_worker_version',d.service_worker_version,
+    'notification_permission',d.notification_permission,
+    'push_supported',d.push_supported,
+    'badge_supported',d.badge_supported,
+    'tel_supported',d.tel_supported,
+    'standalone',d.standalone,
+    'native_bridge',d.native_bridge,
+    'channel_preferences',d.channel_preferences,
+    'quiet_hours',d.quiet_hours,
+    'last_seen_at',d.last_seen_at,
+    'last_push_handled_at',d.last_push_handled_at,
+    'last_notification_opened_at',d.last_notification_opened_at,
+    'last_failure_code',d.last_failure_code,
+    'last_failure_at',d.last_failure_at,
+    'active',d.active,
+    'push_subscription_count',(
+      select count(*) from public.aos_push_subscriptions_v1 s
+      where s.device_id=d.id and s.active=true
+    )
+  ) order by d.last_seen_at desc nulls last,d.created_at desc),'[]'::jsonb)
+  into v_rows
+  from public.aos_devices_v1 d
+  where d.user_id=v_actor;
+
+  return jsonb_build_object('ok',true,'rows',v_rows);
+end
+$$;
+
+create or replace function public.aos_device_preferences_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid;
+  v_device uuid;
+  v_channels jsonb := coalesce(p_payload->'channel_preferences','{}'::jsonb);
+  v_quiet jsonb := coalesce(p_payload->'quiet_hours','{}'::jsonb);
+begin
+  begin
+    v_actor := nullif(p_payload->>'actor_id','')::uuid;
+    v_device := nullif(p_payload->>'device_id','')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_DEVICE_IDENTITY');
+  end;
+
+  if jsonb_typeof(v_channels) <> 'object' or jsonb_typeof(v_quiet) <> 'object' then
+    return jsonb_build_object('ok',false,'error','INVALID_PREFERENCES');
+  end if;
+
+  if pg_column_size(v_channels) > 8192 or pg_column_size(v_quiet) > 4096 then
+    return jsonb_build_object('ok',false,'error','PREFERENCES_TOO_LARGE');
+  end if;
+
+  update public.aos_devices_v1 d
+     set channel_preferences=v_channels,
+         quiet_hours=v_quiet,
+         updated_at=now()
+   where d.id=v_device and d.user_id=v_actor and d.active=true;
+
+  if not found then
+    return jsonb_build_object('ok',false,'error','ACTIVE_DEVICE_REQUIRED');
+  end if;
+
+  return jsonb_build_object('ok',true,'device_id',v_device);
+end
+$$;
+
+create or replace function public.aos_device_rename_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid;
+  v_device uuid;
+  v_name text := left(nullif(trim(coalesce(p_payload->>'device_name','')),''),160);
+begin
+  begin
+    v_actor := nullif(p_payload->>'actor_id','')::uuid;
+    v_device := nullif(p_payload->>'device_id','')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_DEVICE_IDENTITY');
+  end;
+
+  if v_name is null then return jsonb_build_object('ok',false,'error','DEVICE_NAME_REQUIRED'); end if;
+
+  update public.aos_devices_v1 d
+     set device_name=v_name,updated_at=now()
+   where d.id=v_device and d.user_id=v_actor and d.active=true;
+
+  if not found then return jsonb_build_object('ok',false,'error','ACTIVE_DEVICE_REQUIRED'); end if;
+  return jsonb_build_object('ok',true,'device_id',v_device,'device_name',v_name);
+end
+$$;
+
+create or replace function public.aos_device_disable_actor_v1(p_payload jsonb)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid;
+  v_device uuid;
+begin
+  begin
+    v_actor := nullif(p_payload->>'actor_id','')::uuid;
+    v_device := nullif(p_payload->>'device_id','')::uuid;
+  exception when others then
+    return jsonb_build_object('ok',false,'error','INVALID_DEVICE_IDENTITY');
+  end;
+
+  update public.aos_devices_v1 d
+     set active=false,updated_at=now()
+   where d.id=v_device and d.user_id=v_actor and d.active=true;
+
+  if not found then return jsonb_build_object('ok',false,'error','ACTIVE_DEVICE_REQUIRED'); end if;
+
+  update public.aos_push_subscriptions_v1 s
+     set active=false,updated_at=now()
+   where s.device_id=v_device and s.user_id=v_actor;
+
+  return jsonb_build_object('ok',true,'device_id',v_device,'disabled',true);
+end
+$$;
+
+revoke all on function public.aos_devices_actor_v1(jsonb) from public, anon, authenticated;
+revoke all on function public.aos_device_preferences_actor_v1(jsonb) from public, anon, authenticated;
+revoke all on function public.aos_device_rename_actor_v1(jsonb) from public, anon, authenticated;
+revoke all on function public.aos_device_disable_actor_v1(jsonb) from public, anon, authenticated;
+grant execute on function public.aos_devices_actor_v1(jsonb) to service_role;
+grant execute on function public.aos_device_preferences_actor_v1(jsonb) to service_role;
+grant execute on function public.aos_device_rename_actor_v1(jsonb) to service_role;
+grant execute on function public.aos_device_disable_actor_v1(jsonb) to service_role;

--- a/supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql
+++ b/supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql
@@ -1,0 +1,12 @@
+-- APP-PWA-V2 #517 rollback for 20260912073000_app_pwa_v2_device_registry.sql
+-- Use only before any production dependency is attached to these objects.
+
+drop function if exists public.aos_effective_presence_v1(jsonb);
+drop function if exists public.aos_app_presence_touch_v1(jsonb);
+drop function if exists public.aos_device_upsert_v1(jsonb);
+
+alter table if exists public.aos_push_subscriptions_v1
+  drop column if exists device_id;
+
+drop table if exists public.aos_app_presence_v1;
+drop table if exists public.aos_devices_v1;

--- a/supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql
+++ b/supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql
@@ -1,6 +1,10 @@
 -- APP-PWA-V2 #517 rollback for 20260912073000_app_pwa_v2_device_registry.sql
 -- Use only before any production dependency is attached to these objects.
 
+drop function if exists public.aos_device_disable_actor_v1(jsonb);
+drop function if exists public.aos_device_rename_actor_v1(jsonb);
+drop function if exists public.aos_device_preferences_actor_v1(jsonb);
+drop function if exists public.aos_devices_actor_v1(jsonb);
 drop function if exists public.aos_effective_presence_v1(jsonb);
 drop function if exists public.aos_app_presence_touch_v1(jsonb);
 drop function if exists public.aos_device_upsert_v1(jsonb);


### PR DESCRIPTION
Closes no issue yet; tracks #517.

## Qué incluye
- Contract Freeze APP-PWA-V2.
- Device Registry V2 migration **preparada, no aplicada**.
- rollback.
- actor-bound device/presence API module **no conectado**.
- detector de capacidades PWA **no importado**.
- Centro de Dispositivos y Notificaciones en español **no enlazado**.
- contract checks de aislamiento/seguridad.

## Qué NO cambia
- Meta Channel Gateway.
- WhatsApp send/webhook/routing.
- AI SEND / AUTO routing / kill switch.
- `phase2-service-worker.js`.
- `app/public/app.html`.
- Railway PROD.
- Supabase PROD.

## Gate
PR deliberadamente DRAFT. No merge/deploy hasta revisar exact diff y seleccionar canary. Base exacta: `aa00b7bc75340cc956311ff1fcc6b5bd0f0e2186`.

La integración del service worker y app shell será un cambio separado para reducir blast radius.