### PR TITLE
CONV-L1: bounded real Meta startup canary

### DIFF
--- a/app/railway.json
+++ b/app/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "echo 'Skip build — Phase S outer runtime: node server-phase-s-f17.js -> server-phase-s.js -> server-f17.js -> server-f5.js -> server-wa4.js -> server-wa3.js -> server-wa2.js -> server-f4.js'"
   },
   "deploy": {
-    "startCommand": "env AOS_STUDIO_BACKGROUND_ENABLED=false NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s-f17.js",
+    "startCommand": "node conv-l1-real-meta-probe.js && env AOS_STUDIO_BACKGROUND_ENABLED=false NODE_OPTIONS='--require ./sentinel-sentry-init.cjs --require ./email-runtime-env-compat.cjs --require ./supabase-quota-circuit-preload.cjs' node server-phase-s-f17.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE"


### PR DESCRIPTION
Temporary, reversible CONV-L1 canary wiring under #505.

Purpose:
- execute the already-merged `conv-l1-real-meta-probe.js` exactly once before the normal Railway outer runtime;
- exercise the owner-authorized real Meta matrix only against the existing `zi vital` test conversation;
- fail the new deployment closed if the probe fails, leaving the previous healthy deployment serving traffic;
- preserve legacy AI autonomy SAFE-OFF.

This PR changes only the production start command. After evidence is captured, the start command will be reverted and the temporary CONV_L1_* variables cleared.