### PR TITLE
CONV-L0 audit — follow active CONV execution lock

### DIFF
--- a/ci/conv-l0/audit_contract.js
+++ b/ci/conv-l0/audit_contract.js
@@ -61,8 +61,11 @@ assert(contracts.includes('interface OutboundPolicy'), 'OutboundPolicy contract 
 assert(contracts.includes('interface ConversationJob'), 'JobOutbox contract missing')
 assert(benchmark.includes('FROZEN V1 BY CONV-L0'), '40-case benchmark is not frozen')
 assert(audit.includes('RC-1 — Deep proxy/process chain'), 'Root-cause audit missing')
-assert(lock.includes('**ACTIVE HIGH/CRITICAL LOCK:** `CONV-L1 #505 — NATIVE META CHANNEL GATEWAY`'), 'CONV-L1 active lock missing')
-assert(lock.includes('RUN UNTIL BLOCKED'), 'CONV-L1 owner execution mode missing')
+assert(/\*\*ACTIVE HIGH\/CRITICAL LOCK:\*\* `CONV-L[1-8] #[0-9]+ — /.test(lock), 'Active CONV HIGH/CRITICAL execution lock missing')
+assert(lock.includes('CONV-001 remains the active program.'), 'CONV-001 active-program marker missing')
+assert(lock.includes('**LAST CLOSED:** `CONV-L1 #505 — NATIVE META CHANNEL GATEWAY · PROVIDER CERTIFIED`'), 'CONV-L1 provider-certified closeout evidence missing')
+assert(lock.includes('RUN UNTIL BLOCKED'), 'CONV owner execution mode missing')
+assert(lock.includes('SAFE-OFF'), 'CONV production SAFE-OFF marker missing')
 assert(readiness.includes('TECHNICAL PASS / CLOSED'), 'L0 technical closeout marker missing')
 assert(readiness.includes('L1 OWNER AUTHORIZATION RECEIVED / ACTIVE'), 'L1 authorization transition missing')
 


### PR DESCRIPTION
## Scope
CI-contract only. No runtime, Meta, WhatsApp, PWA, Railway or Supabase mutation.

## Why
`ci/conv-l0/audit_contract.js` was hardcoded to require CONV-L1 as the active lock. CONV-L1 is already provider-certified and `main` correctly advanced to CONV-L2, so the global Ascenda CI failed even though the product/runtime checks passed.

## Change
- require an active CONV-L1..L8 HIGH/CRITICAL execution lock;
- retain CONV-001 active-program evidence;
- retain exact CONV-L1 provider-certified closeout evidence;
- retain RUN UNTIL BLOCKED and SAFE-OFF requirements.

This prevents false CI failures as the authorized CONV program progresses while preserving governance evidence.