### PR TITLE
Governance: transfer active lock to Google integration V1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md — ASCENDA OS CURRENT
 
-**Current HIGH/CRITICAL program:** `CONV-001 — ASCENDA CONVERSATIONS CORE V1`  
-**Current HIGH/CRITICAL lock:** `CONV-L2 #506 — CONVERSATION CORE + EVENT-DRIVEN PANEL TRANSPORT`  
-**Owner mode:** `RUN UNTIL BLOCKED hasta la siguiente prueba · WhatsApp humano activo · AI autonomy SAFE-OFF`  
-**Last closed:** `CONV-L1 #505 — PROVIDER CERTIFIED`  
+**Current HIGH/CRITICAL program:** `INT-GOOGLE-001 — GOOGLE CALENDAR + CONTACTS`  
+**Current HIGH/CRITICAL lock:** `GC-0/GC-1 — OAuth + secure connection foundation`  
+**Owner mode:** `PROCEDE · implementar todo en el sistema · RUN UNTIL BLOCKED hasta canary humano`  
+**Paused HIGH/CRITICAL lane:** `CONV-001 / CONV-L2 — preserve current evidence, no competing mutations`  
 **Legacy WA-L10 #456:** `FROZEN · SAFE-OFF · EVIDENCE ONLY`
 
 ## Purpose
@@ -19,7 +19,7 @@ This file defines mandatory operating rules for every AI/Codex/development agent
 5. `docs/MEMORY_CURRENT.md`
 6. `docs/control/ASCENDA_ZERO_COST_VALIDATION_STANDARD.md`
 7. `docs/control/ASCENDA_ZERO_COST_CI_V2_HANDOFF.md`
-8. the CURRENT Control Maestro / phase checkpoint of **one selected project only**
+8. the CURRENT Control Maestro / phase checkpoint of **one selected project only** (for the active Google workstream: `docs/control/ASCENDA_GOOGLE_INTEGRATION_V1_CURRENT.md`)
 9. exact GitHub `main`, branch/PR/checks and live Supabase/Railway evidence
 10. for ASCENDA Conversations work, `docs/control/ASCENDA_CONVERSATIONS_CORE_V1_ROADMAP_CURRENT.md`, `docs/control/ASCENDA_CONVERSATIONS_RUN_UNTIL_BLOCKED_PROTOCOL_CURRENT.md`, `docs/control/ASCENDA_CONVERSATIONS_L0_READINESS_CURRENT.md`, `docs/control/ASCENDA_CONVERSATIONS_L1_READINESS_CURRENT.md`, `docs/control/ASCENDA_CONVERSATIONS_BLUEPRINT_REGISTRY_CURRENT.md` and `docs/control/ASCENDA_CONVERSATIONS_BENCHMARK_V1.md`; legacy WhatsApp Revenue Hub docs are evidence/reference only;
 11. for Revenue F5 / identity / historical data work, `docs/control/REV_F5_LEARNING_INTERCONNECTION_CURRENT_20260819.md`;

--- a/docs/MEMORY_CURRENT.md
+++ b/docs/MEMORY_CURRENT.md
@@ -1,10 +1,11 @@
 # ASCENDA OS — MEMORY CURRENT
 
-**Captured:** 2026-09-11 America/Lima  
-**ACTIVE PROGRAM:** `CONV-001 — ASCENDA CONVERSATIONS CORE V1`  
+**Captured:** 2026-09-12 America/Lima  
+**ACTIVE PROGRAM:** `INT-GOOGLE-001 — GOOGLE CALENDAR + CONTACTS`  
 **MAIN AT L0 TECHNICAL CLOSEOUT:** `60b987f75e5efe8906c2eed0d8c560ff449de3b7`  
-**ACTIVE HIGH/CRITICAL GATE:** `CONV-L2 #506 — CONVERSATION CORE + EVENT-DRIVEN PANEL TRANSPORT`  
-**OWNER MODE:** `RUN UNTIL BLOCKED hasta la siguiente prueba · WhatsApp humano activo · AI autonomy SAFE-OFF`  
+**ACTIVE HIGH/CRITICAL GATE:** `GC-0/GC-1 — OAuth + secure connection foundation`  
+**OWNER MODE:** `PROCEDE · implementar todo en el sistema · RUN UNTIL BLOCKED hasta canary humano`  
+**PAUSED LANE:** `CONV-001 / CONV-L2 — evidence preserved; no competing mutations`  
 **LAST CLOSED:** `CONV-L1 #505 — PROVIDER CERTIFIED`  
 **PARENT:** `#502`  
 **LEGACY WA-L10 #456:** `FROZEN · SAFE-OFF · EVIDENCE ONLY`  
@@ -17,7 +18,8 @@
 3. `docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md`;
 4. `docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md`;
 5. this file;
-6. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`;
+6. `docs/control/ASCENDA_GOOGLE_INTEGRATION_V1_CURRENT.md`;
+7. `docs/control/ASCENDA_AGENT_BOOTSTRAP_CURRENT.md`;
 7. `docs/control/ASCENDA_CONVERSATIONS_CORE_V1_ROADMAP_CURRENT.md`;
 8. `docs/control/ASCENDA_CONVERSATIONS_RUN_UNTIL_BLOCKED_PROTOCOL_CURRENT.md`;
 9. `docs/control/ASCENDA_CONVERSATIONS_L0_READINESS_CURRENT.md`;
@@ -173,3 +175,8 @@ Evidence:
 - certified Railway bootstrap restored after temporary probe runs.
 
 The owner then authorized continuing to the next proof so WhatsApp can be exposed as an active human-operated channel. This activates CONV-L2 #506 only; it does not authorize autonomous AI or L3.
+
+
+## Google integration lock transfer — 2026-09-12
+
+Owner explicitly authorized implementation of Google Calendar + Contacts after completing Google Cloud OAuth setup and Railway secret configuration. INT-GOOGLE-001 now owns the single HIGH/CRITICAL mutable lane until the bounded human canary or a new explicit owner transfer. Calendar/Contacts feature flags remain false until certified.

--- a/docs/control/ASCENDA_GOOGLE_INTEGRATION_V1_CURRENT.md
+++ b/docs/control/ASCENDA_GOOGLE_INTEGRATION_V1_CURRENT.md
@@ -1,0 +1,83 @@
+# ASCENDA OS — GOOGLE CALENDAR + CONTACTS INTEGRATION V1 — CURRENT
+
+**Captured:** 2026-09-12 America/Lima  
+**Program:** `INT-GOOGLE-001 — GOOGLE CALENDAR + CONTACTS`  
+**Active gate:** `GC-0/GC-1 — OAuth + secure connection foundation`  
+**Owner authorization:** `PROCEDE · implementar todo en el sistema · run until blocked hasta canary humano`  
+**Risk:** CRITICAL (OAuth, secrets, external side-effects, Agenda)  
+**Production sync flags:** SAFE-OFF
+
+## Objective
+
+Complete the existing `Google Calendar + Contacts` connector in ASCENDA so a client such as ZIVITAL can connect, change or disconnect an authorized Google account from Configuración without hardcoding Gmail accounts in source.
+
+ASCENDA remains the source of truth. Google Calendar and Google Contacts are synchronized projections.
+
+## Preserved authorities
+
+- `public.aos_agenda_citas` remains the canonical appointment ledger.
+- Existing governed booking/rebook/status authorities remain unchanged.
+- Existing Resend email templates remain the communication authority; Google adds Calendar UX, not a replacement email system.
+- Patient identity remains in ASCENDA. Google Contacts receives only the minimum operational contact data.
+- No Google failure may roll back or corrupt an already-confirmed ASCENDA appointment.
+
+## Google platform configuration already completed
+
+- Google Cloud project: `ASCENDA OS`.
+- Calendar API enabled.
+- People API enabled.
+- OAuth web client created.
+- Redirect URI: `https://ascenda-os-production.up.railway.app/api/google/oauth/callback`.
+- Test user configured.
+- Railway production variables present:
+  - `GOOGLE_CLIENT_ID`
+  - `GOOGLE_CLIENT_SECRET`
+  - `GOOGLE_REDIRECT_URI`
+  - `GOOGLE_INTEGRATION_ENABLED=false`
+  - `GOOGLE_CALENDAR_SYNC_ENABLED=false`
+  - `GOOGLE_CONTACT_SYNC_ENABLED=false`
+
+Secrets remain environment-only and must never be committed or surfaced to the browser.
+
+## Target flow
+
+`Booking authority -> canonical appointment -> transactional/event side-effect intent -> Google worker -> Calendar/People`.
+
+OAuth flow:
+`Configuración > Integraciones > Google Calendar + Contacts -> Conectar Google -> Google consent -> callback -> encrypted refresh-token storage -> calendar selection`.
+
+Calendar:
+- create one deterministic event per appointment;
+- store/use `gcal_event_id`;
+- patient email is attendee when valid;
+- rebook patches the same event;
+- cancel removes/cancels the same event;
+- private extended properties carry ASCENDA appointment/revision identifiers;
+- timezone `America/Lima`.
+
+Contacts:
+- one Google person link per canonical patient/account;
+- dedupe priority: existing local link/resourceName -> ASCENDA external ID -> exact normalized phone/email -> review on conflict;
+- never dedupe by name alone;
+- mutations serialized per Google account;
+- naming rule for ZIVITAL is configurable, initial form: `{nombre} {apellido} - {tag} - {mes}{yy}`.
+
+## Rollout gates
+
+1. GC-0 security/contract and exact-current preflight.
+2. GC-1 OAuth connect/change/disconnect and encrypted token storage.
+3. GC-2 Calendar create with flags SAFE-OFF until canary.
+4. GC-3 rebook/cancel same-event behavior.
+5. GC-4 existing Resend template gains Calendar action/link.
+6. GC-5 Contacts reconcile/upsert without duplicates.
+7. GC-6 unified outbox/retry/reconciliation path.
+8. GC-7 bounded human canary with owner/test account.
+9. GC-8 future-appointment backfill after canary evidence.
+
+## Safety
+
+- No plaintext Google refresh token in browser, logs, GitHub, docs or generic integration tables.
+- No synchronous Google HTTP call inside PostgreSQL triggers or the canonical booking transaction.
+- No mass backfill before canary.
+- Production feature flags remain false until the exact SHA is validated and the owner authorizes the live canary.
+- CONV-001 is paused for HIGH/CRITICAL mutations during this lock transfer; its production AI autonomy remains SAFE-OFF.

--- a/docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md
+++ b/docs/control/ASCENDA_PROJECT_PORTFOLIO_CURRENT.md
@@ -1,15 +1,15 @@
 # ASCENDA OS — PROJECT PORTFOLIO CURRENT
 
-**Captured:** 2026-09-11 America/Lima  
+**Captured:** 2026-09-12 America/Lima  
 **Current main at L0 technical closeout:** `60b987f75e5efe8906c2eed0d8c560ff449de3b7`  
-**ACTIVE PORTFOLIO OWNER:** `CONV-001 — ASCENDA CONVERSATIONS CORE V1`  
-**ACTIVE HIGH/CRITICAL GATE:** `CONV-L2 #506 — Conversation Core + event-driven panel transport`  
-**OWNER MODE:** `RUN UNTIL BLOCKED hasta la siguiente prueba · WhatsApp humano activo · AI autonomy SAFE-OFF`  
-**LAST CLOSED:** `CONV-L1 #505 — PROVIDER CERTIFIED`
+**ACTIVE PORTFOLIO OWNER:** `INT-GOOGLE-001 — GOOGLE CALENDAR + CONTACTS`  
+**ACTIVE HIGH/CRITICAL GATE:** `GC-0/GC-1 — OAuth + secure connection foundation`  
+**OWNER MODE:** `PROCEDE · implementar todo en el sistema · RUN UNTIL BLOCKED hasta canary humano`  
+**PAUSED LANE:** `CONV-001 / CONV-L2 — evidence preserved, no competing HIGH/CRITICAL mutations`
 
 ## Current owner state
 
-CONV-001 remains the active portfolio program. CONV-L2 #506 is the sole HIGH/CRITICAL mutable lane.
+Owner authorization on 2026-09-12 transfers the sole HIGH/CRITICAL mutable lane to INT-GOOGLE-001. CONV-001 / CONV-L2 is paused for competing mutations while its current evidence and SAFE-OFF production posture are preserved.
 
 Legacy WA-L10 #456 is FROZEN / SAFE-OFF evidence only. No new conversational feature patching is permitted on the legacy hot path except narrowly scoped P0 security/privacy/data-loss/production-break remediation.
 
@@ -17,7 +17,8 @@ Legacy WA-L10 #456 is FROZEN / SAFE-OFF evidence only. No new conversational fea
 
 | Program | Preserved input | Current state |
 |---|---|---|
-| CONV-001 Conversations Core V1 | existing panel, WA evidence, Meta integration knowledge, canonical ASCENDA business authorities | **ACTIVE / CONV-L2 MUTABLE OWNER** |
+| INT-GOOGLE-001 Google Calendar + Contacts | Agenda authority, patient identity, existing integration catalog, Resend templates | **ACTIVE / GC-0/GC-1 MUTABLE OWNER** |
+| CONV-001 Conversations Core V1 | existing panel, WA evidence, Meta integration knowledge, canonical ASCENDA business authorities | **PAUSED / EVIDENCE PRESERVED** |
 | Legacy WhatsApp Revenue Hub WA-* | WA3/3.5 UI, L4 authority, L5 booking, L6 attribution, L7 cost, L8 security, L9/L10 evidence | **FROZEN / EVIDENCE + EXTRACTION SOURCE** |
 | Revenue REV-* | patient/product/revenue identity and 360 authorities | READ-ONLY dependency source |
 | Agenda / Call Center / Marketing | current operational systems | PROTECTED regression dependencies |

--- a/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
+++ b/docs/control/ASCENDA_WORKSTREAM_LOCK_CURRENT.md
@@ -1,9 +1,9 @@
 # ASCENDA OS — WORKSTREAM EXECUTION LOCK CURRENT
 
-**Captured:** 2026-09-11 America/Lima  
-**ACTIVE HIGH/CRITICAL LOCK:** `CONV-L2 #506 — CONVERSATION CORE + EVENT-DRIVEN PANEL TRANSPORT`  
-**OWNER AUTHORIZATION:** `RUN UNTIL BLOCKED hasta la siguiente prueba · exponer WhatsApp humano activo · mantener AI autonomy SAFE-OFF`  
-**LAST CLOSED:** `CONV-L1 #505 — NATIVE META CHANNEL GATEWAY · PROVIDER CERTIFIED`  
+**Captured:** 2026-09-12 America/Lima  
+**ACTIVE HIGH/CRITICAL LOCK:** `INT-GOOGLE-001 / GC-0/GC-1 — GOOGLE CALENDAR + CONTACTS OAUTH FOUNDATION`  
+**OWNER AUTHORIZATION:** `PROCEDE · implementar todo en el sistema · RUN UNTIL BLOCKED hasta canary humano`  
+**PAUSED HIGH/CRITICAL LANE:** `CONV-001 / CONV-L2 — preserve evidence; no competing mutations`  
 **Legacy WA-L10 #456:** `FROZEN · SAFE-OFF EVIDENCE ONLY · NO NEW FEATURE PATCHING`  
 **P0 #485:** `CLOSED / COMPLETED — PROD RECURRENCE+LOAD PASS`  
 **GitHub authority:** Issue `#502` = `OPEN`; Issue `#456` = `OPEN / FROZEN`  
@@ -16,7 +16,7 @@
 
 The owner approved a consolidation pivot after the R8/R9 WhatsApp canary investigation showed that continuing to stack patches on the WA2/WA3/WA4/F4/L4-L10 hot path was creating latency, operational coupling and debugging complexity without yet meeting the required conversational-sales experience.
 
-CONV-001 remains the active program. **CONV-L2 #506 now owns the sole HIGH/CRITICAL implementation lane** under explicit owner authorization.
+Owner authorization on 2026-09-12 supersedes the prior mutable-lane assignment for the duration of this integration loop. **INT-GOOGLE-001 / GC-0/GC-1 owns the sole HIGH/CRITICAL implementation lane**. CONV-001 remains preserved but paused for competing mutations.
 
 External projects such as Chatwoot, Fazer clinical sales agent patterns, LangGraph and official Meta samples are engineering blueprints only. They are not runtime dependencies unless separately approved.
 
@@ -50,6 +50,6 @@ WA-L10 #456 remains preserved for audit/evidence and rollback knowledge, but is 
 
 ## Immediate next gate
 
-**CONV-L2 #506 is ACTIVE.** Consolidate the canonical conversation lifecycle and panel transport on top of the certified Meta gateway. The next real proof is bounded human messaging/takeover on the existing `zi vital` test conversation. AI autonomy remains SAFE-OFF; L3 is not authorized.
+**INT-GOOGLE-001 / GC-0/GC-1 is ACTIVE.** Build and certify server-side OAuth, encrypted connection persistence and the existing Configuración > Integraciones Google connector. Keep all Google sync flags SAFE-OFF until the bounded human canary. CONV production AI autonomy remains SAFE-OFF.
 
 See Issue #502 and `docs/control/ASCENDA_CONVERSATIONS_CORE_V1_ROADMAP_CURRENT.md`.


### PR DESCRIPTION
Owner-authorized lock transfer for INT-GOOGLE-001. Pauses competing CONV HIGH/CRITICAL mutations, preserves SAFE-OFF, and establishes the Google Calendar + Contacts control contract. Docs/governance only.