### PR TITLE
CONV-L3: semantic-turn recency fix

### DIFF
--- a/app/conv-l3-real-model-benchmark.js
+++ b/app/conv-l3-real-model-benchmark.js
@@ -5,7 +5,7 @@ const ai=require('./ai-router');
 const resilience=require('./wa4-ai-resilience');
 const {createAgentRuntime}=require('./conversation-agent-runtime');
 
-const VERSION='CONV-L3-REAL-MODEL-BENCH-V1';
+const VERSION='CONV-L3-REAL-MODEL-BENCH-V2';
 const TOOL_REGISTRY=Object.freeze([
   'get_prices',
   'get_promotions',
@@ -77,6 +77,7 @@ function adapter(keys,telemetry){
         'No envías mensajes ni ejecutas herramientas: solo decides el siguiente paso.',
         'Devuelve SOLO JSON con tool_calls,draft_reply,next_best_action.',
         'Máximo 2 tool_calls y usa únicamente available_tools.',
+        'CURRENT_TURN contiene el turno semántico actual: todos los INBOUND consecutivos posteriores al último OUTBOUND. CURRENT_TURN manda sobre intenciones anteriores; el historial previo solo da contexto. Si el cliente cambia de tema, selecciona la herramienta del tema nuevo.',
         'Reglas de selección: precios->get_prices; promociones u objeción de precio->get_promotions; sedes/ubicación->get_locations; medios de pago->get_payment_methods; horarios->get_hours; intención de reservar/agendar->get_booking_availability.',
         'Si falta un dato autoritativo, pide o consulta la herramienta correspondiente; no inventes precio, descuento, horario, disponibilidad, diagnóstico, dosis ni contraindicación.',
         'El draft_reply debe sonar natural, breve, útil y comercial, sin decir que eres un bot.',
@@ -87,6 +88,7 @@ function adapter(keys,telemetry){
         {role:'user',content:JSON.stringify({
           conversation:input.conversation,
           history,
+          CURRENT_TURN:input.current_turn,
           available_tools:input.available_tools,
           constraints:input.constraints
         })}

--- a/app/conversation-agent-runtime.js
+++ b/app/conversation-agent-runtime.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AGENT_RUNTIME_VERSION='CONV-L3-SHADOW-V1';
+const AGENT_RUNTIME_VERSION='CONV-L3-SHADOW-V2';
 const MAX_TOOL_CALLS=2;
 const DEFAULT_MAX_MESSAGES=12;
 const DEFAULT_MAX_CHARS=6000;
@@ -23,6 +23,15 @@ function clipMemory(messages,maxMessages,maxChars){
     used+=take;
   }
   return picked.reverse();
+}
+
+function semanticTurn(memory){
+  const src=Array.isArray(memory)?memory:[];
+  let start=0;
+  for(let i=src.length-1;i>=0;i--){
+    if(src[i]&&src[i].direction==='OUTBOUND'){start=i+1;break;}
+  }
+  return src.slice(start).filter(m=>m&&m.direction==='INBOUND').map(m=>text(m.body)).filter(Boolean).join('\n');
 }
 
 function detectBoundary(memory){
@@ -78,6 +87,7 @@ function createAgentRuntime(options){
     const modelResult=await modelAdapter.decide({
       conversation:{id:conversation.id||null,state:conversation.state||null,version:currentVersion},
       memory,
+      current_turn:semanticTurn(memory),
       available_tools:toolRegistry.map(x=>text(x&&x.name||x)).filter(Boolean),
       constraints:{max_tool_calls:MAX_TOOL_CALLS,provider_send:false,direct_sql:false,direct_meta:false}
     });
@@ -98,4 +108,4 @@ function createAgentRuntime(options){
   return {version:AGENT_RUNTIME_VERSION,shadowTurn};
 }
 
-module.exports={AGENT_RUNTIME_VERSION,MAX_TOOL_CALLS,clipMemory,detectBoundary,validateToolCalls,createAgentRuntime};
+module.exports={AGENT_RUNTIME_VERSION,MAX_TOOL_CALLS,clipMemory,semanticTurn,detectBoundary,validateToolCalls,createAgentRuntime};

--- a/ci/conv-l3/agent_runtime_contract.js
+++ b/ci/conv-l3/agent_runtime_contract.js
@@ -4,13 +4,14 @@ const assert=require('assert');
 const {
   AGENT_RUNTIME_VERSION,
   clipMemory,
+  semanticTurn,
   detectBoundary,
   validateToolCalls,
   createAgentRuntime
 }=require('../../app/conversation-agent-runtime');
 
 (async()=>{
-  assert.strictEqual(AGENT_RUNTIME_VERSION,'CONV-L3-SHADOW-V1');
+  assert.strictEqual(AGENT_RUNTIME_VERSION,'CONV-L3-SHADOW-V2');
 
   const memory=clipMemory([
     {direction:'INBOUND',message_body:'hola'},
@@ -19,6 +20,16 @@ const {
   ],2,1000);
   assert.strictEqual(memory.length,2);
   assert.strictEqual(memory[1].body,'quiero precio');
+  assert.strictEqual(semanticTurn([
+    {direction:'INBOUND',body:'quiero precio de toxina'},
+    {direction:'OUTBOUND',body:'te ayudo'},
+    {direction:'INBOUND',body:'antes dime dónde queda San Isidro'}
+  ]),'antes dime dónde queda San Isidro');
+  assert.strictEqual(semanticTurn([
+    {direction:'INBOUND',body:'hola'},
+    {direction:'INBOUND',body:'quiero saber precio'},
+    {direction:'INBOUND',body:'de toxina'}
+  ]),'hola\nquiero saber precio\nde toxina');
 
   assert.deepStrictEqual(detectBoundary([{direction:'INBOUND',body:'STOP'}]),{kind:'STOP',reason:'customer_stop_or_suppression'});
   assert.deepStrictEqual(detectBoundary([{direction:'INBOUND',body:'¿qué dosis me recomiendas?'}]),{kind:'HANDOFF',reason:'clinical_sensitive'});
@@ -75,6 +86,7 @@ const {
   assert.strictEqual(planned.tool_calls.length,1);
   assert.strictEqual(planned.tool_calls[0].name,'get_prices');
   assert.strictEqual(planned.provider_send_eligible,false);
+  assert.strictEqual(seenInput.current_turn,'¿Cuánto cuesta la toxina botulínica?');
   assert.strictEqual(seenInput.constraints.provider_send,false);
   assert.strictEqual(seenInput.constraints.direct_sql,false);
   assert.strictEqual(seenInput.constraints.direct_meta,false);

--- a/ci/conv-l3/shadow_benchmark.js
+++ b/ci/conv-l3/shadow_benchmark.js
@@ -33,9 +33,7 @@ function classify(text){
     const runtime=createAgentRuntime({
       toolRegistry:['get_prices','get_promotions','get_locations','get_payment_methods'],
       modelAdapter:{async decide(input){
-        const inbound=input.memory.filter(x=>x.direction==='INBOUND');
-        const last=inbound.length?inbound[inbound.length-1].body:'';
-        const tool=classify(last);
+        const tool=classify(input.current_turn);
         return {
           tool_calls:[{name:tool,args:{}}],
           draft_reply:'Respuesta de benchmark en modo shadow.',


### PR DESCRIPTION
## Scope
Fixes the only defect found by the first real-provider L3 benchmark in #507.

The runtime now computes an explicit `current_turn` from consecutive INBOUND messages after the most recent OUTBOUND. This makes the active semantic turn authoritative while retaining older memory as context.

### Why
Run 1 scored 11/12. The context-switch case incorrectly preferred an older price intent over the latest location question.

### Changes
- bump shadow runtime to `CONV-L3-SHADOW-V2`;
- add `semanticTurn(memory)`;
- expose `current_turn` to the model adapter;
- real-model prompt treats CURRENT_TURN as authoritative;
- deterministic benchmark uses the same semantic-turn contract;
- tests cover both context switch and multi-message burst behavior.

### Safety
No provider send path is added. `provider_send_eligible=false`, direct SQL false, direct Meta false, human takeover, STOP, clinical handoff and stale-turn gates remain unchanged.