### PR TITLE
CONV-L3: shadow-only sales agent runtime foundation

### DIFF
--- a/.github/workflows/conv-l3-shadow-runtime.yml
+++ b/.github/workflows/conv-l3-shadow-runtime.yml
@@ -1,0 +1,26 @@
+name: CONV-L3 Shadow Runtime
+
+on:
+  pull_request:
+    paths:
+      - 'app/conversation-agent-runtime.js'
+      - 'ci/conv-l3/**'
+      - '.github/workflows/conv-l3-shadow-runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Syntax
+        run: node --check app/conversation-agent-runtime.js && node --check ci/conv-l3/agent_runtime_contract.js
+      - name: Shadow runtime safety contract
+        run: node ci/conv-l3/agent_runtime_contract.js

--- a/app/conversation-agent-runtime.js
+++ b/app/conversation-agent-runtime.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const AGENT_RUNTIME_VERSION='CONV-L3-SHADOW-V1';
+const MAX_TOOL_CALLS=2;
+const DEFAULT_MAX_MESSAGES=12;
+const DEFAULT_MAX_CHARS=6000;
+
+function text(v){return String(v==null?'':v).trim();}
+function upper(v){return text(v).toUpperCase();}
+
+function clipMemory(messages,maxMessages,maxChars){
+  const src=Array.isArray(messages)?messages:[];
+  const picked=[];
+  let used=0;
+  for(let i=src.length-1;i>=0&&picked.length<maxMessages;i--){
+    const m=src[i]||{};
+    const body=text(m.message_body||m.body);
+    if(!body)continue;
+    const direction=upper(m.direction)==='OUTBOUND'?'OUTBOUND':'INBOUND';
+    const take=Math.max(0,Math.min(body.length,maxChars-used));
+    if(take<=0)break;
+    picked.push({direction,body:body.slice(0,take),created_at:m.created_at||null});
+    used+=take;
+  }
+  return picked.reverse();
+}
+
+function detectBoundary(memory){
+  const inbound=memory.filter(m=>m.direction==='INBOUND').map(m=>m.body).join('\n');
+  const u=upper(inbound);
+  if(/(^|\b)(STOP|BAJA|NO QUIERO RECIBIR|NO ME ESCRIBAN|NO CONTACTAR)(\b|$)/i.test(inbound)){
+    return {kind:'STOP',reason:'customer_stop_or_suppression'};
+  }
+  if(/\b(DIAGNOSTIC|DIAGNOSTICO|DIAGNÓSTICO|DOSIS|EMBARAZ|ALERG|CONTRAINDIC|RECETA|PRESCRIP|URGENT|EMERGENC)\b/i.test(u)){
+    return {kind:'HANDOFF',reason:'clinical_sensitive'};
+  }
+  return null;
+}
+
+function validateToolCalls(requested,registry){
+  const allowed=new Set(Array.isArray(registry)?registry.map(x=>text(x&&x.name||x)).filter(Boolean):[]);
+  const out=[];
+  for(const call of Array.isArray(requested)?requested:[]){
+    if(out.length>=MAX_TOOL_CALLS)break;
+    const name=text(call&&call.name);
+    if(!name||!allowed.has(name))continue;
+    out.push({name,args:(call&&call.args&&typeof call.args==='object')?call.args:{}});
+  }
+  return out;
+}
+
+function createAgentRuntime(options){
+  options=options||{};
+  const modelAdapter=options.modelAdapter;
+  const toolRegistry=Array.isArray(options.toolRegistry)?options.toolRegistry:[];
+  const maxMessages=Math.max(1,Math.min(30,Number(options.maxMessages||DEFAULT_MAX_MESSAGES)));
+  const maxChars=Math.max(500,Math.min(12000,Number(options.maxChars||DEFAULT_MAX_CHARS)));
+  if(!modelAdapter||typeof modelAdapter.decide!=='function')throw new Error('CONV_L3_MODEL_ADAPTER_REQUIRED');
+
+  async function shadowTurn(input){
+    input=input||{};
+    const conversation=input.conversation||{};
+    const currentVersion=Number(conversation.version||0);
+    const expectedVersion=input.expected_version==null?currentVersion:Number(input.expected_version);
+    const memory=clipMemory(input.messages,maxMessages,maxChars);
+
+    if(conversation.state==='HUMAN_ACTIVE'){
+      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'HUMAN_CONTROL',reason:'human_takeover_wins',memory,tool_calls:[],provider_send_eligible:false};
+    }
+    if(expectedVersion!==currentVersion){
+      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'STALE_TURN',reason:'conversation_version_changed',memory,tool_calls:[],provider_send_eligible:false};
+    }
+    const boundary=detectBoundary(memory);
+    if(boundary){
+      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:boundary.kind,reason:boundary.reason,memory,tool_calls:[],provider_send_eligible:false};
+    }
+
+    const modelResult=await modelAdapter.decide({
+      conversation:{id:conversation.id||null,state:conversation.state||null,version:currentVersion},
+      memory,
+      available_tools:toolRegistry.map(x=>text(x&&x.name||x)).filter(Boolean),
+      constraints:{max_tool_calls:MAX_TOOL_CALLS,provider_send:false,direct_sql:false,direct_meta:false}
+    });
+    const toolCalls=validateToolCalls(modelResult&&modelResult.tool_calls,toolRegistry);
+    return {
+      version:AGENT_RUNTIME_VERSION,
+      mode:'SHADOW',
+      decision:'PLAN_READY',
+      reason:'shadow_reasoning_complete',
+      memory,
+      tool_calls:toolCalls,
+      draft_reply:text(modelResult&&modelResult.draft_reply).slice(0,3000),
+      next_best_action:text(modelResult&&modelResult.next_best_action).slice(0,160)||null,
+      provider_send_eligible:false
+    };
+  }
+
+  return {version:AGENT_RUNTIME_VERSION,shadowTurn};
+}
+
+module.exports={AGENT_RUNTIME_VERSION,MAX_TOOL_CALLS,clipMemory,detectBoundary,validateToolCalls,createAgentRuntime};

--- a/ci/conv-l3/agent_runtime_contract.js
+++ b/ci/conv-l3/agent_runtime_contract.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert=require('assert');
+const {
+  AGENT_RUNTIME_VERSION,
+  clipMemory,
+  detectBoundary,
+  validateToolCalls,
+  createAgentRuntime
+}=require('../../app/conversation-agent-runtime');
+
+(async()=>{
+  assert.strictEqual(AGENT_RUNTIME_VERSION,'CONV-L3-SHADOW-V1');
+
+  const memory=clipMemory([
+    {direction:'INBOUND',message_body:'hola'},
+    {direction:'OUTBOUND',message_body:'hola, ¿en qué te ayudo?'},
+    {direction:'INBOUND',message_body:'quiero precio'}
+  ],2,1000);
+  assert.strictEqual(memory.length,2);
+  assert.strictEqual(memory[1].body,'quiero precio');
+
+  assert.deepStrictEqual(detectBoundary([{direction:'INBOUND',body:'STOP'}]),{kind:'STOP',reason:'customer_stop_or_suppression'});
+  assert.deepStrictEqual(detectBoundary([{direction:'INBOUND',body:'¿qué dosis me recomiendas?'}]),{kind:'HANDOFF',reason:'clinical_sensitive'});
+
+  const calls=validateToolCalls([
+    {name:'get_prices',args:{q:'toxina'}},
+    {name:'raw_sql',args:{sql:'select 1'}},
+    {name:'get_locations',args:{}},
+    {name:'get_promotions',args:{}}
+  ],['get_prices','get_locations','get_promotions']);
+  assert.deepStrictEqual(calls.map(x=>x.name),['get_prices','get_locations']);
+
+  let seenInput=null;
+  const runtime=createAgentRuntime({
+    toolRegistry:['get_prices','get_locations'],
+    modelAdapter:{
+      async decide(input){
+        seenInput=input;
+        return {
+          tool_calls:[{name:'get_prices',args:{service:'toxina'}},{name:'raw_sql',args:{sql:'select *'}}],
+          draft_reply:'Te ayudo con el precio vigente.',
+          next_best_action:'consult_price'
+        };
+      }
+    }
+  });
+
+  const human=await runtime.shadowTurn({
+    conversation:{id:'c1',state:'HUMAN_ACTIVE',version:7},expected_version:7,
+    messages:[{direction:'INBOUND',message_body:'hola'}]
+  });
+  assert.strictEqual(human.decision,'HUMAN_CONTROL');
+  assert.strictEqual(human.provider_send_eligible,false);
+
+  const stale=await runtime.shadowTurn({
+    conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:7,
+    messages:[{direction:'INBOUND',message_body:'hola'}]
+  });
+  assert.strictEqual(stale.decision,'STALE_TURN');
+  assert.strictEqual(stale.provider_send_eligible,false);
+
+  const stopped=await runtime.shadowTurn({
+    conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
+    messages:[{direction:'INBOUND',message_body:'No quiero recibir mensajes, STOP'}]
+  });
+  assert.strictEqual(stopped.decision,'STOP');
+  assert.strictEqual(stopped.provider_send_eligible,false);
+
+  const planned=await runtime.shadowTurn({
+    conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
+    messages:[{direction:'INBOUND',message_body:'¿Cuánto cuesta la toxina botulínica?'}]
+  });
+  assert.strictEqual(planned.decision,'PLAN_READY');
+  assert.strictEqual(planned.tool_calls.length,1);
+  assert.strictEqual(planned.tool_calls[0].name,'get_prices');
+  assert.strictEqual(planned.provider_send_eligible,false);
+  assert.strictEqual(seenInput.constraints.provider_send,false);
+  assert.strictEqual(seenInput.constraints.direct_sql,false);
+  assert.strictEqual(seenInput.constraints.direct_meta,false);
+
+  console.log('CONV_L3_SHADOW_RUNTIME_CONTRACT_PASS');
+})().catch(err=>{console.error(err);process.exit(1)});


### PR DESCRIPTION
## Scope
Implements the first CONV-L3 shadow-only runtime slice for #507.

### Adds
- bounded short-term memory window from the canonical message ledger input;
- deterministic STOP and clinical-sensitive handoff boundaries;
- human takeover precedence;
- stale-turn/version guard;
- typed tool allowlist with max 2 tool calls;
- model-adapter boundary;
- draft response / next-best-action planning;
- hard `provider_send_eligible=false` in every path;
- explicit no direct SQL / no direct Meta constraints;
- dedicated contract test and GitHub Actions gate.

### Safety boundary
This PR does **not** wire the runtime into the inbound webhook, outbound dispatcher, MetaCloudAdapter, or production autonomous path. It is offline/shadow only. `AUTO_OFF`, kill switch, AI send OFF and auto-routing OFF remain untouched.

### Rollback
Revert this PR. No schema or production data mutation.

Closes no issue; #507 remains active until the frozen conversational benchmark is completed.