### PR TITLE
CI — restore Zero-Cost runner for CONV-L3 shadow gate

### DIFF
--- a/.github/workflows/conv-l3-shadow-runtime.yml
+++ b/.github/workflows/conv-l3-shadow-runtime.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   contract:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Scope
CI-only repair. No runtime, Meta, WhatsApp, Google Integration, Supabase, PWA or Railway logic changes.

## Why
`main` currently contains `.github/workflows/conv-l3-shadow-runtime.yml` with `runs-on: ubuntu-latest`, which violates the repository-wide Zero-Cost policy and causes unrelated PRs such as APP-PWA-V2 #519 to fail global CI.

## Change
Replace only:
`runs-on: ubuntu-latest`
with:
`runs-on: [self-hosted, Linux, X64, ascenda-zero-cost-v2]`

This restores the canonical self-hosted policy without changing CONV-L3 behavior.