### PR TITLE
CONV-L3: enforce PLAN → OBSERVE → COMPOSE

### DIFF
--- a/app/conv-l3-real-model-benchmark.js
+++ b/app/conv-l3-real-model-benchmark.js
@@ -5,62 +5,37 @@ const ai=require('./ai-router');
 const resilience=require('./wa4-ai-resilience');
 const {createAgentRuntime}=require('./conversation-agent-runtime');
 
-const VERSION='CONV-L3-REAL-MODEL-BENCH-V2';
+const VERSION='CONV-L3-REAL-MODEL-BENCH-V3';
 const TOOL_REGISTRY=Object.freeze([
-  'get_prices',
-  'get_promotions',
-  'get_locations',
-  'get_payment_methods',
-  'get_hours',
-  'get_booking_availability'
+  'get_prices','get_promotions','get_locations','get_payment_methods','get_hours','get_booking_availability'
 ]);
 
 function loadGroqSecret(){
-  const sb=String(process.env.SUPABASE_URL||'');
-  const serviceKey=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'');
+  const sb=String(process.env.SUPABASE_URL||''),serviceKey=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'');
   if(!sb||!serviceKey)return Promise.resolve('');
   return new Promise(resolve=>{
     let u;try{u=new URL(sb);}catch(_){return resolve('');}
     const path='/rest/v1/aos_integration_secrets_v1?tipo=eq.groq&select=api_key&limit=1';
     const q=https.request({
-      hostname:u.hostname,
-      port:u.port||443,
-      path,
-      method:'GET',
-      headers:{
-        apikey:serviceKey,
-        Authorization:'Bearer '+serviceKey,
-        'Content-Type':'application/json',
-        'User-Agent':'AscendaOS-CONV-L3-Benchmark/1.0'
-      },
+      hostname:u.hostname,port:u.port||443,path,method:'GET',
+      headers:{apikey:serviceKey,Authorization:'Bearer '+serviceKey,'Content-Type':'application/json','User-Agent':'AscendaOS-CONV-L3-Benchmark/1.0'},
       timeout:5000
     },r=>{
-      let raw='';
-      r.on('data',c=>raw+=c);
-      r.on('end',()=>{
+      let raw='';r.on('data',c=>raw+=c);r.on('end',()=>{
         let rows=[];try{rows=JSON.parse(raw||'[]');}catch(_){}
         const value=r.statusCode>=200&&r.statusCode<300&&Array.isArray(rows)&&rows[0]&&typeof rows[0].api_key==='string'?rows[0].api_key:'';
         resolve(value.length>10?value:'');
       });
     });
-    q.on('timeout',()=>q.destroy());
-    q.on('error',()=>resolve(''));
-    q.end();
+    q.on('timeout',()=>q.destroy());q.on('error',()=>resolve(''));q.end();
   });
 }
 
-function schema(){
+function planSchema(){
   return {
     type:'object',
     properties:{
-      tool_calls:{
-        type:'array',
-        items:{
-          type:'object',
-          properties:{name:{type:'string'},args:{type:'object'}},
-          required:['name','args']
-        }
-      },
+      tool_calls:{type:'array',items:{type:'object',properties:{name:{type:'string'},args:{type:'object'}},required:['name','args']}},
       draft_reply:{type:'string'},
       next_best_action:{type:'string'}
     },
@@ -68,66 +43,106 @@ function schema(){
   };
 }
 
-function adapter(keys,telemetry){
+function composeSchema(){
+  return {
+    type:'object',
+    properties:{
+      draft_reply:{type:'string'},
+      next_best_action:{type:'string'},
+      cited_tools:{type:'array',items:{type:'string'}}
+    },
+    required:['draft_reply','next_best_action','cited_tools']
+  };
+}
+
+function modelAdapter(keys,telemetry){
+  async function invoke(stage,messages,schema,maxTokens){
+    const started=Date.now();
+    const out=await resilience.chat(keys,ai.MODELS.fast,messages,{
+      maxTokens,reasoningEffort:'low',timeoutMs:7000,geminiTimeoutMs:10000,jsonSchema:schema
+    });
+    telemetry.push({
+      stage,provider:out.provider||'unknown',model:out.model||'unknown',
+      latency_ms:Date.now()-started,fallback_used:out.fallback_used===true,
+      estimated_cost_usd:Number(out.estimated_cost_usd||0)
+    });
+    return out.json;
+  }
   return {
     async decide(input){
-      const history=input.memory.map(m=>m.direction+': '+m.body).join('\n');
       const system=[
-        'Eres el planificador comercial SHADOW de ASCENDA OS para una clínica estética.',
-        'No envías mensajes ni ejecutas herramientas: solo decides el siguiente paso.',
+        'Eres el PLANIFICADOR comercial SHADOW de ASCENDA OS.',
+        'No envías mensajes, no ejecutas herramientas y no inventas hechos.',
         'Devuelve SOLO JSON con tool_calls,draft_reply,next_best_action.',
-        'Máximo 2 tool_calls y usa únicamente available_tools.',
-        'CURRENT_TURN contiene el turno semántico actual: todos los INBOUND consecutivos posteriores al último OUTBOUND. CURRENT_TURN manda sobre intenciones anteriores; el historial previo solo da contexto. Si el cliente cambia de tema, selecciona la herramienta del tema nuevo.',
-        'Reglas de selección: precios->get_prices; promociones u objeción de precio->get_promotions; sedes/ubicación->get_locations; medios de pago->get_payment_methods; horarios->get_hours; intención de reservar/agendar->get_booking_availability.',
-        'Si falta un dato autoritativo, pide o consulta la herramienta correspondiente; no inventes precio, descuento, horario, disponibilidad, diagnóstico, dosis ni contraindicación.',
-        'El draft_reply debe sonar natural, breve, útil y comercial, sin decir que eres un bot.',
-        'Respeta que provider_send=false,direct_sql=false,direct_meta=false.'
+        'CURRENT_TURN manda sobre intenciones anteriores. El historial previo solo da contexto.',
+        'Si la respuesta requiere un hecho autoritativo, selecciona exactamente la herramienta correspondiente y deja draft_reply vacío.',
+        'precios->get_prices; promociones/objeción de precio->get_promotions; sedes->get_locations; pagos->get_payment_methods; horarios->get_hours; agendar/reservar->get_booking_availability.',
+        'Para un saludo general sin petición factual, usa tool_calls=[] y puedes redactar una respuesta breve.',
+        'Máximo 2 herramientas. provider_send=false,direct_sql=false,direct_meta=false.'
       ].join(' ');
-      const messages=[
+      return invoke('PLAN',[
         {role:'system',content:system},
         {role:'user',content:JSON.stringify({
-          conversation:input.conversation,
-          history,
+          history:input.memory.map(m=>m.direction+': '+m.body).join('\n'),
           CURRENT_TURN:input.current_turn,
           available_tools:input.available_tools,
           constraints:input.constraints
         })}
-      ];
-      const started=Date.now();
-      const out=await resilience.chat(keys,ai.MODELS.fast,messages,{
-        maxTokens:220,
-        reasoningEffort:'low',
-        timeoutMs:7000,
-        geminiTimeoutMs:10000,
-        jsonSchema:schema()
-      });
-      telemetry.push({
-        provider:out.provider||'unknown',
-        model:out.model||'unknown',
-        latency_ms:Date.now()-started,
-        fallback_used:out.fallback_used===true,
-        estimated_cost_usd:Number(out.estimated_cost_usd||0)
-      });
-      return out.json;
+      ],planSchema(),180);
+    },
+    async compose(input){
+      const system=[
+        'Eres el COMPOSITOR comercial SHADOW de ASCENDA OS.',
+        'Redacta una respuesta natural, breve y útil usando EXCLUSIVAMENTE los hechos presentes en TOOL_OBSERVATIONS.',
+        'No inventes precio, promoción, dirección, medios de pago, horario ni disponibilidad.',
+        'Devuelve SOLO JSON con draft_reply,next_best_action,cited_tools.',
+        'cited_tools debe listar únicamente herramientas realmente presentes en TOOL_OBSERVATIONS.',
+        'No menciones herramientas, sistema, SQL, Meta ni que eres un bot.',
+        'provider_send=false,direct_sql=false,direct_meta=false.'
+      ].join(' ');
+      return invoke('COMPOSE',[
+        {role:'system',content:system},
+        {role:'user',content:JSON.stringify({
+          CURRENT_TURN:input.current_turn,
+          TOOL_OBSERVATIONS:input.tool_observations,
+          constraints:input.constraints
+        })}
+      ],composeSchema(),180);
     }
   };
 }
 
 function msgs(rows){
-  return rows.map((x,i)=>({
-    direction:x[0],
-    message_body:x[1],
-    created_at:new Date(1789240000000+i*1000).toISOString()
-  }));
+  return rows.map((x,i)=>({direction:x[0],message_body:x[1],created_at:new Date(1789240000000+i*1000).toISOString()}));
 }
 
-function moneyMention(text){
-  return /(?:s\/\.?\s*|sol(?:es)?\s*)\d/i.test(String(text||''));
+const OBS=Object.freeze({
+  get_prices:{service:'Toxina botulínica',currency:'PEN',amount:420,authority:'SYNTHETIC_GOVERNED_BENCH'},
+  get_promotions:{name:'Promo benchmark',discount_percent:15,scope:'Toxina botulínica',authority:'SYNTHETIC_GOVERNED_BENCH'},
+  get_locations:{branch:'San Isidro',address:'Av. Benchmark 1234, San Isidro',authority:'SYNTHETIC_GOVERNED_BENCH'},
+  get_payment_methods:{methods:['Visa','Yape'],authority:'SYNTHETIC_GOVERNED_BENCH'},
+  get_hours:{branch:'San Isidro',day:'sábado',opens:'09:00',closes:'14:00',authority:'SYNTHETIC_GOVERNED_BENCH'},
+  get_booking_availability:{branch:'San Isidro',date:'2026-09-15',slots:['10:30'],authority:'SYNTHETIC_GOVERNED_BENCH'}
+});
+
+function factualCheck(tool,reply){
+  const t=String(reply||'');
+  if(tool==='get_prices')return /420/.test(t);
+  if(tool==='get_promotions')return /15/.test(t);
+  if(tool==='get_locations')return /1234/.test(t);
+  if(tool==='get_payment_methods')return /yape/i.test(t);
+  if(tool==='get_hours')return /(09:00|9:00|9\s*a\.?\s*m\.?)/i.test(t)&&/(14:00|2:00|2\s*p\.?\s*m\.?)/i.test(t);
+  if(tool==='get_booking_availability')return /10:30/.test(t);
+  return true;
+}
+
+function cleanReply(reply){
+  const t=String(reply||'');
+  return t.length>=8&&!/(raw_sql|select\s+|graph\.facebook|meta cloud|tool_observations|soy un bot)/i.test(t);
 }
 
 async function runBootBenchmark(){
   if(String(process.env.AOS_CONV_L3_REAL_BENCHMARK_ON_BOOT||'')!=='1')return {skipped:true,version:VERSION};
-
   const [groq,gemini]=await Promise.all([loadGroqSecret(),resilience.loadGeminiSecret()]);
   if(!groq&&!gemini){
     console.error('[CONV-L3-REAL-BENCH] providers-unavailable');
@@ -135,83 +150,91 @@ async function runBootBenchmark(){
   }
 
   const telemetry=[];
-  const modelAdapter=adapter({groq,gemini},telemetry);
-  const runtime=createAgentRuntime({toolRegistry:TOOL_REGISTRY,modelAdapter,maxMessages:12,maxChars:6000});
+  const adapter=modelAdapter({groq,gemini},telemetry);
+  const runtime=createAgentRuntime({toolRegistry:TOOL_REGISTRY,modelAdapter:adapter,maxMessages:12,maxChars:6000});
   const cases=[
-    {name:'price',messages:[['INBOUND','Hola, quisiera información sobre toxina botulínica y saber el precio.']],decision:'PLAN_READY',tool:'get_prices'},
-    {name:'promotion_objection',messages:[['INBOUND','Me interesa, pero se me hace caro. ¿Tienen alguna promoción o alternativa?']],decision:'PLAN_READY',tool:'get_promotions'},
-    {name:'location',messages:[['INBOUND','¿Dónde queda la sede de San Isidro?']],decision:'PLAN_READY',tool:'get_locations'},
-    {name:'payment',messages:[['INBOUND','¿Puedo pagar con tarjeta o Yape?']],decision:'PLAN_READY',tool:'get_payment_methods'},
-    {name:'hours',messages:[['INBOUND','¿Atienden los sábados y hasta qué hora?']],decision:'PLAN_READY',tool:'get_hours'},
-    {name:'booking',messages:[['INBOUND','Perfecto, quiero separar una cita para esta semana.']],decision:'PLAN_READY',tool:'get_booking_availability'},
-    {name:'context_switch',messages:[['INBOUND','Quiero saber el precio de toxina'],['OUTBOUND','Claro, te ayudo.'],['INBOUND','Antes dime dónde queda San Isidro']],decision:'PLAN_READY',tool:'get_locations'},
-    {name:'burst',messages:[['INBOUND','hola'],['INBOUND','quiero saber precio'],['INBOUND','de toxina']],decision:'PLAN_READY',tool:'get_prices'},
-    {name:'stop',messages:[['INBOUND','Gracias, ya no quiero recibir mensajes. STOP']],decision:'STOP',tool:null},
-    {name:'clinical',messages:[['INBOUND','Estoy embarazada, ¿qué dosis me recomiendan?']],decision:'HANDOFF',tool:null},
-    {name:'human_takeover',state:'HUMAN_ACTIVE',messages:[['INBOUND','Hola, quiero información']],decision:'HUMAN_CONTROL',tool:null},
-    {name:'stale',version:12,expectedVersion:11,messages:[['INBOUND','Quiero una cita']],decision:'STALE_TURN',tool:null}
+    {name:'price',messages:[['INBOUND','Hola, quisiera información sobre toxina botulínica y saber el precio.']],tool:'get_prices'},
+    {name:'promotion_objection',messages:[['INBOUND','Me interesa, pero se me hace caro. ¿Tienen alguna promoción o alternativa?']],tool:'get_promotions'},
+    {name:'location',messages:[['INBOUND','¿Dónde queda la sede de San Isidro?']],tool:'get_locations'},
+    {name:'payment',messages:[['INBOUND','¿Puedo pagar con tarjeta o Yape?']],tool:'get_payment_methods'},
+    {name:'hours',messages:[['INBOUND','¿Atienden los sábados y hasta qué hora?']],tool:'get_hours'},
+    {name:'booking',messages:[['INBOUND','Perfecto, quiero separar una cita para esta semana.']],tool:'get_booking_availability'},
+    {name:'context_switch',messages:[['INBOUND','Quiero saber el precio de toxina'],['OUTBOUND','Claro, te ayudo.'],['INBOUND','Antes dime dónde queda San Isidro']],tool:'get_locations'},
+    {name:'burst',messages:[['INBOUND','hola'],['INBOUND','quiero saber precio'],['INBOUND','de toxina']],tool:'get_prices'},
+    {name:'greeting',messages:[['INBOUND','Hola 👋']],tool:null},
+    {name:'stop',messages:[['INBOUND','Gracias, ya no quiero recibir mensajes. STOP']],boundary:'STOP'},
+    {name:'clinical',messages:[['INBOUND','Estoy embarazada, ¿qué dosis me recomiendan?']],boundary:'HANDOFF'},
+    {name:'human_takeover',state:'HUMAN_ACTIVE',messages:[['INBOUND','Hola, quiero información']],boundary:'HUMAN_CONTROL'},
+    {name:'stale',version:12,expectedVersion:11,messages:[['INBOUND','Quiero una cita']],boundary:'STALE_TURN'}
   ];
 
   const results=[];
-  let okCount=0;
+  let passed=0;
   const startedAll=Date.now();
 
   for(const c of cases){
     const before=telemetry.length;
+    const version=c.version||12;
     try{
-      const version=c.version||12;
-      const result=await runtime.shadowTurn({
-        conversation:{id:'conv-l3-bench-'+c.name,state:c.state||'BOT_ACTIVE',version},
-        expected_version:c.expectedVersion==null?version:c.expectedVersion,
-        messages:msgs(c.messages)
+      const conversation={id:'conv-l3-bench-'+c.name,state:c.state||'BOT_ACTIVE',version};
+      const messages=msgs(c.messages);
+      const plan=await runtime.shadowTurn({
+        conversation,expected_version:c.expectedVersion==null?version:c.expectedVersion,messages
       });
-      const tool=result.tool_calls&&result.tool_calls[0]&&result.tool_calls[0].name||null;
-      let ok=result.decision===c.decision && result.provider_send_eligible===false;
-      if(c.decision==='PLAN_READY'){
-        ok=ok&&tool===c.tool&&String(result.draft_reply||'').trim().length>=8;
-        if(['get_prices','get_promotions','get_hours','get_booking_availability'].includes(c.tool))ok=ok&&!moneyMention(result.draft_reply);
-      }else{
-        ok=ok&&(!result.tool_calls||result.tool_calls.length===0)&&telemetry.length===before;
+
+      if(c.boundary){
+        const ok=plan.decision===c.boundary&&plan.provider_send_eligible===false&&telemetry.length===before;
+        if(ok)passed++;
+        const row={name:c.name,ok,stage:'BOUNDARY',decision:plan.decision,expected_decision:c.boundary,provider_send_eligible:plan.provider_send_eligible===true};
+        results.push(row);console.log('[CONV-L3-REAL-BENCH] case',row);continue;
       }
-      if(ok)okCount++;
-      const t=telemetry.length>before?telemetry[telemetry.length-1]:null;
+
+      const selected=plan.tool_calls&&plan.tool_calls[0]&&plan.tool_calls[0].name||null;
+      if(!c.tool){
+        const ok=plan.decision==='PLAN_READY'&&plan.response_state==='READY'&&selected===null&&cleanReply(plan.draft_reply)&&plan.provider_send_eligible===false;
+        if(ok)passed++;
+        const t=telemetry[telemetry.length-1];
+        const row={name:c.name,ok,stage:'PLAN_ONLY',decision:plan.decision,tool:selected,provider:t&&t.provider||null,model:t&&t.model||null,provider_send_eligible:plan.provider_send_eligible===true};
+        results.push(row);console.log('[CONV-L3-REAL-BENCH] case',row);continue;
+      }
+
+      const planOk=plan.decision==='PLAN_READY'&&plan.response_state==='AWAITING_TOOL_OBSERVATION'&&selected===c.tool&&plan.draft_reply===''&&plan.provider_send_eligible===false;
+      const compose=await runtime.shadowCompose({
+        conversation,expected_version:version,messages,
+        planned_tool_names:plan.planned_tool_names,
+        tool_observations:[{name:c.tool,data:OBS[c.tool]}]
+      });
+      const reply=compose.draft_reply||'';
+      const composeOk=compose.decision==='RESPONSE_READY'&&compose.response_state==='READY'&&
+        compose.cited_tools.includes(c.tool)&&cleanReply(reply)&&factualCheck(c.tool,reply)&&compose.provider_send_eligible===false;
+      const ok=planOk&&composeOk;
+      if(ok)passed++;
+      const caseTelemetry=telemetry.slice(before);
       const row={
-        name:c.name,
-        ok,
-        decision:result.decision,
-        expected_decision:c.decision,
-        tool,
-        expected_tool:c.tool,
-        provider:t&&t.provider||null,
-        model:t&&t.model||null,
-        latency_ms:t&&t.latency_ms||0,
-        fallback_used:t&&t.fallback_used===true,
-        provider_send_eligible:result.provider_send_eligible===true
+        name:c.name,ok,stage:'PLAN_OBSERVE_COMPOSE',decision:compose.decision,
+        tool:selected,expected_tool:c.tool,plan_ok:planOk,compose_ok:composeOk,
+        provider_chain:caseTelemetry.map(x=>x.provider),
+        model_chain:caseTelemetry.map(x=>x.model),
+        latency_ms:caseTelemetry.reduce((n,x)=>n+Number(x.latency_ms||0),0),
+        fallback_used:caseTelemetry.some(x=>x.fallback_used),
+        provider_send_eligible:compose.provider_send_eligible===true
       };
-      results.push(row);
-      console.log('[CONV-L3-REAL-BENCH] case',row);
+      results.push(row);console.log('[CONV-L3-REAL-BENCH] case',row);
     }catch(e){
       const row={name:c.name,ok:false,error:String(e&&e.message||'BENCH_ERROR').slice(0,100),provider_send_eligible:false};
-      results.push(row);
-      console.error('[CONV-L3-REAL-BENCH] case',row);
+      results.push(row);console.error('[CONV-L3-REAL-BENCH] case',row);
     }
   }
 
   const cost=telemetry.reduce((n,x)=>n+Number(x.estimated_cost_usd||0),0);
-  const modelCases=results.filter(x=>x.provider);
   const summary={
-    version:VERSION,
-    ok:okCount===cases.length,
-    passed:okCount,
-    total:cases.length,
-    model_cases:modelCases.length,
-    fallback_count:modelCases.filter(x=>x.fallback_used).length,
-    total_latency_ms:Date.now()-startedAll,
-    estimated_cost_usd:Number(cost.toFixed(8)),
+    version:VERSION,ok:passed===cases.length,passed,total:cases.length,
+    model_calls:telemetry.length,fallback_count:telemetry.filter(x=>x.fallback_used).length,
+    total_latency_ms:Date.now()-startedAll,estimated_cost_usd:Number(cost.toFixed(8)),
     provider_send_eligible:false
   };
   console.log('[CONV-L3-REAL-BENCH] summary',summary);
   return Object.assign(summary,{results});
 }
 
-module.exports={VERSION,TOOL_REGISTRY,runBootBenchmark};
+module.exports={VERSION,TOOL_REGISTRY,OBS,runBootBenchmark};

--- a/app/conversation-agent-runtime.js
+++ b/app/conversation-agent-runtime.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const AGENT_RUNTIME_VERSION='CONV-L3-SHADOW-V2';
+const AGENT_RUNTIME_VERSION='CONV-L3-SHADOW-V3';
 const MAX_TOOL_CALLS=2;
 const DEFAULT_MAX_MESSAGES=12;
 const DEFAULT_MAX_CHARS=6000;
+const MAX_OBSERVATION_CHARS=12000;
 
 function text(v){return String(v==null?'':v).trim();}
 function upper(v){return text(v).toUpperCase();}
@@ -31,7 +32,11 @@ function semanticTurn(memory){
   for(let i=src.length-1;i>=0;i--){
     if(src[i]&&src[i].direction==='OUTBOUND'){start=i+1;break;}
   }
-  return src.slice(start).filter(m=>m&&m.direction==='INBOUND').map(m=>text(m.body)).filter(Boolean).join('\n');
+  return src.slice(start)
+    .filter(m=>m&&m.direction==='INBOUND')
+    .map(m=>text(m.body))
+    .filter(Boolean)
+    .join('\n');
 }
 
 function detectBoundary(memory){
@@ -46,16 +51,69 @@ function detectBoundary(memory){
   return null;
 }
 
+function registryNames(registry){
+  return Array.isArray(registry)?registry.map(x=>text(x&&x.name||x)).filter(Boolean):[];
+}
+
 function validateToolCalls(requested,registry){
-  const allowed=new Set(Array.isArray(registry)?registry.map(x=>text(x&&x.name||x)).filter(Boolean):[]);
+  const allowed=new Set(registryNames(registry));
   const out=[];
   for(const call of Array.isArray(requested)?requested:[]){
     if(out.length>=MAX_TOOL_CALLS)break;
     const name=text(call&&call.name);
-    if(!name||!allowed.has(name))continue;
-    out.push({name,args:(call&&call.args&&typeof call.args==='object')?call.args:{}});
+    if(!name||!allowed.has(name)||out.some(x=>x.name===name))continue;
+    out.push({name,args:(call&&call.args&&typeof call.args==='object'&&!Array.isArray(call.args))?call.args:{}});
   }
   return out;
+}
+
+function safeObservationData(value){
+  if(!value||typeof value!=='object'||Array.isArray(value))return {};
+  try{
+    const raw=JSON.stringify(value);
+    if(!raw||raw.length>MAX_OBSERVATION_CHARS)return {};
+    return JSON.parse(raw);
+  }catch(_){return {};}
+}
+
+function validateToolObservations(observations,registry,plannedNames){
+  const allowed=new Set(registryNames(registry));
+  const planned=new Set((Array.isArray(plannedNames)?plannedNames:[]).map(text).filter(Boolean));
+  const out=[];
+  for(const observation of Array.isArray(observations)?observations:[]){
+    if(out.length>=MAX_TOOL_CALLS)break;
+    const name=text(observation&&observation.name);
+    if(!name||!allowed.has(name)||!planned.has(name)||out.some(x=>x.name===name))continue;
+    out.push({name,data:safeObservationData(observation&&observation.data)});
+  }
+  return out;
+}
+
+function preflight(conversation,expectedVersion,memory){
+  const currentVersion=Number(conversation&&conversation.version||0);
+  if(conversation&&conversation.state==='HUMAN_ACTIVE'){
+    return {decision:'HUMAN_CONTROL',reason:'human_takeover_wins',currentVersion};
+  }
+  if(Number(expectedVersion)!==currentVersion){
+    return {decision:'STALE_TURN',reason:'conversation_version_changed',currentVersion};
+  }
+  const boundary=detectBoundary(memory);
+  if(boundary)return {decision:boundary.kind,reason:boundary.reason,currentVersion};
+  return {decision:null,reason:null,currentVersion};
+}
+
+function boundaryResult(pre,memory){
+  return {
+    version:AGENT_RUNTIME_VERSION,
+    mode:'SHADOW',
+    decision:pre.decision,
+    response_state:'BLOCKED',
+    reason:pre.reason,
+    memory,
+    tool_calls:[],
+    draft_reply:'',
+    provider_send_eligible:false
+  };
 }
 
 function createAgentRuntime(options){
@@ -72,40 +130,104 @@ function createAgentRuntime(options){
     const currentVersion=Number(conversation.version||0);
     const expectedVersion=input.expected_version==null?currentVersion:Number(input.expected_version);
     const memory=clipMemory(input.messages,maxMessages,maxChars);
-
-    if(conversation.state==='HUMAN_ACTIVE'){
-      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'HUMAN_CONTROL',reason:'human_takeover_wins',memory,tool_calls:[],provider_send_eligible:false};
-    }
-    if(expectedVersion!==currentVersion){
-      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'STALE_TURN',reason:'conversation_version_changed',memory,tool_calls:[],provider_send_eligible:false};
-    }
-    const boundary=detectBoundary(memory);
-    if(boundary){
-      return {version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:boundary.kind,reason:boundary.reason,memory,tool_calls:[],provider_send_eligible:false};
-    }
+    const pre=preflight(conversation,expectedVersion,memory);
+    if(pre.decision)return boundaryResult(pre,memory);
 
     const modelResult=await modelAdapter.decide({
       conversation:{id:conversation.id||null,state:conversation.state||null,version:currentVersion},
       memory,
       current_turn:semanticTurn(memory),
-      available_tools:toolRegistry.map(x=>text(x&&x.name||x)).filter(Boolean),
+      available_tools:registryNames(toolRegistry),
       constraints:{max_tool_calls:MAX_TOOL_CALLS,provider_send:false,direct_sql:false,direct_meta:false}
     });
     const toolCalls=validateToolCalls(modelResult&&modelResult.tool_calls,toolRegistry);
+    const awaiting=toolCalls.length>0;
     return {
       version:AGENT_RUNTIME_VERSION,
       mode:'SHADOW',
       decision:'PLAN_READY',
-      reason:'shadow_reasoning_complete',
+      response_state:awaiting?'AWAITING_TOOL_OBSERVATION':'READY',
+      reason:awaiting?'tool_observation_required':'shadow_reasoning_complete',
       memory,
       tool_calls:toolCalls,
-      draft_reply:text(modelResult&&modelResult.draft_reply).slice(0,3000),
+      planned_tool_names:toolCalls.map(x=>x.name),
+      draft_reply:awaiting?'':text(modelResult&&modelResult.draft_reply).slice(0,3000),
       next_best_action:text(modelResult&&modelResult.next_best_action).slice(0,160)||null,
       provider_send_eligible:false
     };
   }
 
-  return {version:AGENT_RUNTIME_VERSION,shadowTurn};
+  async function shadowCompose(input){
+    input=input||{};
+    const conversation=input.conversation||{};
+    const currentVersion=Number(conversation.version||0);
+    const expectedVersion=input.expected_version==null?currentVersion:Number(input.expected_version);
+    const memory=clipMemory(input.messages,maxMessages,maxChars);
+    const pre=preflight(conversation,expectedVersion,memory);
+    if(pre.decision)return boundaryResult(pre,memory);
+
+    const planned=Array.from(new Set((Array.isArray(input.planned_tool_names)?input.planned_tool_names:[]).map(text).filter(Boolean))).slice(0,MAX_TOOL_CALLS);
+    const allowed=new Set(registryNames(toolRegistry));
+    const validPlanned=planned.filter(name=>allowed.has(name));
+    if(!validPlanned.length){
+      return {
+        version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'OBSERVATION_REQUIRED',
+        response_state:'BLOCKED',reason:'planned_tool_required',memory,tool_calls:[],
+        tool_observations:[],draft_reply:'',provider_send_eligible:false
+      };
+    }
+
+    const observations=validateToolObservations(input.tool_observations,toolRegistry,validPlanned);
+    const observed=new Set(observations.map(x=>x.name));
+    const missing=validPlanned.filter(name=>!observed.has(name));
+    if(missing.length){
+      return {
+        version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'OBSERVATION_REQUIRED',
+        response_state:'AWAITING_TOOL_OBSERVATION',reason:'missing_tool_observation',
+        memory,tool_calls:[],planned_tool_names:validPlanned,missing_tool_names:missing,
+        tool_observations:observations,draft_reply:'',provider_send_eligible:false
+      };
+    }
+    if(typeof modelAdapter.compose!=='function')throw new Error('CONV_L3_COMPOSE_ADAPTER_REQUIRED');
+
+    const composed=await modelAdapter.compose({
+      conversation:{id:conversation.id||null,state:conversation.state||null,version:currentVersion},
+      memory,
+      current_turn:semanticTurn(memory),
+      tool_observations:observations,
+      constraints:{provider_send:false,direct_sql:false,direct_meta:false,observed_tools_only:true}
+    });
+    const draft=text(composed&&composed.draft_reply).slice(0,3000);
+    if(!draft){
+      return {
+        version:AGENT_RUNTIME_VERSION,mode:'SHADOW',decision:'COMPOSE_INVALID',
+        response_state:'BLOCKED',reason:'empty_composed_reply',memory,tool_calls:[],
+        tool_observations:observations,draft_reply:'',provider_send_eligible:false
+      };
+    }
+    const cited=Array.from(new Set((Array.isArray(composed&&composed.cited_tools)?composed.cited_tools:[])
+      .map(text).filter(name=>observed.has(name))));
+    return {
+      version:AGENT_RUNTIME_VERSION,
+      mode:'SHADOW',
+      decision:'RESPONSE_READY',
+      response_state:'READY',
+      reason:'tool_observation_composed',
+      memory,
+      tool_calls:[],
+      planned_tool_names:validPlanned,
+      tool_observations:observations,
+      cited_tools:cited,
+      draft_reply:draft,
+      next_best_action:text(composed&&composed.next_best_action).slice(0,160)||null,
+      provider_send_eligible:false
+    };
+  }
+
+  return {version:AGENT_RUNTIME_VERSION,shadowTurn,shadowCompose};
 }
 
-module.exports={AGENT_RUNTIME_VERSION,MAX_TOOL_CALLS,clipMemory,semanticTurn,detectBoundary,validateToolCalls,createAgentRuntime};
+module.exports={
+  AGENT_RUNTIME_VERSION,MAX_TOOL_CALLS,clipMemory,semanticTurn,detectBoundary,
+  validateToolCalls,validateToolObservations,createAgentRuntime
+};

--- a/ci/conv-l3/agent_runtime_contract.js
+++ b/ci/conv-l3/agent_runtime_contract.js
@@ -7,11 +7,12 @@ const {
   semanticTurn,
   detectBoundary,
   validateToolCalls,
+  validateToolObservations,
   createAgentRuntime
 }=require('../../app/conversation-agent-runtime');
 
 (async()=>{
-  assert.strictEqual(AGENT_RUNTIME_VERSION,'CONV-L3-SHADOW-V2');
+  assert.strictEqual(AGENT_RUNTIME_VERSION,'CONV-L3-SHADOW-V3');
 
   const memory=clipMemory([
     {direction:'INBOUND',message_body:'hola'},
@@ -42,16 +43,32 @@ const {
   ],['get_prices','get_locations','get_promotions']);
   assert.deepStrictEqual(calls.map(x=>x.name),['get_prices','get_locations']);
 
-  let seenInput=null;
+  const observations=validateToolObservations([
+    {name:'raw_sql',data:{secret:true}},
+    {name:'get_prices',data:{amount:420,currency:'PEN'}},
+    {name:'get_locations',data:{address:'should-not-pass'}}
+  ],['get_prices','get_locations'],['get_prices']);
+  assert.deepStrictEqual(observations,[{name:'get_prices',data:{amount:420,currency:'PEN'}}]);
+
+  let seenPlan=null,seenCompose=null,composeCalls=0;
   const runtime=createAgentRuntime({
     toolRegistry:['get_prices','get_locations'],
     modelAdapter:{
       async decide(input){
-        seenInput=input;
+        seenPlan=input;
         return {
           tool_calls:[{name:'get_prices',args:{service:'toxina'}},{name:'raw_sql',args:{sql:'select *'}}],
-          draft_reply:'Te ayudo con el precio vigente.',
+          draft_reply:'Este borrador factual debe descartarse antes de observar la herramienta.',
           next_best_action:'consult_price'
+        };
+      },
+      async compose(input){
+        composeCalls++;
+        seenCompose=input;
+        return {
+          draft_reply:'El precio oficial observado es S/ 420.',
+          next_best_action:'offer_booking',
+          cited_tools:['get_prices','raw_sql']
         };
       }
     }
@@ -69,27 +86,53 @@ const {
     messages:[{direction:'INBOUND',message_body:'hola'}]
   });
   assert.strictEqual(stale.decision,'STALE_TURN');
-  assert.strictEqual(stale.provider_send_eligible,false);
 
   const stopped=await runtime.shadowTurn({
     conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
     messages:[{direction:'INBOUND',message_body:'No quiero recibir mensajes, STOP'}]
   });
   assert.strictEqual(stopped.decision,'STOP');
-  assert.strictEqual(stopped.provider_send_eligible,false);
 
   const planned=await runtime.shadowTurn({
     conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
     messages:[{direction:'INBOUND',message_body:'¿Cuánto cuesta la toxina botulínica?'}]
   });
   assert.strictEqual(planned.decision,'PLAN_READY');
+  assert.strictEqual(planned.response_state,'AWAITING_TOOL_OBSERVATION');
   assert.strictEqual(planned.tool_calls.length,1);
   assert.strictEqual(planned.tool_calls[0].name,'get_prices');
+  assert.strictEqual(planned.draft_reply,'');
   assert.strictEqual(planned.provider_send_eligible,false);
-  assert.strictEqual(seenInput.current_turn,'¿Cuánto cuesta la toxina botulínica?');
-  assert.strictEqual(seenInput.constraints.provider_send,false);
-  assert.strictEqual(seenInput.constraints.direct_sql,false);
-  assert.strictEqual(seenInput.constraints.direct_meta,false);
+  assert.strictEqual(seenPlan.current_turn,'¿Cuánto cuesta la toxina botulínica?');
+  assert.strictEqual(seenPlan.constraints.direct_sql,false);
 
-  console.log('CONV_L3_SHADOW_RUNTIME_CONTRACT_PASS');
+  const missing=await runtime.shadowCompose({
+    conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
+    messages:[{direction:'INBOUND',message_body:'¿Cuánto cuesta la toxina botulínica?'}],
+    planned_tool_names:['get_prices'],tool_observations:[]
+  });
+  assert.strictEqual(missing.decision,'OBSERVATION_REQUIRED');
+  assert.strictEqual(composeCalls,0);
+  assert.strictEqual(missing.provider_send_eligible,false);
+
+  const composed=await runtime.shadowCompose({
+    conversation:{id:'c1',state:'BOT_ACTIVE',version:8},expected_version:8,
+    messages:[{direction:'INBOUND',message_body:'¿Cuánto cuesta la toxina botulínica?'}],
+    planned_tool_names:['get_prices'],
+    tool_observations:[
+      {name:'get_prices',data:{amount:420,currency:'PEN'}},
+      {name:'raw_sql',data:{sql:'select 1'}}
+    ]
+  });
+  assert.strictEqual(composed.decision,'RESPONSE_READY');
+  assert.strictEqual(composed.response_state,'READY');
+  assert.strictEqual(composed.draft_reply,'El precio oficial observado es S/ 420.');
+  assert.deepStrictEqual(composed.cited_tools,['get_prices']);
+  assert.strictEqual(composeCalls,1);
+  assert.strictEqual(seenCompose.tool_observations.length,1);
+  assert.strictEqual(seenCompose.tool_observations[0].data.amount,420);
+  assert.strictEqual(seenCompose.constraints.observed_tools_only,true);
+  assert.strictEqual(composed.provider_send_eligible,false);
+
+  console.log('CONV_L3_SHADOW_RUNTIME_V3_CONTRACT_PASS');
 })().catch(err=>{console.error(err);process.exit(1)});

--- a/ci/conv-l3/real_model_benchmark_contract.js
+++ b/ci/conv-l3/real_model_benchmark_contract.js
@@ -1,9 +1,18 @@
 'use strict';
 const assert=require('assert');
 const fs=require('fs');
-const bench=fs.readFileSync(require('path').join(__dirname,'../../app/conv-l3-real-model-benchmark.js'),'utf8');
-const server=fs.readFileSync(require('path').join(__dirname,'../../app/server-f17.js'),'utf8');
+const path=require('path');
+const bench=fs.readFileSync(path.join(__dirname,'../../app/conv-l3-real-model-benchmark.js'),'utf8');
+const runtime=fs.readFileSync(path.join(__dirname,'../../app/conversation-agent-runtime.js'),'utf8');
+const server=fs.readFileSync(path.join(__dirname,'../../app/server-f17.js'),'utf8');
 
+assert(runtime.includes("CONV-L3-SHADOW-V3"));
+assert(runtime.includes("shadowCompose"));
+assert(runtime.includes("AWAITING_TOOL_OBSERVATION"));
+assert(runtime.includes("tool_observations"));
+assert(runtime.includes("provider_send_eligible:false"));
+assert(bench.includes("PLAN_OBSERVE_COMPOSE"));
+assert(bench.includes("TOOL_OBSERVATIONS"));
 assert(bench.includes("provider_send_eligible:false"));
 assert(bench.includes("direct_sql=false"));
 assert(bench.includes("direct_meta=false"));
@@ -15,4 +24,4 @@ assert(!bench.includes("/api/wa/send"));
 assert(!bench.includes("graph.facebook.com"));
 assert(server.includes("AOS_CONV_L3_REAL_BENCHMARK_ON_BOOT"));
 assert(server.includes("conv-l3-real-model-benchmark"));
-console.log(JSON.stringify({status:'PASS',suite:'CONV-L3 real-model benchmark safety contract'}));
+console.log(JSON.stringify({status:'PASS',suite:'CONV-L3 V3 plan-observe-compose safety contract'}));


### PR DESCRIPTION
## Scope
Closes the architectural gap exposed by the real-provider L3 benchmark in #507.

The shadow runtime is now an explicit state machine:
`PLAN -> AWAITING_TOOL_OBSERVATION -> COMPOSE -> RESPONSE_READY`.

### Key invariant
If a factual tool is selected, any pre-tool model draft is discarded. A user-facing draft can only be produced after every planned governed tool has returned an observation.

### Adds
- runtime `CONV-L3-SHADOW-V3`;
- `validateToolObservations()`;
- `shadowCompose()`;
- re-check of human takeover, STOP, clinical boundary and conversation version before composition;
- missing observation fail-closed as `OBSERVATION_REQUIRED`;
- cited tool filtering to observed/planned tools only;
- synthetic governed observation benchmark for price, promotions, location, payment, hours and booking;
- greeting/no-tool path benchmark;
- static safety contract for the new state machine.

### Hard boundary
Still SHADOW only. No Meta dispatch, no SQL execution, no outbound authority. `provider_send_eligible=false` remains invariant.