### PR TITLE
APP-PWA-V2 #517 — Zero-Cost schema, ownership y rollback gate

### DIFF
--- a/.github/workflows/app-pwa-v2-schema-gate.yml
+++ b/.github/workflows/app-pwa-v2-schema-gate.yml
@@ -1,0 +1,87 @@
+name: APP-PWA-V2 Device Registry Zero-Cost Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql'
+      - 'supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql'
+      - 'ci/app-pwa-v2/**'
+      - '.github/workflows/app-pwa-v2-schema-gate.yml'
+  push:
+    branches:
+      - 'app-pwa-v2-*'
+    paths:
+      - 'supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql'
+      - 'supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql'
+      - 'ci/app-pwa-v2/**'
+      - '.github/workflows/app-pwa-v2-schema-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-pwa-v2-schema-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  device-registry-db:
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
+    timeout-minutes: 12
+    env:
+      DB_URL: postgresql://postgres:postgres@127.0.0.1:59327/postgres
+      DB_CONTAINER: ascenda-app-pwa-v2-db
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Runner health
+        run: |
+          set -euo pipefail
+          bash scripts/ci/runner-healthcheck.sh
+
+      - name: Static APP-PWA-V2 contract
+        run: node ci/app-pwa-v2/contract.js
+
+      - name: Start isolated PostgreSQL 17
+        run: |
+          set -euo pipefail
+          docker rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
+          docker run -d --name "$DB_CONTAINER" \
+            -e POSTGRES_PASSWORD=postgres \
+            -p 127.0.0.1:59327:5432 \
+            postgres:17-alpine
+          for i in $(seq 1 40); do
+            if docker exec "$DB_CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs "$DB_CONTAINER" || true
+          exit 1
+
+      - name: Build synthetic authority fixture
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/app-pwa-v2/device_registry_fixture.sql
+
+      - name: Apply exact migration twice
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/migrations/20260912073000_app_pwa_v2_device_registry.sql
+
+      - name: Ownership / ACL / presence contracts
+        run: psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f ci/app-pwa-v2/device_registry_db_contract.sql
+
+      - name: Rollback exact migration
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/rollback/20260912073000_app_pwa_v2_device_registry_rollback.sql
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_devices_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select to_regclass('public.aos_app_presence_v1') is null")" = "t"
+          test "$(psql "$DB_URL" -X -qAt -c "select count(*) from information_schema.columns where table_schema='public' and table_name='aos_push_subscriptions_v1' and column_name='device_id'")" = "0"
+          echo APP_PWA_V2_ROLLBACK=PASS
+
+      - name: Cleanup isolated database
+        if: always()
+        run: docker rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true

--- a/ci/app-pwa-v2/device_registry_db_contract.sql
+++ b/ci/app-pwa-v2/device_registry_db_contract.sql
@@ -1,0 +1,89 @@
+\set ON_ERROR_STOP on
+\pset tuples_only on
+\pset format unaligned
+
+do $$
+declare
+  u1 uuid := '11111111-1111-1111-1111-111111111111';
+  u2 uuid := '22222222-2222-2222-2222-222222222222';
+  inactive uuid := '33333333-3333-3333-3333-333333333333';
+  installation uuid := 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  dev uuid;
+  j jsonb;
+begin
+  j := public.aos_device_upsert_v1(jsonb_build_object(
+    'user_id',u1,'installation_id',installation,'device_name','CI Device',
+    'os_family','LINUX','form_factor','DESKTOP','runtime_surface','PWA',
+    'notification_permission','granted','push_supported',true,'badge_supported',true,
+    'tel_supported',true,'standalone',true,'native_bridge',false
+  ));
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'device upsert failed: %',j; end if;
+  dev := (j->>'device_id')::uuid;
+
+  if (select count(*) from public.aos_devices_v1 where id=dev and user_id=u1 and active) <> 1 then
+    raise exception 'device ownership persistence failed';
+  end if;
+
+  j := public.aos_device_upsert_v1(jsonb_build_object('user_id',inactive,'installation_id',gen_random_uuid()));
+  if j->>'error' <> 'ACTIVE_USER_REQUIRED' then raise exception 'inactive user negative failed: %',j; end if;
+
+  j := public.aos_devices_actor_v1(jsonb_build_object('actor_id',u2));
+  if jsonb_array_length(j->'rows') <> 0 then raise exception 'cross-user device read leak: %',j; end if;
+
+  j := public.aos_app_presence_touch_v1(jsonb_build_object('user_id',u2,'device_id',dev,'labor_state','ACTIVO'));
+  if j->>'error' <> 'ACTIVE_DEVICE_REQUIRED' then raise exception 'cross-user presence write allowed: %',j; end if;
+
+  j := public.aos_app_presence_touch_v1(jsonb_build_object(
+    'user_id',u1,'device_id',dev,'labor_state','EN LLAMADA','focused',true,'visible',true,'runtime_surface','PWA'
+  ));
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'presence touch failed: %',j; end if;
+
+  j := public.aos_effective_presence_v1(jsonb_build_object('user_id',u1,'stale_seconds',120));
+  if j->>'status' <> 'EN LLAMADA' or coalesce((j->>'stale')::boolean,true) then
+    raise exception 'effective presence wrong: %',j;
+  end if;
+
+  j := public.aos_device_preferences_actor_v1(jsonb_build_object(
+    'actor_id',u2,'device_id',dev,'channel_preferences',jsonb_build_object('SALES',false),'quiet_hours','{}'::jsonb
+  ));
+  if j->>'error' <> 'ACTIVE_DEVICE_REQUIRED' then raise exception 'cross-user preferences allowed: %',j; end if;
+
+  j := public.aos_device_preferences_actor_v1(jsonb_build_object(
+    'actor_id',u1,'device_id',dev,'channel_preferences',jsonb_build_object('SALES',false),'quiet_hours','{}'::jsonb
+  ));
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'preferences failed: %',j; end if;
+
+  j := public.aos_device_rename_actor_v1(jsonb_build_object('actor_id',u2,'device_id',dev,'device_name','LEAK'));
+  if j->>'error' <> 'ACTIVE_DEVICE_REQUIRED' then raise exception 'cross-user rename allowed: %',j; end if;
+
+  j := public.aos_device_rename_actor_v1(jsonb_build_object('actor_id',u1,'device_id',dev,'device_name','CI Renamed'));
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'rename failed: %',j; end if;
+
+  insert into public.aos_push_subscriptions_v1(user_id,endpoint,active,device_id)
+  values(u1,'https://ci.invalid/push',true,dev);
+
+  j := public.aos_device_disable_actor_v1(jsonb_build_object('actor_id',u2,'device_id',dev));
+  if j->>'error' <> 'ACTIVE_DEVICE_REQUIRED' then raise exception 'cross-user disable allowed: %',j; end if;
+
+  j := public.aos_device_disable_actor_v1(jsonb_build_object('actor_id',u1,'device_id',dev));
+  if coalesce((j->>'ok')::boolean,false) is not true then raise exception 'disable failed: %',j; end if;
+
+  if exists(select 1 from public.aos_devices_v1 where id=dev and active) then raise exception 'device still active'; end if;
+  if exists(select 1 from public.aos_push_subscriptions_v1 where device_id=dev and active) then raise exception 'push subscription still active'; end if;
+end $$;
+
+do $$
+begin
+  if has_table_privilege('anon','public.aos_devices_v1','SELECT') then raise exception 'anon table SELECT leak'; end if;
+  if has_table_privilege('authenticated','public.aos_devices_v1','SELECT') then raise exception 'authenticated table SELECT leak'; end if;
+  if not has_table_privilege('service_role','public.aos_devices_v1','SELECT') then raise exception 'service_role table SELECT missing'; end if;
+
+  if has_function_privilege('anon','public.aos_device_upsert_v1(jsonb)','EXECUTE') then raise exception 'anon function EXECUTE leak'; end if;
+  if has_function_privilege('authenticated','public.aos_device_upsert_v1(jsonb)','EXECUTE') then raise exception 'authenticated function EXECUTE leak'; end if;
+  if not has_function_privilege('service_role','public.aos_device_upsert_v1(jsonb)','EXECUTE') then raise exception 'service_role function EXECUTE missing'; end if;
+
+  if not (select relrowsecurity from pg_class where oid='public.aos_devices_v1'::regclass) then raise exception 'devices RLS disabled'; end if;
+  if not (select relrowsecurity from pg_class where oid='public.aos_app_presence_v1'::regclass) then raise exception 'presence RLS disabled'; end if;
+end $$;
+
+select 'APP_PWA_V2_DEVICE_REGISTRY_DB_CONTRACT=PASS';

--- a/ci/app-pwa-v2/device_registry_fixture.sql
+++ b/ci/app-pwa-v2/device_registry_fixture.sql
@@ -1,0 +1,27 @@
+-- APP-PWA-V2 #517 — minimal synthetic authority fixture
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  if not exists(select 1 from pg_roles where rolname='anon') then create role anon nologin; end if;
+  if not exists(select 1 from pg_roles where rolname='authenticated') then create role authenticated nologin; end if;
+  if not exists(select 1 from pg_roles where rolname='service_role') then create role service_role nologin; end if;
+end $$;
+
+create table public.aos_usuarios (
+  id uuid primary key,
+  activo boolean not null default true
+);
+
+create table public.aos_push_subscriptions_v1 (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.aos_usuarios(id) on delete cascade,
+  endpoint text not null unique,
+  active boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.aos_usuarios(id,activo) values
+('11111111-1111-1111-1111-111111111111',true),
+('22222222-2222-2222-2222-222222222222',true),
+('33333333-3333-3333-3333-333333333333',false);


### PR DESCRIPTION
Gate aislado posterior a #518. Valida en Postgres 17 efímero: fixture sintético, migración exacta aplicada dos veces, ownership negativo, ACL/RLS, presencia, preferencias, disable y rollback exacto. No usa datos reales, no toca Supabase PROD, Railway ni Meta/WhatsApp.